### PR TITLE
ci: harden WebUI gates and decouple nightly lint

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -43,6 +43,20 @@ jobs:
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
           golangci-lint --version
 
+      - name: Run nightly gates
+        run: make ci-nightly
+
+  nightly-doc-lint:
+    name: Nightly Spec/Docs Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      TZ: UTC
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
       - name: Setup Node for OpenAPI + Markdown lint
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
@@ -59,6 +73,3 @@ jobs:
         run: |
           set -euo pipefail
           npx --yes markdownlint-cli2@0.14.0 "docs/**/*.md" ".github/**/*.md" "*.md"
-
-      - name: Run nightly gates
-        run: make ci-nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - "config.example.yaml"
       - "config.generated.example.yaml"
       - "docs/**"
+      - "e2e/**"
       - "internal/**"
       - "Dockerfile"
       - "Dockerfile.*"
@@ -103,6 +104,12 @@ jobs:
 
       - name: Build WebUI assets (required for embed contract)
         run: make ui-build
+
+      - name: Run WebUI unit tests
+        run: |
+          set -euo pipefail
+          cd webui
+          npm run test
 
       - name: Install System Dependencies
         run: |

--- a/internal/validate/imports_test.go
+++ b/internal/validate/imports_test.go
@@ -204,11 +204,8 @@ func findGoFiles(root string) ([]string, error) {
 		if info.IsDir() {
 			return nil
 		}
-		// Ignore AppleDouble metadata files created on macOS volumes.
-		if strings.HasPrefix(info.Name(), "._") {
-			return nil
-		}
-		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+		// Ignore test files and AppleDouble metadata files created on macOS volumes.
+		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") && !strings.HasPrefix(info.Name(), "._") {
 			files = append(files, path)
 		}
 		return nil

--- a/internal/validate/imports_test.go
+++ b/internal/validate/imports_test.go
@@ -201,7 +201,14 @@ func findGoFiles(root string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+		if info.IsDir() {
+			return nil
+		}
+		// Ignore AppleDouble metadata files created on macOS volumes.
+		if strings.HasPrefix(info.Name(), "._") {
+			return nil
+		}
+		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
 			files = append(files, path)
 		}
 		return nil


### PR DESCRIPTION
## Summary
- add `e2e/**` to CI PR trigger paths so frontend e2e-only changes do not bypass the main gate
- run WebUI unit tests (`npm run test`) in the main PR gate after `make ui-build`
- split CI Nightly into separate jobs so deep gates run even when OpenAPI/Markdown lint fails
- ignore macOS AppleDouble metadata files (`._*.go`) in deprecated package scan to avoid false growth alarms

## Validation
- `go test ./internal/validate -run TestDeprecatedPackages -count=1`
- `go test ./internal/validate -count=1`
- WebUI tests could not be executed locally due filesystem I/O errors on this volume during `npm ci` (`TAR_ENTRY_ERROR EIO`)
