### PR TITLE
refactor(p2): split v3 router registration by bounded context

### DIFF
--- a/internal/control/http/v3/router_v3.go
+++ b/internal/control/http/v3/router_v3.go
@@ -47,19 +47,19 @@ func NewRouter(si ServerInterface, options RouterOptions) http.Handler {
 	}
 
 	register := routeRegistrar{baseURL: options.BaseURL, router: r}
-	registerAuthRoutes(register, wrapper)
-	registerDVRRoutes(register, wrapper)
-	registerEPGRoutes(register, wrapper)
-	registerIntentRoutes(register, wrapper)
-	registerLogRoutes(register, wrapper)
-	registerReceiverRoutes(register, wrapper)
-	registerRecordingRoutes(register, wrapper)
-	registerSeriesRoutes(register, wrapper)
-	registerServiceRoutes(register, wrapper)
-	registerSessionRoutes(register, wrapper)
-	registerStreamRoutes(register, wrapper)
-	registerSystemRoutes(register, wrapper)
-	registerTimerRoutes(register, wrapper)
+	registerAuthRoutes(register, &wrapper)
+	registerDVRRoutes(register, &wrapper)
+	registerEPGRoutes(register, &wrapper)
+	registerIntentRoutes(register, &wrapper)
+	registerLogRoutes(register, &wrapper)
+	registerReceiverRoutes(register, &wrapper)
+	registerRecordingRoutes(register, &wrapper)
+	registerSeriesRoutes(register, &wrapper)
+	registerServiceRoutes(register, &wrapper)
+	registerSessionRoutes(register, &wrapper)
+	registerStreamRoutes(register, &wrapper)
+	registerSystemRoutes(register, &wrapper)
+	registerTimerRoutes(register, &wrapper)
 
 	return r
 }

--- a/internal/control/http/v3/router_v3_ports.go
+++ b/internal/control/http/v3/router_v3_ports.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "net/http"
+
+type authRoutes interface {
+	CreateSession(w http.ResponseWriter, r *http.Request)
+}
+
+type dvrRoutes interface {
+	GetDvrCapabilities(w http.ResponseWriter, r *http.Request)
+	GetDvrStatus(w http.ResponseWriter, r *http.Request)
+}
+
+type epgRoutes interface {
+	GetEpg(w http.ResponseWriter, r *http.Request)
+}
+
+type intentRoutes interface {
+	CreateIntent(w http.ResponseWriter, r *http.Request)
+}
+
+type logRoutes interface {
+	GetLogs(w http.ResponseWriter, r *http.Request)
+}
+
+type receiverRoutes interface {
+	GetReceiverCurrent(w http.ResponseWriter, r *http.Request)
+}
+
+type recordingRoutes interface {
+	GetRecordings(w http.ResponseWriter, r *http.Request)
+	DeleteRecording(w http.ResponseWriter, r *http.Request)
+	GetRecordingHLSPlaylist(w http.ResponseWriter, r *http.Request)
+	GetRecordingHLSPlaylistHead(w http.ResponseWriter, r *http.Request)
+	GetRecordingsRecordingIdStatus(w http.ResponseWriter, r *http.Request)
+	GetRecordingPlaybackInfo(w http.ResponseWriter, r *http.Request)
+	PostRecordingPlaybackInfo(w http.ResponseWriter, r *http.Request)
+	StreamRecordingDirect(w http.ResponseWriter, r *http.Request)
+	ProbeRecordingMp4(w http.ResponseWriter, r *http.Request)
+	GetRecordingHLSTimeshift(w http.ResponseWriter, r *http.Request)
+	GetRecordingHLSTimeshiftHead(w http.ResponseWriter, r *http.Request)
+	GetRecordingHLSCustomSegment(w http.ResponseWriter, r *http.Request)
+	GetRecordingHLSCustomSegmentHead(w http.ResponseWriter, r *http.Request)
+}
+
+type seriesRoutes interface {
+	GetSeriesRules(w http.ResponseWriter, r *http.Request)
+	CreateSeriesRule(w http.ResponseWriter, r *http.Request)
+	RunAllSeriesRules(w http.ResponseWriter, r *http.Request)
+	DeleteSeriesRule(w http.ResponseWriter, r *http.Request)
+	UpdateSeriesRule(w http.ResponseWriter, r *http.Request)
+	RunSeriesRule(w http.ResponseWriter, r *http.Request)
+}
+
+type serviceRoutes interface {
+	GetServices(w http.ResponseWriter, r *http.Request)
+	GetServicesBouquets(w http.ResponseWriter, r *http.Request)
+	PostServicesNowNext(w http.ResponseWriter, r *http.Request)
+	PostServicesIdToggle(w http.ResponseWriter, r *http.Request)
+}
+
+type sessionRoutes interface {
+	ListSessions(w http.ResponseWriter, r *http.Request)
+	GetSessionState(w http.ResponseWriter, r *http.Request)
+	ServeHLS(w http.ResponseWriter, r *http.Request)
+	ServeHLSHead(w http.ResponseWriter, r *http.Request)
+	ReportPlaybackFeedback(w http.ResponseWriter, r *http.Request)
+}
+
+type streamRoutes interface {
+	GetStreams(w http.ResponseWriter, r *http.Request)
+	DeleteStreamsId(w http.ResponseWriter, r *http.Request)
+}
+
+type systemRoutes interface {
+	GetSystemConfig(w http.ResponseWriter, r *http.Request)
+	PutSystemConfig(w http.ResponseWriter, r *http.Request)
+	GetSystemHealth(w http.ResponseWriter, r *http.Request)
+	GetSystemHealthz(w http.ResponseWriter, r *http.Request)
+	GetSystemInfo(w http.ResponseWriter, r *http.Request)
+	PostSystemRefresh(w http.ResponseWriter, r *http.Request)
+	GetSystemScanStatus(w http.ResponseWriter, r *http.Request)
+	TriggerSystemScan(w http.ResponseWriter, r *http.Request)
+}
+
+type timerRoutes interface {
+	GetTimers(w http.ResponseWriter, r *http.Request)
+	AddTimer(w http.ResponseWriter, r *http.Request)
+	PreviewConflicts(w http.ResponseWriter, r *http.Request)
+	DeleteTimer(w http.ResponseWriter, r *http.Request)
+	GetTimer(w http.ResponseWriter, r *http.Request)
+	UpdateTimer(w http.ResponseWriter, r *http.Request)
+}

