### PR TITLE
ops: add workspace cleanup script and fail-closed hygiene

### DIFF
--- a/docs/ops/WORKSPACE_CLEANUP.md
+++ b/docs/ops/WORKSPACE_CLEANUP.md
@@ -1,0 +1,35 @@
+# Workspace Cleanup Runbook
+
+Use this when root disk usage exceeds 90% or before creating release-split branches.
+
+## Quick Check
+
+```bash
+df -h /root /tmp
+```
+
+## Preview Cleanup (Safe)
+
+```bash
+scripts/ops/cleanup-workspace.sh
+```
+
+## Apply Cleanup
+
+```bash
+scripts/ops/cleanup-workspace.sh --apply
+```
+
+## Aggressive Cleanup (`/tmp/xg2g-*` stale dirs)
+
+```bash
+scripts/ops/cleanup-workspace.sh --apply --aggressive
+```
+
+## Notes
+
+- Script removes only clean auxiliary worktrees (`.worktrees/*`, `/tmp/xg2g-*`).
+- Dirty worktrees are skipped and must be handled manually.
+- Root log artifacts (`build.log`, `full_v3_test*.log`, etc.) are removed.
+- Hygiene gate blocks committed `.worktrees/` paths and transient log artifacts.
+

--- a/hack/verify-repo-hygiene.sh
+++ b/hack/verify-repo-hygiene.sh
@@ -7,14 +7,16 @@ fail() { echo "ERROR: $*" >&2; exit 1; }
 
 cd "$ROOT"
 
-# 1) exactly one .git directory (this repo)
-gitdirs="$(find . -name .git -type d -prune 2>/dev/null | sed 's|^\./||' | sort)"
-count="$(printf "%s\n" "$gitdirs" | sed '/^$/d' | wc -l | tr -d ' ')"
+# 1) root git metadata must exist; nested .git metadata is forbidden
+if [[ ! -e .git ]]; then
+  fail "Repo hygiene violation: missing root .git metadata."
+fi
 
-if [[ "$count" -ne 1 ]]; then
-  echo "Found .git directories:" >&2
-  printf "%s\n" "$gitdirs" >&2
-  fail "Repo hygiene violation: expected exactly 1 .git directory, found $count."
+nested_git_meta="$(find . -mindepth 2 \( -type d -name .git -o -type f -name .git \) 2>/dev/null | sed 's|^\./||' | sort)"
+if [[ -n "$nested_git_meta" ]]; then
+  echo "Nested .git metadata found:" >&2
+  printf "%s\n" "$nested_git_meta" >&2
+  fail "Repo hygiene violation: nested .git metadata is not allowed."
 fi
 
 # 2) forbid common drift copies inside repo
@@ -45,6 +47,15 @@ if [[ -n "$forbidden_hits" ]]; then
   echo "Forbidden artifact-like files are committed:" >&2
   printf '%s\n' "$forbidden_hits" >&2
   fail "Repo hygiene violation: remove transient runtime/test/security artifacts from git."
+fi
+
+# 3b) forbid committed local worktree internals
+forbidden_path_re='^\.worktrees($|/)'
+forbidden_path_hits="$(git ls-files | grep -E "$forbidden_path_re" || true)"
+if [[ -n "$forbidden_path_hits" ]]; then
+  echo "Forbidden local workspace paths are committed:" >&2
+  printf '%s\n' "$forbidden_path_hits" >&2
+  fail "Repo hygiene violation: .worktrees is local-only and must never be committed."
 fi
 
 # 4) fail-closed scan for runtime-sensitive patterns in tracked text artifacts
@@ -79,4 +90,4 @@ if [[ "$sensitive_violations" -ne 0 ]]; then
   fail "Repo hygiene violation: sensitive runtime markers detected outside scrubbed fixture allowlist."
 fi
 
-echo "OK: repo hygiene clean (single .git, no drift copies, no artifact leaks)."
+echo "OK: repo hygiene clean (root git metadata, no nested git metadata, no drift copies, no artifact leaks)."

