### PR TITLE
test(webui): retry on 503 during session readiness

### DIFF
--- a/webui/tests/V3Player.errors.test.tsx
+++ b/webui/tests/V3Player.errors.test.tsx
@@ -134,6 +134,91 @@ describe('V3Player Error Semantics (UI-ERR-PLAYER-001)', () => {
     }
   });
 
+  it('retries readiness loop on 503 and recovers without terminal error state', async () => {
+    let readinessCalls = 0;
+    const mockChannel = { id: 'ch-503', serviceRef: '1:0:1:...' };
+
+    const response = (
+      status: number,
+      body: Record<string, unknown> = {},
+      headers: Record<string, string> = {}
+    ) => ({
+      ok: status >= 200 && status < 300,
+      status,
+      url: 'http://localhost/api/v3/sessions/sess-503',
+      headers: {
+        get: (key: string) => headers[key] ?? headers[key.toLowerCase()] ?? null
+      },
+      json: async () => body,
+      text: async () => JSON.stringify(body)
+    });
+
+    (globalThis.fetch as any).mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('/intents')) {
+        const parsed = init?.body ? JSON.parse(String(init.body)) : {};
+        if (parsed?.type === 'stream.start') {
+          return Promise.resolve(response(200, { sessionId: 'sess-503' }));
+        }
+        return Promise.resolve(response(200, {})); // stream.stop
+      }
+
+      if (url.includes('/sessions/sess-503') && !url.includes('/heartbeat')) {
+        readinessCalls++;
+        if (readinessCalls === 1) {
+          return Promise.resolve(response(503, { detail: 'upstream_warming' }));
+        }
+        return Promise.resolve(
+          response(200, {
+            state: 'READY',
+            playbackUrl: '/live.m3u8',
+            heartbeat_interval: 1
+          })
+        );
+      }
+
+      return Promise.resolve(response(200, {}));
+    });
+
+    vi.useFakeTimers();
+    try {
+      render(<V3Player autoStart={true} channel={mockChannel as any} />);
+
+      await act(async () => {
+        await flushMicrotasks();
+        await flushMicrotasks();
+        await vi.advanceTimersByTimeAsync(0);
+        await flushMicrotasks();
+      });
+
+      expect(readinessCalls).toBe(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(499);
+        await flushMicrotasks();
+      });
+      expect(readinessCalls).toBe(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+        await flushMicrotasks();
+        await flushMicrotasks();
+      });
+
+      expect(readinessCalls).toBe(2);
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.queryByText(/player\.sessionFailed/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/player\.sessionExpired/i)).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+        await flushMicrotasks();
+      });
+      expect(readinessCalls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('tears down on 410 GONE (Session Expired) during heartbeat', async () => {
     let heartbeatCount = 0;
 


### PR DESCRIPTION
## Scope
- Add one deterministic V3Player readiness test for 503 recovery
- No production code changes

## What this proves
- Readiness polling retries on transient 503
- Backoff is respected before retry
- No terminal error state is shown for this recoverable path

## Determinism
- Uses vi.useFakeTimers() and explicit timer advancement
- Uses stable RTL assertions

## Validation
- npm test -- tests/V3Player.errors.test.tsx