### PR TITLE
chore(docker): pin runtime container base images to SHA256

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN BUILD_REF="${GIT_REF:-${VERSION:-dev}}" && \
   ${GO_GCFLAGS:+-gcflags="${GO_GCFLAGS}"} \
   -o /out/xg2g ./cmd/daemon
 
-FROM alpine:3.22.2
+FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 RUN apk add --no-cache ca-certificates tzdata wget ffmpeg && \
   addgroup -g 65532 -S xg2g && \
   adduser -u 65532 -S -G xg2g -h /app -s /bin/false xg2g && \

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
   -o /out/xg2g ./cmd/daemon
 
 # Runtime stage (distroless with CA certs, running as root for volume compatibility)
-FROM gcr.io/distroless/base-debian12:latest
+FROM gcr.io/distroless/base-debian12:latest@sha256:9e9b50d2048db3741f86a48d939b4e4cc775f5889b3496439343301ff54cdba8
 WORKDIR /app
 # Copy binary
 COPY --from=builder /out/xg2g /app/xg2g

--- a/internal/jobs/refresh_test.go
+++ b/internal/jobs/refresh_test.go
@@ -3,6 +3,7 @@ package jobs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -267,6 +268,7 @@ func TestRefresh_M3UWriteError(t *testing.T) {
 	if !strings.Contains(err.Error(), "failed to write M3U playlist") {
 		t.Errorf("expected error to contain 'failed to write M3U playlist', got: %v", err)
 	}
+	assertRenameFailure(t, err)
 }
 
 func TestValidateConfig(t *testing.T) {
@@ -391,6 +393,22 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func assertRenameFailure(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected rename failure error, got nil")
+	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return
+	}
+	var linkErr *os.LinkError
+	if errors.As(err, &linkErr) {
+		return
+	}
+	t.Fatalf("expected *os.PathError or *os.LinkError, got %T: %v", err, err)
 }
 
 func TestMakeStableIDFromSRef(t *testing.T) {

--- a/transcoder/Dockerfile
+++ b/transcoder/Dockerfile
@@ -44,7 +44,7 @@ RUN RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU} -C opt-level=${RUST_OPT_LEVEL}" 
     strip /build/target/release/xg2g-transcoder
 
 # Runtime image
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:78d2f66e0fec9e5a39fb2c72ea5e052b548df75602b5215ed01a17171529f706
 
 # Install runtime dependencies
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- pin the runtime stages in all Dockerfiles to immutable image digests to satisfy dependency pinning guidance

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_6901b1768e28833393f7aa1151de28bd