### PR TITLE
obs(codec): add decision summary fields and structured planner log

### DIFF
--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -6,12 +6,13 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		in         Input
-		wantPath   Path
-		wantCodec  string
-		wantReason Reason
-		wantUseHW  bool
+		name          string
+		in            Input
+		wantPath      Path
+		wantCodec     string
+		wantReason    Reason
+		wantUseHW     bool
+		wantRequested string
 	}{
 		{
 			name: "direct when source codec/container are client compatible",
@@ -21,9 +22,10 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				ClientCodecs:     []string{"h264", "hevc"},
 				ClientContainers: []string{"mp4", "fmp4"},
 			},
-			wantPath:   PathDirectPlay,
-			wantCodec:  "h264",
-			wantReason: ReasonDirectPlaySupported,
+			wantPath:      PathDirectPlay,
+			wantCodec:     "h264",
+			wantReason:    ReasonDirectPlaySupported,
+			wantRequested: "auto",
 		},
 		{
 			name: "remux when codec is supported but container is not",
@@ -33,9 +35,10 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				ClientCodecs:     []string{"h264"},
 				ClientContainers: []string{"mp4"},
 			},
-			wantPath:   PathRemux,
-			wantCodec:  "h264",
-			wantReason: ReasonRemuxRequired,
+			wantPath:      PathRemux,
+			wantCodec:     "h264",
+			wantReason:    ReasonRemuxRequired,
+			wantRequested: "auto",
 		},
 		{
 			name: "av1_hw prefers av1 on hw but falls back to hevc hw when av1 hw unavailable",
@@ -45,10 +48,11 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				Profile:      "av1_hw",
 				Server:       ServerCapabilities{HWAccelAvailable: true, SupportedHWCodecs: []string{"hevc", "h264"}},
 			},
-			wantPath:   PathTranscodeHW,
-			wantCodec:  "hevc",
-			wantReason: ReasonProfilePreference,
-			wantUseHW:  true,
+			wantPath:      PathTranscodeHW,
+			wantCodec:     "hevc",
+			wantReason:    ReasonProfilePreference,
+			wantUseHW:     true,
+			wantRequested: "av1",
 		},
 		{
 			name: "av1_required rejects when av1 hw is unavailable",
@@ -58,9 +62,10 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				Profile:      "av1_required",
 				Server:       ServerCapabilities{HWAccelAvailable: true, SupportedHWCodecs: []string{"hevc", "h264"}},
 			},
-			wantPath:   PathReject,
-			wantCodec:  "",
-			wantReason: ReasonHWCodecUnavailable,
+			wantPath:      PathReject,
+			wantCodec:     "",
+			wantReason:    ReasonHWCodecUnavailable,
+			wantRequested: "av1",
 		},
 		{
 			name: "cpu-only chooses h264 over hevc on cost",
@@ -69,9 +74,10 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				ClientCodecs: []string{"h264", "hevc"},
 				Server:       ServerCapabilities{HWAccelAvailable: false},
 			},
-			wantPath:   PathTranscodeCPU,
-			wantCodec:  "h264",
-			wantReason: ReasonCPUPreferred,
+			wantPath:      PathTranscodeCPU,
+			wantCodec:     "h264",
+			wantReason:    ReasonCPUPreferred,
+			wantRequested: "auto",
 		},
 		{
 			name: "gpu hevc beats cpu h264 when hevc hw is available",
@@ -80,10 +86,11 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				ClientCodecs: []string{"h264", "hevc"},
 				Server:       ServerCapabilities{HWAccelAvailable: true, SupportedHWCodecs: []string{"hevc"}},
 			},
-			wantPath:   PathTranscodeHW,
-			wantCodec:  "hevc",
-			wantReason: ReasonCodecSelected,
-			wantUseHW:  true,
+			wantPath:      PathTranscodeHW,
+			wantCodec:     "hevc",
+			wantReason:    ReasonCodecSelected,
+			wantUseHW:     true,
+			wantRequested: "auto",
 		},
 		{
 			name: "safari_hevc is hard constrained to hevc even on cpu",
@@ -93,9 +100,10 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				Profile:      "safari_hevc",
 				Server:       ServerCapabilities{HWAccelAvailable: false},
 			},
-			wantPath:   PathTranscodeCPU,
-			wantCodec:  "hevc",
-			wantReason: ReasonProfileConstraint,
+			wantPath:      PathTranscodeCPU,
+			wantCodec:     "hevc",
+			wantReason:    ReasonProfileConstraint,
+			wantRequested: "hevc",
 		},
 		{
 			name: "safari prefers h264 on cpu without hard constraint reason",
@@ -105,9 +113,10 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 				Profile:      "safari",
 				Server:       ServerCapabilities{HWAccelAvailable: false},
 			},