--- a/internal/control/http/v3/router_v3_routes_core.go
+++ b/internal/control/http/v3/router_v3_routes_core.go
@@ -6,27 +6,27 @@ package v3
 
 import "net/http"
 
-func registerAuthRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodPost, "/auth/session", "CreateSession", wrapper.CreateSession)
+func registerAuthRoutes(register routeRegistrar, handler authRoutes) {
+	register.add(http.MethodPost, "/auth/session", "CreateSession", handler.CreateSession)
 }
 
-func registerDVRRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/dvr/capabilities", "GetDvrCapabilities", wrapper.GetDvrCapabilities)
-	register.add(http.MethodGet, "/dvr/status", "GetDvrStatus", wrapper.GetDvrStatus)
+func registerDVRRoutes(register routeRegistrar, handler dvrRoutes) {
+	register.add(http.MethodGet, "/dvr/capabilities", "GetDvrCapabilities", handler.GetDvrCapabilities)
+	register.add(http.MethodGet, "/dvr/status", "GetDvrStatus", handler.GetDvrStatus)
 }
 
-func registerEPGRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/epg", "GetEpg", wrapper.GetEpg)
+func registerEPGRoutes(register routeRegistrar, handler epgRoutes) {
+	register.add(http.MethodGet, "/epg", "GetEpg", handler.GetEpg)
 }
 
-func registerIntentRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodPost, "/intents", "CreateIntent", wrapper.CreateIntent)
+func registerIntentRoutes(register routeRegistrar, handler intentRoutes) {
+	register.add(http.MethodPost, "/intents", "CreateIntent", handler.CreateIntent)
 }
 
-func registerLogRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/logs", "GetLogs", wrapper.GetLogs)
+func registerLogRoutes(register routeRegistrar, handler logRoutes) {
+	register.add(http.MethodGet, "/logs", "GetLogs", handler.GetLogs)
 }
 
-func registerReceiverRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/receiver/current", "GetReceiverCurrent", wrapper.GetReceiverCurrent)
+func registerReceiverRoutes(register routeRegistrar, handler receiverRoutes) {
+	register.add(http.MethodGet, "/receiver/current", "GetReceiverCurrent", handler.GetReceiverCurrent)
 }

