### PR TITLE
feat(hdhr,openwebif,read): sync baseline to b6c40d8

### DIFF
--- a/internal/control/read/serviceref.go
+++ b/internal/control/read/serviceref.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 )
 
+// CanonicalServiceRef normalizes service references to one stable form.
+func CanonicalServiceRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	return strings.TrimRight(ref, ":")
+}
+
 // ExtractServiceRef extracts a stable service reference from a stream URL.
 // Contract:
 // 1. If parseable URL:
@@ -48,16 +54,11 @@ func ExtractServiceRef(rawURL string, fallback string) string {
 		}
 	}
 
-	// Sanitize candidate (trim spaces just in case)
-	candidate = strings.TrimSpace(candidate)
-
 	// 3. If empty, use fallback
-	if candidate == "" {
+	if CanonicalServiceRef(candidate) == "" {
 		candidate = fallback
 	}
 
-	// 4. Always trim trailing ":"
-	// Repeatedly? contract just says "trim trailing :". Usually one suffix.
-	// But Enigma2 refs often look like "1:0:1...:"
-	return strings.TrimSuffix(candidate, ":")
+	// 4. Canonicalize to prevent ref drift across consumers.
+	return CanonicalServiceRef(candidate)
 }

--- a/internal/control/read/serviceref_test.go
+++ b/internal/control/read/serviceref_test.go
@@ -72,3 +72,38 @@ func TestExtractServiceRef(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalServiceRef(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already canonical",
+			in:   "1:0:1:ABCD:1:1:0:0:0:0",
+			want: "1:0:1:ABCD:1:1:0:0:0:0",
+		},
+		{
+			name: "single trailing colon",
+			in:   "1:0:1:ABCD:1:1:0:0:0:0:",
+			want: "1:0:1:ABCD:1:1:0:0:0:0",
+		},
+		{
+			name: "double trailing colon",
+			in:   "1:0:1:ABCD:1:1:0:0:0:0::",
+			want: "1:0:1:ABCD:1:1:0:0:0:0",
+		},
+		{
+			name: "whitespace trimmed",
+			in:   "  1:0:1:ABCD:1:1:0:0:0:0:  ",
+			want: "1:0:1:ABCD:1:1:0:0:0:0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, CanonicalServiceRef(tt.in))
+		})
+	}
+}

