### PR TITLE
fix(config): centralize default HLS segment seconds

### DIFF
--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -42,6 +42,12 @@ const (
 	TypeAny    ValueType = "any"
 )
 
+const (
+	// DefaultHLSSegmentSeconds is the standard-profile segment length used
+	// across config defaults and pipeline fallbacks.
+	DefaultHLSSegmentSeconds = 6
+)
+
 // ConfigEntry defines a single configuration option's metadata.
 type ConfigEntry struct {
 	Path          string    // User-facing Path (e.g. "api.listenAddr")
@@ -147,8 +153,8 @@ func buildRegistry() (*Registry, error) {
 
 		// --- HLS ---
 		{Path: "hls.root", Env: "XG2G_HLS_ROOT", FieldPath: "HLS.Root", Profile: ProfileAdvanced, Status: StatusActive},
-		{Path: "hls.dvrWindow", Env: "XG2G_HLS_DVR_WINDOW", FieldPath: "HLS.DVRWindow", Profile: ProfileAdvanced, Status: StatusActive, Default: 45 * time.Minute}, // Fix B key
-		{Path: "hls.segmentSeconds", Env: "XG2G_HLS_SEGMENT_SECONDS", FieldPath: "HLS.SegmentSeconds", Profile: ProfileAdvanced, Status: StatusActive, Default: 6}, // Best Practice 2026 Standard Profile (was 4, which failed validation)
+		{Path: "hls.dvrWindow", Env: "XG2G_HLS_DVR_WINDOW", FieldPath: "HLS.DVRWindow", Profile: ProfileAdvanced, Status: StatusActive, Default: 45 * time.Minute},                        // Fix B key
+		{Path: "hls.segmentSeconds", Env: "XG2G_HLS_SEGMENT_SECONDS", FieldPath: "HLS.SegmentSeconds", Profile: ProfileAdvanced, Status: StatusActive, Default: DefaultHLSSegmentSeconds}, // Best Practice 2026 Standard Profile (was 4, which failed validation)
 
 		// --- FFMPEG ---
 		{Path: "ffmpeg.bin", Env: "XG2G_FFMPEG_BIN", FieldPath: "FFmpeg.Bin", Profile: ProfileAdvanced, Status: StatusActive, Default: "ffmpeg"},

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -238,7 +238,7 @@ func Validate(cfg AppConfig) error {
 			if cfg.HLS.DVRWindow < 10*time.Second {
 				v.AddError("HLS.DVRWindow", "must be >= 10s for low latency", cfg.HLS.DVRWindow)
 			}
-		case 6: // Standard Profile
+		case DefaultHLSSegmentSeconds: // Standard Profile
 			if cfg.HLS.DVRWindow < 1*time.Minute {
 				v.AddError("HLS.DVRWindow", "must be >= 1m for standard profile", cfg.HLS.DVRWindow)
 			}

--- a/internal/infra/media/ffmpeg/adapter_defaults_test.go
+++ b/internal/infra/media/ffmpeg/adapter_defaults_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/config"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,5 +29,5 @@ func TestNewLocalAdapter_DefaultSegmentSecondsMatchesRegistry(t *testing.T) {
 		"",
 	)
 
-	assert.Equal(t, 6, adapter.SegmentSeconds)
+	assert.Equal(t, config.DefaultHLSSegmentSeconds, adapter.SegmentSeconds)
 }


### PR DESCRIPTION
## Summary
- introduce config.DefaultHLSSegmentSeconds
- use the constant in config registry default entry
- use the same constant in validation and ffmpeg adapter fallback
- align adapter default regression test with the shared constant

## Why
Addresses PR224 feedback about duplicated magic values for HLS segment defaults.

## Validation
- go test ./internal/infra/media/ffmpeg
- go test ./internal/api ./cmd/daemon ./internal/infra/media/ffmpeg ./internal/openwebif ./internal/control/http/v3