--- a/internal/control/http/v3/router_v3_routes_core.go
+++ b/internal/control/http/v3/router_v3_routes_core.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "net/http"
+
+func registerAuthRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodPost, "/auth/session", "CreateSession", wrapper.CreateSession)
+}
+
+func registerDVRRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/dvr/capabilities", "GetDvrCapabilities", wrapper.GetDvrCapabilities)
+	register.add(http.MethodGet, "/dvr/status", "GetDvrStatus", wrapper.GetDvrStatus)
+}
+
+func registerEPGRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/epg", "GetEpg", wrapper.GetEpg)
+}
+
+func registerIntentRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodPost, "/intents", "CreateIntent", wrapper.CreateIntent)
+}
+
+func registerLogRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/logs", "GetLogs", wrapper.GetLogs)
+}
+
+func registerReceiverRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/receiver/current", "GetReceiverCurrent", wrapper.GetReceiverCurrent)
+}

--- a/internal/control/http/v3/router_v3_routes_recordings.go
+++ b/internal/control/http/v3/router_v3_routes_recordings.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "net/http"
+
+func registerRecordingRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/recordings", "GetRecordings", wrapper.GetRecordings)
+	register.add(http.MethodDelete, "/recordings/{recordingId}", "DeleteRecording", wrapper.DeleteRecording)
+	register.add(http.MethodGet, "/recordings/{recordingId}/playlist.m3u8", "GetRecordingHLSPlaylist", wrapper.GetRecordingHLSPlaylist)
+	register.add(http.MethodHead, "/recordings/{recordingId}/playlist.m3u8", "GetRecordingHLSPlaylistHead", wrapper.GetRecordingHLSPlaylistHead)
+	register.add(http.MethodGet, "/recordings/{recordingId}/status", "GetRecordingsRecordingIdStatus", wrapper.GetRecordingsRecordingIdStatus)
+	register.add(http.MethodGet, "/recordings/{recordingId}/stream-info", "GetRecordingPlaybackInfo", wrapper.GetRecordingPlaybackInfo)
+	register.add(http.MethodPost, "/recordings/{recordingId}/stream-info", "PostRecordingPlaybackInfo", wrapper.PostRecordingPlaybackInfo)
+	register.add(http.MethodGet, "/recordings/{recordingId}/stream.mp4", "StreamRecordingDirect", wrapper.StreamRecordingDirect)
+	register.add(http.MethodHead, "/recordings/{recordingId}/stream.mp4", "ProbeRecordingMp4", wrapper.ProbeRecordingMp4)
+	register.add(http.MethodGet, "/recordings/{recordingId}/timeshift.m3u8", "GetRecordingHLSTimeshift", wrapper.GetRecordingHLSTimeshift)
+	register.add(http.MethodHead, "/recordings/{recordingId}/timeshift.m3u8", "GetRecordingHLSTimeshiftHead", wrapper.GetRecordingHLSTimeshiftHead)
+	register.add(http.MethodGet, "/recordings/{recordingId}/{segment}", "GetRecordingHLSCustomSegment", wrapper.GetRecordingHLSCustomSegment)
+	register.add(http.MethodHead, "/recordings/{recordingId}/{segment}", "GetRecordingHLSCustomSegmentHead", wrapper.GetRecordingHLSCustomSegmentHead)
+}

--- a/internal/control/http/v3/router_v3_routes_recordings.go
+++ b/internal/control/http/v3/router_v3_routes_recordings.go
@@ -6,18 +6,18 @@ package v3
 
 import "net/http"
 
