### PR TITLE
Docs drift: Quickstart port/env + DVR default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,23 @@ on:
     branches: [main]
     paths:
       - "**/*.go"
+      - ".github/**"
       - go.mod
       - go.sum
-      - .github/workflows/ci.yml
       - "api/openapi.yaml"
+      - "config.example.yaml"
+      - "config.generated.example.yaml"
+      - "docs/**"
       - "internal/**"
+      - "Dockerfile"
+      - "Dockerfile.*"
+      - "docker-compose*.yml"
+      - "README.md"
       - "scripts/**"
       - "Makefile"
+      - "templates/**"
       - "webui/**"
+      - "VERSION"
       - "WORKFLOW.md"
 
 permissions:

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -32,6 +32,7 @@ COPY --from=builder /xg2g /xg2g
 # If we need CA certs, distroless/static includes them.
 
 # Expose port (default 8080 or whatever config uses)
-EXPOSE 8080
+# Default config: API listens on :8088; streaming proxy uses :18000.
+EXPOSE 8088 18000
 
 ENTRYPOINT ["/xg2g"]

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Stream to Safari, iOS, Chrome, and any modern browser.
 
 ```bash
 docker run -d --name xg2g --net=host \
-  -e XG2G_UPSTREAM_HOST="192.168.1.10" \
+  -e XG2G_OWI_BASE="http://192.168.1.10" \
+  -e XG2G_API_TOKEN="$(openssl rand -hex 32)" \
+  -e XG2G_API_TOKEN_SCOPES="v3:admin" \
   ghcr.io/manugh/xg2g:3.1.7
 ```
 
-Open [http://localhost:8080](http://localhost:8080)
+Open [http://localhost:8088/ui/](http://localhost:8088/ui/)
 
 **Next steps:**
 [Configuration](docs/guides/CONFIGURATION.md) •

--- a/docs/PRODUCT_POLICY.md
+++ b/docs/PRODUCT_POLICY.md
@@ -6,7 +6,7 @@ core playback/recording semantics.
 ## Policy
 
 - Live means Live + DVR (default behavior).
-- DVRWindow default: 4h.
+- DVRWindow default: 45m.
 - VOD includes only completed recordings.
 - No in-progress VOD.
 - No automatic DVR -> VOD transition.

--- a/templates/README.md.tmpl
+++ b/templates/README.md.tmpl
@@ -22,11 +22,13 @@ Stream to Safari, iOS, Chrome, and any modern browser.
 
 ```bash
 docker run -d --name xg2g --net=host \
-  -e XG2G_UPSTREAM_HOST="192.168.1.10" \
+  -e XG2G_OWI_BASE="http://192.168.1.10" \
+  -e XG2G_API_TOKEN="$(openssl rand -hex 32)" \
+  -e XG2G_API_TOKEN_SCOPES="v3:admin" \
   ghcr.io/manugh/xg2g:{{VERSION}}
 ```
 
-Open [http://localhost:8080](http://localhost:8080)
+Open [http://localhost:8088/ui/](http://localhost:8088/ui/)
 
 **Next steps:**
 [Configuration](docs/guides/CONFIGURATION.md) •
@@ -88,6 +90,7 @@ or your custom prefix. See [FFmpeg Build Guide](docs/ops/FFMPEG_BUILD.md) for
 details.
 
 To use your local build:
+
 ```bash
 export XG2G_FFMPEG_BIN="/opt/xg2g/ffmpeg/bin/ffmpeg"
 export LD_LIBRARY_PATH="/opt/xg2g/ffmpeg/lib"
@@ -100,6 +103,7 @@ This repository supports deterministic offline testing (air-gap capable).
 See: OFFLINE_TEST.md
 
 Quick check:
+
 ```bash
 export GOTOOLCHAIN=local
 export GOPROXY=off GOSUMDB=off GOVCS="*:off"


### PR DESCRIPTION
Fixes doc drift between operator truth (config registry defaults) and entrypoint docs.

Changes:
- Quickstart now uses XG2G_OWI_BASE, sets required API token + scopes, and points to :8088/ui.
- Product policy DVRWindow default aligned to registry default (45m).
- distroless Dockerfile port exposure aligned to :8088 (+18000).