### PR TITLE
ci: fix Scorecard SARIF upload + runner-based gosec

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -34,18 +34,26 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install gosec (pinned)
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.11
+
       - name: Run gosec security scan
-        uses: securego/gosec@424fc4cd9c82ea0fd6bee9cd49c2db2c3cc0c93f # v2.22.11
-        with:
-          # -fmt sarif: Output in SARIF format
-          # -out gosec.sarif: Save output to file
-          # -severity medium: Fail on medium or higher severity issues
-          # ./...: Scan all packages
-          # Fail only on high+ to keep this scan actionable in day-to-day PRs.
-          args: -fmt=sarif -out=gosec.sarif -severity=high -tags=nogpu -exclude-generated -exclude-dir=test -exclude-dir=internal/test -exclude-dir=internal/api -exclude-dir=.github -exclude-dir=vendor ./...
+        run: |
+          gosec \
+            -fmt=sarif \
+            -out=gosec.sarif \
+            -severity=high \
+            -tags=nogpu \
+            -exclude-generated \
+            -exclude-dir=test \
+            -exclude-dir=internal/test \
+            -exclude-dir=internal/api \
+            -exclude-dir=.github \
+            -exclude-dir=vendor \
+            ./...
 
       - name: Upload SARIF to GitHub Security
-        if: always()
+        if: always() && hashFiles('gosec.sarif') != ''
         uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314
         with:
           sarif_file: gosec.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/init@6bc82e05fd0ea64601dd4b465378bbcf57de0314
+        uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Fixes two red workflows on main:

- Scorecard: replace forbidden `github/codeql-action/init` with `github/codeql-action/upload-sarif` so publishing works again.
- gosec: stop using the Docker-based `securego/gosec` action (Go toolchain mismatch vs `go.mod`), install pinned gosec on the runner via `go install`, run SARIF scan, then upload SARIF.

Expected outcome:
- Scorecard workflow publishes successfully (no 400 workflow verification failure).
- gosec no longer fails due to Go version mismatch.