-func registerRecordingRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/recordings", "GetRecordings", wrapper.GetRecordings)
-	register.add(http.MethodDelete, "/recordings/{recordingId}", "DeleteRecording", wrapper.DeleteRecording)
-	register.add(http.MethodGet, "/recordings/{recordingId}/playlist.m3u8", "GetRecordingHLSPlaylist", wrapper.GetRecordingHLSPlaylist)
-	register.add(http.MethodHead, "/recordings/{recordingId}/playlist.m3u8", "GetRecordingHLSPlaylistHead", wrapper.GetRecordingHLSPlaylistHead)
-	register.add(http.MethodGet, "/recordings/{recordingId}/status", "GetRecordingsRecordingIdStatus", wrapper.GetRecordingsRecordingIdStatus)
-	register.add(http.MethodGet, "/recordings/{recordingId}/stream-info", "GetRecordingPlaybackInfo", wrapper.GetRecordingPlaybackInfo)
-	register.add(http.MethodPost, "/recordings/{recordingId}/stream-info", "PostRecordingPlaybackInfo", wrapper.PostRecordingPlaybackInfo)
-	register.add(http.MethodGet, "/recordings/{recordingId}/stream.mp4", "StreamRecordingDirect", wrapper.StreamRecordingDirect)
-	register.add(http.MethodHead, "/recordings/{recordingId}/stream.mp4", "ProbeRecordingMp4", wrapper.ProbeRecordingMp4)
-	register.add(http.MethodGet, "/recordings/{recordingId}/timeshift.m3u8", "GetRecordingHLSTimeshift", wrapper.GetRecordingHLSTimeshift)
-	register.add(http.MethodHead, "/recordings/{recordingId}/timeshift.m3u8", "GetRecordingHLSTimeshiftHead", wrapper.GetRecordingHLSTimeshiftHead)
-	register.add(http.MethodGet, "/recordings/{recordingId}/{segment}", "GetRecordingHLSCustomSegment", wrapper.GetRecordingHLSCustomSegment)
-	register.add(http.MethodHead, "/recordings/{recordingId}/{segment}", "GetRecordingHLSCustomSegmentHead", wrapper.GetRecordingHLSCustomSegmentHead)
+func registerRecordingRoutes(register routeRegistrar, handler recordingRoutes) {
+	register.add(http.MethodGet, "/recordings", "GetRecordings", handler.GetRecordings)
+	register.add(http.MethodDelete, "/recordings/{recordingId}", "DeleteRecording", handler.DeleteRecording)
+	register.add(http.MethodGet, "/recordings/{recordingId}/playlist.m3u8", "GetRecordingHLSPlaylist", handler.GetRecordingHLSPlaylist)
+	register.add(http.MethodHead, "/recordings/{recordingId}/playlist.m3u8", "GetRecordingHLSPlaylistHead", handler.GetRecordingHLSPlaylistHead)
+	register.add(http.MethodGet, "/recordings/{recordingId}/status", "GetRecordingsRecordingIdStatus", handler.GetRecordingsRecordingIdStatus)
+	register.add(http.MethodGet, "/recordings/{recordingId}/stream-info", "GetRecordingPlaybackInfo", handler.GetRecordingPlaybackInfo)
+	register.add(http.MethodPost, "/recordings/{recordingId}/stream-info", "PostRecordingPlaybackInfo", handler.PostRecordingPlaybackInfo)
+	register.add(http.MethodGet, "/recordings/{recordingId}/stream.mp4", "StreamRecordingDirect", handler.StreamRecordingDirect)
+	register.add(http.MethodHead, "/recordings/{recordingId}/stream.mp4", "ProbeRecordingMp4", handler.ProbeRecordingMp4)
+	register.add(http.MethodGet, "/recordings/{recordingId}/timeshift.m3u8", "GetRecordingHLSTimeshift", handler.GetRecordingHLSTimeshift)
+	register.add(http.MethodHead, "/recordings/{recordingId}/timeshift.m3u8", "GetRecordingHLSTimeshiftHead", handler.GetRecordingHLSTimeshiftHead)
+	register.add(http.MethodGet, "/recordings/{recordingId}/{segment}", "GetRecordingHLSCustomSegment", handler.GetRecordingHLSCustomSegment)
+	register.add(http.MethodHead, "/recordings/{recordingId}/{segment}", "GetRecordingHLSCustomSegmentHead", handler.GetRecordingHLSCustomSegmentHead)
 }

