### PR TITLE
ci(codeql): queue runs instead of canceling

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,8 @@ on:
 
 concurrency:
   group: repo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # CodeQL is relatively heavy; queue newer runs instead of canceling in-progress work.
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Stops CodeQL from auto-canceling in-progress runs when a newer run is queued for the same ref.

This removes the noisy log message:
"Canceling since a higher priority waiting request for repo-CodeQL-refs/heads/main exists".

Change:
- `.github/workflows/codeql.yml`: set `concurrency.cancel-in-progress` to `false`.