### PR TITLE
Fix DVR defaults and audio-only HLS mapping

### DIFF
--- a/internal/control/read/dvr.go
+++ b/internal/control/read/dvr.go
@@ -37,7 +37,7 @@ func GetDvrCapabilities(ctx context.Context, src DvrSource) (DvrCapabilities, er
 		return DvrCapabilities{SeriesMode: "none"}, nil
 	}
 
-	canEdit := true // Defaults to true via fallback?
+	canEdit := false // Fail-closed when capability detection fails
 	cap, err := src.DetectTimerChange(ctx)
 	if err == nil {
 		canEdit = cap.Supported

--- a/internal/control/read/dvr_test.go
+++ b/internal/control/read/dvr_test.go
@@ -32,3 +32,15 @@ func TestGetDvrCapabilities_CanEditReflectsCapability(t *testing.T) {
 	assert.False(t, caps.CanEdit, "CanEdit should respect DetectTimerChange capability")
 	assert.False(t, caps.ReceiverAware, "ReceiverAware should track edit capability")
 }
+
+func TestGetDvrCapabilities_CanEditFailClosedOnError(t *testing.T) {
+	src := &mockDvrSource{
+		cap: openwebif.TimerChangeCap{Supported: true},
+		err: assert.AnError,
+	}
+
+	caps, err := GetDvrCapabilities(context.Background(), src)
+	require.NoError(t, err)
+	assert.False(t, caps.CanEdit, "CanEdit should fail-closed on capability detection errors")
+	assert.False(t, caps.ReceiverAware, "ReceiverAware should fail-closed on capability detection errors")
+}

--- a/internal/infra/media/ffmpeg/adapter.go
+++ b/internal/infra/media/ffmpeg/adapter.go
@@ -673,7 +673,7 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 		// Use -sn to disable subtitles/teletext, as they often cause "Invalid data" errors
 		// during transcoding (mapped to WebVTT by default) with Stream Relay sources.
 		args = append(args,
-			"-map", "0:v:0",
+			"-map", "0:v:0?",
 			"-map", "0:a:0?",
 			"-c:v", "libx264",
 			"-preset", "ultrafast", // Ultra-fast encoding for low latency

--- a/internal/infra/media/ffmpeg/adapter_args_test.go
+++ b/internal/infra/media/ffmpeg/adapter_args_test.go
@@ -1,0 +1,47 @@
+package ffmpeg
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildArgs_UsesOptionalVideoMap(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"",
+		t.TempDir(),
+		nil,
+		zerolog.New(io.Discard),
+		"",
+		"",
+		0,
+		0,
+		false,
+		2*time.Second,
+		6,
+		0,
+		0,
+	)
+
+	spec := ports.StreamSpec{
+		SessionID: "sid-1",
+		Mode:      ports.ModeLive,
+		Format:    ports.FormatHLS,
+		Quality:   ports.QualityStandard,
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+	assert.Contains(t, args, "0:v:0?", "video map should be optional for audio-only inputs")
+	assert.Contains(t, args, "0:a:0?", "audio map should remain optional")
+}


### PR DESCRIPTION
## Summary
- fail-closed DVR edit capability when detection errors
- align pipeline intent DVR window default with config registry
- allow audio-only inputs by making video mapping optional in ffmpeg args
- add tests for DVR capability fail-closed + optional video map

## Testing
- go test ./internal/control/read ./internal/infra/media/ffmpeg ./internal/pipeline/api
