### PR TITLE
Fix DVR edit capability reporting

### DIFF
--- a/internal/control/read/dvr.go
+++ b/internal/control/read/dvr.go
@@ -45,7 +45,7 @@ func GetDvrCapabilities(ctx context.Context, src DvrSource) (DvrCapabilities, er
 
 	return DvrCapabilities{
 		CanDelete:        true,
-		CanEdit:          true,
+		CanEdit:          canEdit,
 		ReadBackVerify:   true,
 		ConflictsPreview: true,
 		ReceiverAware:    canEdit,

--- a/internal/control/read/dvr_test.go
+++ b/internal/control/read/dvr_test.go
@@ -1,0 +1,34 @@
+package read
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/openwebif"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDvrSource struct {
+	cap openwebif.TimerChangeCap
+	err error
+}
+
+func (m *mockDvrSource) GetStatusInfo(ctx context.Context) (*openwebif.StatusInfo, error) {
+	return nil, nil
+}
+
+func (m *mockDvrSource) DetectTimerChange(ctx context.Context) (openwebif.TimerChangeCap, error) {
+	return m.cap, m.err
+}
+
+func TestGetDvrCapabilities_CanEditReflectsCapability(t *testing.T) {
+	src := &mockDvrSource{
+		cap: openwebif.TimerChangeCap{Supported: false},
+	}
+
+	caps, err := GetDvrCapabilities(context.Background(), src)
+	require.NoError(t, err)
+	assert.False(t, caps.CanEdit, "CanEdit should respect DetectTimerChange capability")
+	assert.False(t, caps.ReceiverAware, "ReceiverAware should track edit capability")
+}


### PR DESCRIPTION
## Summary
- fix: GetDvrCapabilities now honors DetectTimerChange for CanEdit
- test: add coverage to ensure CanEdit and ReceiverAware reflect capability

## Testing
- go test ./internal/control/read -run TestGetDvrCapabilities_CanEditReflectsCapability
