### PR TITLE
docs: update testing guide and clarify transcoder build modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,18 @@ docker run -d \
 
 **Build Requirements:**
 
+**Core (required):**
+
 - **Go 1.25+** (stable release) - [Install from go.dev](https://go.dev/dl/)
-- **Rust 1.70+** (for native audio transcoder) - [Install via rustup](https://rustup.rs/)
+- Docker (recommended, for containerized deployment)
+
+**Optional (for native transcoder):**
+
+- **Rust 1.70+** (for Rust audio transcoder) - [Install via rustup](https://rustup.rs/)
 - **FFmpeg libraries** (libavcodec, libavformat) - Required for AC3/AAC codecs
-- Docker (optional, for containerized deployment)
+
+> **Note:** By default, xg2g builds with a **stub transcoder** (no Rust dependency).
+> Enable the native Rust transcoder with `CGO_ENABLED=1 go build -tags=transcoder` when needed.
 
 ---
 
@@ -97,6 +105,68 @@ docker run -d \
 ```
 
 **📖 See [Architecture Documentation](docs/ARCHITECTURE.md) for detailed component design and data flow.**
+
+---
+
+## Build Modes
+
+xg2g supports two operational modes for audio transcoding:
+
+### 1. Stub Transcoder (Default, Recommended)
+
+**Use when:** Developing, testing, or deploying without Rust requirements
+
+**Characteristics:**
+
+- ✅ No Rust toolchain required
+- ✅ Fast builds (`go build ./cmd/daemon`)
+- ✅ Zero native dependencies
+- ✅ Suitable for CI, unit tests, development
+- ⚠️ Audio transcoding disabled (fallback to FFmpeg subprocess if needed)
+
+**Build:**
+
+```bash
+go build -o xg2g ./cmd/daemon
+# or
+make build
+```
+
+### 2. Native Rust Transcoder (Production, High-Performance)
+
+**Use when:** Production deployments requiring real-time audio transcoding (AC3/MP2 → AAC)
+
+**Characteristics:**
+
+- ✅ Native Rust audio remuxer (140x faster than FFmpeg)
+- ✅ Ultra-low latency (1.4ms processing time)
+- ✅ Hardware-optimized (SIMD, zero-copy)
+- ⚠️ Requires Rust toolchain + CGO
+- ⚠️ Requires FFmpeg development headers
+
+**Build:**
+
+```bash
+# Build Rust library
+cd transcoder && cargo build --release
+
+# Build with transcoder tag
+CGO_ENABLED=1 go build -tags=transcoder -o xg2g ./cmd/daemon
+
+# or
+make build-rust
+make build-ffi
+```
+
+**Test:**
+
+```bash
+make test                # Fast, stub mode
+make test-transcoder     # Full, with Rust FFI
+```
+
+> **💡 Tip:** Start with stub mode for development. Enable the Rust transcoder only when you need
+> production-grade audio remuxing for iOS/Safari clients.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates documentation to align with the new Make-based testing workflow and transcoder build modes:

- **CONTRIBUTING.md**: Rewrote Testing section with Make targets as canonical interface (`make test`, `make test-transcoder`, `make test-schema`)
- **CONTRIBUTING.md**: Marked Rust as optional dependency, added CI alignment table
- **README.md**: Added "Build Modes" section clearly explaining stub vs. Rust transcoder
- **README.md**: Clarified build requirements (Go + Docker required, Rust optional)

## Context

This documentation aligns with the new CI v2 workflow (currently in shadow mode). See `.github/CI_MIGRATION.md` for migration plan.

Key improvements:
- Contributors can now develop and test **without Rust dependency** using stub transcoder
- Clear separation: `make test` (fast, stub) vs `make test-transcoder` (Rust FFI)
- Schema tests isolated behind `make test-schema` (requires check-jsonschema)
- Testing instructions mirror CI pipeline jobs

## Test plan

- [x] Documentation changes are clear and accurate
- [x] `make test` command referenced matches Makefile target
- [x] `make test-transcoder` command referenced matches Makefile target
- [x] `make test-schema` command referenced matches Makefile target
- [x] Build mode examples use correct build tags (`-tags=transcoder`)
- [ ] Verify documentation renders correctly on GitHub
- [ ] CI checks pass (markdown lint, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)