### PR TITLE
refactor(pipeline): decouple HLS content types from control layer

### DIFF
--- a/internal/control/http/hls_contract.go
+++ b/internal/control/http/hls_contract.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/ManuGH/xg2g/internal/control/http/problem"
+	"github.com/ManuGH/xg2g/internal/platform/httpx"
 )
 
 const (
-	ContentTypeHLSPlaylist = "application/vnd.apple.mpegurl"
-	ContentTypeHLSSegment  = "video/mp2t"
-	ContentTypeFMP4Segment = "video/mp4"
+	ContentTypeHLSPlaylist = httpx.ContentTypeHLSPlaylist
+	ContentTypeHLSSegment  = httpx.ContentTypeHLSSegment
+	ContentTypeFMP4Segment = httpx.ContentTypeFMP4Segment
 )
 
 // WriteHLSPlaylistHeaders applies deterministic headers for HLS playlists.

--- a/internal/pipeline/api/hls.go
+++ b/internal/pipeline/api/hls.go
@@ -17,10 +17,10 @@ import (
 	"strings"
 	"time"
 
-	xg2ghttp "github.com/ManuGH/xg2g/internal/control/http"
 	"github.com/ManuGH/xg2g/internal/domain/session/model"
 	"github.com/ManuGH/xg2g/internal/log"
 	"github.com/ManuGH/xg2g/internal/platform/fs"
+	"github.com/ManuGH/xg2g/internal/platform/httpx"
 )
 
 const hlsPlaylistWaitTimeout = 5 * time.Second
@@ -250,14 +250,14 @@ func ServeHLS(w http.ResponseWriter, r *http.Request, store HLSStore, hlsRoot, s
 
 	// 5. Set Headers
 	if isPlaylist {
-		w.Header().Set("Content-Type", xg2ghttp.ContentTypeHLSPlaylist)
+		w.Header().Set("Content-Type", httpx.ContentTypeHLSPlaylist)
 		w.Header().Set("Cache-Control", "no-store")
 	} else if isSegment || isLegacySegment {
 		// Set segment headers based on artifact kind (TS vs fMP4)
 		if strings.HasSuffix(filename, ".m4s") {
-			w.Header().Set("Content-Type", xg2ghttp.ContentTypeFMP4Segment)
+			w.Header().Set("Content-Type", httpx.ContentTypeFMP4Segment)
 		} else {
-			w.Header().Set("Content-Type", xg2ghttp.ContentTypeHLSSegment)
+			w.Header().Set("Content-Type", httpx.ContentTypeHLSSegment)
 		}
 		// User Req: "Cache-Control: public, max-age=60"
 		w.Header().Set("Cache-Control", "public, max-age=60")
@@ -265,7 +265,7 @@ func ServeHLS(w http.ResponseWriter, r *http.Request, store HLSStore, hlsRoot, s
 		// Safari cannot decode gzip-compressed fMP4 segments
 		w.Header().Set("Content-Encoding", "identity")
 	} else if isInit {
-		w.Header().Set("Content-Type", xg2ghttp.ContentTypeFMP4Segment)
+		w.Header().Set("Content-Type", httpx.ContentTypeFMP4Segment)
 		w.Header().Set("Cache-Control", "public, max-age=3600")
 		// CRITICAL: Disable compression for init segment (proxy-safe)
 		w.Header().Set("Content-Encoding", "identity")

--- a/internal/pipeline/origin/handler.go
+++ b/internal/pipeline/origin/handler.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"strings"
 
-	xg2ghttp "github.com/ManuGH/xg2g/internal/control/http"
 	"github.com/ManuGH/xg2g/internal/domain/session/model"
 	"github.com/ManuGH/xg2g/internal/domain/session/store"
+	"github.com/ManuGH/xg2g/internal/platform/httpx"
 )
 
 const minimalManifest = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:10\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-ENDLIST\n"
@@ -52,7 +52,7 @@ func NewHLSOriginHandler(st store.StateStore, downstream http.Handler) http.Hand
 			downstream.ServeHTTP(w, r)
 			return
 		case model.SessionStarting, model.SessionPriming, model.SessionNew:
-			w.Header().Set("Content-Type", xg2ghttp.ContentTypeHLSPlaylist)
+			w.Header().Set("Content-Type", httpx.ContentTypeHLSPlaylist)
 			w.Header().Set("Cache-Control", "no-store")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(minimalManifest))

--- a/internal/platform/httpx/hls_content_types.go
+++ b/internal/platform/httpx/hls_content_types.go
@@ -1,0 +1,7 @@
+package httpx
+
+const (
+	ContentTypeHLSPlaylist = "application/vnd.apple.mpegurl"
+	ContentTypeHLSSegment  = "video/mp2t"
+	ContentTypeFMP4Segment = "video/mp4"
+)


### PR DESCRIPTION
## Summary
- add neutral HLS content type constants in `internal/platform/httpx`
- switch pipeline packages to import `platform/httpx` instead of `internal/control/http`
- keep `internal/control/http` API stable via constant re-exports backed by `httpx`

## Architecture Findings Addressed
- ARCH-004 (pipeline depending on control package for MIME constants)
- partially supports ARCH-003 layering cleanup by removing one control <- pipeline dependency edge

## Validation
- `go test ./internal/control/http ./internal/pipeline/api -count=1`
- `go test -tags v3 ./internal/pipeline/origin -count=1`
