### PR TITLE
fix(api): Allow HEAD requests for /files/ endpoint

### DIFF
--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -674,7 +674,7 @@ func (s *Server) secureFileServer() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := log.WithComponentFromContext(r.Context(), "api")
 
-		if r.Method != http.MethodGet {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			logger.Warn().Str("event", "file_req.denied").Str("path", r.URL.Path).Str("reason", "method_not_allowed").Msg("method not allowed")
 			recordFileRequestDenied("method_not_allowed")
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)


### PR DESCRIPTION
## Summary
Fixes M3U tuner functionality in Jellyfin and other IPTV clients by allowing HEAD requests for `/files/` endpoints.

## Problem
Jellyfin and many IPTV clients send HEAD requests to check M3U playlist availability before downloading. The `/files/` handler was rejecting these with **405 Method Not Allowed**, breaking M3U tuner setup with error: "Wiedergabefehler - Player-Fehler"

## Root Cause
In `internal/api/http.go` line 677, the secure file server only allowed `GET` requests:
```go
if r.Method != http.MethodGet {
    // Reject all other methods including HEAD
```

## Solution
Changed to allow both GET and HEAD methods:
```go
if r.Method != http.MethodGet && r.Method != http.MethodHead {
```

## Testing
- ✅ `curl -X GET http://localhost:8080/files/playlist.m3u` → 200 OK
- ✅ `curl -X HEAD http://localhost:8080/files/playlist.m3u` → 200 OK (was 405)
- ✅ Jellyfin M3U tuner setup now works
- ✅ HDHomeRun mode continues to work (unchanged)

## Impact
- **Before**: M3U mode fails in Jellyfin with 405 errors
- **After**: Both M3U and HDHomeRun modes work correctly

## Related
- HDHomeRun mode was unaffected because it proxies streams directly via `/auto/vX` without requiring static file HEAD requests
- XMLTV endpoint already supports HEAD: `r.HandleFunc("/xmltv.xml", s.handleXMLTV).Methods("GET", "HEAD")` (line 168)

Fixes #[issue] (if exists)

Generated with [Claude Code](https://claude.com/claude-code)