### PR TITLE
fix(api): fail fast when channel/series manager state cannot load

### DIFF
--- a/cmd/daemon/api_wiring.go
+++ b/cmd/daemon/api_wiring.go
@@ -13,21 +13,18 @@ import (
 	"github.com/ManuGH/xg2g/internal/config"
 	"github.com/ManuGH/xg2g/internal/dvr"
 	"github.com/ManuGH/xg2g/internal/recordings"
-	"github.com/rs/zerolog"
 )
 
-func buildAPIConstructorDeps(cfg config.AppConfig, snap config.Snapshot, logger zerolog.Logger) (api.ConstructorDeps, error) {
+func buildAPIConstructorDeps(cfg config.AppConfig, snap config.Snapshot) (api.ConstructorDeps, error) {
 	var loadErrs []error
 
 	channelManager := channels.NewManager(cfg.DataDir)
 	if err := channelManager.Load(); err != nil {
-		logger.Error().Err(err).Msg("failed to load channel states")
 		loadErrs = append(loadErrs, fmt.Errorf("load channel states: %w", err))
 	}
 
 	seriesManager := dvr.NewManager(cfg.DataDir)
 	if err := seriesManager.Load(); err != nil {
-		logger.Error().Err(err).Msg("failed to load series rules")
 		loadErrs = append(loadErrs, fmt.Errorf("load series rules: %w", err))
 	}
 

--- a/cmd/daemon/api_wiring.go
+++ b/cmd/daemon/api_wiring.go
@@ -5,6 +5,9 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/ManuGH/xg2g/internal/api"
 	"github.com/ManuGH/xg2g/internal/channels"
 	"github.com/ManuGH/xg2g/internal/config"
@@ -13,15 +16,23 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func buildAPIConstructorDeps(cfg config.AppConfig, snap config.Snapshot, logger zerolog.Logger) api.ConstructorDeps {
+func buildAPIConstructorDeps(cfg config.AppConfig, snap config.Snapshot, logger zerolog.Logger) (api.ConstructorDeps, error) {
+	var loadErrs []error
+
 	channelManager := channels.NewManager(cfg.DataDir)
 	if err := channelManager.Load(); err != nil {
 		logger.Error().Err(err).Msg("failed to load channel states")
+		loadErrs = append(loadErrs, fmt.Errorf("load channel states: %w", err))
 	}
 
 	seriesManager := dvr.NewManager(cfg.DataDir)
 	if err := seriesManager.Load(); err != nil {
 		logger.Error().Err(err).Msg("failed to load series rules")
+		loadErrs = append(loadErrs, fmt.Errorf("load series rules: %w", err))
+	}
+
+	if len(loadErrs) > 0 {
+		return api.ConstructorDeps{}, errors.Join(loadErrs...)
 	}
 
 	snapshot := snap
@@ -30,5 +41,5 @@ func buildAPIConstructorDeps(cfg config.AppConfig, snap config.Snapshot, logger 
 		SeriesManager:       seriesManager,
 		Snapshot:            &snapshot,
 		RecordingPathMapper: recordings.NewPathMapper(cfg.RecordingPathMappings),
-	}
+	}, nil
 }

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -393,7 +393,7 @@ func main() {
 	// Configure proxy (enabled by default in v2.0 for Zero Config experience)
 
 	// Create API handler
-	apiDeps, err := buildAPIConstructorDeps(cfg, snap, logger)
+	apiDeps, err := buildAPIConstructorDeps(cfg, snap)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to build API constructor dependencies")
 	}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -393,7 +393,10 @@ func main() {
 	// Configure proxy (enabled by default in v2.0 for Zero Config experience)
 
 	// Create API handler
-	apiDeps := buildAPIConstructorDeps(cfg, snap, logger)
+	apiDeps, err := buildAPIConstructorDeps(cfg, snap, logger)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("failed to build API constructor dependencies")
+	}
 	s, err := api.NewWithDeps(cfg, configMgr, apiDeps)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize API server")
@@ -567,10 +570,10 @@ func main() {
 		ProxyOnly: false, // Deprecated, always false now
 
 		// Inject Shared V3 Components
-		V3Bus:         v3Bus,
-		V3Store:       v3Store,
-		ResumeStore:   resumeStore,
-		ScanManager:   v3Scan,
+		V3Bus:       v3Bus,
+		V3Store:     v3Store,
+		ResumeStore: resumeStore,
+		ScanManager: v3Scan,
 		ReceiverHealthCheck: func(ctx context.Context) error {
 			client := openwebif.NewWithPort(cfg.Enigma2.BaseURL, 0, openwebif.Options{
 				Timeout:  2 * time.Second,

--- a/internal/api/server_new.go
+++ b/internal/api/server_new.go
@@ -27,7 +27,11 @@ func NewWithDeps(cfg config.AppConfig, cfgMgr *config.Manager, constructorDeps C
 	// 1. Initialized root context for server lifecycle (MUST be before v3Handler)
 	rootCtx, rootCancel := context.WithCancel(context.Background())
 
-	deps := resolveConstructorDeps(cfg, constructorDeps)
+	deps, err := resolveConstructorDeps(cfg, constructorDeps)
+	if err != nil {
+		rootCancel()
+		return nil, err
+	}
 
 	s := &Server{
 		cfg:                 cfg,


### PR DESCRIPTION
## Summary
- return constructor dependency load failures from daemon API wiring
- propagate constructor load failures from API dependency resolver
- stop API server initialization when persisted channels/series state is unreadable
- add regression tests for failing channel and series load paths

## Why
Addresses review feedback from PR216 that load errors were logged but ignored, leaving degraded runtime state.

## Validation
- go test ./internal/api ./cmd/daemon
- go test ./internal/api ./cmd/daemon ./internal/infra/media/ffmpeg ./internal/openwebif ./internal/control/http/v3