-			wantPath:   PathTranscodeCPU,
-			wantCodec:  "h264",
-			wantReason: ReasonCPUPreferred,
+			wantPath:      PathTranscodeCPU,
+			wantCodec:     "h264",
+			wantReason:    ReasonCPUPreferred,
+			wantRequested: "h264",
 		},
 	}
 
@@ -128,6 +137,32 @@ func TestDecide_CodecNegotiationContract(t *testing.T) {
 			}
 			if got.UseHWAccel != tt.wantUseHW {
 				t.Fatalf("useHW mismatch: got=%v want=%v", got.UseHWAccel, tt.wantUseHW)
+			}
+
+			inSummary := tt.in.Summary()
+			if inSummary.RequestedCodec != tt.wantRequested {
+				t.Fatalf("summary requested_codec mismatch: got=%q want=%q", inSummary.RequestedCodec, tt.wantRequested)
+			}
+			if inSummary.HWAccelAvailable != tt.in.Server.HWAccelAvailable {
+				t.Fatalf("summary hwaccel_available mismatch: got=%v want=%v", inSummary.HWAccelAvailable, tt.in.Server.HWAccelAvailable)
+			}
+
+			outSummary := got.Summary()
+			if outSummary.Path != string(tt.wantPath) {
+				t.Fatalf("summary path mismatch: got=%q want=%q", outSummary.Path, tt.wantPath)
+			}
+			wantSummaryCodec := tt.wantCodec
+			if wantSummaryCodec == "" {
+				wantSummaryCodec = "none"
+			}
+			if outSummary.OutputCodec != wantSummaryCodec {
+				t.Fatalf("summary output_codec mismatch: got=%q want=%q", outSummary.OutputCodec, wantSummaryCodec)
+			}
+			if outSummary.Reason != string(tt.wantReason) {
+				t.Fatalf("summary reason mismatch: got=%q want=%q", outSummary.Reason, tt.wantReason)
+			}
+			if outSummary.UseHWAccel != tt.wantUseHW {
+				t.Fatalf("summary use_hwaccel mismatch: got=%v want=%v", outSummary.UseHWAccel, tt.wantUseHW)
 			}
 		})
 	}

--- a/internal/decision/summary.go
+++ b/internal/decision/summary.go
@@ -1,0 +1,55 @@
+package decision
+
+type InputSummary struct {
+	Profile           string
+	RequestedCodec    string
+	SupportedHWCodecs []string
+	HWAccelAvailable  bool
+}
+
+type OutputSummary struct {
+	Path        string
+	OutputCodec string
+	UseHWAccel  bool
+	Reason      string
+}
+
+func (in Input) Summary() InputSummary {
+	n := normalizeInput(in)
+	requested := n.RequestedCodec
+	if requested == "" {
+		rule := ruleForProfile(n.Profile, n.RequestedCodec)
+		switch {
+		case rule.preferredCodec != "":
+			requested = rule.preferredCodec
+		case rule.hardCodec != "":
+			requested = rule.hardCodec
+		default:
+			requested = "auto"
+		}
+	}
+
+	hwCodecs := make([]string, len(n.Server.SupportedHWCodecs))
+	copy(hwCodecs, n.Server.SupportedHWCodecs)
+
+	return InputSummary{
+		Profile:           n.Profile,
+		RequestedCodec:    requested,
+		SupportedHWCodecs: hwCodecs,
+		HWAccelAvailable:  n.Server.HWAccelAvailable,
+	}
+}
+
+func (out Output) Summary() OutputSummary {
+	codec := out.OutputCodec
+	if codec == "" {
+		codec = "none"
+	}
+
+	return OutputSummary{
+		Path:        string(out.Path),
+		OutputCodec: codec,
+		UseHWAccel:  out.UseHWAccel,
+		Reason:      string(out.Reason),
+	}
+}


### PR DESCRIPTION
## Scope
- observability only (no decision branch changes)
- one structured decision summary log per planning run
- stable summary fields from decision input/output

## Commits
1. obs(decision): expose decision summary fields
2. obs(adapter): log decision input/output summary
3. test(obs): assert decision summary fields

## Added fields
- profile
- requested_codec
- supported_hw_codecs
- hwaccel_available
- path
- output_codec
- use_hwaccel
- reason

## Safety
- no session IDs, URLs, IPs, or headers in the new summary log
- no new decision logic or feature drift

## Verification
- go test -count=1 ./internal/decision/...
- go test -count=1 ./internal/infra/media/ffmpeg/...
- go test -count=1 ./internal/control/http/v3/...