### PR TITLE
fix(openwebif): harden stream URL host handling and capability cache expiry

### DIFF
--- a/internal/openwebif/client_hygiene_test.go
+++ b/internal/openwebif/client_hygiene_test.go
@@ -83,7 +83,14 @@ func TestConnectionHygiene_Invariants(t *testing.T) {
 func TestAdHocGuards_AST(t *testing.T) {
 	fset := token.NewFileSet()
 	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go") // Skip tests
+		name := fi.Name()
+		if strings.HasSuffix(name, "_test.go") {
+			return false // Skip tests
+		}
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "._") {
+			return false // Ignore Finder/metadata files from shared volumes
+		}
+		return true
 	}, 0)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- preserve parsed host formatting when building WebIF stream URLs (IPv6-safe)
- avoid deleting refreshed service capability entries by re-checking under write lock
- ignore Finder metadata files in AST hygiene test runs on shared/macOS volumes

## Why
Addresses review feedback from PR220/PR221 around host reconstruction correctness and cache-expiry race behavior.

## Validation
- go test ./internal/openwebif ./internal/control/http/v3
- go test ./internal/api ./cmd/daemon ./internal/infra/media/ffmpeg ./internal/openwebif ./internal/control/http/v3
- ./scripts/pre-push-sanity.sh