### PR TITLE
fix(config): align ffmpeg HLS segment fallback with registry default

### DIFF
--- a/internal/infra/media/ffmpeg/adapter.go
+++ b/internal/infra/media/ffmpeg/adapter.go
@@ -76,7 +76,7 @@ func NewLocalAdapter(binPath string, ffprobeBin string, hlsRoot string, e2 *enig
 		killTimeout = 5 * time.Second
 	}
 	if segmentSeconds <= 0 {
-		segmentSeconds = 4 // Best Practice 2026 Low Latency default
+		segmentSeconds = 6 // Keep in sync with config registry default (hls.segmentSeconds)
 	}
 	httpClient := &http.Client{
 		Timeout: preflightTimeout,

--- a/internal/infra/media/ffmpeg/adapter_defaults_test.go
+++ b/internal/infra/media/ffmpeg/adapter_defaults_test.go
@@ -1,0 +1,32 @@
+package ffmpeg
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLocalAdapter_DefaultSegmentSecondsMatchesRegistry(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg",
+		"",
+		t.TempDir(),
+		nil,
+		zerolog.New(io.Discard),
+		"",
+		"",
+		0,
+		0,
+		false,
+		2*time.Second,
+		0, // unset
+		0,
+		0,
+		"",
+	)
+
+	assert.Equal(t, 6, adapter.SegmentSeconds)
+}


### PR DESCRIPTION
## Summary
- change ffmpeg adapter fallback for `segmentSeconds <= 0` from `4` to `6`
- keep adapter default aligned with config registry (`hls.segmentSeconds` default = `6`)
- add unit test proving constructor default behavior when segment seconds are unset

## Architecture Findings Addressed
- ARCH-017 (default drift between config registry/validation and ffmpeg adapter fallback)

## Validation
- `go test ./internal/infra/media/ffmpeg -count=1`
