### PR TITLE
fix(p0): fail-on-timeout event bus and rooted runtime contexts

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -417,7 +417,10 @@ func main() {
 	resumeStore, err := resume.NewStore(cfg.Store.Backend, cfg.Store.Path)
 	if err != nil {
 		logger.Warn().Err(err).Msg("failed to initialize resume store, falling back to memory")
-		resumeStore, _ = resume.NewStore("memory", "")
+		resumeStore, err = resume.NewStore("memory", "")
+		if err != nil {
+			logger.Fatal().Err(err).Msg("failed to initialize fallback resume store")
+		}
 	}
 
 	// Scan Manager & Store
@@ -584,7 +587,8 @@ func main() {
 		shutdownOnce.Do(func() {
 			stop()
 			if ctx == nil {
-				ctx = context.Background()
+				shutdownErr = fmt.Errorf("shutdown context is nil")
+				return
 			}
 			shutdownErr = mgr.Shutdown(ctx)
 		})

--- a/internal/control/vod/lifecycle_test.go
+++ b/internal/control/vod/lifecycle_test.go
@@ -1,0 +1,50 @@
+package vod
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerShutdownContext_DrainsProberWorkers(t *testing.T) {
+	mgr, err := NewManager(&mockRunner{}, &mockProber{}, nil)
+	require.NoError(t, err)
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+	mgr.StartProberPool(rootCtx)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, mgr.ShutdownContext(shutdownCtx))
+}
+
+func TestManagerShutdownContext_DrainsBuildWorkers(t *testing.T) {
+	progress := make(chan ProgressEvent)
+	runner := NewMockRunner(nil, &MockHandleBehavior{
+		WaitBlocks:   true,
+		StopUnblocks: true,
+		ProgressChan: progress,
+	})
+	mgr, err := NewManager(runner, &mockProber{}, nil)
+	require.NoError(t, err)
+
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
+	mgr.StartProberPool(rootCtx)
+
+	workDir := t.TempDir()
+	outputTemp := "index.live.m3u8"
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, outputTemp), []byte("#EXTM3U"), 0600))
+
+	_, err = mgr.StartBuild(context.Background(), "job-1", "meta-1", "/tmp/input.ts", workDir, outputTemp, "", ProfileDefault)
+	require.NoError(t, err)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	require.NoError(t, mgr.ShutdownContext(shutdownCtx))
+}

--- a/internal/daemon/app.go
+++ b/internal/daemon/app.go
@@ -8,6 +8,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -187,8 +188,11 @@ func (a *App) Run(ctx context.Context) error {
 		err := a.manager.Start(ctx)
 		if err != nil {
 			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-			_ = a.manager.Shutdown(shutdownCtx)
+			shutdownErr := a.manager.Shutdown(shutdownCtx)
 			cancel()
+			if shutdownErr != nil {
+				return fmt.Errorf("%w (shutdown: %v)", err, shutdownErr)
+			}
 		}
 		return err
 	})

--- a/internal/daemon/manager_v3_worker.go
+++ b/internal/daemon/manager_v3_worker.go
@@ -93,6 +93,11 @@ func (m *manager) registerV3StoreCloseHooks(deps v3WorkerRuntimeDeps) {
 			return c.Close()
 		})
 	}
+	if deps.scanManager != nil {
+		m.RegisterShutdownHook("scan_store_close", func(ctx context.Context) error {
+			return deps.scanManager.Close()
+		})
+	}
 }
 
 func (m *manager) newAdmissionController(cfg config.AppConfig) *admission.Controller {

--- a/internal/metrics/bus.go
+++ b/internal/metrics/bus.go
@@ -14,12 +14,26 @@ var (
 		Name: "xg2g_bus_drop_total",
 		Help: "Total number of in-memory bus message drops (backpressure)",
 	}, []string{"topic"})
+
+	BusDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_bus_dropped_total",
+		Help: "Total number of in-memory bus message drops by topic and reason",
+	}, []string{"topic", "reason"})
 )
 
 // IncBusDrop records a dropped bus message for the given topic.
 func IncBusDrop(topic string) {
+	IncBusDropReason(topic, "full")
+}
+
+// IncBusDropReason records a dropped bus message with a concrete reason.
+func IncBusDropReason(topic, reason string) {
 	if topic == "" {
 		topic = "unknown"
 	}
+	if reason == "" {
+		reason = "unknown"
+	}
 	BusDropsTotal.WithLabelValues(topic).Inc()
+	BusDroppedTotal.WithLabelValues(topic, reason).Inc()
 }

--- a/internal/pipeline/scan/manager.go
+++ b/internal/pipeline/scan/manager.go
@@ -67,6 +67,14 @@ func (m *Manager) GetStatus() ScanStatus {
 	return m.status
 }
 
+// Close releases the underlying capability store resources.
+func (m *Manager) Close() error {
+	if m == nil || m.store == nil {
+		return nil
+	}
+	return m.store.Close()
+}
+
 // ExtractServiceRef extracts the service reference from a stream URL
 // Robust implementation using net/url
 func ExtractServiceRef(rawURL string) string {


### PR DESCRIPTION
## Scope (P0 completion)
- CON-03: in-memory bus publish no longer silently drops events (already in first commit)
- B1/ERR-03: runtime contexts + startup/shutdown error propagation hardened
- B2: ProberPool lifecycle now context-rooted and joined on shutdown
- B3: Build monitor goroutines are tracked and joined on shutdown
- B4: runtime resource closure completed (scan store + library store)

## Key changes
- `internal/pipeline/bus/memory_bus.go`: publish fail-on-timeout semantics + explicit context errors
- `internal/metrics/bus.go`: reasoned drop metric path (`xg2g_bus_dropped_total{topic,reason}`)
- `internal/control/vod/manager.go`: `ShutdownContext(ctx)` + wait-for-join of prober/build workers
- `internal/control/vod/prober.go`: `StartProberPool(ctx)` rooted to runtime context
- `internal/control/http/v3/server.go`: `SetRuntimeContext(ctx)`, `Shutdown(ctx)` and runtime-context-aware VOD wiring
- `internal/api/server_lifecycle.go`: API shutdown now propagates errors and delegates deterministic v3/vod shutdown
- `internal/daemon/manager.go`, `internal/daemon/app.go`: fail-fast nil-context checks, detached-but-bounded shutdown contexts, no swallowed shutdown errors
- `internal/pipeline/scan/manager.go`: `Close()` to release capability store
- `internal/daemon/manager_v3_worker.go`: shutdown hook for scan store close
- `internal/control/vod/lifecycle_test.go`: lifecycle tests for prober/build worker drain

## Validation
- `go test ./...`
