### PR TITLE
refactor(v3): route intent preflight and admission through module snapshots

### DIFF
--- a/internal/control/http/v3/contract_v3_coverage_test.go
+++ b/internal/control/http/v3/contract_v3_coverage_test.go
@@ -123,6 +123,10 @@ func TestV3RFC7807Compliance(t *testing.T) {
 		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
+		base := filepath.Base(path)
+		if strings.HasPrefix(base, ".") || strings.HasPrefix(base, "._") {
+			return nil
+		}
 		if strings.HasSuffix(path, "_test.go") || strings.HasSuffix(path, "_gen.go") {
 			return nil
 		}

--- a/internal/control/http/v3/module_boundary_test.go
+++ b/internal/control/http/v3/module_boundary_test.go
@@ -14,12 +14,14 @@ import (
 // snapshots rather than reaching directly into Server runtime fields.
 func TestModuleBoundaries_NoDirectServerStateFieldAccess(t *testing.T) {
 	forbiddenFields := map[string]struct{}{
-		"v3Store":        {},
-		"v3Bus":          {},
-		"resumeStore":    {},
-		"v3Scan":         {},
-		"scanSource":     {},
-		"admissionState": {},
+		"v3Store":           {},
+		"v3Bus":             {},
+		"resumeStore":       {},
+		"v3Scan":            {},
+		"scanSource":        {},
+		"admission":         {},
+		"admissionState":    {},
+		"preflightProvider": {},
 	}
 
 	allowedFiles := map[string]struct{}{
@@ -52,6 +54,7 @@ func TestModuleBoundaries_NoDirectServerStateFieldAccess(t *testing.T) {
 		if parseErr != nil {
 			t.Fatalf("parse %s: %v", name, parseErr)
 		}
+		receiverNames := serverReceiverNames(f)
 
 		ast.Inspect(f, func(n ast.Node) bool {
 			sel, ok := n.(*ast.SelectorExpr)
@@ -59,7 +62,10 @@ func TestModuleBoundaries_NoDirectServerStateFieldAccess(t *testing.T) {
 				return true
 			}
 			recv, ok := sel.X.(*ast.Ident)
-			if !ok || recv.Name != "s" {
+			if !ok {
+				return true
+			}
+			if _, isServerReceiver := receiverNames[recv.Name]; !isServerReceiver {
 				return true
 			}
 			if _, bad := forbiddenFields[sel.Sel.Name]; !bad {
@@ -70,5 +76,36 @@ func TestModuleBoundaries_NoDirectServerStateFieldAccess(t *testing.T) {
 			t.Errorf("%s:%d:%d direct access to s.%s is forbidden; use module deps snapshot", filepath.Base(pos.Filename), pos.Line, pos.Column, sel.Sel.Name)
 			return true
 		})
+	}
+}
+
+func serverReceiverNames(f *ast.File) map[string]struct{} {
+	names := make(map[string]struct{})
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || len(fn.Recv.List) != 1 {
+			continue
+		}
+		recv := fn.Recv.List[0]
+		if !isServerType(recv.Type) {
+			continue
+		}
+		for _, n := range recv.Names {
+			if n != nil && n.Name != "" {
+				names[n.Name] = struct{}{}
+			}
+		}
+	}
+	return names
+}
+
+func isServerType(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name == "Server"
+	case *ast.StarExpr:
+		return isServerType(t.X)
+	default:
+		return false
 	}
 }

--- a/internal/control/http/v3/preflight_gate.go
+++ b/internal/control/http/v3/preflight_gate.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/ManuGH/xg2g/internal/config"
 	"github.com/ManuGH/xg2g/internal/control/vod/preflight"
 	"github.com/ManuGH/xg2g/internal/log"
 	"github.com/ManuGH/xg2g/internal/metrics"
@@ -17,33 +16,32 @@ type streamURLProvider interface {
 	StreamURL(ctx context.Context, ref, name string) (string, error)
 }
 
-func (s *Server) enforcePreflight(ctx context.Context, w http.ResponseWriter, r *http.Request, cfg config.AppConfig, serviceRef string) bool {
-	s.mu.RLock()
-	provider := s.preflightProvider
-	snap := s.snap
-	s.mu.RUnlock()
-
+func enforcePreflight(ctx context.Context, w http.ResponseWriter, r *http.Request, deps sessionsModuleDeps, serviceRef string) bool {
+	provider := deps.preflight
 	if provider == nil {
 		return false
 	}
 
-	sourceURL, err := s.resolvePreflightSourceURL(ctx, cfg, snap, serviceRef)
+	sourceURL, err := resolvePreflightSourceURL(ctx, deps, serviceRef)
 	if err != nil {
-		return s.rejectPreflight(w, r, preflight.PreflightInternal, err)
+		return rejectPreflight(w, r, preflight.PreflightInternal, err)
 	}
 
 	res, err := provider.Check(ctx, preflight.SourceRef{URL: sourceURL})
 	outcome := res.Outcome
 	if err != nil || outcome == "" {
-		return s.rejectPreflight(w, r, preflight.PreflightInternal, err)
+		return rejectPreflight(w, r, preflight.PreflightInternal, err)
 	}
 	if outcome == preflight.PreflightOK {
 		return false
 	}
-	return s.rejectPreflight(w, r, outcome, err)
+	return rejectPreflight(w, r, outcome, err)
 }
 
-func (s *Server) resolvePreflightSourceURL(ctx context.Context, cfg config.AppConfig, snap config.Snapshot, serviceRef string) (string, error) {
+func resolvePreflightSourceURL(ctx context.Context, deps sessionsModuleDeps, serviceRef string) (string, error) {
+	cfg := deps.cfg
+	snap := deps.snap
+
 	serviceRef = strings.TrimSpace(serviceRef)
 	if serviceRef == "" {
 		return "", fmt.Errorf("serviceRef empty")
@@ -57,7 +55,10 @@ func (s *Server) resolvePreflightSourceURL(ctx context.Context, cfg config.AppCo
 		return normalized, nil
 	}
 
-	receiver := s.owi(cfg, snap)
+	if deps.receiver == nil {
+		return "", fmt.Errorf("receiver control factory unavailable")
+	}
+	receiver := deps.receiver(cfg, snap)
 	streamer, ok := receiver.(streamURLProvider)
 	if !ok {
 		return "", fmt.Errorf("stream url provider unavailable")
@@ -72,7 +73,7 @@ func (s *Server) resolvePreflightSourceURL(ctx context.Context, cfg config.AppCo
 	return platformnet.ValidateOutboundURL(ctx, rawURL, outboundPolicyFromConfig(cfg))
 }
 
-func (s *Server) rejectPreflight(w http.ResponseWriter, r *http.Request, outcome preflight.PreflightOutcome, err error) bool {
+func rejectPreflight(w http.ResponseWriter, r *http.Request, outcome preflight.PreflightOutcome, err error) bool {
 	status, problemType, title := preflight.MapPreflightOutcome(outcome)
 	detail := preflightDetail(outcome)
 	code := preflightProblemCode(outcome)

--- a/internal/control/http/v3/server_modules.go
+++ b/internal/control/http/v3/server_modules.go
@@ -6,6 +6,7 @@ package v3
 
 import (
 	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/control/admission"
 	"github.com/ManuGH/xg2g/internal/control/http/v3/recordings/artifacts"
 	"github.com/ManuGH/xg2g/internal/control/read"
 	recservice "github.com/ManuGH/xg2g/internal/control/recordings"
@@ -28,7 +29,10 @@ type sessionsModuleDeps struct {
 	resumeStore    resume.Store
 	scanSource     ScanSource
 	epgCache       *epg.TV
-	v3Scan         ChannelScanner
+	channelScanner ChannelScanner
+	preflight      PreflightProvider
+	receiver       receiverControlFactory
+	admission      *admission.Controller
 	admissionState AdmissionState
 }
 
@@ -43,7 +47,10 @@ func (s *Server) sessionsModuleDeps() sessionsModuleDeps {
 		resumeStore:    s.resumeStore,
 		scanSource:     s.scanSource,
 		epgCache:       s.epgCache,
-		v3Scan:         s.v3Scan,
+		channelScanner: s.v3Scan,
+		preflight:      s.preflightProvider,
+		receiver:       s.owi,
+		admission:      s.admission,
 		admissionState: s.admissionState,
 	}
 }


### PR DESCRIPTION
## Summary
- extend sessions module snapshot deps with preflight/admission/receiver handles
- move preflight enforcement and URL resolution to dependency-driven helpers
- switch intent handler flow to module snapshot deps instead of direct server runtime fields
- harden module-boundary AST checks for any Server receiver name
- ignore Finder metadata files in v3 AST coverage walk

## Why
Addresses PR219 boundary feedback by tightening module seams and reducing direct handler-to-server coupling.

## Validation
- go test ./internal/control/http/v3
- go test ./internal/api ./cmd/daemon ./internal/infra/media/ffmpeg ./internal/openwebif ./internal/control/http/v3