### PR TITLE
refactor(api): inject constructor deps from composition root

### DIFF
--- a/cmd/daemon/api_wiring.go
+++ b/cmd/daemon/api_wiring.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package main
+
+import (
+	"github.com/ManuGH/xg2g/internal/api"
+	"github.com/ManuGH/xg2g/internal/channels"
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/dvr"
+	"github.com/ManuGH/xg2g/internal/recordings"
+	"github.com/rs/zerolog"
+)
+
+func buildAPIConstructorDeps(cfg config.AppConfig, snap config.Snapshot, logger zerolog.Logger) api.ConstructorDeps {
+	channelManager := channels.NewManager(cfg.DataDir)
+	if err := channelManager.Load(); err != nil {
+		logger.Error().Err(err).Msg("failed to load channel states")
+	}
+
+	seriesManager := dvr.NewManager(cfg.DataDir)
+	if err := seriesManager.Load(); err != nil {
+		logger.Error().Err(err).Msg("failed to load series rules")
+	}
+
+	snapshot := snap
+	return api.ConstructorDeps{
+		ChannelManager:      channelManager,
+		SeriesManager:       seriesManager,
+		Snapshot:            &snapshot,
+		RecordingPathMapper: recordings.NewPathMapper(cfg.RecordingPathMappings),
+	}
+}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -393,7 +393,8 @@ func main() {
 	// Configure proxy (enabled by default in v2.0 for Zero Config experience)
 
 	// Create API handler
-	s, err := api.New(cfg, configMgr)
+	apiDeps := buildAPIConstructorDeps(cfg, snap, logger)
+	s, err := api.NewWithDeps(cfg, configMgr, apiDeps)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize API server")
 	}

--- a/internal/api/server_constructor_deps.go
+++ b/internal/api/server_constructor_deps.go
@@ -1,0 +1,72 @@
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package api
+
+import (
+	"github.com/ManuGH/xg2g/internal/channels"
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/dvr"
+	"github.com/ManuGH/xg2g/internal/log"
+	"github.com/ManuGH/xg2g/internal/recordings"
+)
+
+// ConstructorDeps allows composition roots to provide pre-built API dependencies.
+// Any nil field falls back to default API-local construction for compatibility.
+type ConstructorDeps struct {
+	ChannelManager      *channels.Manager
+	SeriesManager       *dvr.Manager
+	Snapshot            *config.Snapshot
+	RecordingPathMapper *recordings.PathMapper
+}
+
+type resolvedConstructorDeps struct {
+	channelManager *channels.Manager
+	seriesManager  *dvr.Manager
+	snapshot       config.Snapshot
+	pathMapper     *recordings.PathMapper
+}
+
+func resolveConstructorDeps(cfg config.AppConfig, deps ConstructorDeps) resolvedConstructorDeps {
+	channelManager := deps.ChannelManager
+	if channelManager == nil {
+		channelManager = channels.NewManager(cfg.DataDir)
+		if err := channelManager.Load(); err != nil {
+			log.L().Error().Err(err).Msg("failed to load channel states")
+		}
+	}
+
+	seriesManager := deps.SeriesManager
+	if seriesManager == nil {
+		seriesManager = dvr.NewManager(cfg.DataDir)
+		if err := seriesManager.Load(); err != nil {
+			log.L().Error().Err(err).Msg("failed to load series rules")
+		}
+	}
+
+	snapshot := defaultSnapshot(cfg)
+	if deps.Snapshot != nil {
+		snapshot = *deps.Snapshot
+	}
+
+	pathMapper := deps.RecordingPathMapper
+	if pathMapper == nil {
+		pathMapper = recordings.NewPathMapper(cfg.RecordingPathMappings)
+	}
+
+	return resolvedConstructorDeps{
+		channelManager: channelManager,
+		seriesManager:  seriesManager,
+		snapshot:       snapshot,
+		pathMapper:     pathMapper,
+	}
+}
+
+func defaultSnapshot(cfg config.AppConfig) config.Snapshot {
+	env, err := config.ReadOSRuntimeEnv()
+	if err != nil {
+		log.L().Warn().Err(err).Msg("failed to read runtime environment, using defaults")
+		env = config.DefaultEnv()
+	}
+	return config.BuildSnapshot(cfg, env)
+}

--- a/internal/api/server_new_with_deps_test.go
+++ b/internal/api/server_new_with_deps_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/channels"
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/dvr"
+	"github.com/ManuGH/xg2g/internal/recordings"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWithDeps_UsesInjectedConstructorDeps(t *testing.T) {
+	cfg := config.AppConfig{
+		DataDir: t.TempDir(),
+	}
+	cfgMgr := config.NewManager("")
+
+	channelManager := channels.NewManager(cfg.DataDir)
+	seriesManager := dvr.NewManager(cfg.DataDir)
+	pathMapper := recordings.NewPathMapper(cfg.RecordingPathMappings)
+	snap := config.BuildSnapshot(cfg, config.DefaultEnv())
+	snap.Runtime.PlaylistFilename = "deps-playlist.m3u"
+
+	s, err := NewWithDeps(cfg, cfgMgr, ConstructorDeps{
+		ChannelManager:      channelManager,
+		SeriesManager:       seriesManager,
+		Snapshot:            &snap,
+		RecordingPathMapper: pathMapper,
+	})
+	require.NoError(t, err)
+	require.Same(t, channelManager, s.channelManager)
+	require.Same(t, seriesManager, s.seriesManager)
+	require.Same(t, pathMapper, s.recordingPathMapper)
+	require.Equal(t, "deps-playlist.m3u", s.snap.Runtime.PlaylistFilename)
+}


### PR DESCRIPTION
## Summary
- add `api.NewWithDeps(...)` to accept pre-built constructor dependencies from the composition root
- keep `api.New(...)` as compatibility wrapper using default internal construction
- move daemon startup wiring to `buildAPIConstructorDeps(...)` in `cmd/daemon`
- add constructor-deps coverage test for `api.NewWithDeps`

## Why
- advances P2/DG-03: reduce API package constructor ownership over runtime wiring
- composition root (`cmd/daemon`) now controls snapshot + manager construction explicitly
- preserves existing behavior for tests and secondary callers through `api.New(...)`

## Validation
- `go test ./internal/api ./cmd/daemon`
- `go test ./internal/control/http/v3/... ./internal/api ./cmd/daemon`
- `go test ./...`