--- a/scripts/ops/cleanup-workspace.sh
+++ b/scripts/ops/cleanup-workspace.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: cleanup-workspace.sh [--apply] [--aggressive]
+
+Dry-run by default. With --apply, removes safe local workspace clutter:
+- clean git worktrees under .worktrees/ and /tmp/xg2g-*
+- stale /tmp/xg2g-* directories (with --aggressive)
+- known local root log artifacts
+
+Options:
+  --apply       Execute cleanup actions (default is preview only)
+  --aggressive  Also remove unregistered /tmp/xg2g-* directories
+  -h, --help    Show this help
+EOF
+}
+
+APPLY=0
+AGGRESSIVE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=1 ;;
+    --aggressive) AGGRESSIVE=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $arg" >&2; usage; exit 2 ;;
+  esac
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+CURRENT="$(pwd -P)"
+
+echo "repo_root=$ROOT"
+echo "current_dir=$CURRENT"
+echo "mode=$([[ "$APPLY" -eq 1 ]] && echo apply || echo dry-run)"
+echo "aggressive=$([[ "$AGGRESSIVE" -eq 1 ]] && echo true || echo false)"
+echo
+
+declare -a WORKTREE_PATHS=()
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  WORKTREE_PATHS+=("$line")
+done < <(git -C "$ROOT" worktree list --porcelain | awk 'substr($0,1,9)=="worktree "{print substr($0,10)}')
+
+is_registered_worktree() {
+  local path="$1"
+  local wt
+  for wt in "${WORKTREE_PATHS[@]}"; do
+    if [[ "$wt" == "$path" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_clean_worktree() {
+  local path="$1"
+  git -C "$path" diff --quiet &&
+  git -C "$path" diff --cached --quiet &&
+  [[ -z "$(git -C "$path" status --porcelain --untracked-files=normal)" ]]
+}
+
+act() {
+  local msg="$1"
+  shift
+  if [[ "$APPLY" -eq 1 ]]; then
+    echo "APPLY: $msg"
+    "$@"
+  else
+    echo "DRYRUN: $msg"
+  fi
+}
+
+maybe_remove_worktree() {
+  local path="$1"
+  if [[ "$path" == "$ROOT" || "$path" == "$CURRENT" ]]; then
+    echo "SKIP: keep active worktree $path"
+    return 0
+  fi
+  if [[ ! -d "$path" ]]; then
+    echo "SKIP: worktree path missing $path"
+    return 0
+  fi
+  if ! is_clean_worktree "$path"; then
+    echo "SKIP: dirty worktree $path"
+    return 0
+  fi
+  act "git worktree remove $path" git -C "$ROOT" worktree remove "$path"
+}
+
+echo "== Candidate clean worktrees =="
+for wt in "${WORKTREE_PATHS[@]}"; do
+  if [[ "$wt" == "$ROOT/.worktrees/"* || "$wt" == /tmp/xg2g-* ]]; then
+    maybe_remove_worktree "$wt"
+  fi
+done
+echo
+
+echo "== Stale /tmp xg2g directories =="
+for d in /tmp/xg2g-*; do
+  [[ -e "$d" ]] || continue
+  [[ -d "$d" ]] || continue
+  if is_registered_worktree "$d"; then
+    continue
+  fi
+  if [[ "$AGGRESSIVE" -eq 1 ]]; then
+    act "rm -rf $d" rm -rf "$d"
+  else
+    echo "DRYRUN: stale candidate (use --aggressive to delete): $d"
+  fi
+done
+echo
+
+echo "== Root log artifacts =="
+for f in \
+  "$ROOT/build.log" \
+  "$ROOT/curl.log" \
+  "$ROOT/traceback.log" \
+  "$ROOT/test_hang.log" \
+  "$ROOT/v3_test_output.log"; do
+  [[ -f "$f" ]] || continue
+  act "rm -f $f" rm -f "$f"
+done
+for f in "$ROOT"/full_v3_test*.log; do
+  [[ -f "$f" ]] || continue
+  act "rm -f $f" rm -f "$f"
+done
+echo
+
+echo "== Prune worktree metadata =="
+act "git worktree prune" git -C "$ROOT" worktree prune
+
+if [[ "$APPLY" -eq 1 ]]; then
+  echo "Cleanup complete."
+else
+  echo "Preview complete. Re-run with --apply to execute."
+fi
+


### PR DESCRIPTION
## Summary
- add `scripts/ops/cleanup-workspace.sh` for safe local cleanup (dry-run default)
- harden `hack/verify-repo-hygiene.sh` to fail on committed `.worktrees/**`
- add `docs/ops/WORKSPACE_CLEANUP.md` runbook for root-disk pressure and pre-release cleanup

## Why
- avoid release failures due to full root disk and local worktree/log buildup
- keep repo hygiene fail-closed for local workspace artifacts

## Validation
- `bash -n scripts/ops/cleanup-workspace.sh`
- `scripts/ops/cleanup-workspace.sh` (dry-run)
- `./hack/verify-repo-hygiene.sh`

## Scope
- ops/governance mechanics only
- no product feature behavior changes
