### PR TITLE
fix(devx): validate XG2G_MAX_UNTRACKED in pre-push sanity

### DIFF
--- a/scripts/pre-push-sanity.sh
+++ b/scripts/pre-push-sanity.sh
@@ -13,6 +13,10 @@ fail() {
   exit 1
 }
 
+if ! [[ "${MAX_UNTRACKED}" =~ ^[0-9]+$ ]]; then
+  fail "XG2G_MAX_UNTRACKED must be a non-negative integer (got '${MAX_UNTRACKED}')"
+fi
+
 current_branch="$(git symbolic-ref --quiet --short HEAD || true)"
 if [[ -z "${current_branch}" ]]; then
   fail "detached HEAD is not allowed for normal pushes"


### PR DESCRIPTION
## Summary
- validate XG2G_MAX_UNTRACKED is numeric before numeric comparison
- fail with explicit message when invalid

## Why
Addresses PR208 feedback where non-numeric env input could break guard behavior.

## Validation
- XG2G_MAX_UNTRACKED=abc ./scripts/pre-push-sanity.sh (fails closed with message)
- ./scripts/pre-push-sanity.sh (passes with default config)