### PR TITLE
ci: avoid cross-workflow cancellations

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: repo-${{ github.event.pull_request.number || github.ref }}
+  group: repo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: repo-${{ github.event.pull_request.number || github.ref }}
+  group: repo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fixes cancelled CI required check runs caused by repo-wide concurrency group collisions.

Change:
- Use `repo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}` as the concurrency group key in CI workflows so only the same workflow cancels its own stale runs.

Files:
- .github/workflows/ci.yml
- .github/workflows/ci-v2.yml