### PR TITLE
governance: fail closed on empty PR delta

### DIFF
--- a/.github/workflows/pr-required-gates.yml
+++ b/.github/workflows/pr-required-gates.yml
@@ -24,6 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check non-empty diff
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
+          ./scripts/ci/check-empty-delta.sh "origin/${{ github.base_ref }}"
+
       - name: Resolve PR scopes
         id: scope
         shell: bash

--- a/scripts/ci/check-empty-delta.sh
+++ b/scripts/ci/check-empty-delta.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+
+# Best-effort refresh for local usage; CI can pass an explicit base ref.
+git fetch origin >/dev/null 2>&1 || true
+
+if git diff --quiet "${BASE}...HEAD"; then
+  echo "ERROR: empty diff against ${BASE}; nothing to propose"
+  exit 1
+fi
+
+echo "OK: non-empty diff against ${BASE}"


### PR DESCRIPTION
## Scope
- add local preflight script: scripts/ci/check-empty-delta.sh
- enforce non-empty PR diff in required gates workflow

## Behavior
- fail-closed when git diff BASE...HEAD is empty
- PR Required Gates now checks this early
- workflow_dispatch is not blocked by this step (pull_request only)

## Validation
- scripts/ci/check-empty-delta.sh origin/main => OK: non-empty diff against origin/main