### PR TITLE
feat(ffmpeg): VAAPI GPU transcoding via ProfileSpec

### DIFF
--- a/config.generated.example.yaml
+++ b/config.generated.example.yaml
@@ -56,6 +56,7 @@ ffmpeg:
   bin: ffmpeg
   ffprobeBin: ""
   killTimeout: 5s
+  vaapiDevice: ""
 hdhr:
   baseUrl: ""
   deviceId: ""

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -111,6 +111,7 @@ Aliases: `openWebIF.*` (compat; prefer `enigma2.*`).
 | `ffmpeg.bin` | `XG2G_FFMPEG_BIN` | `ffmpeg` | Active | Advanced |
 | `ffmpeg.ffprobeBin` | `XG2G_FFPROBE_BIN` | - | Active | Advanced |
 | `ffmpeg.killTimeout` | `XG2G_FFMPEG_KILL_TIMEOUT` | `5s` | Active | Advanced |
+| `ffmpeg.vaapiDevice` | `XG2G_VAAPI_DEVICE` | `""` | Active | Advanced |
 
 ### hdhr
 

--- a/docs/guides/config.schema.json
+++ b/docs/guides/config.schema.json
@@ -521,6 +521,10 @@
         "killTimeout": {
           "default": "5s",
           "type": "string"
+        },
+        "vaapiDevice": {
+          "default": "",
+          "type": "string"
         }
       },
       "type": "object"

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -327,6 +327,22 @@ func (l *Loader) mergeFileConfig(dst *AppConfig, src *FileConfig) error {
 		}
 	}
 