--- a/internal/control/read/services.go
+++ b/internal/control/read/services.go
@@ -2,7 +2,6 @@ package read
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -286,7 +285,7 @@ func GetServices(cfg config.AppConfig, snap config.Snapshot, source ServicesSour
 		number := ch.Number
 
 		// Extract serviceRef from URL for streaming
-		serviceRef := extractServiceRef(ch.URL, id)
+		serviceRef := ExtractServiceRef(ch.URL, id)
 
 		// Rewrite Logo to use local proxy (avoids mixed content & external reachability issues)
 		if serviceRef != "" {
@@ -310,33 +309,4 @@ func GetServices(cfg config.AppConfig, snap config.Snapshot, source ServicesSour
 	// If we found 0 services (and read was successful), legacy behavior: usually null (if initialized as nil)
 	// We return default EmptyEncodingNull.
 	return ServicesResult{Items: services}, nil
-}
-
-func extractServiceRef(rawURL string, id string) string {
-	serviceRef := ""
-	if rawURL != "" {
-		if u, err := url.Parse(rawURL); err == nil {
-			// Check query params first (e.g. stream.m3u?ref=...)
-			if ref := u.Query().Get("ref"); ref != "" {
-				serviceRef = ref
-			} else {
-				// Fallback to path logic
-				parts := strings.Split(u.Path, "/")
-				if len(parts) > 0 {
-					serviceRef = parts[len(parts)-1]
-				}
-			}
-		} else {
-			// Fallback for non-parseable URLs
-			parts := strings.Split(rawURL, "/")
-			if len(parts) > 0 {
-				serviceRef = parts[len(parts)-1]
-			}
-		}
-	}
-	// Fallback to TvgID if serviceRef not found
-	if serviceRef == "" {
-		serviceRef = id
-	}
-	return serviceRef
 }

--- a/internal/control/read/streams.go
+++ b/internal/control/read/streams.go
@@ -89,6 +89,8 @@ func GetStreams(ctx context.Context, cfg config.AppConfig, snap config.Snapshot,
 			continue
 		}
 
+		serviceRef := CanonicalServiceRef(r.ServiceRef)
+
 		// Map State: Domain → Contract
 		// Use the deterministic truth engine (PR-P3-2)
 		lifecycleState := model.DeriveLifecycleState(r, time.Now())
@@ -105,9 +107,9 @@ func GetStreams(ctx context.Context, cfg config.AppConfig, snap config.Snapshot,
 		}
 
 		// Resolve Name
-		name := nameMap[r.ServiceRef]
+		name := nameMap[serviceRef]
 		if name == "" {
-			name = r.ServiceRef // Fallback
+			name = serviceRef // Fallback
 		}
 
 		// Resolve IP (Gated)
@@ -127,7 +129,7 @@ func GetStreams(ctx context.Context, cfg config.AppConfig, snap config.Snapshot,
 		sessions = append(sessions, StreamSession{
 			ID:          r.SessionID,
 			ChannelName: name,
-			ServiceRef:  r.ServiceRef,
+			ServiceRef:  serviceRef,
 			ClientIP:    ip,
 			StartedAt:   startedAt,
 			State:       contractState,

--- a/internal/hdhr/hdhr_test.go
+++ b/internal/hdhr/hdhr_test.go
@@ -11,12 +11,15 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -208,6 +211,90 @@ func TestHandleLineup(t *testing.T) {
 	assert.Empty(t, response) // Currently returns empty array
 }
 
+func TestLineup_UsesCache_InvalidatesOnMtime(t *testing.T) {
+	logger := zerolog.New(os.Stdout)
+	tmpDir := t.TempDir()
+	playlistPath := filepath.Join(tmpDir, "playlist.m3u")
+
+	writeTestPlaylist(t, playlistPath, []string{
+		`#EXTINF:-1 tvg-id="id1",Channel 1`,
+		`http://127.0.0.1/stream/1`,
+	})
+
+	server := NewServer(Config{
+		Logger:  logger,
+		DataDir: tmpDir,
+	}, nil)
+
+	first := httptest.NewRecorder()
+	server.HandleLineup(first, httptest.NewRequest(http.MethodGet, "/lineup.json", nil))
+	require.Equal(t, http.StatusOK, first.Code)
+	require.EqualValues(t, 1, server.lineupBuilds.Load())
+	require.Len(t, decodeLineup(t, first.Body.Bytes()), 1)
+
+	second := httptest.NewRecorder()
+	server.HandleLineup(second, httptest.NewRequest(http.MethodGet, "/lineup.json", nil))
+	require.Equal(t, http.StatusOK, second.Code)
+	require.EqualValues(t, 1, server.lineupBuilds.Load(), "second request should use cache")
+	require.Len(t, decodeLineup(t, second.Body.Bytes()), 1)
+
+	writeTestPlaylist(t, playlistPath, []string{
+		`#EXTINF:-1 tvg-id="id1",Channel 1`,
+		`http://127.0.0.1/stream/1`,
+		`#EXTINF:-1 tvg-id="id2",Channel 2`,
+		`http://127.0.0.1/stream/2`,
+	})
+	fi, err := os.Stat(playlistPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Chtimes(playlistPath, fi.ModTime().Add(2*time.Second), fi.ModTime().Add(2*time.Second)))
+
+	third := httptest.NewRecorder()
+	server.HandleLineup(third, httptest.NewRequest(http.MethodGet, "/lineup.json", nil))
+	require.Equal(t, http.StatusOK, third.Code)
+	require.EqualValues(t, 2, server.lineupBuilds.Load(), "mtime/size change should invalidate cache")
+	require.Len(t, decodeLineup(t, third.Body.Bytes()), 2)
+}
+
+func TestLineup_CacheSingleflightUnderConcurrency(t *testing.T) {
+	logger := zerolog.New(os.Stdout)
+	tmpDir := t.TempDir()
+	playlistPath := filepath.Join(tmpDir, "playlist.m3u")
+
+	writeTestPlaylist(t, playlistPath, []string{
+		`#EXTINF:-1 tvg-id="id1",Channel 1`,
+		`http://127.0.0.1/stream/1`,
+	})
+
+	server := NewServer(Config{
+		Logger:  logger,
+		DataDir: tmpDir,
+	}, nil)
+
+	const n = 50
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	var failures atomic.Int64
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			w := httptest.NewRecorder()
+			server.HandleLineup(w, httptest.NewRequest(http.MethodGet, "/lineup.json", nil))
+			if w.Code != http.StatusOK {
+				failures.Add(1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.EqualValues(t, 0, failures.Load())
+	require.EqualValues(t, 1, server.lineupBuilds.Load(), "singleflight should collapse concurrent rebuilds")
+}
+
 func TestHandleLineupPost(t *testing.T) {
 	logger := zerolog.New(os.Stdout)
 	server := NewServer(Config{Logger: logger}, nil)
@@ -340,6 +427,19 @@ func TestServerGetLocalIP(t *testing.T) {
 		parts := strings.Split(ip, ".")
 		assert.Len(t, parts, 4, "IP should have 4 parts")
 	}
+}
+
+func writeTestPlaylist(t *testing.T, path string, lines []string) {
+	t.Helper()
+	content := "#EXTM3U\n" + strings.Join(lines, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+}
+
+func decodeLineup(t *testing.T, payload []byte) []LineupEntry {
+	t.Helper()
+	var out []LineupEntry
+	require.NoError(t, json.Unmarshal(payload, &out), fmt.Sprintf("payload=%s", string(payload)))
+	return out
 }
 
 // TestSSDPIntegration tests SSDP functionality with timeout

--- a/internal/openwebif/client.go
+++ b/internal/openwebif/client.go
@@ -741,13 +741,6 @@ func (c *Client) servicesCapabilitySet(preferFlat bool) {
 	c.servicesCapMu.Unlock()
 }
 
-func (c *Client) cacheServicesResult(ctx context.Context, cacheKey string, result [][2]string) {
-	if c.cache != nil {
-		c.cache.Set(cacheKey, result, c.cacheTTL)
-		c.loggerFor(ctx).Debug().Str("event", "cache.set").Str("key", cacheKey).Dur("ttl", c.cacheTTL).Msg("cached result")
-	}
-}
-
 // GetTimers retrieves the list of timers from the receiver.
 func (c *Client) GetTimers(ctx context.Context) ([]Timer, error) {
 	// Timers change frequently, so we don't cache them aggressively

--- a/internal/openwebif/client.go
+++ b/internal/openwebif/client.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unicode/utf8"
@@ -40,6 +41,8 @@ const (
 	// maxErrBody caps the amount of response body we read for error reporting (non-200).
 	// We want enough context for stack traces but not unbounded memory usage.
 	maxErrBody = 8 * 1024
+
+	defaultServicesCapTTL = time.Hour
 )
 
 // Client is an OpenWebIF HTTP client for communicating with Enigma2 receivers.
@@ -66,6 +69,10 @@ type Client struct {
 	cache    Cacher
 	cacheTTL time.Duration
 
+	servicesCapMu  sync.RWMutex
+	servicesCaps   map[string]servicesCapability
+	servicesCapTTL time.Duration
+
 	// Rate limiting for receiver protection (v1.7.0+)
 	// Protects the Enigma2 receiver from being overwhelmed by requests
 	receiverLimiter *rate.Limiter
@@ -81,6 +88,11 @@ type Cacher interface {
 	Set(key string, value any, ttl time.Duration)
 	Delete(key string)
 	Clear()
+}
+
+type servicesCapability struct {
+	PreferFlat bool
+	ExpiresAt  time.Time
 }
 
 // Options configures the OpenWebIF client behavior.
@@ -334,6 +346,8 @@ func NewWithPort(base string, streamPort int, opts Options) *Client {
 		streamBaseURL:   strings.TrimSpace(opts.StreamBaseURL),
 		cache:           opts.Cache, // Optional cache (nil = no caching)
 		cacheTTL:        cacheTTL,
+		servicesCaps:    make(map[string]servicesCapability),
+		servicesCapTTL:  defaultServicesCapTTL,
 		receiverLimiter: rate.NewLimiter(receiverRPS, receiverBurst),
 		cb:              resilience.NewCircuitBreaker("openwebif", 5, 10, 60*time.Second, 30*time.Second),
 	}
@@ -461,6 +475,8 @@ type svcPayloadFlat struct {
 	} `json:"services"`
 }
 
+var errServicesSchemaMismatch = errors.New("openwebif: services schema mismatch")
+
 // EPGEvent represents a single programme entry from OpenWebIF EPG API
 type EPGEvent struct {
 	ID                  int    `json:"id"`
@@ -524,22 +540,44 @@ func (c *Client) Services(ctx context.Context, bouquetRef string) ([][2]string, 
 	decorate := func(zc *zerolog.Context) {
 		zc.Str("bouquet_ref", maskedRef)
 	}
-	try := func(urlPath, operation string) ([][2]string, error) {
-		body, err := c.get(ctx, urlPath, operation, decorate)
+	type endpointSpec struct {
+		path       string
+		operation  string
+		preferFlat bool
+	}
+	try := func(ep endpointSpec) ([][2]string, error) {
+		body, err := c.get(ctx, ep.path, ep.operation, decorate)
 		if err != nil {
 			return nil, err
 		}
 
-		// For flat endpoint, decode directly into svcPayloadFlat to preserve subservices
-		if operation == "services.flat" {
+		// Fast schema check: ensure "services" key exists and is not null.
+		var shape struct {
+			Services json.RawMessage `json:"services"`
+		}
+		if err := json.Unmarshal(body, &shape); err != nil {
+			c.loggerFor(ctx).Error().Err(err).
+				Str("event", "openwebif.decode").
+				Str("operation", ep.operation).
+				Str("bouquet_ref", maskedRef).
+				Msg("failed to decode services response shape")
+			return nil, fmt.Errorf("%w: %v", errServicesSchemaMismatch, err)
+		}
+		trimmedServices := strings.TrimSpace(string(shape.Services))
+		if trimmedServices == "" || trimmedServices == "null" {
+			return nil, fmt.Errorf("%w: missing services field", errServicesSchemaMismatch)
+		}
+
+		// Flat endpoint: decode preserving subservices.
+		if ep.preferFlat {
 			var flat svcPayloadFlat
 			if err := json.Unmarshal(body, &flat); err != nil {
 				c.loggerFor(ctx).Error().Err(err).
 					Str("event", "openwebif.decode").
-					Str("operation", operation).
+					Str("operation", ep.operation).
 					Str("bouquet_ref", maskedRef).
 					Msg("failed to decode services response (flat)")
-				return nil, err
+				return nil, fmt.Errorf("%w: %v", errServicesSchemaMismatch, err)
 			}
 			out := make([][2]string, 0, len(flat.Services)*4)
 			for _, s := range flat.Services {
@@ -569,10 +607,10 @@ func (c *Client) Services(ctx context.Context, bouquetRef string) ([][2]string, 
 		if err := json.Unmarshal(body, &p); err != nil {
 			c.loggerFor(ctx).Error().Err(err).
 				Str("event", "openwebif.decode").
-				Str("operation", operation).
+				Str("operation", ep.operation).
 				Str("bouquet_ref", maskedRef).
 				Msg("failed to decode services response")
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", errServicesSchemaMismatch, err)
 		}
 		out := make([][2]string, 0, len(p.Services))
 		for _, s := range p.Services {
@@ -585,24 +623,129 @@ func (c *Client) Services(ctx context.Context, bouquetRef string) ([][2]string, 
 		return out, nil
 	}
 
-	// Try bouquet-specific endpoint (more reliable than getallservices)
-	if out, err := try("/api/getservices?sRef="+url.QueryEscape(bouquetRef), "services.nested"); err == nil && len(out) > 0 {
-		// Cache the result
-		if c.cache != nil {
-			c.cache.Set(cacheKey, out, c.cacheTTL)
-			c.loggerFor(ctx).Debug().Str("event", "cache.set").Str("key", cacheKey).Dur("ttl", c.cacheTTL).Msg("cached result")
-		}
-		c.loggerFor(ctx).Info().Str("event", "openwebif.services").Str("bouquet_ref", maskedRef).Int("count", len(out)).Msg("fetched services via nested endpoint")
-		return out, nil
+	endpoints := []endpointSpec{
+		{
+			path:       "/api/getservices?sRef=" + url.QueryEscape(bouquetRef),
+			operation:  "services.nested",
+			preferFlat: false,
+		},
+		{
+			path:       "/api/getallservices?sRef=" + url.QueryEscape(bouquetRef),
+			operation:  "services.flat",
+			preferFlat: true,
+		},
 	}
-	c.loggerFor(ctx).Warn().Str("event", "openwebif.services").Str("bouquet_ref", maskedRef).Msg("no services found for bouquet")
+	if preferFlat, ok := c.servicesCapabilityGet(); ok && preferFlat {
+		endpoints[0], endpoints[1] = endpoints[1], endpoints[0]
+	}
 
-	// Cache empty result to avoid repeated failed lookups
-	empty := [][2]string{}
-	if c.cache != nil {
-		c.cache.Set(cacheKey, empty, c.cacheTTL)
+	var empty [][2]string
+	var successfulEndpoint string
+
+	for i, ep := range endpoints {
+		out, err := try(ep)
+		if err != nil {
+			if i == 0 && shouldTryServicesFallback(err) {
+				c.loggerFor(ctx).Warn().
+					Err(err).
+					Str("event", "openwebif.services").
+					Str("bouquet_ref", maskedRef).
+					Str("from", ep.operation).
+					Str("to", endpoints[1].operation).
+					Msg("services fetch incompatible, trying fallback endpoint")
+				continue
+			}
+			return nil, err
+		}
+
+		successfulEndpoint = ep.operation
+		c.servicesCapabilitySet(ep.preferFlat)
+		if len(out) > 0 {
+			if c.cache != nil {
+				c.cache.Set(cacheKey, out, c.cacheTTL)
+				c.loggerFor(ctx).Debug().Str("event", "cache.set").Str("key", cacheKey).Dur("ttl", c.cacheTTL).Msg("cached result")
+			}
+			c.loggerFor(ctx).Info().
+				Str("event", "openwebif.services").
+				Str("bouquet_ref", maskedRef).
+				Str("operation", ep.operation).
+				Int("count", len(out)).
+				Msg("fetched services")
+			return out, nil
+		}
+
+		empty = out
+		if i == 0 {
+			continue
+		}
 	}
-	return empty, nil
+
+	// No services found but at least one endpoint returned a compatible payload.
+	if successfulEndpoint != "" {
+		if empty == nil {
+			empty = [][2]string{}
+		}
+		if c.cache != nil {
+			c.cache.Set(cacheKey, empty, c.cacheTTL)
+		}
+		c.loggerFor(ctx).Warn().
+			Str("event", "openwebif.services").
+			Str("bouquet_ref", maskedRef).
+			Str("operation", successfulEndpoint).
+			Msg("no services found for bouquet")
+		return empty, nil
+	}
+
+	return nil, fmt.Errorf("%w: no compatible services endpoint", errServicesSchemaMismatch)
+}
+
+func shouldTryServicesFallback(err error) bool {
+	return errors.Is(err, errServicesSchemaMismatch)
+}
+
+func (c *Client) servicesCapabilityKey() string {
+	return c.host
+}
+
+func (c *Client) servicesCapabilityGet() (bool, bool) {
+	key := c.servicesCapabilityKey()
+	now := time.Now()
+
+	c.servicesCapMu.RLock()
+	cap, ok := c.servicesCaps[key]
+	c.servicesCapMu.RUnlock()
+	if !ok {
+		return false, false
+	}
+	if now.After(cap.ExpiresAt) {
+		c.servicesCapMu.Lock()
+		delete(c.servicesCaps, key)
+		c.servicesCapMu.Unlock()
+		return false, false
+	}
+	return cap.PreferFlat, true
+}
+
+func (c *Client) servicesCapabilitySet(preferFlat bool) {
+	if c.servicesCapTTL <= 0 {
+		return
+	}
+	key := c.servicesCapabilityKey()
+	exp := time.Now().Add(c.servicesCapTTL)
+
+	c.servicesCapMu.Lock()
+	c.servicesCaps[key] = servicesCapability{
+		PreferFlat: preferFlat,
+		ExpiresAt:  exp,
+	}
+	c.servicesCapMu.Unlock()
+}
+
+func (c *Client) cacheServicesResult(ctx context.Context, cacheKey string, result [][2]string) {
+	if c.cache != nil {
+		c.cache.Set(cacheKey, result, c.cacheTTL)
+		c.loggerFor(ctx).Debug().Str("event", "cache.set").Str("key", cacheKey).Dur("ttl", c.cacheTTL).Msg("cached result")
+	}
 }
 
 // GetTimers retrieves the list of timers from the receiver.


### PR DESCRIPTION
## Summary
This PR brings `main` to the baseline commit used by the architecture-fix stack.

Included commits:
- hdhr: render device.xml via encoding/xml (escape-safe)
- hdhr: cache lineup.json by mtime/size with singleflight
- openwebif: services endpoint cascade + per-host capability cache
- read: canonicalize ServiceRef across lookup and streams

## Why
The architecture PR stack (#218 -> #219 -> #220) currently builds on commit `b6c40d8`.
Merging this baseline first keeps the follow-up PRs clean and single-purpose.

## Follow-up merge order
1. this PR
2. #218
3. #219
4. #220
