### PR TITLE
fix(codec): engine-first negotiation; adapter plans from decision output

### DIFF
--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -1,0 +1,343 @@
+package decision
+
+import (
+	"sort"
+	"strings"
+)
+
+type Path string
+
+const (
+	PathDirectPlay   Path = "direct"
+	PathRemux        Path = "remux"
+	PathTranscodeCPU Path = "transcode_cpu"
+	PathTranscodeHW  Path = "transcode_hw"
+	PathReject       Path = "reject"
+)
+
+type Reason string
+
+const (
+	ReasonDirectPlaySupported Reason = "direct_play_supported"
+	ReasonRemuxRequired       Reason = "remux_required"
+	ReasonProfilePreference   Reason = "profile_preference"
+	ReasonHWCodecUnavailable  Reason = "hw_codec_unavailable"
+	ReasonProfileConstraint   Reason = "profile_constraint"
+	ReasonCPUPreferred        Reason = "cost_cpu_preferred"
+	ReasonCodecSelected       Reason = "codec_selected"
+	ReasonNoCompatibleCodec   Reason = "no_compatible_codec"
+)
+
+type Input struct {
+	SourceCodec      string
+	SourceContainer  string
+	ClientCodecs     []string
+	ClientContainers []string
+	Profile          string
+	RequestedCodec   string
+	RequireHW        bool
+	Server           ServerCapabilities
+}
+
+type ServerCapabilities struct {
+	HWAccelAvailable  bool
+	SupportedHWCodecs []string
+}
+
+type Output struct {
+	Path        Path
+	OutputCodec string
+	UseHWAccel  bool
+	Reason      Reason
+}
+
+type profileRule struct {
+	preferredCodec string
+	hardCodec      string
+	preferHW       bool
+	requireHW      bool
+}
+
+type candidate struct {
+	codec string
+	hw    bool
+	score int
+}
+
+func Decide(in Input) Output {
+	in = normalizeInput(in)
+
+	// Direct/remux only applies when source truth + client capabilities are known.
+	if in.SourceCodec != "" && len(in.ClientCodecs) > 0 && contains(in.ClientCodecs, in.SourceCodec) {
+		if in.SourceContainer != "" && len(in.ClientContainers) > 0 && contains(in.ClientContainers, in.SourceContainer) {
+			return Output{Path: PathDirectPlay, OutputCodec: in.SourceCodec, Reason: ReasonDirectPlaySupported}
+		}
+		return Output{Path: PathRemux, OutputCodec: in.SourceCodec, Reason: ReasonRemuxRequired}
+	}
+
+	rule := ruleForProfile(in.Profile, in.RequestedCodec)
+
+	// Explicit hard requirement: codec must be available via HW.
+	if rule.requireHW {
+		required := rule.preferredCodec
+		if required == "" {
+			required = in.RequestedCodec
+		}
+		if required == "" || !hwCodecAvailable(in.Server, required) {
+			return Output{Path: PathReject, Reason: ReasonHWCodecUnavailable}
+		}
+		return Output{
+			Path:        PathTranscodeHW,
+			OutputCodec: required,
+			UseHWAccel:  true,
+			Reason:      ReasonProfileConstraint,
+		}
+	}
+
+	// Adapter-level hard requirement: caller requested strict HW usage.
+	if in.RequireHW {
+		required := in.RequestedCodec
+		if required == "" {
+			required = rule.preferredCodec
+		}
+		if required != "" {
+			if !hwCodecAvailable(in.Server, required) {
+				return Output{Path: PathReject, Reason: ReasonHWCodecUnavailable}
+			}
+			return Output{
+				Path:        PathTranscodeHW,
+				OutputCodec: required,
+				UseHWAccel:  true,
+				Reason:      ReasonProfileConstraint,
+			}
+		}
+	}
+
+	allowedCodecs := normalizedCodecs(in.ClientCodecs)
+	if len(allowedCodecs) == 0 {
+		allowedCodecs = []string{"h264", "hevc", "av1"}
+	}
+
+	// Hard codec constraint profile (e.g. safari_hevc).
+	if rule.hardCodec != "" {
+		if !contains(allowedCodecs, rule.hardCodec) {
+			return Output{Path: PathReject, Reason: ReasonNoCompatibleCodec}
+		}
+		out, ok := pickBestCandidate(in, []string{rule.hardCodec}, rule)
+		if !ok {
+			return Output{Path: PathReject, Reason: ReasonNoCompatibleCodec}
+		}
+		out.Reason = ReasonProfileConstraint
+		return out
+	}
+
+	out, ok := pickBestCandidate(in, allowedCodecs, rule)
+	if !ok {
+		return Output{Path: PathReject, Reason: ReasonNoCompatibleCodec}
+	}
+
+	if rule.preferredCodec != "" {
+		if out.OutputCodec != rule.preferredCodec || (rule.preferHW && !out.UseHWAccel) {
+			out.Reason = ReasonProfilePreference
+			return out
+		}
+	}
+
+	if !out.UseHWAccel && out.OutputCodec == "h264" {
+		out.Reason = ReasonCPUPreferred
+		return out
+	}
+
+	out.Reason = ReasonCodecSelected
+	return out
+}
+
+func pickBestCandidate(in Input, codecs []string, rule profileRule) (Output, bool) {
+	var candidates []candidate
+	for _, codec := range codecs {
+		c := canonicalCodec(codec)
+		if c == "" {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			codec: c,
+			hw:    false,
+			score: scoreCandidate(c, false, rule),
+		})
+		if hwCodecAvailable(in.Server, c) {
+			candidates = append(candidates, candidate{
+				codec: c,
+				hw:    true,
+				score: scoreCandidate(c, true, rule),
+			})
+		}
+	}
+
+	if len(candidates) == 0 {
+		return Output{}, false
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		if candidates[i].hw != candidates[j].hw {
+			return candidates[i].hw
+		}
+		return codecRank(candidates[i].codec) > codecRank(candidates[j].codec)
+	})
+
+	best := candidates[0]
+	out := Output{
+		OutputCodec: best.codec,
+		UseHWAccel:  best.hw,
+		Path:        PathTranscodeCPU,
+	}
+	if best.hw {
+		out.Path = PathTranscodeHW
+	}
+	return out, true
+}
+
+func scoreCandidate(codec string, hw bool, rule profileRule) int {
+	score := 0
+
+	switch codec {
+	case "av1":
+		score += 60
+	case "hevc":
+		score += 50
+	case "h264":
+		score += 40
+	}
+
+	if hw {
+		score += 30
+	} else {
+		switch codec {
+		case "h264":
+			score += 15
+		case "hevc":
+			score -= 10
+		case "av1":
+			score -= 20
+		}
+	}
+
+	if rule.preferredCodec != "" && codec == rule.preferredCodec {
+		score += 20
+	}
+	if rule.preferHW && hw {
+		score += 10
+	}
+
+	return score
+}
+
+func ruleForProfile(profile string, requestedCodec string) profileRule {
+	p := strings.ToLower(strings.TrimSpace(profile))
+	switch p {
+	case "av1_hw":
+		return profileRule{preferredCodec: "av1", preferHW: true}
+	case "av1_required":
+		return profileRule{preferredCodec: "av1", requireHW: true}
+	case "safari_hevc":
+		return profileRule{hardCodec: "hevc"}
+	case "safari_hevc_hw", "safari_hevc_hw_ll":
+		return profileRule{preferredCodec: "hevc", preferHW: true}
+	case "safari":
+		return profileRule{preferredCodec: "h264"}
+	}
+
+	if requestedCodec != "" {
+		return profileRule{preferredCodec: canonicalCodec(requestedCodec)}
+	}
+	return profileRule{}
+}
+
+func normalizeInput(in Input) Input {
+	in.SourceCodec = canonicalCodec(in.SourceCodec)
+	in.SourceContainer = normalizeToken(in.SourceContainer)
+	in.Profile = strings.ToLower(strings.TrimSpace(in.Profile))
+	in.RequestedCodec = canonicalCodec(in.RequestedCodec)
+	in.ClientCodecs = normalizedCodecs(in.ClientCodecs)
+	in.ClientContainers = normalizedTokens(in.ClientContainers)
+	in.Server.SupportedHWCodecs = normalizedCodecs(in.Server.SupportedHWCodecs)
+	return in
+}
+
+func normalizedCodecs(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, v := range values {
+		c := canonicalCodec(v)
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+func normalizedTokens(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, v := range values {
+		t := normalizeToken(v)
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+func canonicalCodec(raw string) string {
+	v := normalizeToken(raw)
+	switch v {
+	case "h264", "avc", "avc1", "libx264", "h264_vaapi":
+		return "h264"
+	case "hevc", "h265", "h.265", "libx265", "hevc_vaapi":
+		return "hevc"
+	case "av1", "av01", "av1_vaapi", "libsvtav1", "libaom-av1":
+		return "av1"
+	default:
+		return v
+	}
+}
+
+func normalizeToken(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func hwCodecAvailable(server ServerCapabilities, codec string) bool {
+	if !server.HWAccelAvailable {
+		return false
+	}
+	return contains(server.SupportedHWCodecs, codec)
+}
+
+func contains(slice []string, value string) bool {
+	v := normalizeToken(value)
+	for _, item := range slice {
+		if normalizeToken(item) == v {
+			return true
+		}
+	}
+	return false
+}
+
+func codecRank(codec string) int {
+	switch codec {
+	case "av1":
+		return 3
+	case "hevc":
+		return 2
+	case "h264":
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -1,0 +1,134 @@
+package decision
+
+import "testing"
+
+func TestDecide_CodecNegotiationContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		in         Input
+		wantPath   Path
+		wantCodec  string
+		wantReason Reason
+		wantUseHW  bool
+	}{
+		{
+			name: "direct when source codec/container are client compatible",
+			in: Input{
+				SourceCodec:      "h264",
+				SourceContainer:  "mp4",
+				ClientCodecs:     []string{"h264", "hevc"},
+				ClientContainers: []string{"mp4", "fmp4"},
+			},
+			wantPath:   PathDirectPlay,
+			wantCodec:  "h264",
+			wantReason: ReasonDirectPlaySupported,
+		},
+		{
+			name: "remux when codec is supported but container is not",
+			in: Input{
+				SourceCodec:      "h264",
+				SourceContainer:  "mkv",
+				ClientCodecs:     []string{"h264"},
+				ClientContainers: []string{"mp4"},
+			},
+			wantPath:   PathRemux,
+			wantCodec:  "h264",
+			wantReason: ReasonRemuxRequired,
+		},
+		{
+			name: "av1_hw prefers av1 on hw but falls back to hevc hw when av1 hw unavailable",
+			in: Input{
+				SourceCodec:  "vp9",
+				ClientCodecs: []string{"h264", "hevc", "av1"},
+				Profile:      "av1_hw",
+				Server:       ServerCapabilities{HWAccelAvailable: true, SupportedHWCodecs: []string{"hevc", "h264"}},
+			},
+			wantPath:   PathTranscodeHW,
+			wantCodec:  "hevc",
+			wantReason: ReasonProfilePreference,
+			wantUseHW:  true,
+		},
+		{
+			name: "av1_required rejects when av1 hw is unavailable",
+			in: Input{
+				SourceCodec:  "vp9",
+				ClientCodecs: []string{"h264", "hevc", "av1"},
+				Profile:      "av1_required",
+				Server:       ServerCapabilities{HWAccelAvailable: true, SupportedHWCodecs: []string{"hevc", "h264"}},
+			},
+			wantPath:   PathReject,
+			wantCodec:  "",
+			wantReason: ReasonHWCodecUnavailable,
+		},
+		{
+			name: "cpu-only chooses h264 over hevc on cost",
+			in: Input{
+				SourceCodec:  "vp9",
+				ClientCodecs: []string{"h264", "hevc"},
+				Server:       ServerCapabilities{HWAccelAvailable: false},
+			},
+			wantPath:   PathTranscodeCPU,
+			wantCodec:  "h264",
+			wantReason: ReasonCPUPreferred,
+		},
+		{
+			name: "gpu hevc beats cpu h264 when hevc hw is available",
+			in: Input{
+				SourceCodec:  "vp9",
+				ClientCodecs: []string{"h264", "hevc"},
+				Server:       ServerCapabilities{HWAccelAvailable: true, SupportedHWCodecs: []string{"hevc"}},
+			},
+			wantPath:   PathTranscodeHW,
+			wantCodec:  "hevc",
+			wantReason: ReasonCodecSelected,
+			wantUseHW:  true,
+		},
+		{
+			name: "safari_hevc is hard constrained to hevc even on cpu",
+			in: Input{
+				SourceCodec:  "vp9",
+				ClientCodecs: []string{"h264", "hevc"},
+				Profile:      "safari_hevc",
+				Server:       ServerCapabilities{HWAccelAvailable: false},
+			},
+			wantPath:   PathTranscodeCPU,
+			wantCodec:  "hevc",
+			wantReason: ReasonProfileConstraint,
+		},
+		{
+			name: "safari prefers h264 on cpu without hard constraint reason",
+			in: Input{
+				SourceCodec:  "vp9",
+				ClientCodecs: []string{"h264", "hevc"},
+				Profile:      "safari",
+				Server:       ServerCapabilities{HWAccelAvailable: false},
+			},
+			wantPath:   PathTranscodeCPU,
+			wantCodec:  "h264",
+			wantReason: ReasonCPUPreferred,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Decide(tt.in)
+			if got.Path != tt.wantPath {
+				t.Fatalf("path mismatch: got=%q want=%q", got.Path, tt.wantPath)
+			}
+			if got.OutputCodec != tt.wantCodec {
+				t.Fatalf("output codec mismatch: got=%q want=%q", got.OutputCodec, tt.wantCodec)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("reason mismatch: got=%q want=%q", got.Reason, tt.wantReason)
+			}
+			if got.UseHWAccel != tt.wantUseHW {
+				t.Fatalf("useHW mismatch: got=%v want=%v", got.UseHWAccel, tt.wantUseHW)
+			}
+		})
+	}
+}

--- a/internal/infra/media/ffmpeg/adapter.go
+++ b/internal/infra/media/ffmpeg/adapter.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	codecdecision "github.com/ManuGH/xg2g/internal/decision"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/ManuGH/xg2g/internal/media/ffmpeg/watchdog"
 	"github.com/ManuGH/xg2g/internal/metrics"
@@ -37,26 +38,26 @@ var vaapiEncodersToTest = []string{"h264_vaapi", "hevc_vaapi"}
 
 // LocalAdapter implements ports.MediaPipeline using local exec.Command.
 type LocalAdapter struct {
-	BinPath          string
-	FFprobeBin       string
-	HLSRoot          string
-	AnalyzeDuration  string
-	ProbeSize        string
-	DVRWindow        time.Duration
-	KillTimeout      time.Duration
-	httpClient       *http.Client
-	Logger           zerolog.Logger
-	E2               *enigma2.Client // Dependency for Tuner operations
-	FallbackTo8001   bool
-	PreflightTimeout time.Duration
-	SegmentSeconds   int
-	StartTimeout     time.Duration
-	StallTimeout     time.Duration
-	VaapiDevice        string            // e.g. "/dev/dri/renderD128"; empty = no VAAPI
-	vaapiEncoders      map[string]bool   // per-encoder preflight results ("h264_vaapi" -> true)
-	vaapiDeviceChecked bool              // device-level preflight ran
-	vaapiDeviceErr     error             // device-level preflight error
-	mu               sync.Mutex
+	BinPath            string
+	FFprobeBin         string
+	HLSRoot            string
+	AnalyzeDuration    string
+	ProbeSize          string
+	DVRWindow          time.Duration
+	KillTimeout        time.Duration
+	httpClient         *http.Client
+	Logger             zerolog.Logger
+	E2                 *enigma2.Client // Dependency for Tuner operations
+	FallbackTo8001     bool
+	PreflightTimeout   time.Duration
+	SegmentSeconds     int
+	StartTimeout       time.Duration
+	StallTimeout       time.Duration
+	VaapiDevice        string          // e.g. "/dev/dri/renderD128"; empty = no VAAPI
+	vaapiEncoders      map[string]bool // per-encoder preflight results ("h264_vaapi" -> true)
+	vaapiDeviceChecked bool            // device-level preflight ran
+	vaapiDeviceErr     error           // device-level preflight error
+	mu                 sync.Mutex
 	// activeProcs maps run handles to running commands
 	activeProcs map[ports.RunHandle]*exec.Cmd
 }
@@ -722,16 +723,46 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 		"-reconnect_on_http_error", "4xx,5xx",
 	)
 
+	useHWPath := spec.Profile.HWAccel == "vaapi"
+	if isPreferHWProfile(spec.Profile.Name) {
+		useHWPath = true
+	}
+
+	hardVAAPIRequest := spec.Profile.HWAccel == "vaapi" && !isPreferHWProfile(spec.Profile.Name)
+	neg := codecdecision.Decide(codecdecision.Input{
+		Profile:        spec.Profile.Name,
+		RequestedCodec: spec.Profile.VideoCodec,
+		RequireHW:      hardVAAPIRequest,
+		Server: codecdecision.ServerCapabilities{
+			HWAccelAvailable:  useHWPath,
+			SupportedHWCodecs: a.supportedHWCodecs(),
+		},
+	})
+	if neg.Path == codecdecision.PathReject && !hardVAAPIRequest {
+		return nil, fmt.Errorf("codec negotiation rejected (profile=%s codec=%s reason=%s)", spec.Profile.Name, spec.Profile.VideoCodec, neg.Reason)
+	}
+	resolvedCodec := neg.OutputCodec
+	if resolvedCodec == "" && hardVAAPIRequest {
+		resolvedCodec = normalizeRequestedCodec(spec.Profile.VideoCodec)
+	}
+	if resolvedCodec == "" {
+		resolvedCodec = "h264"
+	}
+	useVAAPI := neg.Path == codecdecision.PathTranscodeHW
+	if hardVAAPIRequest {
+		useVAAPI = true
+	}
+
 	// VAAPI device init (must come before -i for hwaccel decode).
 	// Fail-closed: two independent checks must pass before VAAPI args are emitted.
-	if spec.Profile.HWAccel == "vaapi" {
+	if useVAAPI {
 		if a.VaapiDevice == "" {
 			return nil, fmt.Errorf("vaapi requested by profile but no vaapi device configured on adapter")
 		}
 		// Resolve the encoder name for per-encoder preflight check
-		reqEncoder := "h264_vaapi"
-		if spec.Profile.VideoCodec == "hevc" {
-			reqEncoder = "hevc_vaapi"
+		reqEncoder, ok := codecToVAAPIEncoder(resolvedCodec)
+		if !ok {
+			return nil, fmt.Errorf("unsupported vaapi codec resolved by decision engine: %s", resolvedCodec)
 		}
 		if !a.VaapiEncoderVerified(reqEncoder) {
 			return nil, fmt.Errorf("vaapi encoder %s not verified by preflight (device=%s, deviceErr=%v)", reqEncoder, a.VaapiDevice, a.vaapiDeviceErr)
@@ -803,10 +834,10 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 		)
 
 		// Video encoding (two paths: VAAPI GPU or CPU)
-		if spec.Profile.HWAccel == "vaapi" {
-			args = a.buildVaapiVideoArgs(args, spec, gop, segmentDurationSec)
+		if useVAAPI {
+			args = a.buildVaapiVideoArgs(args, spec, resolvedCodec, gop, segmentDurationSec)
 		} else {
-			args = a.buildCPUVideoArgs(args, spec, gop, segmentDurationSec)
+			args = a.buildCPUVideoArgs(args, spec, resolvedCodec, gop, segmentDurationSec)
 		}
 
 		// Audio (same for all paths)
@@ -846,13 +877,13 @@ func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inp
 
 // buildVaapiVideoArgs constructs video encoding arguments for the VAAPI GPU pipeline.
 // Frames are already in GPU memory from -hwaccel vaapi -hwaccel_output_format vaapi.
-func (a *LocalAdapter) buildVaapiVideoArgs(args []string, spec ports.StreamSpec, gop, segmentSec int) []string {
+func (a *LocalAdapter) buildVaapiVideoArgs(args []string, spec ports.StreamSpec, outputCodec string, gop, segmentSec int) []string {
 	prof := spec.Profile
 	a.Logger.Info().
 		Str("sessionId", spec.SessionID).
 		Str("transcode.mode", "vaapi").
 		Str("vaapi.device", a.VaapiDevice).
-		Str("video.codec", prof.VideoCodec).
+		Str("video.codec", outputCodec).
 		Int("video.maxRateK", prof.VideoMaxRateK).
 		Int("video.bufSizeK", prof.VideoBufSizeK).
 		Bool("deinterlace", prof.Deinterlace).
@@ -865,8 +896,10 @@ func (a *LocalAdapter) buildVaapiVideoArgs(args []string, spec ports.StreamSpec,
 
 	// Encoder
 	encoder := "h264_vaapi"
-	if prof.VideoCodec == "hevc" {
+	if outputCodec == "hevc" {
 		encoder = "hevc_vaapi"
+	} else if outputCodec == "av1" {
+		encoder = "av1_vaapi"
 	}
 	args = append(args, "-c:v", encoder)
 
@@ -900,12 +933,12 @@ func (a *LocalAdapter) buildVaapiVideoArgs(args []string, spec ports.StreamSpec,
 // When ProfileSpec is zero-valued (VideoCodec="" + TranscodeVideo=false), applies
 // legacy defaults: libx264 + yadif + ultrafast + CRF 20. This ensures backwards
 // compat for code paths that don't set ProfileSpec yet.
-func (a *LocalAdapter) buildCPUVideoArgs(args []string, spec ports.StreamSpec, gop, segmentSec int) []string {
+func (a *LocalAdapter) buildCPUVideoArgs(args []string, spec ports.StreamSpec, outputCodec string, gop, segmentSec int) []string {
 	prof := spec.Profile
 	// Detect zero-valued profile → apply legacy defaults.
 	// A zero-valued ProfileSpec has VideoCodec="" and TranscodeVideo=false,
 	// which happens when the orchestrator doesn't pass a resolved profile.
-	legacy := prof.VideoCodec == "" && !prof.TranscodeVideo
+	legacy := prof.VideoCodec == "" && !prof.TranscodeVideo && outputCodec == "h264"
 
 	codec := "libx264"
 	preset := "ultrafast" // legacy default
@@ -913,10 +946,12 @@ func (a *LocalAdapter) buildCPUVideoArgs(args []string, spec ports.StreamSpec, g
 	deinterlace := true // legacy default: always deinterlace DVB streams
 
 	if !legacy {
-		if prof.VideoCodec == "hevc" {
+		if outputCodec == "hevc" {
 			codec = "libx265"
-		} else if prof.VideoCodec != "" && prof.VideoCodec != "h264" {
-			codec = prof.VideoCodec
+		} else if outputCodec == "av1" {
+			codec = "libsvtav1"
+		} else if outputCodec != "" && outputCodec != "h264" {
+			codec = outputCodec
 		}
 		if prof.Preset != "" {
 			preset = prof.Preset
@@ -965,6 +1000,52 @@ func (a *LocalAdapter) buildCPUVideoArgs(args []string, spec ports.StreamSpec, g
 		"-profile:v", "main",
 	)
 	return args
+}
+
+func (a *LocalAdapter) supportedHWCodecs() []string {
+	codecs := make([]string, 0, 3)
+	if a.VaapiEncoderVerified("h264_vaapi") {
+		codecs = append(codecs, "h264")
+	}
+	if a.VaapiEncoderVerified("hevc_vaapi") {
+		codecs = append(codecs, "hevc")
+	}
+	if a.VaapiEncoderVerified("av1_vaapi") {
+		codecs = append(codecs, "av1")
+	}
+	return codecs
+}
+
+func isPreferHWProfile(profileName string) bool {
+	p := strings.ToLower(strings.TrimSpace(profileName))
+	return p == "av1_hw" || strings.HasSuffix(p, "_hw") || strings.HasSuffix(p, "_hw_ll")
+}
+
+func codecToVAAPIEncoder(codec string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(codec)) {
+	case "h264":
+		return "h264_vaapi", true
+	case "hevc":
+		return "hevc_vaapi", true
+	case "av1":
+		return "av1_vaapi", true
+	default:
+		return "", false
+	}
+}
+
+func normalizeRequestedCodec(codec string) string {
+	c := strings.ToLower(strings.TrimSpace(codec))
+	switch c {
+	case "", "h264", "avc", "avc1", "libx264", "h264_vaapi":
+		return "h264"
+	case "hevc", "h265", "h.265", "libx265", "hevc_vaapi":
+		return "hevc"
+	case "av1", "av01", "av1_vaapi", "libsvtav1", "libaom-av1":
+		return "av1"
+	default:
+		return c
+	}
 }
 
 func (a *LocalAdapter) detectFPS(ctx context.Context, inputURL string) (int, error) {

--- a/internal/infra/media/ffmpeg/adapter.go
+++ b/internal/infra/media/ffmpeg/adapter.go
@@ -896,9 +896,10 @@ func (a *LocalAdapter) buildVaapiVideoArgs(args []string, spec ports.StreamSpec,
 
 	// Encoder
 	encoder := "h264_vaapi"
-	if outputCodec == "hevc" {
+	switch outputCodec {
+	case "hevc":
 		encoder = "hevc_vaapi"
-	} else if outputCodec == "av1" {
+	case "av1":
 		encoder = "av1_vaapi"
 	}
 	args = append(args, "-c:v", encoder)


### PR DESCRIPTION
## Scope
- Engine-first codec negotiation in internal/decision
- FFmpeg adapter consumes decision output for planning
- No profile mutation in adapter

## Commits
1. test(decision): add codec negotiation contract tests
2. fix(engine): add fail-closed codec negotiation with profile constraints
3. fix(adapter): plan ffmpeg args from decision output without profile mutation
4. fix(ffmpeg): satisfy staticcheck switch recommendation (mechanical only)

## Invariants
- Single truth for codec/HW choice: internal/decision.Decide
- profiles/* remains policy input
- adapter is planner only (DecisionOutput to args)

## Audit checks
- Remux case is explicit container mismatch (mkv source vs mp4 client)
- Safari CPU case asserts ReasonCPUPreferred (no preference-fallback mislabel)

## Verification
- go test -count=1 ./internal/decision/...
- go test -count=1 ./internal/infra/media/ffmpeg/...
- go test -count=1 ./internal/control/http/v3/...