### PR TITLE
refactor(daemon): introduce v3 orchestrator factory port (DG-04)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -573,6 +573,8 @@ func main() {
 		ScanManager:   v3Scan,
 		E2Client:      e2Client,
 		MediaPipeline: mediaPipeline,
+		// DG-04: daemon receives only a factory port; concrete worker wiring stays in composition root.
+		V3OrchestratorFactory: buildV3OrchestratorFactory(),
 	}
 
 	// Create daemon manager

--- a/cmd/daemon/v3_orchestrator_factory.go
+++ b/cmd/daemon/v3_orchestrator_factory.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/daemon"
+	worker "github.com/ManuGH/xg2g/internal/domain/session/manager"
+	"github.com/ManuGH/xg2g/internal/infra/bus"
+	"github.com/ManuGH/xg2g/internal/infra/platform"
+	platformnet "github.com/ManuGH/xg2g/internal/platform/net"
+	"github.com/google/uuid"
+)
+
+type v3OrchestratorFactory struct{}
+
+func buildV3OrchestratorFactory() daemon.V3OrchestratorFactory {
+	return v3OrchestratorFactory{}
+}
+
+func (v3OrchestratorFactory) Build(cfg config.AppConfig, inputs daemon.V3OrchestratorInputs) (daemon.V3Orchestrator, error) {
+	if inputs.Bus == nil {
+		return nil, fmt.Errorf("v3 orchestrator input bus is required")
+	}
+	if inputs.Store == nil {
+		return nil, fmt.Errorf("v3 orchestrator input store is required")
+	}
+	if inputs.Pipeline == nil {
+		return nil, fmt.Errorf("v3 orchestrator input pipeline is required")
+	}
+
+	host, _ := os.Hostname()
+	workerOwner := fmt.Sprintf("%s-%d-%s", host, os.Getpid(), uuid.New().String())
+
+	orch := &worker.Orchestrator{
+		Store:               inputs.Store,
+		Bus:                 bus.NewAdapter(inputs.Bus),
+		Platform:            platform.NewOSPlatform(),
+		LeaseTTL:            30 * time.Second,
+		HeartbeatEvery:      10 * time.Second,
+		Owner:               workerOwner,
+		TunerSlots:          cfg.Engine.TunerSlots,
+		HLSRoot:             cfg.HLS.Root,
+		PipelineStopTimeout: 5 * time.Second,
+		StartConcurrency:    10,
+		StopConcurrency:     10,
+		Sweeper: worker.SweeperConfig{
+			IdleTimeout:      cfg.Engine.IdleTimeout,
+			Interval:         1 * time.Minute,
+			SessionRetention: 24 * time.Hour,
+		},
+		OutboundPolicy: platformnet.OutboundPolicy{
+			Enabled: cfg.Network.Outbound.Enabled,
+			Allow: platformnet.OutboundAllowlist{
+				Hosts:   append([]string(nil), cfg.Network.Outbound.Allow.Hosts...),
+				CIDRs:   append([]string(nil), cfg.Network.Outbound.Allow.CIDRs...),
+				Ports:   append([]int(nil), cfg.Network.Outbound.Allow.Ports...),
+				Schemes: append([]string(nil), cfg.Network.Outbound.Allow.Schemes...),
+			},
+		},
+	}
+	orch.Pipeline = inputs.Pipeline
+	return orch, nil
+}

