### PR TITLE
fix(errors): preserve chains and use typed not-found errors

### DIFF
--- a/internal/api/server_lifecycle.go
+++ b/internal/api/server_lifecycle.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -56,7 +57,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("server shutdown errors: %v", errs)
+		return fmt.Errorf("server shutdown errors: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/internal/control/http/v3/dvr.go
+++ b/internal/control/http/v3/dvr.go
@@ -240,7 +240,7 @@ func (s *Server) RunSeriesRule(w http.ResponseWriter, r *http.Request, id string
 
 	reports, err := s.seriesEngine.RunOnce(r.Context(), trigger, id)
 	if err != nil {
-		if err.Error() == "rule not found: "+id {
+		if errors.Is(err, dvr.ErrRuleNotFound) {
 			writeProblem(w, r, http.StatusNotFound, "dvr/not_found", "Rule Not Found", "NOT_FOUND", "The specified rule does not exist", nil)
 			return
 		}

--- a/internal/control/http/v3/library.go
+++ b/internal/control/http/v3/library.go
@@ -75,7 +75,7 @@ func (s *Server) GetLibraryRootItems(w http.ResponseWriter, r *http.Request, roo
 		}
 
 		// Check for root not found
-		if err.Error() == "root not found: "+rootId {
+		if errors.Is(err, library.ErrRootNotFound) {
 			RespondError(w, r, http.StatusNotFound, ErrLibraryRootNotFound, nil)
 			return
 		}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -132,7 +132,7 @@ func (m *manager) Start(ctx context.Context) error {
 		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if shutdownErr := m.Shutdown(shutdownCtx); shutdownErr != nil {
-			return fmt.Errorf("%w (shutdown: %v)", err, shutdownErr)
+			return fmt.Errorf("server error and shutdown failure: %w", errors.Join(err, shutdownErr))
 		}
 		return err
 	case <-ctx.Done():
@@ -292,7 +292,7 @@ func (m *manager) Shutdown(ctx context.Context) error {
 		m.logger.Error().
 			Int("error_count", len(errs)).
 			Msg("Shutdown completed with errors")
-		return fmt.Errorf("shutdown errors: %v", errs)
+		return fmt.Errorf("shutdown errors: %w", errors.Join(errs...))
 	}
 
 	m.logger.Info().Msg("Daemon manager stopped cleanly")

--- a/internal/dvr/engine.go
+++ b/internal/dvr/engine.go
@@ -67,7 +67,7 @@ func (e *SeriesEngine) RunOnce(ctx context.Context, trigger string, ruleID strin
 			if r, ok := e.ruleManager.GetRule(ruleID); ok {
 				rules = []SeriesRule{r}
 			} else {
-				return nil, fmt.Errorf("rule not found: %s", ruleID)
+				return nil, fmt.Errorf("%w: %s", ErrRuleNotFound, ruleID)
 			}
 		} else {
 			rules = e.ruleManager.GetRules()
@@ -268,7 +268,6 @@ func (e *SeriesEngine) processRule(ctx context.Context, client OWIClient, rule S
 						inWindow = true
 					}
 				}
-
 
 				if !inWindow {
 					continue

--- a/internal/dvr/engine_test.go
+++ b/internal/dvr/engine_test.go
@@ -6,6 +6,7 @@ package dvr
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -157,4 +158,17 @@ func TestSeriesEngine_RunOnce(t *testing.T) {
 	assert.Equal(t, "skipped", reports2[0].Decisions[0].Action)
 
 	mockClient2.AssertExpectations(t)
+}
+
+func TestSeriesEngine_RunOnce_RuleNotFound(t *testing.T) {
+	rm := NewManager(t.TempDir())
+	engine := NewSeriesEngine(config.AppConfig{}, rm, func() OWIClient { return new(MockClient) })
+
+	_, err := engine.RunOnce(context.Background(), "manual", "missing-rule-id")
+	if err == nil {
+		t.Fatal("expected error for missing rule")
+	}
+	if !errors.Is(err, ErrRuleNotFound) {
+		t.Fatalf("expected ErrRuleNotFound, got: %v", err)
+	}
 }

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -6,6 +6,7 @@ package library
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -60,7 +61,7 @@ func (s *Service) GetRootItems(ctx context.Context, rootID string, limit, offset
 		return nil, 0, fmt.Errorf("get root: %w", err)
 	}
 	if root == nil {
-		return nil, 0, fmt.Errorf("root not found: %s", rootID)
+		return nil, 0, fmt.Errorf("%w: %s", ErrRootNotFound, rootID)
 	}
 
 	// Check if scan is running
@@ -157,4 +158,7 @@ func (s *Service) GetConfigs() []RootConfig {
 
 // ErrScanRunning is returned when a scan is already in progress.
 // Per P0+ Gate #2: This triggers a 503 response with Retry-After header.
-var ErrScanRunning = fmt.Errorf("scan already running")
+var ErrScanRunning = errors.New("scan already running")
+
+// ErrRootNotFound is returned when a requested library root does not exist.
+var ErrRootNotFound = errors.New("root not found")

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package library
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestServiceGetRootItems_RootNotFound(t *testing.T) {
+	store, err := NewStore(filepath.Join(t.TempDir(), "library.db"))
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	svc := NewService(nil, store)
+	_, _, err = svc.GetRootItems(context.Background(), "missing-root", 10, 0)
+	if err == nil {
+		t.Fatal("expected error for missing root")
+	}
+	if !errors.Is(err, ErrRootNotFound) {
+		t.Fatalf("expected ErrRootNotFound, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- replace `%v` error aggregation with `errors.Join` in API and daemon shutdown paths
- remove string-based `rule not found` matching from v3 DVR path by returning wrapped `dvr.ErrRuleNotFound`
- add typed library root-not-found sentinel and use `errors.Is` in v3 library handler
- add regression tests for missing DVR rule and missing library root

## Validation
- `go test ./internal/dvr ./internal/library ./internal/api ./internal/daemon ./internal/control/http/v3 -run 'TestSeriesEngine_RunOnce_RuleNotFound|TestServiceGetRootItems_RootNotFound|TestNonExistent' -count=1`