--- a/internal/control/http/v3/router_v3_routes_series_services.go
+++ b/internal/control/http/v3/router_v3_routes_series_services.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "net/http"
+
+func registerSeriesRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/series-rules", "GetSeriesRules", wrapper.GetSeriesRules)
+	register.add(http.MethodPost, "/series-rules", "CreateSeriesRule", wrapper.CreateSeriesRule)
+	register.add(http.MethodPost, "/series-rules/run", "RunAllSeriesRules", wrapper.RunAllSeriesRules)
+	register.add(http.MethodDelete, "/series-rules/{id}", "DeleteSeriesRule", wrapper.DeleteSeriesRule)
+	register.add(http.MethodPut, "/series-rules/{id}", "UpdateSeriesRule", wrapper.UpdateSeriesRule)
+	register.add(http.MethodPost, "/series-rules/{id}/run", "RunSeriesRule", wrapper.RunSeriesRule)
+}
+
+func registerServiceRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/services", "GetServices", wrapper.GetServices)
+	register.add(http.MethodGet, "/services/bouquets", "GetServicesBouquets", wrapper.GetServicesBouquets)
+	register.add(http.MethodPost, "/services/now-next", "PostServicesNowNext", wrapper.PostServicesNowNext)
+	register.add(http.MethodPost, "/services/{id}/toggle", "PostServicesIdToggle", wrapper.PostServicesIdToggle)
+}

--- a/internal/control/http/v3/router_v3_routes_series_services.go
+++ b/internal/control/http/v3/router_v3_routes_series_services.go
@@ -6,18 +6,18 @@ package v3
 
 import "net/http"
 
-func registerSeriesRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/series-rules", "GetSeriesRules", wrapper.GetSeriesRules)
-	register.add(http.MethodPost, "/series-rules", "CreateSeriesRule", wrapper.CreateSeriesRule)
-	register.add(http.MethodPost, "/series-rules/run", "RunAllSeriesRules", wrapper.RunAllSeriesRules)
-	register.add(http.MethodDelete, "/series-rules/{id}", "DeleteSeriesRule", wrapper.DeleteSeriesRule)
-	register.add(http.MethodPut, "/series-rules/{id}", "UpdateSeriesRule", wrapper.UpdateSeriesRule)
-	register.add(http.MethodPost, "/series-rules/{id}/run", "RunSeriesRule", wrapper.RunSeriesRule)
+func registerSeriesRoutes(register routeRegistrar, handler seriesRoutes) {
+	register.add(http.MethodGet, "/series-rules", "GetSeriesRules", handler.GetSeriesRules)
+	register.add(http.MethodPost, "/series-rules", "CreateSeriesRule", handler.CreateSeriesRule)
+	register.add(http.MethodPost, "/series-rules/run", "RunAllSeriesRules", handler.RunAllSeriesRules)
+	register.add(http.MethodDelete, "/series-rules/{id}", "DeleteSeriesRule", handler.DeleteSeriesRule)
+	register.add(http.MethodPut, "/series-rules/{id}", "UpdateSeriesRule", handler.UpdateSeriesRule)
+	register.add(http.MethodPost, "/series-rules/{id}/run", "RunSeriesRule", handler.RunSeriesRule)
 }
 
-func registerServiceRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/services", "GetServices", wrapper.GetServices)
-	register.add(http.MethodGet, "/services/bouquets", "GetServicesBouquets", wrapper.GetServicesBouquets)
-	register.add(http.MethodPost, "/services/now-next", "PostServicesNowNext", wrapper.PostServicesNowNext)
-	register.add(http.MethodPost, "/services/{id}/toggle", "PostServicesIdToggle", wrapper.PostServicesIdToggle)
+func registerServiceRoutes(register routeRegistrar, handler serviceRoutes) {
+	register.add(http.MethodGet, "/services", "GetServices", handler.GetServices)
+	register.add(http.MethodGet, "/services/bouquets", "GetServicesBouquets", handler.GetServicesBouquets)
+	register.add(http.MethodPost, "/services/now-next", "PostServicesNowNext", handler.PostServicesNowNext)
+	register.add(http.MethodPost, "/services/{id}/toggle", "PostServicesIdToggle", handler.PostServicesIdToggle)
 }

--- a/internal/control/http/v3/router_v3_routes_sessions_streams.go
+++ b/internal/control/http/v3/router_v3_routes_sessions_streams.go
@@ -6,15 +6,15 @@ package v3
 
 import "net/http"
 
