### PR TITLE
fix(daemon): close runtime stores even when engine worker is disabled

### DIFF
--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -100,6 +100,9 @@ func (m *manager) Start(ctx context.Context) error {
 
 	// Error channel for server failures
 	errChan := make(chan error, 3)
+	// Register close hooks independent of engine mode so runtime stores are always
+	// cleaned up during shutdown, even when the v3 worker is disabled.
+	m.registerV3RuntimeCloseHooks()
 
 	// Start metrics server if configured (skip in proxy-only mode)
 	if !m.deps.ProxyOnly && m.deps.MetricsHandler != nil {

--- a/internal/daemon/manager_runtime_hooks_test.go
+++ b/internal/daemon/manager_runtime_hooks_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/config"
+	sessionstore "github.com/ManuGH/xg2g/internal/domain/session/store"
+	"github.com/ManuGH/xg2g/internal/log"
+	"github.com/ManuGH/xg2g/internal/pipeline/resume"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type trackingStateStore struct {
+	sessionstore.StateStore
+	closed atomic.Int32
+}
+
+func (s *trackingStateStore) Close() error {
+	s.closed.Add(1)
+	return nil
+}
+
+type trackingResumeStore struct {
+	resume.Store
+	closed atomic.Int32
+}
+
+func (s *trackingResumeStore) Close() error {
+	s.closed.Add(1)
+	return nil
+}
+
+type trackingScanStore struct {
+	closed atomic.Int32
+}
+
+func (s *trackingScanStore) Close() error {
+	s.closed.Add(1)
+	return nil
+}
+
+func TestManager_Start_ShutdownClosesRuntimeStoresWhenEngineDisabled(t *testing.T) {
+	v3Store := &trackingStateStore{StateStore: sessionstore.NewMemoryStore()}
+	resumeStore := &trackingResumeStore{Store: resume.NewMemoryStore()}
+	scanStore := &trackingScanStore{}
+
+	mgrIface, err := NewManager(config.ServerConfig{ShutdownTimeout: 2 * time.Second}, Deps{
+		Logger:      log.WithComponent("test"),
+		Config:      config.AppConfig{Engine: config.EngineConfig{Enabled: false}},
+		ProxyOnly:   true,
+		V3Store:     v3Store,
+		ResumeStore: resumeStore,
+		ScanManager: scanStore,
+	})
+	require.NoError(t, err)
+
+	mgr := mgrIface.(*manager)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- mgr.Start(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case startErr := <-errCh:
+		require.NoError(t, startErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("manager.Start did not return after cancellation")
+	}
+
+	assert.Equal(t, int32(1), v3Store.closed.Load())
+	assert.Equal(t, int32(1), resumeStore.closed.Load())
+	assert.Equal(t, int32(1), scanStore.closed.Load())
+}

--- a/internal/daemon/manager_v3_worker.go
+++ b/internal/daemon/manager_v3_worker.go
@@ -33,7 +33,6 @@ func (m *manager) startV3Worker(ctx context.Context, errChan chan<- error) error
 	if err != nil {
 		return err
 	}
-	m.registerV3RuntimeCloseHooks()
 
 	orch, err := m.buildV3Orchestrator(cfg, runtimeDeps)
 	if err != nil {


### PR DESCRIPTION
## Summary
- register runtime close hooks in `manager.Start()` regardless of `Engine.Enabled`
- keep `startV3Worker` focused on worker startup (remove duplicate close-hook registration there)
- add regression test proving `V3Store`, `ResumeStore`, and `ScanManager` are closed on shutdown with `Engine.Enabled=false`

## Architecture Findings Addressed
- ARCH-016 (store/resource leak risk when engine worker is disabled)

## Validation
- `go test ./internal/daemon -count=1`