--- a/cmd/daemon/v3_orchestrator_factory_test.go
+++ b/cmd/daemon/v3_orchestrator_factory_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/daemon"
+	worker "github.com/ManuGH/xg2g/internal/domain/session/manager"
+	sessionstore "github.com/ManuGH/xg2g/internal/domain/session/store"
+	"github.com/ManuGH/xg2g/internal/infra/media/stub"
+	pipebus "github.com/ManuGH/xg2g/internal/pipeline/bus"
+)
+
+func TestV3OrchestratorFactoryBuild_RequiresInputs(t *testing.T) {
+	factory := buildV3OrchestratorFactory()
+
+	tests := []struct {
+		name   string
+		inputs daemon.V3OrchestratorInputs
+		want   string
+	}{
+		{
+			name:   "missing bus",
+			inputs: daemon.V3OrchestratorInputs{},
+			want:   "input bus is required",
+		},
+		{
+			name: "missing store",
+			inputs: daemon.V3OrchestratorInputs{
+				Bus: pipebus.NewMemoryBus(),
+			},
+			want: "input store is required",
+		},
+		{
+			name: "missing pipeline",
+			inputs: daemon.V3OrchestratorInputs{
+				Bus:   pipebus.NewMemoryBus(),
+				Store: sessionstore.NewMemoryStore(),
+			},
+			want: "input pipeline is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := factory.Build(config.AppConfig{}, tc.inputs)
+			if err == nil {
+				t.Fatal("expected Build() error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Build() error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestV3OrchestratorFactoryBuild_ConfiguresWorker(t *testing.T) {
+	factory := buildV3OrchestratorFactory()
+	cfg := config.AppConfig{
+		Engine: config.EngineConfig{
+			IdleTimeout: time.Minute,
+			TunerSlots:  []int{1, 2, 3},
+		},
+		HLS: config.HLSConfig{
+			Root: "/tmp/hls",
+		},
+		Network: config.NetworkConfig{
+			Outbound: config.OutboundConfig{
+				Enabled: true,
+				Allow: config.OutboundAllowlist{
+					Hosts:   []string{"receiver.local"},
+					CIDRs:   []string{"192.168.1.0/24"},
+					Ports:   []int{80, 443},
+					Schemes: []string{"http", "https"},
+				},
+			},
+		},
+	}
+	inputs := daemon.V3OrchestratorInputs{
+		Bus:      pipebus.NewMemoryBus(),
+		Store:    sessionstore.NewMemoryStore(),
+		Pipeline: stub.NewAdapter(),
+	}
+
+	orchPort, err := factory.Build(cfg, inputs)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	orch, ok := orchPort.(*worker.Orchestrator)
+	if !ok {
+		t.Fatalf("Build() returned %T, want *worker.Orchestrator", orchPort)
+	}
+
+	if orch.Store != inputs.Store {
+		t.Fatal("expected orchestrator store to match injected input")
+	}
+	if orch.Pipeline != inputs.Pipeline {
+		t.Fatal("expected orchestrator pipeline to match injected input")
+	}
+	if orch.HLSRoot != cfg.HLS.Root {
+		t.Fatalf("HLSRoot = %q, want %q", orch.HLSRoot, cfg.HLS.Root)
+	}
+	if orch.Sweeper.IdleTimeout != cfg.Engine.IdleTimeout {
+		t.Fatalf("Sweeper.IdleTimeout = %v, want %v", orch.Sweeper.IdleTimeout, cfg.Engine.IdleTimeout)
+	}
+	if orch.Owner == "" {
+		t.Fatal("Owner should be generated")
+	}
+
+	cfg.Network.Outbound.Allow.Hosts[0] = "mutated.local"
+	if orch.OutboundPolicy.Allow.Hosts[0] != "receiver.local" {
+		t.Fatalf("outbound host list was not copied defensively, got %v", orch.OutboundPolicy.Allow.Hosts)
+	}
+}

--- a/internal/daemon/errors.go
+++ b/internal/daemon/errors.go
@@ -26,4 +26,10 @@ var (
 
 	// ErrMissingMediaPipeline is returned when v3 is enabled without a pipeline.
 	ErrMissingMediaPipeline = errors.New("media pipeline is required when engine is enabled")
+
+	// ErrMissingV3OrchestratorFactory is returned when v3 is enabled without a factory.
+	ErrMissingV3OrchestratorFactory = errors.New("v3 orchestrator factory is required when engine is enabled")
+
+	// ErrMissingV3Orchestrator is returned when factory build returned nil.
+	ErrMissingV3Orchestrator = errors.New("v3 orchestrator factory returned nil orchestrator")
 )

--- a/internal/daemon/manager_v3_worker_test.go
+++ b/internal/daemon/manager_v3_worker_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/config"
+	sessionstore "github.com/ManuGH/xg2g/internal/domain/session/store"
+	"github.com/ManuGH/xg2g/internal/infra/media/stub"
+	pipebus "github.com/ManuGH/xg2g/internal/pipeline/bus"
+)
+
+type testV3Orchestrator struct{}
+
+func (testV3Orchestrator) Run(context.Context) error { return nil }
+
+type captureV3Factory struct {
+	called bool
+	cfg    config.AppConfig
+	inputs V3OrchestratorInputs
+	orch   V3Orchestrator
+	err    error
+}
+
+func (f *captureV3Factory) Build(cfg config.AppConfig, inputs V3OrchestratorInputs) (V3Orchestrator, error) {
+	f.called = true
+	f.cfg = cfg
+	f.inputs = inputs
+	return f.orch, f.err
+}
+
+func TestBuildV3Orchestrator_MissingFactory(t *testing.T) {
+	m := &manager{}
+	_, err := m.buildV3Orchestrator(config.AppConfig{}, v3WorkerRuntimeDeps{})
+	if !errors.Is(err, ErrMissingV3OrchestratorFactory) {
+		t.Fatalf("buildV3Orchestrator() error = %v, want %v", err, ErrMissingV3OrchestratorFactory)
+	}
+}
+
+func TestBuildV3Orchestrator_DelegatesToFactory(t *testing.T) {
+	b := pipebus.NewMemoryBus()
+	s := sessionstore.NewMemoryStore()
+	p := stub.NewAdapter()
+	factory := &captureV3Factory{orch: testV3Orchestrator{}}
+
+	m := &manager{
+		deps: Deps{
+			V3OrchestratorFactory: factory,
+		},
+	}
+	cfg := config.AppConfig{HLS: config.HLSConfig{Root: "/tmp/hls"}}
+	deps := v3WorkerRuntimeDeps{
+		bus:      b,
+		store:    s,
+		pipeline: p,
+	}
+
+	orch, err := m.buildV3Orchestrator(cfg, deps)
+	if err != nil {
+		t.Fatalf("buildV3Orchestrator() error = %v", err)
+	}
+	if orch == nil {
+		t.Fatal("buildV3Orchestrator() returned nil orchestrator")
+	}
+	if !factory.called {
+		t.Fatal("expected factory to be called")
+	}
+	if factory.inputs.Bus != b {
+		t.Fatal("expected bus input to be forwarded to factory")
+	}
+	if factory.inputs.Store != s {
+		t.Fatal("expected store input to be forwarded to factory")
+	}
+	if factory.inputs.Pipeline != p {
+		t.Fatal("expected pipeline input to be forwarded to factory")
+	}
+	if factory.cfg.HLS.Root != cfg.HLS.Root {
+		t.Fatalf("expected config to be forwarded, got HLS root %q", factory.cfg.HLS.Root)
+	}
+}
+
+func TestBuildV3Orchestrator_FactoryMustReturnOrchestrator(t *testing.T) {
+	factory := &captureV3Factory{}
+	m := &manager{
+		deps: Deps{
+			V3OrchestratorFactory: factory,
+		},
+	}
+
+	_, err := m.buildV3Orchestrator(config.AppConfig{}, v3WorkerRuntimeDeps{})
+	if !errors.Is(err, ErrMissingV3Orchestrator) {
+		t.Fatalf("buildV3Orchestrator() error = %v, want %v", err, ErrMissingV3Orchestrator)
+	}
+}


### PR DESCRIPTION
## Summary
- add daemon-side `V3OrchestratorFactory` / `V3Orchestrator` ports and fail-fast dependency validation
- move concrete v3 worker/orchestrator construction out of `internal/daemon` into `cmd/daemon` composition root
- make manager build orchestrator via injected factory instead of concrete `worker.Orchestrator`
- add unit tests for daemon factory delegation, constructor fail-fast, and composition-root factory behavior
- update bootstrap test harness wiring to satisfy engine-enabled dependencies

## Validation
- `go test ./internal/app/bootstrap ./internal/daemon ./cmd/daemon`
- `go test ./...`