-func registerSessionRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/sessions", "ListSessions", wrapper.ListSessions)
-	register.add(http.MethodGet, "/sessions/{sessionID}", "GetSessionState", wrapper.GetSessionState)
-	register.add(http.MethodGet, "/sessions/{sessionID}/hls/{filename}", "ServeHLS", wrapper.ServeHLS)
-	register.add(http.MethodHead, "/sessions/{sessionID}/hls/{filename}", "ServeHLSHead", wrapper.ServeHLSHead)
-	register.add(http.MethodPost, "/sessions/{sessionId}/feedback", "ReportPlaybackFeedback", wrapper.ReportPlaybackFeedback)
+func registerSessionRoutes(register routeRegistrar, handler sessionRoutes) {
+	register.add(http.MethodGet, "/sessions", "ListSessions", handler.ListSessions)
+	register.add(http.MethodGet, "/sessions/{sessionID}", "GetSessionState", handler.GetSessionState)
+	register.add(http.MethodGet, "/sessions/{sessionID}/hls/{filename}", "ServeHLS", handler.ServeHLS)
+	register.add(http.MethodHead, "/sessions/{sessionID}/hls/{filename}", "ServeHLSHead", handler.ServeHLSHead)
+	register.add(http.MethodPost, "/sessions/{sessionId}/feedback", "ReportPlaybackFeedback", handler.ReportPlaybackFeedback)
 }
 
-func registerStreamRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/streams", "GetStreams", wrapper.GetStreams)
-	register.add(http.MethodDelete, "/streams/{id}", "DeleteStreamsId", wrapper.DeleteStreamsId)
+func registerStreamRoutes(register routeRegistrar, handler streamRoutes) {
+	register.add(http.MethodGet, "/streams", "GetStreams", handler.GetStreams)
+	register.add(http.MethodDelete, "/streams/{id}", "DeleteStreamsId", handler.DeleteStreamsId)
 }

--- a/internal/control/http/v3/router_v3_routes_sessions_streams.go
+++ b/internal/control/http/v3/router_v3_routes_sessions_streams.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "net/http"
+
+func registerSessionRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/sessions", "ListSessions", wrapper.ListSessions)
+	register.add(http.MethodGet, "/sessions/{sessionID}", "GetSessionState", wrapper.GetSessionState)
+	register.add(http.MethodGet, "/sessions/{sessionID}/hls/{filename}", "ServeHLS", wrapper.ServeHLS)
+	register.add(http.MethodHead, "/sessions/{sessionID}/hls/{filename}", "ServeHLSHead", wrapper.ServeHLSHead)
+	register.add(http.MethodPost, "/sessions/{sessionId}/feedback", "ReportPlaybackFeedback", wrapper.ReportPlaybackFeedback)
+}
+
+func registerStreamRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/streams", "GetStreams", wrapper.GetStreams)
+	register.add(http.MethodDelete, "/streams/{id}", "DeleteStreamsId", wrapper.DeleteStreamsId)
+}

--- a/internal/control/http/v3/router_v3_routes_system_timers.go
+++ b/internal/control/http/v3/router_v3_routes_system_timers.go
@@ -6,22 +6,22 @@ package v3
 
 import "net/http"
 
-func registerSystemRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/system/config", "GetSystemConfig", wrapper.GetSystemConfig)
-	register.add(http.MethodPut, "/system/config", "PutSystemConfig", wrapper.PutSystemConfig)
-	register.add(http.MethodGet, "/system/health", "GetSystemHealth", wrapper.GetSystemHealth)
-	register.add(http.MethodGet, "/system/healthz", "GetSystemHealthz", wrapper.GetSystemHealthz)
-	register.add(http.MethodGet, "/system/info", "GetSystemInfo", wrapper.GetSystemInfo)
-	register.add(http.MethodPost, "/system/refresh", "PostSystemRefresh", wrapper.PostSystemRefresh)
-	register.add(http.MethodGet, "/system/scan", "GetSystemScanStatus", wrapper.GetSystemScanStatus)
-	register.add(http.MethodPost, "/system/scan", "TriggerSystemScan", wrapper.TriggerSystemScan)
+func registerSystemRoutes(register routeRegistrar, handler systemRoutes) {
+	register.add(http.MethodGet, "/system/config", "GetSystemConfig", handler.GetSystemConfig)
+	register.add(http.MethodPut, "/system/config", "PutSystemConfig", handler.PutSystemConfig)
+	register.add(http.MethodGet, "/system/health", "GetSystemHealth", handler.GetSystemHealth)
+	register.add(http.MethodGet, "/system/healthz", "GetSystemHealthz", handler.GetSystemHealthz)
+	register.add(http.MethodGet, "/system/info", "GetSystemInfo", handler.GetSystemInfo)
+	register.add(http.MethodPost, "/system/refresh", "PostSystemRefresh", handler.PostSystemRefresh)
+	register.add(http.MethodGet, "/system/scan", "GetSystemScanStatus", handler.GetSystemScanStatus)
+	register.add(http.MethodPost, "/system/scan", "TriggerSystemScan", handler.TriggerSystemScan)
 }
 