+	// FFmpeg (Typed Config)
+	if src.FFmpeg != nil {
+		if src.FFmpeg.Bin != "" {
+			dst.FFmpeg.Bin = expandEnv(src.FFmpeg.Bin)
+		}
+		if src.FFmpeg.FFprobeBin != "" {
+			dst.FFmpeg.FFprobeBin = expandEnv(src.FFmpeg.FFprobeBin)
+		}
+		if src.FFmpeg.KillTimeout > 0 {
+			dst.FFmpeg.KillTimeout = src.FFmpeg.KillTimeout
+		}
+		if src.FFmpeg.VaapiDevice != "" {
+			dst.FFmpeg.VaapiDevice = expandEnv(src.FFmpeg.VaapiDevice)
+		}
+	}
+
 	// Engine mapping (P1.2 Harden)
 	if src.Engine.Enabled != nil {
 		dst.Engine.Enabled = *src.Engine.Enabled
@@ -619,6 +635,7 @@ func (l *Loader) mergeEnvConfig(cfg *AppConfig) {
 	cfg.FFmpeg.Bin = l.envString("XG2G_FFMPEG_BIN", cfg.FFmpeg.Bin)
 	cfg.FFmpeg.FFprobeBin = l.envString("XG2G_FFPROBE_BIN", cfg.FFmpeg.FFprobeBin)
 	cfg.FFmpeg.KillTimeout = l.envDuration("XG2G_FFMPEG_KILL_TIMEOUT", cfg.FFmpeg.KillTimeout)
+	cfg.FFmpeg.VaapiDevice = l.envString("XG2G_VAAPI_DEVICE", cfg.FFmpeg.VaapiDevice)
 
 	// Rate Limiting
 	cfg.RateLimitEnabled = l.envBool("XG2G_RATE_LIMIT_ENABLED", cfg.RateLimitEnabled)

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -154,6 +154,7 @@ func buildRegistry() (*Registry, error) {
 		{Path: "ffmpeg.bin", Env: "XG2G_FFMPEG_BIN", FieldPath: "FFmpeg.Bin", Profile: ProfileAdvanced, Status: StatusActive, Default: "ffmpeg"},
 		{Path: "ffmpeg.ffprobeBin", Env: "XG2G_FFPROBE_BIN", FieldPath: "FFmpeg.FFprobeBin", Profile: ProfileAdvanced, Status: StatusActive},
 		{Path: "ffmpeg.killTimeout", Env: "XG2G_FFMPEG_KILL_TIMEOUT", FieldPath: "FFmpeg.KillTimeout", Profile: ProfileAdvanced, Status: StatusActive, Default: 5 * time.Second},
+		{Path: "ffmpeg.vaapiDevice", Env: "XG2G_VAAPI_DEVICE", FieldPath: "FFmpeg.VaapiDevice", Profile: ProfileAdvanced, Status: StatusActive, Default: ""},
 
 		// --- TLS ---
 		{Path: "tls.enabled", Env: "XG2G_TLS_ENABLED", FieldPath: "TLSEnabled", Profile: ProfileAdvanced, Status: StatusActive, Default: false},

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -447,6 +447,13 @@ type FFmpegConfig struct {
 	Bin         string        `yaml:"bin"`
 	FFprobeBin  string        `yaml:"ffprobeBin,omitempty"`
 	KillTimeout time.Duration `yaml:"killTimeout"`
+	// VaapiDevice is the DRM render node for VAAPI GPU transcoding.
+	// Set to e.g. "/dev/dri/renderD128" (or XG2G_VAAPI_DEVICE env) to enable.
+	// Empty (default) = VAAPI disabled; all transcoding uses CPU (libx264).
+	// When set, a real 5-frame encode preflight runs at startup. Profiles
+	// with HWAccel="vaapi" are only produced when the preflight passes;
+	// otherwise sessions requesting VAAPI will fail-closed.
+	VaapiDevice string `yaml:"vaapiDevice,omitempty"`
 }
 
 // HLSConfig holds HLS output settings

--- a/internal/domain/session/manager/orchestrator_helpers.go
+++ b/internal/domain/session/manager/orchestrator_helpers.go
@@ -210,6 +210,7 @@ func (o *Orchestrator) startPipeline(
 		Mode:      ports.ModeLive, // Default
 		Format:    ports.FormatHLS,
 		Quality:   ports.QualityStandard, // Hardcoded for simplified ProfileSpec mapping for now
+		Profile:   currentProfileSpec,    // Pass through resolved profile (GPU, codec, quality)
 		Source: ports.StreamSource{
 			ID:        sessionCtx.ServiceRef,
 			Type:      ports.SourceTuner, // Default assumes Tuner/Ref

--- a/internal/domain/session/ports/types.go
+++ b/internal/domain/session/ports/types.go
@@ -1,6 +1,10 @@
 package ports
 
-import "time"
+import (
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/model"
+)
 
 // StreamMode defines the intent of the stream.
 type StreamMode string
@@ -55,6 +59,7 @@ type StreamSpec struct {
 	Format    StreamFormat
 	Quality   QualityProfile
 	Source    StreamSource
+	Profile   model.ProfileSpec // Transcoding profile (GPU, codec, quality knobs)
 }
 
 // RunHandle is an opaque token for a running pipeline.

--- a/internal/infra/media/ffmpeg/adapter.go
+++ b/internal/infra/media/ffmpeg/adapter.go
@@ -33,6 +33,9 @@ const (
 	preflightTimeout  = 2 * time.Second
 )
 
+// vaapiEncodersToTest is the list of VAAPI encoders verified during preflight.
+var vaapiEncodersToTest = []string{"h264_vaapi", "hevc_vaapi"}
+
 // LocalAdapter implements ports.MediaPipeline using local exec.Command.
 type LocalAdapter struct {
 	BinPath          string
@@ -149,7 +152,7 @@ func (a *LocalAdapter) PreflightVAAPI() error {
 	encoderList := string(checkOut)
 
 	// 3. Test each encoder with a real 5-frame encode
-	for _, enc := range []string{"h264_vaapi", "hevc_vaapi"} {
+	for _, enc := range vaapiEncodersToTest {
 		if !strings.Contains(encoderList, enc) {
 			a.Logger.Info().Str("encoder", enc).Msg("vaapi preflight: encoder not in ffmpeg build, skipping")
 			continue

--- a/internal/infra/media/ffmpeg/adapter.go
+++ b/internal/infra/media/ffmpeg/adapter.go
@@ -18,10 +18,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/domain/session/model"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/ManuGH/xg2g/internal/media/ffmpeg/watchdog"
 	"github.com/ManuGH/xg2g/internal/metrics"
 	"github.com/ManuGH/xg2g/internal/pipeline/exec/enigma2"
+	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
 	"github.com/ManuGH/xg2g/internal/procgroup"
 	"github.com/rs/zerolog"
 )
@@ -48,13 +50,17 @@ type LocalAdapter struct {
 	SegmentSeconds   int
 	StartTimeout     time.Duration
 	StallTimeout     time.Duration
+	VaapiDevice        string            // e.g. "/dev/dri/renderD128"; empty = no VAAPI
+	vaapiEncoders      map[string]bool   // per-encoder preflight results ("h264_vaapi" -> true)
+	vaapiDeviceChecked bool              // device-level preflight ran
+	vaapiDeviceErr     error             // device-level preflight error
 	mu               sync.Mutex
 	// activeProcs maps run handles to running commands
 	activeProcs map[ports.RunHandle]*exec.Cmd
 }
 
 // NewLocalAdapter creates a new adapter instance.
-func NewLocalAdapter(binPath string, ffprobeBin string, hlsRoot string, e2 *enigma2.Client, logger zerolog.Logger, analyzeDuration string, probeSize string, dvrWindow time.Duration, killTimeout time.Duration, fallbackTo8001 bool, preflightTimeout time.Duration, segmentSeconds int, startTimeout, stallTimeout time.Duration) *LocalAdapter {
+func NewLocalAdapter(binPath string, ffprobeBin string, hlsRoot string, e2 *enigma2.Client, logger zerolog.Logger, analyzeDuration string, probeSize string, dvrWindow time.Duration, killTimeout time.Duration, fallbackTo8001 bool, preflightTimeout time.Duration, segmentSeconds int, startTimeout, stallTimeout time.Duration, vaapiDevice string) *LocalAdapter {
 	analyzeDuration = strings.TrimSpace(analyzeDuration)
 	probeSize = strings.TrimSpace(probeSize)
 	if analyzeDuration == "" {
@@ -99,8 +105,102 @@ func NewLocalAdapter(binPath string, ffprobeBin string, hlsRoot string, e2 *enig
 		FallbackTo8001:   fallbackTo8001,
 		StartTimeout:     startTimeout,
 		StallTimeout:     stallTimeout,
+		VaapiDevice:      strings.TrimSpace(vaapiDevice),
 		activeProcs:      make(map[ports.RunHandle]*exec.Cmd),
 	}
+}
+
+// PreflightVAAPI validates that the configured VAAPI device is functional.
+// Tests each available encoder (h264_vaapi, hevc_vaapi) independently.
+// Results are cached per-encoder: buildArgs checks the specific encoder.
+func (a *LocalAdapter) PreflightVAAPI() error {
+	if a.VaapiDevice == "" {
+		return nil
+	}
+	if a.vaapiDeviceChecked {
+		return a.vaapiDeviceErr
+	}
+
+	a.vaapiEncoders = make(map[string]bool)
+	a.vaapiDeviceChecked = true
+
+	a.Logger.Info().Str("device", a.VaapiDevice).Msg("vaapi preflight: starting")
+
+	// 1. Device accessible
+	if _, err := os.Stat(a.VaapiDevice); err != nil {
+		a.vaapiDeviceErr = fmt.Errorf("vaapi device not accessible: %w", err)
+		a.Logger.Error().Err(a.vaapiDeviceErr).Str("device", a.VaapiDevice).Msg("vaapi preflight: device stat failed")
+		hardware.SetVAAPIPreflightResult(false)
+		return a.vaapiDeviceErr
+	}
+
+	// 2. Enumerate available VAAPI encoders
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// #nosec G204 -- BinPath is trusted from config
+	checkCmd := exec.CommandContext(ctx, a.BinPath, "-hide_banner", "-encoders")
+	checkOut, err := checkCmd.Output()
+	if err != nil {
+		a.vaapiDeviceErr = fmt.Errorf("vaapi preflight: ffmpeg -encoders failed: %w", err)
+		a.Logger.Error().Err(a.vaapiDeviceErr).Msg("vaapi preflight: encoder check failed")
+		hardware.SetVAAPIPreflightResult(false)
+		return a.vaapiDeviceErr
+	}
+	encoderList := string(checkOut)
+
+	// 3. Test each encoder with a real 5-frame encode
+	for _, enc := range []string{"h264_vaapi", "hevc_vaapi"} {
+		if !strings.Contains(encoderList, enc) {
+			a.Logger.Info().Str("encoder", enc).Msg("vaapi preflight: encoder not in ffmpeg build, skipping")
+			continue
+		}
+		if err := a.testVaapiEncoder(enc); err != nil {
+			a.Logger.Warn().Err(err).Str("encoder", enc).Msg("vaapi preflight: encoder test failed")
+		} else {
+			a.vaapiEncoders[enc] = true
+			a.Logger.Info().Str("encoder", enc).Msg("vaapi preflight: encoder verified")
+		}
+	}
+
+	if len(a.vaapiEncoders) == 0 {
+		a.vaapiDeviceErr = fmt.Errorf("vaapi preflight: no working VAAPI encoders found")
+		a.Logger.Error().Err(a.vaapiDeviceErr).Msg("vaapi preflight: failed")
+		hardware.SetVAAPIPreflightResult(false)
+		return a.vaapiDeviceErr
+	}
+
+	hardware.SetVAAPIPreflightResult(true)
+	a.Logger.Info().
+		Str("device", a.VaapiDevice).
+		Int("verified_encoders", len(a.vaapiEncoders)).
+		Msg("vaapi preflight: passed")
+	return nil
+}
+
+// testVaapiEncoder runs a real 5-frame encode test for a specific VAAPI encoder.
+func (a *LocalAdapter) testVaapiEncoder(encoder string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// #nosec G204 -- BinPath and VaapiDevice are trusted from config
+	cmd := exec.CommandContext(ctx, a.BinPath,
+		"-vaapi_device", a.VaapiDevice,
+		"-f", "lavfi",
+		"-i", "testsrc=duration=0.2:size=1280x720:rate=25",
+		"-vf", "format=nv12,hwupload",
+		"-c:v", encoder,
+		"-frames:v", "5",
+		"-f", "null", "-",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("encode test failed: %w (output: %s)", err, string(out))
+	}
+	return nil
+}
+
+// VaapiEncoderVerified returns true if the given encoder passed preflight.
+func (a *LocalAdapter) VaapiEncoderVerified(encoder string) bool {
+	return a.vaapiEncoders[encoder]
 }
 
 // Start initiates the media process.
@@ -620,6 +720,27 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 		"-reconnect_on_http_error", "4xx,5xx",
 	)
 
+	// VAAPI device init (must come before -i for hwaccel decode).
+	// Fail-closed: two independent checks must pass before VAAPI args are emitted.
+	if spec.Profile.HWAccel == "vaapi" {
+		if a.VaapiDevice == "" {
+			return nil, fmt.Errorf("vaapi requested by profile but no vaapi device configured on adapter")
+		}
+		// Resolve the encoder name for per-encoder preflight check
+		reqEncoder := "h264_vaapi"
+		if spec.Profile.VideoCodec == "hevc" {
+			reqEncoder = "hevc_vaapi"
+		}
+		if !a.VaapiEncoderVerified(reqEncoder) {
+			return nil, fmt.Errorf("vaapi encoder %s not verified by preflight (device=%s, deviceErr=%v)", reqEncoder, a.VaapiDevice, a.vaapiDeviceErr)
+		}
+		args = append(args,
+			"-vaapi_device", a.VaapiDevice,
+			"-hwaccel", "vaapi",
+			"-hwaccel_output_format", "vaapi",
+		)
+	}
+
 	// Input
 	switch spec.Source.Type {
 	case ports.SourceTuner:
@@ -671,25 +792,31 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 			}
 		}
 
-		// Use libx264 for video with fast preset for live streaming
+		// Stream mapping (same for all paths)
 		// Use -sn to disable subtitles/teletext, as they often cause "Invalid data" errors
 		// during transcoding (mapped to WebVTT by default) with Stream Relay sources.
 		args = append(args,
 			"-map", "0:v:0?",
 			"-map", "0:a:0?",
-			"-c:v", "libx264",
-			"-preset", "ultrafast", // Ultra-fast encoding for low latency
-			"-tune", "zerolatency", // Minimize buffering
-			"-crf", "20", // Excellent quality with fast encoding
-			"-x264-params", fmt.Sprintf("keyint=%d:min-keyint=%d:scenecut=0", gop, gop),
-			"-g", strconv.Itoa(gop), // Force GOP size matching keyint
-			"-force_key_frames", fmt.Sprintf("expr:gte(t,n_forced*%d)", a.SegmentSeconds),
-			"-flags", "+cgop", // Closed GOP for clean segment boundaries
-			"-pix_fmt", "yuv420p",
-			"-profile:v", "main",
+		)
+
+		// Video encoding (two paths: VAAPI GPU or CPU)
+		prof := spec.Profile
+		if prof.HWAccel == "vaapi" {
+			args = a.buildVaapiVideoArgs(args, prof, gop, segmentDurationSec, spec.SessionID)
+		} else {
+			args = a.buildCPUVideoArgs(args, prof, gop, segmentDurationSec, spec.SessionID)
+		}
+
+		// Audio (same for all paths)
+		audioBitrate := "192k"
+		if prof.AudioBitrateK > 0 {
+			audioBitrate = fmt.Sprintf("%dk", prof.AudioBitrateK)
+		}
+		args = append(args,
 			"-c:a", "aac",
-			"-b:a", "192k", // Universal Stereo (Best Practice 2026)
-			"-ac", "2", // Force Stereo for compatibility
+			"-b:a", audioBitrate,
+			"-ac", "2",
 			"-ar", "48000",
 			"-sn",
 			"-f", "hls",
@@ -714,6 +841,127 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 	}
 
 	return args, nil
+}
+
+// buildVaapiVideoArgs constructs video encoding arguments for the VAAPI GPU pipeline.
+// Frames are already in GPU memory from -hwaccel vaapi -hwaccel_output_format vaapi.
+func (a *LocalAdapter) buildVaapiVideoArgs(args []string, prof model.ProfileSpec, gop, segmentSec int, sessionID string) []string {
+	a.Logger.Info().
+		Str("sessionId", sessionID).
+		Str("transcode.mode", "vaapi").
+		Str("vaapi.device", a.VaapiDevice).
+		Str("video.codec", prof.VideoCodec).
+		Int("video.maxRateK", prof.VideoMaxRateK).
+		Int("video.bufSizeK", prof.VideoBufSizeK).
+		Bool("deinterlace", prof.Deinterlace).
+		Msg("pipeline video: vaapi")
+
+	// Filter: frames are VAAPI surfaces from hwaccel decode
+	if prof.Deinterlace {
+		args = append(args, "-vf", "deinterlace_vaapi")
+	}
+
+	// Encoder
+	encoder := "h264_vaapi"
+	if prof.VideoCodec == "hevc" {
+		encoder = "hevc_vaapi"
+	}
+	args = append(args, "-c:v", encoder)
+
+	// Quality: VAAPI has no CRF; use VBR rate control from ProfileSpec
+	if prof.VideoMaxRateK > 0 {
+		args = append(args,
+			"-b:v", fmt.Sprintf("%dk", prof.VideoMaxRateK),
+			"-maxrate", fmt.Sprintf("%dk", prof.VideoMaxRateK),
+		)
+		if prof.VideoBufSizeK > 0 {
+			args = append(args, "-bufsize", fmt.Sprintf("%dk", prof.VideoBufSizeK))
+		}
+	} else {
+		// Safe default when no rate specified
+		args = append(args, "-global_quality", "23")
+	}
+
+	// GOP / keyframes (same logic as CPU path)
+	args = append(args,
+		"-g", strconv.Itoa(gop),
+		"-force_key_frames", fmt.Sprintf("expr:gte(t,n_forced*%d)", segmentSec),
+		"-flags", "+cgop",
+	)
+
+	args = append(args, "-profile:v", "main")
+	return args
+}
+
+// buildCPUVideoArgs constructs video encoding arguments for the CPU transcode path.
+// Handles both explicit ProfileSpec values and zero-valued ProfileSpec.
+// When ProfileSpec is zero-valued (VideoCodec="" + TranscodeVideo=false), applies
+// legacy defaults: libx264 + yadif + ultrafast + CRF 20. This ensures backwards
+// compat for code paths that don't set ProfileSpec yet.
+func (a *LocalAdapter) buildCPUVideoArgs(args []string, prof model.ProfileSpec, gop, segmentSec int, sessionID string) []string {
+	// Detect zero-valued profile → apply legacy defaults.
+	// A zero-valued ProfileSpec has VideoCodec="" and TranscodeVideo=false,
+	// which happens when the orchestrator doesn't pass a resolved profile.
+	legacy := prof.VideoCodec == "" && !prof.TranscodeVideo
+
+	codec := "libx264"
+	preset := "ultrafast" // legacy default
+	crf := 20
+	deinterlace := true // legacy default: always deinterlace DVB streams
+
+	if !legacy {
+		if prof.VideoCodec == "hevc" {
+			codec = "libx265"
+		} else if prof.VideoCodec != "" && prof.VideoCodec != "h264" {
+			codec = prof.VideoCodec
+		}
+		if prof.Preset != "" {
+			preset = prof.Preset
+		} else {
+			preset = "superfast"
+		}
+		if prof.VideoCRF > 0 {
+			crf = prof.VideoCRF
+		}
+		deinterlace = prof.Deinterlace
+	}
+
+	a.Logger.Info().
+		Str("sessionId", sessionID).
+		Str("transcode.mode", "cpu").
+		Str("video.codec", codec).
+		Int("video.crf", crf).
+		Bool("deinterlace", deinterlace).
+		Bool("legacy_defaults", legacy).
+		Msg("pipeline video: cpu")
+
+	if deinterlace {
+		args = append(args, "-vf", "yadif")
+	}
+
+	args = append(args, "-c:v", codec)
+	args = append(args, "-preset", preset)
+	args = append(args, "-tune", "zerolatency")
+	args = append(args, "-crf", strconv.Itoa(crf))
+
+	if !legacy && prof.VideoMaxRateK > 0 {
+		args = append(args, "-maxrate", fmt.Sprintf("%dk", prof.VideoMaxRateK))
+		if prof.VideoBufSizeK > 0 {
+			args = append(args, "-bufsize", fmt.Sprintf("%dk", prof.VideoBufSizeK))
+		}
+	}
+
+	if codec == "libx264" {
+		args = append(args, "-x264-params", fmt.Sprintf("keyint=%d:min-keyint=%d:scenecut=0", gop, gop))
+	}
+	args = append(args,
+		"-g", strconv.Itoa(gop),
+		"-force_key_frames", fmt.Sprintf("expr:gte(t,n_forced*%d)", segmentSec),
+		"-flags", "+cgop",
+		"-pix_fmt", "yuv420p",
+		"-profile:v", "main",
+	)
+	return args
 }
 
 func (a *LocalAdapter) detectFPS(ctx context.Context, inputURL string) (int, error) {

--- a/internal/infra/media/ffmpeg/adapter_args_test.go
+++ b/internal/infra/media/ffmpeg/adapter_args_test.go
@@ -6,11 +6,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/domain/session/model"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func indexOf(args []string, target string) int {
+	for i, a := range args {
+		if a == target {
+			return i
+		}
+	}
+	return -1
+}
 
 func TestBuildArgs_UsesOptionalVideoMap(t *testing.T) {
 	adapter := NewLocalAdapter(
@@ -28,6 +38,7 @@ func TestBuildArgs_UsesOptionalVideoMap(t *testing.T) {
 		6,
 		0,
 		0,
+		"",
 	)
 
 	spec := ports.StreamSpec{
@@ -45,4 +56,248 @@ func TestBuildArgs_UsesOptionalVideoMap(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, args, "0:v:0?", "video map should be optional for audio-only inputs")
 	assert.Contains(t, args, "0:a:0?", "audio map should remain optional")
+}
+
+func TestBuildArgs_EmptyProfileLegacy(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "",
+	)
+
+	spec := ports.StreamSpec{
+		SessionID: "legacy-1",
+		Mode:      ports.ModeLive,
+		Format:    ports.FormatHLS,
+		Quality:   ports.QualityStandard,
+		// Profile is zero-valued -> legacy path
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+	assert.Contains(t, args, "libx264", "legacy path must use libx264")
+	assert.Contains(t, args, "yadif", "legacy path must use yadif deinterlace")
+	assert.Contains(t, args, "-crf", "legacy path must use CRF")
+	assert.Contains(t, args, "20", "legacy path CRF=20")
+	assert.Contains(t, args, "-preset", "legacy path must have preset")
+	assert.Contains(t, args, "ultrafast", "legacy path preset=ultrafast")
+	assert.NotContains(t, args, "h264_vaapi", "legacy path must not contain VAAPI")
+	assert.NotContains(t, args, "-vaapi_device", "legacy path must not contain vaapi_device")
+}
+
+func TestBuildArgs_VaapiH264Deinterlace(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "/dev/dri/renderD128",
+	)
+	adapter.vaapiEncoders = map[string]bool{"h264_vaapi": true, "hevc_vaapi": true} // simulate passed preflight
+
+	spec := ports.StreamSpec{
+		SessionID: "vaapi-1",
+		Mode:      ports.ModeLive,
+		Format:    ports.FormatHLS,
+		Quality:   ports.QualityStandard,
+		Profile: model.ProfileSpec{
+			TranscodeVideo: true,
+			HWAccel:        "vaapi",
+			VideoCodec:     "h264",
+			Deinterlace:    true,
+			VideoMaxRateK:  20000,
+			VideoBufSizeK:  40000,
+			AudioBitrateK:  192,
+		},
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+
+	// VAAPI device init must appear before -i
+	iIdx := indexOf(args, "-i")
+	require.True(t, iIdx > 0)
+
+	vaapiDevIdx := indexOf(args, "-vaapi_device")
+	require.True(t, vaapiDevIdx >= 0 && vaapiDevIdx < iIdx, "vaapi_device must come before -i")
+	assert.Equal(t, "/dev/dri/renderD128", args[vaapiDevIdx+1])
+
+	assert.Contains(t, args, "-hwaccel")
+	assert.Contains(t, args, "-hwaccel_output_format")
+
+	// Encoder
+	assert.Contains(t, args, "h264_vaapi")
+
+	// Deinterlace in GPU memory (NOT CPU yadif)
+	assert.Contains(t, args, "deinterlace_vaapi")
+	assert.NotContains(t, args, "yadif")
+
+	// VBR rate control (NOT CRF)
+	assert.Contains(t, args, "-b:v")
+	assert.Contains(t, args, "20000k")
+	assert.Contains(t, args, "-maxrate")
+	assert.Contains(t, args, "-bufsize")
+	assert.Contains(t, args, "40000k")
+	assert.NotContains(t, args, "-crf")
+
+	// No CPU-specific flags
+	assert.NotContains(t, args, "-preset")
+	assert.NotContains(t, args, "-tune")
+	assert.NotContains(t, args, "-pix_fmt")
+}
+
+func TestBuildArgs_VaapiHEVC(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "/dev/dri/renderD128",
+	)
+	adapter.vaapiEncoders = map[string]bool{"h264_vaapi": true, "hevc_vaapi": true}
+
+	spec := ports.StreamSpec{
+		SessionID: "vaapi-hevc",
+		Mode:      ports.ModeLive,
+		Format:    ports.FormatHLS,
+		Quality:   ports.QualityStandard,
+		Profile: model.ProfileSpec{
+			TranscodeVideo: true,
+			HWAccel:        "vaapi",
+			VideoCodec:     "hevc",
+			Deinterlace:    false,
+			VideoMaxRateK:  5000,
+			VideoBufSizeK:  10000,
+			AudioBitrateK:  192,
+		},
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+	assert.Contains(t, args, "hevc_vaapi")
+	assert.NotContains(t, args, "h264_vaapi")
+	assert.NotContains(t, args, "deinterlace_vaapi", "progressive source: no deinterlace filter")
+	assert.NotContains(t, args, "yadif")
+}
+
+func TestBuildArgs_VaapiNoPreflightFails(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "/dev/dri/renderD128",
+	)
+	// vaapiEncoders is nil (preflight not run)
+
+	spec := ports.StreamSpec{
+		SessionID: "vaapi-nopreflight",
+		Mode:      ports.ModeLive,
+		Profile: model.ProfileSpec{
+			TranscodeVideo: true,
+			HWAccel:        "vaapi",
+			VideoCodec:     "h264",
+		},
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	_, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not verified by preflight")
+}
+
+func TestBuildArgs_VaapiNoDeviceFails(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "", // no device
+	)
+
+	spec := ports.StreamSpec{
+		SessionID: "vaapi-nodevice",
+		Mode:      ports.ModeLive,
+		Profile: model.ProfileSpec{
+			TranscodeVideo: true,
+			HWAccel:        "vaapi",
+			VideoCodec:     "h264",
+		},
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	_, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no vaapi device configured")
+}
+
+func TestBuildArgs_VaapiDefaultQuality(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "/dev/dri/renderD128",
+	)
+	adapter.vaapiEncoders = map[string]bool{"h264_vaapi": true, "hevc_vaapi": true}
+
+	spec := ports.StreamSpec{
+		SessionID: "vaapi-default-q",
+		Mode:      ports.ModeLive,
+		Profile: model.ProfileSpec{
+			TranscodeVideo: true,
+			HWAccel:        "vaapi",
+			VideoCodec:     "h264",
+			// VideoMaxRateK is 0 (not set)
+		},
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+	assert.Contains(t, args, "-global_quality")
+	assert.Contains(t, args, "23")
+	assert.NotContains(t, args, "-b:v", "no rate when VideoMaxRateK=0")
+}
+
+func TestBuildArgs_CPUProfileDriven(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "",
+	)
+
+	spec := ports.StreamSpec{
+		SessionID: "cpu-profile",
+		Mode:      ports.ModeLive,
+		Profile: model.ProfileSpec{
+			TranscodeVideo: true,
+			VideoCodec:     "libx264",
+			Deinterlace:    true,
+			VideoCRF:       18,
+			VideoMaxRateK:  8000,
+			VideoBufSizeK:  16000,
+			Preset:         "veryfast",
+			AudioBitrateK:  192,
+		},
+		Source: ports.StreamSource{
+			ID:   "http://example.com/stream",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+	assert.Contains(t, args, "libx264")
+	assert.Contains(t, args, "yadif")
+	assert.Contains(t, args, "veryfast")
+	assert.Contains(t, args, "18")
+	assert.Contains(t, args, "-maxrate")
+	assert.Contains(t, args, "8000k")
+	assert.NotContains(t, args, "h264_vaapi")
+	assert.NotContains(t, args, "-vaapi_device")
 }

--- a/internal/infra/media/ffmpeg/adapter_preflight_test.go
+++ b/internal/infra/media/ffmpeg/adapter_preflight_test.go
@@ -25,7 +25,7 @@ func TestPreflightTS_SyncOK(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0, "")
 	result, err := adapter.preflightTS(context.Background(), srv.URL)
 	if err != nil {
 		t.Fatalf("expected preflight success, got error: %v", err)
@@ -46,7 +46,7 @@ func TestPreflightTS_SyncMiss(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0, "")
 	result, err := adapter.preflightTS(context.Background(), srv.URL)
 	if err == nil {
 		t.Fatalf("expected preflight error, got nil")
@@ -64,7 +64,7 @@ func TestPreflightTS_ShortRead(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0, "")
 	result, err := adapter.preflightTS(context.Background(), srv.URL)
 	if err == nil {
 		t.Fatalf("expected preflight error, got nil")
@@ -75,7 +75,7 @@ func TestPreflightTS_ShortRead(t *testing.T) {
 }
 
 func TestSelectStreamURL_FallbackOffFails(t *testing.T) {
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0, "")
 
 	calls := 0
 	preflight := func(ctx context.Context, rawURL string) (preflightResult, error) {
@@ -102,7 +102,7 @@ func TestSelectStreamURL_FallbackOffFails(t *testing.T) {
 }
 
 func TestSelectStreamURL_NoFallbackWhenNotRelay(t *testing.T) {
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, true, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, true, 2*time.Second, 6, 0, 0, "")
 
 	calls := 0
 	preflight := func(ctx context.Context, rawURL string) (preflightResult, error) {
@@ -129,7 +129,7 @@ func TestSelectStreamURL_NoFallbackWhenNotRelay(t *testing.T) {
 }
 
 func TestSelectStreamURL_FallbackTo8001(t *testing.T) {
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, true, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, true, 2*time.Second, 6, 0, 0, "")
 
 	serviceRef := "1:0:19:2B66:3F3:1:C00000:0:0:0:"
 	resolved := "http://127.0.0.1:17999/" + serviceRef
@@ -163,7 +163,7 @@ func TestSelectStreamURL_FallbackTo8001(t *testing.T) {
 }
 
 func TestPreflight_HttpClientWiring(t *testing.T) {
-	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0)
+	adapter := NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, false, 2*time.Second, 6, 0, 0, "")
 
 	if adapter.httpClient == nil {
 		t.Fatal("httpClient should not be nil")

--- a/internal/pipeline/api/intent_handler.go
+++ b/internal/pipeline/api/intent_handler.go
@@ -125,7 +125,7 @@ func (h IntentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	policyID := "universal"
 
 	// Resolve profile (universal)
-	prof := profiles.Resolve(policyID, r.UserAgent(), dvrWindowSec, nil, hardware.HasVAAPI(), profiles.HWAccelAuto)
+	prof := profiles.Resolve(policyID, r.UserAgent(), dvrWindowSec, nil, hardware.IsVAAPIReady(), profiles.HWAccelAuto)
 
 	var acquiredLeases []store.Lease
 	releaseLeases := func() {

--- a/internal/pipeline/hardware/gpu.go
+++ b/internal/pipeline/hardware/gpu.go
@@ -1,7 +1,26 @@
+// Package hardware provides GPU detection and readiness state.
+//
+// Two-tier VAAPI check:
+//
+//  1. HasVAAPI() — device file stat (/dev/dri/renderD128). Cheap, but only
+//     proves the device node exists, not that encoding works.
+//
+//  2. IsVAAPIReady() — fail-closed: returns true only after the FFmpeg adapter's
+//     PreflightVAAPI() has run a real 5-frame encode test and called
+//     SetVAAPIPreflightResult(true). HTTP handlers use this to gate
+//     hwaccel=force and to feed profiles.Resolve(), ensuring that profiles
+//     with HWAccel="vaapi" are never produced unless GPU encoding is verified.
 package hardware
 
 import (
 	"os"
+	"sync"
+)
+
+var (
+	vaapiMu      sync.RWMutex
+	vaapiChecked bool
+	vaapiPassed  bool
 )
 
 // HasVAAPI checks if the VAAPI render device exists
@@ -11,4 +30,23 @@ func HasVAAPI() bool {
 		return true
 	}
 	return false
+}
+
+// SetVAAPIPreflightResult records the result of the real VAAPI encode
+// preflight. Called once at startup by the FFmpeg adapter after running
+// actual encode tests (not just device file stat).
+func SetVAAPIPreflightResult(passed bool) {
+	vaapiMu.Lock()
+	defer vaapiMu.Unlock()
+	vaapiChecked = true
+	vaapiPassed = passed
+}
+
+// IsVAAPIReady returns true only if the VAAPI render device exists AND
+// the real encode preflight has been run AND passed.
+// Fail-closed: returns false if preflight hasn't run yet.
+func IsVAAPIReady() bool {
+	vaapiMu.RLock()
+	defer vaapiMu.RUnlock()
+	return vaapiChecked && vaapiPassed
 }

--- a/internal/pipeline/hardware/gpu_test.go
+++ b/internal/pipeline/hardware/gpu_test.go
@@ -1,0 +1,53 @@
+package hardware
+
+import "testing"
+
+func TestIsVAAPIReady_DefaultFalse(t *testing.T) {
+	// Reset global state for test isolation
+	vaapiMu.Lock()
+	vaapiChecked = false
+	vaapiPassed = false
+	vaapiMu.Unlock()
+
+	if IsVAAPIReady() {
+		t.Fatal("IsVAAPIReady must be false before preflight runs (fail-closed)")
+	}
+}
+
+func TestIsVAAPIReady_AfterPassedPreflight(t *testing.T) {
+	vaapiMu.Lock()
+	vaapiChecked = false
+	vaapiPassed = false
+	vaapiMu.Unlock()
+
+	SetVAAPIPreflightResult(true)
+
+	if !IsVAAPIReady() {
+		t.Fatal("IsVAAPIReady must be true after preflight passed")
+	}
+
+	// cleanup
+	vaapiMu.Lock()
+	vaapiChecked = false
+	vaapiPassed = false
+	vaapiMu.Unlock()
+}
+
+func TestIsVAAPIReady_AfterFailedPreflight(t *testing.T) {
+	vaapiMu.Lock()
+	vaapiChecked = false
+	vaapiPassed = false
+	vaapiMu.Unlock()
+
+	SetVAAPIPreflightResult(false)
+
+	if IsVAAPIReady() {
+		t.Fatal("IsVAAPIReady must be false after preflight failed")
+	}
+
+	// cleanup
+	vaapiMu.Lock()
+	vaapiChecked = false
+	vaapiPassed = false
+	vaapiMu.Unlock()
+}


### PR DESCRIPTION
## Summary

- Wires `ProfileSpec` (HWAccel, VideoCodec, rate control, deinterlace) from `profiles.Resolve()` through `StreamSpec` into `buildArgs()`, replacing the hardcoded libx264+yadif+CRF20 path
- Adds real 5-frame encode preflight per VAAPI encoder (h264_vaapi, hevc_vaapi) at startup — fail-closed, no silent fallback
- HTTP handlers use `hardware.IsVAAPIReady()` to gate `hwaccel=force` at API level (not just device file stat)
- Config: `XG2G_VAAPI_DEVICE=/dev/dri/renderD128` (or `ffmpeg.vaapiDevice` in YAML)

## Changed files (13)

| Layer | File | Change |
|---|---|---|
| Config | `config/types.go`, `registry.go`, `merge.go` | `VaapiDevice` field, ENV/YAML wiring |
| Domain | `ports/types.go` | `Profile model.ProfileSpec` on `StreamSpec` |
| Orchestrator | `orchestrator_helpers.go` | Pass `currentProfileSpec` through |
| FFmpeg adapter | `adapter.go` | PreflightVAAPI(), buildVaapiVideoArgs(), buildCPUVideoArgs(), per-encoder verification |
| HTTP handler | `handlers_intents.go`, `intent_handler.go` | `IsVAAPIReady()` instead of `HasVAAPI()` |
| Hardware | `hardware/gpu.go` | `SetVAAPIPreflightResult()`, `IsVAAPIReady()` (fail-closed) |
| Daemon | `manager.go` | Wire VaapiDevice + run preflight at startup |
| Tests | `adapter_args_test.go`, `adapter_preflight_test.go`, `gpu_test.go` | 11 new tests |

## Design decisions

- **Fail-closed**: VAAPI profile + failed preflight → hard error at `buildArgs` time, never silent CPU fallback
- **Per-encoder preflight**: h264_vaapi and hevc_vaapi tested independently with real 5-frame encode
- **Two paths, not three**: Zero-valued ProfileSpec triggers legacy defaults inside CPU path (no separate legacy codepath)
- **HTTP-level gate**: `hwaccel=force` rejected at API level if preflight failed, with specific error message

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] All ffmpeg adapter tests pass (15 tests)
- [x] Hardware package tests pass (3 tests)
- [x] Profile tests pass
- [x] Config tests pass
- [ ] Deploy with `XG2G_VAAPI_DEVICE=/dev/dri/renderD128`, test ORF1 HD (H.264 720p)
- [ ] Verify ffmpeg CLI contains `h264_vaapi` / `deinterlace_vaapi` / `-vaapi_device`
- [ ] Compare CPU load vs libx264 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)