### PR TITLE
ci: add minimal deep-suite fail alerting

### DIFF
--- a/.github/workflows/ci-deep-scheduled.yml
+++ b/.github/workflows/ci-deep-scheduled.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: repo-${{ github.workflow }}-${{ github.ref }}
@@ -255,3 +256,55 @@ jobs:
             echo "| weekly-security-deep | \`govulncheck -tags=nogpu ./... && gosec -severity=high ... ./...\` | $SECURITY_RESULT | $SECURITY_EXIT |"
             echo "| weekly-governance-deep | \`jsx/legacy-import guards + (cd webui && npm ci && npm run build)\` | $GOVERNANCE_RESULT | $GOVERNANCE_EXIT |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  deep-alert-on-failure:
+    name: deep-alert-on-failure
+    needs: [nightly-race, nightly-integration, weekly-security-deep, weekly-governance-deep, deep-summary]
+    if: >
+      always() &&
+      github.event_name == 'schedule' &&
+      (
+        needs.nightly-race.result == 'failure' || needs.nightly-race.result == 'cancelled' ||
+        needs.nightly-integration.result == 'failure' || needs.nightly-integration.result == 'cancelled' ||
+        needs.weekly-security-deep.result == 'failure' || needs.weekly-security-deep.result == 'cancelled' ||
+        needs.weekly-governance-deep.result == 'failure' || needs.weekly-governance-deep.result == 'cancelled'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Create fail alert issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          RACE_RESULT: ${{ needs.nightly-race.result }}
+          INTEGRATION_RESULT: ${{ needs.nightly-integration.result }}
+          SECURITY_RESULT: ${{ needs.weekly-security-deep.result }}
+          GOVERNANCE_RESULT: ${{ needs.weekly-governance-deep.result }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const title = `[CI Deep] Scheduled run failed: ${process.env.GITHUB_RUN_ID}`;
+
+            const body = [
+              "Scheduled deep-suite run failed.",
+              "",
+              `Run: ${runUrl}`,
+              "",
+              "| Job | Result |",
+              "|---|---:|",
+              `| nightly-race | ${process.env.RACE_RESULT} |`,
+              `| nightly-integration | ${process.env.INTEGRATION_RESULT} |`,
+              `| weekly-security-deep | ${process.env.SECURITY_RESULT} |`,
+              `| weekly-governance-deep | ${process.env.GOVERNANCE_RESULT} |`,
+              "",
+              `Commit: \`${process.env.GITHUB_SHA}\``,
+              `Workflow: \`${process.env.GITHUB_WORKFLOW}\``,
+            ].join("\n");
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+            });


### PR DESCRIPTION
## Summary
- add minimal fail alerting for scheduled deep-suite runs via GitHub Issue creation
- include run link and per-job result matrix in issue body
- keep PR checks non-blocking; alert job is schedule-only

## Details
- update workflow permissions to include `issues: write`
- add `deep-alert-on-failure` job with `if: always()` and schedule-only guard
- trigger on any `failure`/`cancelled` result across deep jobs

## Scope
- only `.github/workflows/ci-deep-scheduled.yml`
- no test or product code changes