-func registerTimerRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
-	register.add(http.MethodGet, "/timers", "GetTimers", wrapper.GetTimers)
-	register.add(http.MethodPost, "/timers", "AddTimer", wrapper.AddTimer)
-	register.add(http.MethodPost, "/timers/conflicts:preview", "PreviewConflicts", wrapper.PreviewConflicts)
-	register.add(http.MethodDelete, "/timers/{timerId}", "DeleteTimer", wrapper.DeleteTimer)
-	register.add(http.MethodGet, "/timers/{timerId}", "GetTimer", wrapper.GetTimer)
-	register.add(http.MethodPatch, "/timers/{timerId}", "UpdateTimer", wrapper.UpdateTimer)
+func registerTimerRoutes(register routeRegistrar, handler timerRoutes) {
+	register.add(http.MethodGet, "/timers", "GetTimers", handler.GetTimers)
+	register.add(http.MethodPost, "/timers", "AddTimer", handler.AddTimer)
+	register.add(http.MethodPost, "/timers/conflicts:preview", "PreviewConflicts", handler.PreviewConflicts)
+	register.add(http.MethodDelete, "/timers/{timerId}", "DeleteTimer", handler.DeleteTimer)
+	register.add(http.MethodGet, "/timers/{timerId}", "GetTimer", handler.GetTimer)
+	register.add(http.MethodPatch, "/timers/{timerId}", "UpdateTimer", handler.UpdateTimer)
 }

--- a/internal/control/http/v3/router_v3_routes_system_timers.go
+++ b/internal/control/http/v3/router_v3_routes_system_timers.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "net/http"
+
+func registerSystemRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/system/config", "GetSystemConfig", wrapper.GetSystemConfig)
+	register.add(http.MethodPut, "/system/config", "PutSystemConfig", wrapper.PutSystemConfig)
+	register.add(http.MethodGet, "/system/health", "GetSystemHealth", wrapper.GetSystemHealth)
+	register.add(http.MethodGet, "/system/healthz", "GetSystemHealthz", wrapper.GetSystemHealthz)
+	register.add(http.MethodGet, "/system/info", "GetSystemInfo", wrapper.GetSystemInfo)
+	register.add(http.MethodPost, "/system/refresh", "PostSystemRefresh", wrapper.PostSystemRefresh)
+	register.add(http.MethodGet, "/system/scan", "GetSystemScanStatus", wrapper.GetSystemScanStatus)
+	register.add(http.MethodPost, "/system/scan", "TriggerSystemScan", wrapper.TriggerSystemScan)
+}
+
+func registerTimerRoutes(register routeRegistrar, wrapper ServerInterfaceWrapper) {
+	register.add(http.MethodGet, "/timers", "GetTimers", wrapper.GetTimers)
+	register.add(http.MethodPost, "/timers", "AddTimer", wrapper.AddTimer)
+	register.add(http.MethodPost, "/timers/conflicts:preview", "PreviewConflicts", wrapper.PreviewConflicts)
+	register.add(http.MethodDelete, "/timers/{timerId}", "DeleteTimer", wrapper.DeleteTimer)
+	register.add(http.MethodGet, "/timers/{timerId}", "GetTimer", wrapper.GetTimer)
+	register.add(http.MethodPatch, "/timers/{timerId}", "UpdateTimer", wrapper.UpdateTimer)
+}


### PR DESCRIPTION
## Summary
- split v3 route registration into bounded-context route groups
- keep operation IDs, methods, paths, and scope wiring unchanged
- retain `NewRouter(...)` as single composition entrypoint with delegated route modules

## Why
- first P2 structural slice for DG-02/IF-01
- reduce router blast radius and make per-domain routing changes isolated
- behavior-preserving refactor to keep CI/contract risk low

## Validation
- `go test ./internal/control/http/v3/...`
- `go test ./internal/api ./cmd/daemon`
