### PR TITLE
feat(recordings): restore blocked-preparing semantics + harden probe orchestration boundary

### DIFF
--- a/CHANGELOG_V3.md
+++ b/CHANGELOG_V3.md
@@ -1,5 +1,15 @@
 # v3 API Change Log
 
+## [Unreleased]
+
+### Changed
+
+- Recordings: `PREPARING` for impossible probe stabilized (`blocked/probe_disabled` instead of false upstream escalation).
+- Recordings: probe orchestration is anchored in the resolver; truth classification remains side-effect free.
+- PlaybackInfo Contract: `Retry-After` now distinguishes `preparing` (`5s`) from `blocked` (`30s`).
+- Error paths: terminal errors retain `MediaTruth` context for handlers/observability.
+- Regression protection: added tests for Option-A semantics, orchestration boundary, and terminal truth payload propagation.
+
 ## [v3.1.0] - 2026-01-22
 
 ### ⚠️ BREAKING CHANGES

--- a/docs/ops/DURATION_TRUTH.md
+++ b/docs/ops/DURATION_TRUTH.md
@@ -33,6 +33,30 @@ Hard guards:
 - overflow/extreme values are clamped (`duration_inconsistent_clamped`)
 - unknown duration emits `duration_unknown_denied_seek`
 
+## Preparing Probe States
+
+When recording truth is not yet fully available, API returns `503 recordings/preparing` with explicit probe progress:
+
+- `probeState=queued`
+  - Probe scheduling accepted and queued.
+  - Typical `Retry-After`: short (for example 5s).
+- `probeState=in_flight`
+  - Probe already running or inside TTL suppression window.
+  - Typical `Retry-After`: short (for example 5s).
+- `probeState=blocked`
+  - Probe cannot run now.
+  - `blockedReason=probe_disabled`: remote probe policy/config disabled.
+  - `blockedReason=probe_backoff`: temporary backoff after recent hard probe failure.
+  - `blockedReason=remote_probe_failed`: explicit remote probe hard-failure state.
+  - Typical `Retry-After`: longer (for example 30s).
+
+Observability contract:
+
+- JSON problem extensions include `probeState`, optional `blockedReason`, and `retryAfterSeconds`.
+- Response header includes `Retry-After`.
+- Metrics include `xg2g_recordings_preparing_total{probe_state,blocked_reason}`.
+- Structured logs include `probe_state`, `blocked_reason` (if set), and `retry_after_seconds`.
+
 ## Backend Wiring
 
 - Domain model and reason SSOT:

--- a/docs/ops/OBSERVABILITY.md
+++ b/docs/ops/OBSERVABILITY.md
@@ -18,6 +18,32 @@
   - `xg2g_sessions_active` – current active stream sessions
   - `xg2g_requests_total` – HTTP request counter by path/status
   - `xg2g_ffmpeg_processes` – active FFmpeg processes
+  - `xg2g_recordings_preparing_total{probe_state,blocked_reason}` – preparing responses for recording playback truth
+  - `xg2g_playback_start_total{schema,mode}` – playback start denominator for SLO ratios
+  - `xg2g_playback_ttff_seconds_bucket{schema,mode,outcome}` – TTFF distribution
+  - `xg2g_playback_rebuffer_total{schema,mode,severity}` – server-side rebuffer proxy events
+  - `xg2g_playback_error_total{schema,stage,code}` – playback error budget numerator
+
+## Playback SLOs
+
+- **Schema labels:** `live|recording` (strict allowlist)
+- **Mode labels:** `hls|native_hls|hlsjs|mp4|unknown` (strict allowlist)
+- **Stages:** `playback_info|intent|playlist|segment|stream` (strict allowlist)
+- **Join keys in logs only:** `request_id`, `session_id`, `recording_id`, `service_ref`
+- **No high-cardinality IDs in metric labels** by contract
+
+TTFF boundaries used by implementation:
+
+- `recording`: start at successful `/recordings/{id}/stream-info` (non-deny), stop at first successful playlist/segment/mp4 media response for `session_id=rec:<recording_id>`.
+- `live`: start at accepted `POST /api/v3/intents` (`stream_start`, stable session id), stop at first successful `/sessions/{sessionID}/hls/{filename}` response.
+
+Rebuffer proxy thresholds:
+
+- `minor`: media gap >= 12s
+- `major`: media gap >= 24s
+- Same thresholds are intentionally used for `live` and `recording` to keep
+  server-side proxy behavior comparable across schemas. We will only split
+  thresholds when reliable per-session target-duration telemetry is available.
 
 ## Tracing (OpenTelemetry)
 

--- a/docs/ops/SLOS.md
+++ b/docs/ops/SLOS.md
@@ -1,0 +1,128 @@
+# Playback SLOs
+
+## Scope
+
+This document defines operator-facing SLOs for playback health and the telemetry contract used for enforcement.
+
+## SLI Definitions
+
+1. Start denominator
+
+- Metric: `xg2g_playback_start_total{schema,mode}`
+- Contract: strict labels only
+  - `schema`: `live|recording`
+  - `mode`: `hls|native_hls|hlsjs|mp4|unknown`
+
+2. TTFF (Time To First Frame/Segment)
+
+- Metric: `xg2g_playback_ttff_seconds_bucket{schema,mode,outcome}`
+- Outcomes:
+  - `ok`: first media served
+  - `failed`: session failed before first media
+  - `aborted`: session stopped before first media
+
+3. Rebuffer proxy
+
+- Metric: `xg2g_playback_rebuffer_total{schema,mode,severity}`
+- Severity:
+  - `minor`: media gap >= 12s
+  - `major`: media gap >= 24s
+- Threshold policy: currently identical for `live` and `recording` by design,
+  because this is a request-gap proxy and must remain cross-schema comparable.
+  Schema-specific thresholds are deferred until per-session target-duration
+  telemetry is available and validated.
+
+4. Error budget numerator
+
+- Metric: `xg2g_playback_error_total{schema,stage,code}`
+- Stages:
+  - `playback_info`
+  - `intent`
+  - `playlist`
+  - `segment`
+  - `stream`
+- `code` is a strict allowlist with unknown mapping (`UNKNOWN`) for safety.
+
+## Default Targets
+
+- TTFF p95:
+  - `recording`: `< 4s`
+  - `live`: `< 5s`
+- Error rate:
+  - `< 1%` over 30m
+- Rebuffer proxy rate:
+  - `< 0.5` events/min/session
+
+## Burn-Rate Alerts (Suggested)
+
+1. Fast burn (critical)
+
+- Window pair: `5m` and `1h`
+- Trigger when error-budget burn exceeds threshold in both windows.
+
+2. Slow burn (warning)
+
+- Window pair: `30m` and `6h`
+- Trigger when sustained burn exceeds threshold in both windows.
+
+### PromQL Examples (2-window)
+
+Assume availability SLO = `99%` over `30d` (error budget = `1%`).
+
+```promql
+# Error rate by schema (recording/live), denominator clamped to avoid divide-by-zero.
+(
+  sum by (schema) (rate(xg2g_playback_error_total[5m]))
+/
+  clamp_min(sum by (schema) (rate(xg2g_playback_start_total[5m])), 1)
+)
+```
+
+```promql
+# Fast burn (critical): both windows must burn fast.
+(
+  (
+    sum by (schema) (rate(xg2g_playback_error_total[5m]))
+  /
+    clamp_min(sum by (schema) (rate(xg2g_playback_start_total[5m])), 1)
+  ) / 0.01
+) > 14.4
+and
+(
+  (
+    sum by (schema) (rate(xg2g_playback_error_total[1h]))
+  /
+    clamp_min(sum by (schema) (rate(xg2g_playback_start_total[1h])), 1)
+  ) / 0.01
+) > 14.4
+```
+
+```promql
+# Slow burn (warning): sustained burn across longer windows.
+(
+  (
+    sum by (schema) (rate(xg2g_playback_error_total[30m]))
+  /
+    clamp_min(sum by (schema) (rate(xg2g_playback_start_total[30m])), 1)
+  ) / 0.01
+) > 6
+and
+(
+  (
+    sum by (schema) (rate(xg2g_playback_error_total[6h]))
+  /
+    clamp_min(sum by (schema) (rate(xg2g_playback_start_total[6h])), 1)
+  ) / 0.01
+) > 6
+```
+
+Use `for: 2m` on fast-burn and `for: 15m` on slow-burn alerts to reduce noise.
+
+## Cardinality Guardrails
+
+- Forbidden metric labels:
+  - `request_id`
+  - `session_id`
+  - `recording_id`
+  - `service_ref`
+- These identifiers are log/trace join keys only, never metric labels.

--- a/internal/control/http/v3/handlers_hls_serving.go
+++ b/internal/control/http/v3/handlers_hls_serving.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/ManuGH/xg2g/internal/log"
+	"github.com/ManuGH/xg2g/internal/metrics"
 	v3api "github.com/ManuGH/xg2g/internal/pipeline/api"
 )
 
@@ -32,7 +34,77 @@ func (s *Server) handleV3HLS(w http.ResponseWriter, r *http.Request) {
 	// 2. Extract Params
 	sessionID := chi.URLParam(r, "sessionID")
 	filename := chi.URLParam(r, "filename")
+	stage := playbackStageLabelFromLiveFilename(filename)
 
 	// 3. Serve via HLS helper
-	v3api.ServeHLS(w, r, store, deps.cfg.HLS.Root, sessionID, filename)
+	wrapped, tracker := wrapResponseWriter(w)
+	v3api.ServeHLS(wrapped, r, store, deps.cfg.HLS.Root, sessionID, filename)
+
+	status := http.StatusOK
+	if st, ok := tracker.(StatusTracker); ok {
+		status = st.StatusCode()
+	}
+
+	if status >= 400 {
+		code := playbackErrorCodeFromStatus(status)
+		metrics.IncPlaybackError(playbackSchemaLiveLabel, stage, code)
+		if deps.playbackSLO != nil {
+			outcome := deps.playbackSLO.MarkOutcome(playbackSessionMeta{
+				SessionID: sessionID,
+				Schema:    playbackSchemaLiveLabel,
+				Mode:      playbackModeHLSLabel,
+			}, "failed")
+			if outcome.TTFFObserved {
+				evt := log.L().Info().
+					Str("event", "playback.slo.ttff").
+					Str("request_id", requestID(r.Context())).
+					Str("session_id", sessionID).
+					Str("schema", outcome.Schema).
+					Str("mode", outcome.Mode).
+					Str("outcome", outcome.Outcome).
+					Float64("ttff_seconds", outcome.TTFFSeconds)
+				if outcome.ServiceRef != "" {
+					evt = evt.Str("service_ref", outcome.ServiceRef)
+				}
+				evt.Msg("live playback ttff outcome observed")
+			}
+		}
+		return
+	}
+
+	if deps.playbackSLO == nil {
+		return
+	}
+	obs := deps.playbackSLO.MarkMediaSuccess(playbackSessionMeta{
+		SessionID: sessionID,
+		Schema:    playbackSchemaLiveLabel,
+		Mode:      playbackModeHLSLabel,
+	})
+	if obs.TTFFObserved {
+		evt := log.L().Info().
+			Str("event", "playback.slo.ttff").
+			Str("request_id", requestID(r.Context())).
+			Str("session_id", sessionID).
+			Str("schema", obs.Schema).
+			Str("mode", obs.Mode).
+			Str("outcome", "ok").
+			Float64("ttff_seconds", obs.TTFFSeconds)
+		if obs.ServiceRef != "" {
+			evt = evt.Str("service_ref", obs.ServiceRef)
+		}
+		evt.Msg("live playback ttff observed")
+	}
+	if obs.RebufferSeverity != "" {
+		evt := log.L().Warn().
+			Str("event", "playback.slo.rebuffer").
+			Str("request_id", requestID(r.Context())).
+			Str("session_id", sessionID).
+			Str("schema", obs.Schema).
+			Str("mode", obs.Mode).
+			Str("severity", obs.RebufferSeverity)
+		if obs.ServiceRef != "" {
+			evt = evt.Str("service_ref", obs.ServiceRef)
+		}
+		evt.Msg("live playback rebuffer proxy event observed")
+	}
 }

--- a/internal/control/http/v3/handlers_playback_info_test.go
+++ b/internal/control/http/v3/handlers_playback_info_test.go
@@ -84,7 +84,7 @@ func TestGetRecordingPlaybackInfo_StrictTruthfulness(t *testing.T) {
 		{
 			name:       "UpstreamError",
 			mockErr:    recservice.ErrUpstream{Op: "probe", Cause: errors.New("timeout")},
-			wantStatus: http.StatusBadGateway,
+			wantStatus: http.StatusServiceUnavailable,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/control/http/v3/handlers_playback_slo_contract_test.go
+++ b/internal/control/http/v3/handlers_playback_slo_contract_test.go
@@ -1,0 +1,133 @@
+package v3_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/control/http/v3/recordings/artifacts"
+	"github.com/ManuGH/xg2g/internal/control/playback"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type staticArtifactsResolver struct {
+	playlist []byte
+	segment  string
+}
+
+func (s *staticArtifactsResolver) ResolvePlaylist(ctx context.Context, recordingID, profile string) (artifacts.ArtifactOK, *artifacts.ArtifactError) {
+	return artifacts.ArtifactOK{
+		Data:    s.playlist,
+		ModTime: time.Now(),
+		Kind:    artifacts.ArtifactKindPlaylist,
+	}, nil
+}
+
+func (s *staticArtifactsResolver) ResolveTimeshift(ctx context.Context, recordingID, profile string) (artifacts.ArtifactOK, *artifacts.ArtifactError) {
+	return s.ResolvePlaylist(ctx, recordingID, profile)
+}
+
+func (s *staticArtifactsResolver) ResolveSegment(ctx context.Context, recordingID string, segment string) (artifacts.ArtifactOK, *artifacts.ArtifactError) {
+	return artifacts.ArtifactOK{
+		AbsPath: s.segment,
+		ModTime: time.Now(),
+		Kind:    artifacts.ArtifactKindSegmentTS,
+	}, nil
+}
+
+func histogramCountForLabels(t *testing.T, metricName string, labels map[string]string) uint64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	var total uint64
+	for _, mf := range mfs {
+		if mf.GetName() != metricName || mf.GetType() != dto.MetricType_HISTOGRAM {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			match := true
+			for key, want := range labels {
+				found := false
+				for _, lp := range metric.GetLabel() {
+					if lp.GetName() == key && lp.GetValue() == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					match = false
+					break
+				}
+			}
+			if match {
+				total += metric.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return total
+}
+
+func TestContract_PlaybackSLO_TTFFRecordedExactlyOnce_OnFirstMedia(t *testing.T) {
+	tmpDir := t.TempDir()
+	segmentPath := filepath.Join(tmpDir, "seg_00001.ts")
+	require.NoError(t, os.WriteFile(segmentPath, []byte("segment-bytes"), 0600))
+
+	svc := new(MockRecordingsService)
+	svc.On("GetMediaTruth", mock.Anything, validRecordingID).Return(playback.MediaTruth{
+		Container:  "ts",
+		VideoCodec: "h264",
+		AudioCodec: "aac",
+		Duration:   120,
+	}, nil)
+
+	srv := createTestServer(svc)
+	srv.SetArtifactsResolver(&staticArtifactsResolver{
+		playlist: []byte("#EXTM3U\n#EXTINF:2,\nseg_00001.ts\n"),
+		segment:  segmentPath,
+	})
+
+	beforeTTFF := histogramCountForLabels(t, "xg2g_playback_ttff_seconds", map[string]string{
+		"schema":  "recording",
+		"outcome": "ok",
+	})
+
+	wInfo := httptest.NewRecorder()
+	rInfo := httptest.NewRequest(http.MethodGet, "/api/v3/recordings/"+validRecordingID+"/stream-info", nil)
+	srv.GetRecordingPlaybackInfo(wInfo, rInfo, validRecordingID)
+	require.Equal(t, http.StatusOK, wInfo.Code)
+
+	var dto map[string]any
+	require.NoError(t, json.Unmarshal(wInfo.Body.Bytes(), &dto))
+	assert.NotEmpty(t, dto["sessionId"])
+
+	wPlaylist := httptest.NewRecorder()
+	rPlaylist := httptest.NewRequest(http.MethodGet, "/api/v3/recordings/"+validRecordingID+"/playlist.m3u8", nil)
+	srv.GetRecordingHLSPlaylist(wPlaylist, rPlaylist, validRecordingID)
+	require.Equal(t, http.StatusOK, wPlaylist.Code)
+
+	afterPlaylistTTFF := histogramCountForLabels(t, "xg2g_playback_ttff_seconds", map[string]string{
+		"schema":  "recording",
+		"outcome": "ok",
+	})
+	assert.Equal(t, beforeTTFF+1, afterPlaylistTTFF)
+
+	wSegment := httptest.NewRecorder()
+	rSegment := httptest.NewRequest(http.MethodGet, "/api/v3/recordings/"+validRecordingID+"/seg_00001.ts", nil)
+	srv.GetRecordingHLSCustomSegment(wSegment, rSegment, validRecordingID, "seg_00001.ts")
+	require.Equal(t, http.StatusOK, wSegment.Code)
+
+	afterSegmentTTFF := histogramCountForLabels(t, "xg2g_playback_ttff_seconds", map[string]string{
+		"schema":  "recording",
+		"outcome": "ok",
+	})
+	assert.Equal(t, afterPlaylistTTFF, afterSegmentTTFF)
+}

--- a/internal/control/http/v3/intent_error_mapping.go
+++ b/internal/control/http/v3/intent_error_mapping.go
@@ -4,7 +4,11 @@
 
 package v3
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/ManuGH/xg2g/internal/metrics"
+)
 
 type IntentErrorKind uint8
 
@@ -48,5 +52,6 @@ func respondIntentFailure(w http.ResponseWriter, r *http.Request, kind IntentErr
 	if !ok {
 		spec = intentErrorMap[IntentErrInternal]
 	}
+	metrics.IncPlaybackError(playbackSchemaLiveLabel, playbackStageIntentLabel, spec.apiErr.Code)
 	RespondError(w, r, spec.status, spec.apiErr, details...)
 }

--- a/internal/control/http/v3/playback_slo_tracker.go
+++ b/internal/control/http/v3/playback_slo_tracker.go
@@ -1,0 +1,356 @@
+package v3
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/metrics"
+)
+
+const (
+	playbackSchemaRecordingLabel = "recording"
+	playbackSchemaLiveLabel      = "live"
+
+	playbackModeHLSLabel       = "hls"
+	playbackModeNativeHLSLabel = "native_hls"
+	playbackModeHLSJSLabel     = "hlsjs"
+	playbackModeMP4Label       = "mp4"
+	playbackModeUnknownLabel   = "unknown"
+
+	playbackStagePlaybackInfoLabel = "playback_info"
+	playbackStageIntentLabel       = "intent"
+	playbackStagePlaylistLabel     = "playlist"
+	playbackStageSegmentLabel      = "segment"
+	playbackStageStreamLabel       = "stream"
+)
+
+const (
+	defaultPlaybackSLOSessionTTL = 20 * time.Minute
+	// SSOT rebuffer thresholds used for metric severity classification.
+	// Intentional: same thresholds for live and recording.
+	// Reason: the proxy signal is request-gap based (server-side only) and must stay
+	// directly comparable across schemas; schema-specific tuning is deferred until we
+	// have reliable per-session target-duration telemetry.
+	playbackRebufferMinorGap = 12 * time.Second
+	playbackRebufferMajorGap = 24 * time.Second
+)
+
+type playbackSessionMeta struct {
+	SessionID   string
+	Schema      string
+	Mode        string
+	RecordingID string
+	ServiceRef  string
+}
+
+type playbackMediaObservation struct {
+	Schema           string
+	Mode             string
+	RecordingID      string
+	ServiceRef       string
+	TTFFObserved     bool
+	TTFFSeconds      float64
+	RebufferSeverity string
+}
+
+type playbackOutcomeObservation struct {
+	Schema       string
+	Mode         string
+	RecordingID  string
+	ServiceRef   string
+	TTFFObserved bool
+	TTFFSeconds  float64
+	Outcome      string
+}
+
+type playbackSessionState struct {
+	Schema      string
+	Mode        string
+	RecordingID string
+	ServiceRef  string
+	StartedAt   time.Time
+	FirstMedia  time.Time
+	LastMedia   time.Time
+}
+
+type playbackSessionTracker struct {
+	mu       sync.Mutex
+	ttl      time.Duration
+	nowFn    func() time.Time
+	sessions map[string]playbackSessionState
+}
+
+func newPlaybackSessionTracker(ttl time.Duration) *playbackSessionTracker {
+	if ttl <= 0 {
+		ttl = defaultPlaybackSLOSessionTTL
+	}
+	return &playbackSessionTracker{
+		ttl:      ttl,
+		nowFn:    time.Now,
+		sessions: make(map[string]playbackSessionState),
+	}
+}
+
+func (t *playbackSessionTracker) Start(meta playbackSessionMeta) {
+	sessionID := strings.TrimSpace(meta.SessionID)
+	if sessionID == "" {
+		return
+	}
+	now := t.nowFn()
+	t.mu.Lock()
+	t.pruneLocked(now)
+	if existing, ok := t.sessions[sessionID]; ok {
+		t.sessions[sessionID] = t.mergeStateMeta(existing, meta)
+		t.mu.Unlock()
+		return
+	}
+	state := playbackSessionState{
+		Schema:      normalizePlaybackSchema(meta.Schema),
+		Mode:        normalizePlaybackMode(meta.Mode),
+		RecordingID: strings.TrimSpace(meta.RecordingID),
+		ServiceRef:  strings.TrimSpace(meta.ServiceRef),
+		StartedAt:   now,
+	}
+	t.sessions[sessionID] = state
+	t.mu.Unlock()
+
+	metrics.IncPlaybackStart(state.Schema, state.Mode)
+}
+
+func (t *playbackSessionTracker) MarkMediaSuccess(meta playbackSessionMeta) playbackMediaObservation {
+	sessionID := strings.TrimSpace(meta.SessionID)
+	if sessionID == "" {
+		return playbackMediaObservation{
+			Schema:      normalizePlaybackSchema(meta.Schema),
+			Mode:        normalizePlaybackMode(meta.Mode),
+			RecordingID: strings.TrimSpace(meta.RecordingID),
+			ServiceRef:  strings.TrimSpace(meta.ServiceRef),
+		}
+	}
+
+	now := t.nowFn()
+	t.mu.Lock()
+	t.pruneLocked(now)
+	state, ok := t.sessions[sessionID]
+	if !ok {
+		state = playbackSessionState{
+			Schema:      normalizePlaybackSchema(meta.Schema),
+			Mode:        normalizePlaybackMode(meta.Mode),
+			RecordingID: strings.TrimSpace(meta.RecordingID),
+			ServiceRef:  strings.TrimSpace(meta.ServiceRef),
+			StartedAt:   now,
+			FirstMedia:  now,
+			LastMedia:   now,
+		}
+		t.sessions[sessionID] = state
+		t.mu.Unlock()
+		return playbackMediaObservation{
+			Schema:      state.Schema,
+			Mode:        state.Mode,
+			RecordingID: state.RecordingID,
+			ServiceRef:  state.ServiceRef,
+		}
+	}
+
+	state = t.mergeStateMeta(state, meta)
+	out := playbackMediaObservation{
+		Schema:      state.Schema,
+		Mode:        state.Mode,
+		RecordingID: state.RecordingID,
+		ServiceRef:  state.ServiceRef,
+	}
+	if state.FirstMedia.IsZero() {
+		state.FirstMedia = now
+		ttff := now.Sub(state.StartedAt).Seconds()
+		if ttff < 0 {
+			ttff = 0
+		}
+		out.TTFFObserved = true
+		out.TTFFSeconds = ttff
+		metrics.ObservePlaybackTTFF(state.Schema, state.Mode, "ok", ttff)
+	}
+
+	if !state.LastMedia.IsZero() {
+		gap := now.Sub(state.LastMedia)
+		if severity := classifyPlaybackRebufferSeverity(gap); severity != "" {
+			out.RebufferSeverity = severity
+			metrics.IncPlaybackRebuffer(state.Schema, state.Mode, severity)
+		}
+	}
+	state.LastMedia = now
+	t.sessions[sessionID] = state
+	t.mu.Unlock()
+	return out
+}
+
+func (t *playbackSessionTracker) MarkOutcome(meta playbackSessionMeta, outcome string) playbackOutcomeObservation {
+	sessionID := strings.TrimSpace(meta.SessionID)
+	if sessionID == "" {
+		return playbackOutcomeObservation{
+			Schema:      normalizePlaybackSchema(meta.Schema),
+			Mode:        normalizePlaybackMode(meta.Mode),
+			RecordingID: strings.TrimSpace(meta.RecordingID),
+			ServiceRef:  strings.TrimSpace(meta.ServiceRef),
+			Outcome:     strings.ToLower(strings.TrimSpace(outcome)),
+		}
+	}
+
+	now := t.nowFn()
+	t.mu.Lock()
+	t.pruneLocked(now)
+	state, ok := t.sessions[sessionID]
+	if !ok {
+		t.mu.Unlock()
+		return playbackOutcomeObservation{
+			Schema:      normalizePlaybackSchema(meta.Schema),
+			Mode:        normalizePlaybackMode(meta.Mode),
+			RecordingID: strings.TrimSpace(meta.RecordingID),
+			ServiceRef:  strings.TrimSpace(meta.ServiceRef),
+			Outcome:     strings.ToLower(strings.TrimSpace(outcome)),
+		}
+	}
+	state = t.mergeStateMeta(state, meta)
+	delete(t.sessions, sessionID)
+	t.mu.Unlock()
+
+	out := playbackOutcomeObservation{
+		Schema:      state.Schema,
+		Mode:        state.Mode,
+		RecordingID: state.RecordingID,
+		ServiceRef:  state.ServiceRef,
+		Outcome:     strings.ToLower(strings.TrimSpace(outcome)),
+	}
+	if state.FirstMedia.IsZero() {
+		ttff := now.Sub(state.StartedAt).Seconds()
+		if ttff < 0 {
+			ttff = 0
+		}
+		out.TTFFObserved = true
+		out.TTFFSeconds = ttff
+		metrics.ObservePlaybackTTFF(state.Schema, state.Mode, out.Outcome, ttff)
+	}
+	return out
+}
+
+func (t *playbackSessionTracker) mergeStateMeta(state playbackSessionState, meta playbackSessionMeta) playbackSessionState {
+	if state.Schema == "unknown" {
+		state.Schema = normalizePlaybackSchema(meta.Schema)
+	}
+	if state.Mode == playbackModeUnknownLabel {
+		state.Mode = normalizePlaybackMode(meta.Mode)
+	}
+	if state.RecordingID == "" {
+		state.RecordingID = strings.TrimSpace(meta.RecordingID)
+	}
+	if state.ServiceRef == "" {
+		state.ServiceRef = strings.TrimSpace(meta.ServiceRef)
+	}
+	return state
+}
+
+func (t *playbackSessionTracker) pruneLocked(now time.Time) {
+	for id, st := range t.sessions {
+		latest := st.StartedAt
+		if st.LastMedia.After(latest) {
+			latest = st.LastMedia
+		}
+		if st.FirstMedia.After(latest) {
+			latest = st.FirstMedia
+		}
+		if now.Sub(latest) > t.ttl {
+			delete(t.sessions, id)
+		}
+	}
+}
+
+func normalizePlaybackSchema(schema string) string {
+	switch strings.ToLower(strings.TrimSpace(schema)) {
+	case playbackSchemaRecordingLabel, playbackSchemaLiveLabel:
+		return strings.ToLower(strings.TrimSpace(schema))
+	default:
+		return "unknown"
+	}
+}
+
+func normalizePlaybackMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case playbackModeHLSLabel, playbackModeNativeHLSLabel, playbackModeHLSJSLabel, playbackModeMP4Label:
+		return strings.ToLower(strings.TrimSpace(mode))
+	default:
+		return playbackModeUnknownLabel
+	}
+}
+
+func playbackModeLabelFromPlaybackInfoMode(mode PlaybackInfoMode) string {
+	switch mode {
+	case PlaybackInfoModeDirectMp4:
+		return playbackModeMP4Label
+	case PlaybackInfoModeNativeHls:
+		return playbackModeNativeHLSLabel
+	case PlaybackInfoModeHlsjs:
+		return playbackModeHLSJSLabel
+	case PlaybackInfoModeTranscode:
+		return playbackModeHLSLabel
+	default:
+		return playbackModeUnknownLabel
+	}
+}
+
+func playbackModeLabelFromIntentPlaybackMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "direct_mp4":
+		return playbackModeMP4Label
+	case "native_hls":
+		return playbackModeNativeHLSLabel
+	case "hlsjs":
+		return playbackModeHLSJSLabel
+	case "transcode":
+		return playbackModeHLSLabel
+	default:
+		return playbackModeUnknownLabel
+	}
+}
+
+func playbackStageLabelFromLiveFilename(filename string) string {
+	name := strings.ToLower(strings.TrimSpace(filename))
+	if strings.HasSuffix(name, ".m3u8") {
+		return playbackStagePlaylistLabel
+	}
+	return playbackStageSegmentLabel
+}
+
+func playbackErrorCodeFromStatus(status int) string {
+	switch status {
+	case 400:
+		return "INVALID_INPUT"
+	case 401:
+		return "UNAUTHORIZED"
+	case 403:
+		return "FORBIDDEN"
+	case 404:
+		return "NOT_FOUND"
+	case 410:
+		return "SESSION_GONE"
+	case 416:
+		return "INVALID_INPUT"
+	case 503:
+		return "SERVICE_UNAVAILABLE"
+	default:
+		if status >= 500 {
+			return "INTERNAL_ERROR"
+		}
+		return "UNKNOWN"
+	}
+}
+
+func classifyPlaybackRebufferSeverity(gap time.Duration) string {
+	switch {
+	case gap >= playbackRebufferMajorGap:
+		return "major"
+	case gap >= playbackRebufferMinorGap:
+		return "minor"
+	default:
+		return ""
+	}
+}

--- a/internal/control/http/v3/playback_slo_tracker_test.go
+++ b/internal/control/http/v3/playback_slo_tracker_test.go
@@ -1,0 +1,182 @@
+package v3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+func counterValueForLabels(t *testing.T, metricName string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() != metricName || mf.GetType() != dto.MetricType_COUNTER {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if metricHasLabels(metric, labels) {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func histogramCountForLabelsTracker(t *testing.T, metricName string, labels map[string]string) uint64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range mfs {
+		if mf.GetName() != metricName || mf.GetType() != dto.MetricType_HISTOGRAM {
+			continue
+		}
+		for _, metric := range mf.GetMetric() {
+			if metricHasLabels(metric, labels) {
+				return metric.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func metricHasLabels(metric *dto.Metric, labels map[string]string) bool {
+	for key, want := range labels {
+		found := false
+		for _, lp := range metric.GetLabel() {
+			if lp.GetName() == key && lp.GetValue() == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPlaybackSessionTracker_StartIsIdempotentAndTTFFObservedOnce(t *testing.T) {
+	tracker := newPlaybackSessionTracker(10 * time.Minute)
+	now := time.Unix(1700000000, 0)
+	tracker.nowFn = func() time.Time { return now }
+
+	meta := playbackSessionMeta{
+		SessionID:   "rec:test-id",
+		Schema:      playbackSchemaRecordingLabel,
+		Mode:        playbackModeHLSLabel,
+		RecordingID: "test-id",
+	}
+
+	startLabels := map[string]string{
+		"schema": "recording",
+		"mode":   "hls",
+	}
+	ttffLabels := map[string]string{
+		"schema":  "recording",
+		"mode":    "hls",
+		"outcome": "ok",
+	}
+
+	beforeStarts := counterValueForLabels(t, "xg2g_playback_start_total", startLabels)
+	beforeTTFF := histogramCountForLabelsTracker(t, "xg2g_playback_ttff_seconds", ttffLabels)
+
+	tracker.Start(meta)
+	now = now.Add(2 * time.Second)
+	tracker.Start(meta) // repeated start must not reset start timestamp
+
+	afterStarts := counterValueForLabels(t, "xg2g_playback_start_total", startLabels)
+	require.Equal(t, beforeStarts+1, afterStarts)
+
+	now = now.Add(3 * time.Second)
+	obs1 := tracker.MarkMediaSuccess(meta)
+	require.True(t, obs1.TTFFObserved)
+	require.Equal(t, 5.0, obs1.TTFFSeconds)
+
+	now = now.Add(1 * time.Second)
+	obs2 := tracker.MarkMediaSuccess(meta)
+	require.False(t, obs2.TTFFObserved)
+
+	afterTTFF := histogramCountForLabelsTracker(t, "xg2g_playback_ttff_seconds", ttffLabels)
+	require.Equal(t, beforeTTFF+1, afterTTFF)
+
+	now = now.Add(1 * time.Second)
+	tracker.Start(meta)
+	afterStartsAgain := counterValueForLabels(t, "xg2g_playback_start_total", startLabels)
+	require.Equal(t, afterStarts, afterStartsAgain)
+}
+
+func TestClassifyPlaybackRebufferSeverity_Boundaries(t *testing.T) {
+	require.Equal(t, "", classifyPlaybackRebufferSeverity(playbackRebufferMinorGap-time.Millisecond))
+	require.Equal(t, "minor", classifyPlaybackRebufferSeverity(playbackRebufferMinorGap))
+	require.Equal(t, "minor", classifyPlaybackRebufferSeverity(playbackRebufferMajorGap-time.Millisecond))
+	require.Equal(t, "major", classifyPlaybackRebufferSeverity(playbackRebufferMajorGap))
+}
+
+func TestPlaybackSessionTracker_RebufferBoundaries_EmitExpectedSeverity(t *testing.T) {
+	tracker := newPlaybackSessionTracker(10 * time.Minute)
+	base := time.Unix(1700001000, 0)
+	now := base
+	tracker.nowFn = func() time.Time { return now }
+
+	baseMeta := playbackSessionMeta{
+		Schema:      playbackSchemaRecordingLabel,
+		Mode:        playbackModeHLSLabel,
+		RecordingID: "gap-test",
+	}
+
+	minorLabels := map[string]string{
+		"schema":   "recording",
+		"mode":     "hls",
+		"severity": "minor",
+	}
+	majorLabels := map[string]string{
+		"schema":   "recording",
+		"mode":     "hls",
+		"severity": "major",
+	}
+	beforeMinor := counterValueForLabels(t, "xg2g_playback_rebuffer_total", minorLabels)
+	beforeMajor := counterValueForLabels(t, "xg2g_playback_rebuffer_total", majorLabels)
+
+	// below minor threshold -> no event
+	metaBelow := baseMeta
+	metaBelow.SessionID = "rec:gap-below"
+	tracker.Start(metaBelow)
+	now = base.Add(1 * time.Second)
+	_ = tracker.MarkMediaSuccess(metaBelow)
+	now = now.Add(playbackRebufferMinorGap - time.Millisecond)
+	belowMinor := tracker.MarkMediaSuccess(metaBelow)
+	require.Equal(t, "", belowMinor.RebufferSeverity)
+
+	// exactly at minor threshold -> minor
+	metaMinor := baseMeta
+	metaMinor.SessionID = "rec:gap-minor"
+	now = base.Add(30 * time.Second)
+	tracker.Start(metaMinor)
+	now = now.Add(1 * time.Second)
+	_ = tracker.MarkMediaSuccess(metaMinor)
+	now = now.Add(playbackRebufferMinorGap)
+	atMinor := tracker.MarkMediaSuccess(metaMinor)
+	require.Equal(t, "minor", atMinor.RebufferSeverity)
+
+	// exactly at major threshold -> major
+	metaMajor := baseMeta
+	metaMajor.SessionID = "rec:gap-major"
+	now = base.Add(60 * time.Second)
+	tracker.Start(metaMajor)
+	now = now.Add(1 * time.Second)
+	_ = tracker.MarkMediaSuccess(metaMajor)
+	now = now.Add(playbackRebufferMajorGap)
+	atMajor := tracker.MarkMediaSuccess(metaMajor)
+	require.Equal(t, "major", atMajor.RebufferSeverity)
+
+	afterMinor := counterValueForLabels(t, "xg2g_playback_rebuffer_total", minorLabels)
+	afterMajor := counterValueForLabels(t, "xg2g_playback_rebuffer_total", majorLabels)
+	require.Equal(t, beforeMinor+1, afterMinor)
+	require.Equal(t, beforeMajor+1, afterMajor)
+}

--- a/internal/control/http/v3/server.go
+++ b/internal/control/http/v3/server.go
@@ -74,6 +74,7 @@ type Server struct {
 	liveDecisionKeyring    liveDecisionKeyring
 	liveDecisionSigningKey []byte
 	liveDecisionTTL        time.Duration
+	playbackSLO            *playbackSessionTracker
 
 	// Lifecycle
 	requestShutdown   func(context.Context) error
@@ -135,6 +136,7 @@ func NewServer(cfg config.AppConfig, cfgMgr *config.Manager, rootCancel context.
 		liveDecisionKeyring:    liveDecisionKeyring,
 		liveDecisionSigningKey: signingKey,
 		liveDecisionTTL:        defaultLivePlaybackDecisionTTL,
+		playbackSLO:            newPlaybackSessionTracker(defaultPlaybackSLOSessionTTL),
 		// owiFactory defaults to nil (uses newOpenWebIFClient in prod)
 	}
 	s.epgSource = &epgAdapter{s}
@@ -258,6 +260,13 @@ func (s *Server) SetRecordingsService(svc recservice.Service) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.recordingsService = svc
+}
+
+// SetArtifactsResolver overrides the recordings artifact resolver (tests).
+func (s *Server) SetArtifactsResolver(res artifacts.Resolver) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.artifacts = res
 }
 
 // SetAdmission sets the resource monitor for admission control.

--- a/internal/control/http/v3/server_modules.go
+++ b/internal/control/http/v3/server_modules.go
@@ -37,6 +37,7 @@ type sessionsModuleDeps struct {
 	receiver       receiverControlFactory
 	admission      *admission.Controller
 	admissionState AdmissionState
+	playbackSLO    *playbackSessionTracker
 }
 
 func (s *Server) sessionsModuleDeps() sessionsModuleDeps {
@@ -55,6 +56,7 @@ func (s *Server) sessionsModuleDeps() sessionsModuleDeps {
 		receiver:       s.owi,
 		admission:      s.admission,
 		admissionState: s.admissionState,
+		playbackSLO:    s.playbackSLO,
 	}
 }
 
@@ -66,6 +68,7 @@ type recordingsModuleDeps struct {
 	pathMapper        *recinfra.PathMapper
 	vodManager        *vod.Manager
 	resumeStore       resume.Store
+	playbackSLO       *playbackSessionTracker
 }
 
 func (s *Server) recordingsModuleDeps() recordingsModuleDeps {
@@ -78,6 +81,7 @@ func (s *Server) recordingsModuleDeps() recordingsModuleDeps {
 		pathMapper:        s.recordingPathMapper,
 		vodManager:        s.vodManager,
 		resumeStore:       s.resumeStore,
+		playbackSLO:       s.playbackSLO,
 	}
 }
 

--- a/internal/control/playback/types.go
+++ b/internal/control/playback/types.go
@@ -102,11 +102,40 @@ type MediaTruth struct {
 	DurationSource     string
 	DurationConfidence string
 	DurationReasons    []string
+	ProbeState         ProbeState
+	ProbeBlockedReason ProbeBlockedReason
+	RetryAfterSeconds  int
 	Width              int
 	Height             int
 	FPS                float64
 	Interlaced         bool
 }
+
+type ProbeState string
+
+const (
+	ProbeStateUnknown  ProbeState = ""
+	ProbeStateQueued   ProbeState = "queued"
+	ProbeStateInFlight ProbeState = "in_flight"
+	ProbeStateBlocked  ProbeState = "blocked"
+)
+
+type ProbeBlockedReason string
+
+const (
+	ProbeBlockedReasonNone     ProbeBlockedReason = ""
+	ProbeBlockedReasonDisabled ProbeBlockedReason = "probe_disabled"
+	ProbeBlockedReasonBackoff  ProbeBlockedReason = "probe_backoff"
+	// ProbeBlockedReasonRemoteProbeFailed is reserved for explicit hard remote probe failures.
+	ProbeBlockedReasonRemoteProbeFailed ProbeBlockedReason = "remote_probe_failed"
+)
+
+const (
+	// RetryAfterPreparingDefault is the default poll interval for active/queued preparing states.
+	RetryAfterPreparingDefault = 5
+	// RetryAfterPreparingBlockedDefault is the default poll interval for blocked preparing states.
+	RetryAfterPreparingBlockedDefault = 30
+)
 
 // PlaybackCapabilities represents the core capability set for playback decisions.
 // This struct is intended to be the domain truth, mapped to/from OpenAPI or shims.

--- a/internal/metrics/playback_slo.go
+++ b/internal/metrics/playback_slo.go
@@ -1,0 +1,173 @@
+package metrics
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	playbackSchemaLive      = "live"
+	playbackSchemaRecording = "recording"
+
+	playbackModeHLS       = "hls"
+	playbackModeNativeHLS = "native_hls"
+	playbackModeHLSJS     = "hlsjs"
+	playbackModeMP4       = "mp4"
+	playbackModeUnknown   = "unknown"
+
+	playbackOutcomeOK      = "ok"
+	playbackOutcomeFailed  = "failed"
+	playbackOutcomeAborted = "aborted"
+
+	playbackRebufferMinor = "minor"
+	playbackRebufferMajor = "major"
+
+	playbackStagePlaybackInfo = "playback_info"
+	playbackStageIntent       = "intent"
+	playbackStagePlaylist     = "playlist"
+	playbackStageSegment      = "segment"
+	playbackStageStream       = "stream"
+
+	playbackCodeUnknown = "UNKNOWN"
+)
+
+var (
+	playbackTTFFSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "xg2g_playback_ttff_seconds",
+		Help:    "Playback TTFF (time to first frame/segment) from start intent to first successful media response",
+		Buckets: []float64{0.25, 0.5, 1, 2, 3, 4, 5, 8, 13, 20, 30, 45, 60},
+	}, []string{"schema", "mode", "outcome"})
+
+	playbackRebufferTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_playback_rebuffer_total",
+		Help: "Server-side playback rebuffer proxy events by schema/mode/severity",
+	}, []string{"schema", "mode", "severity"})
+
+	playbackErrorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_playback_error_total",
+		Help: "Playback errors by schema/stage/code",
+	}, []string{"schema", "stage", "code"})
+
+	playbackStartTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_playback_start_total",
+		Help: "Playback start attempts by schema/mode",
+	}, []string{"schema", "mode"})
+)
+
+// IncPlaybackStart increments playback starts with strict low-cardinality labels.
+func IncPlaybackStart(schema, mode string) {
+	playbackStartTotal.WithLabelValues(
+		normalizePlaybackSchemaLabel(schema),
+		normalizePlaybackModeLabel(mode),
+	).Inc()
+}
+
+// ObservePlaybackTTFF records TTFF in seconds with strict low-cardinality labels.
+func ObservePlaybackTTFF(schema, mode, outcome string, seconds float64) {
+	playbackTTFFSeconds.WithLabelValues(
+		normalizePlaybackSchemaLabel(schema),
+		normalizePlaybackModeLabel(mode),
+		normalizePlaybackOutcomeLabel(outcome),
+	).Observe(seconds)
+}
+
+// IncPlaybackRebuffer increments server-side rebuffer proxy counters.
+func IncPlaybackRebuffer(schema, mode, severity string) {
+	playbackRebufferTotal.WithLabelValues(
+		normalizePlaybackSchemaLabel(schema),
+		normalizePlaybackModeLabel(mode),
+		normalizePlaybackSeverityLabel(severity),
+	).Inc()
+}
+
+// IncPlaybackError increments playback error counters with stable code allowlists.
+func IncPlaybackError(schema, stage, code string) {
+	playbackErrorTotal.WithLabelValues(
+		normalizePlaybackSchemaLabel(schema),
+		normalizePlaybackStageLabel(stage),
+		normalizePlaybackCodeLabel(code),
+	).Inc()
+}
+
+func normalizePlaybackSchemaLabel(schema string) string {
+	switch strings.ToLower(strings.TrimSpace(schema)) {
+	case playbackSchemaLive, playbackSchemaRecording:
+		return strings.ToLower(strings.TrimSpace(schema))
+	default:
+		return "unknown"
+	}
+}
+
+func normalizePlaybackModeLabel(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case playbackModeHLS, playbackModeNativeHLS, playbackModeHLSJS, playbackModeMP4:
+		return strings.ToLower(strings.TrimSpace(mode))
+	default:
+		return playbackModeUnknown
+	}
+}
+
+func normalizePlaybackOutcomeLabel(outcome string) string {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case playbackOutcomeOK, playbackOutcomeFailed, playbackOutcomeAborted:
+		return strings.ToLower(strings.TrimSpace(outcome))
+	default:
+		return "unknown"
+	}
+}
+
+func normalizePlaybackSeverityLabel(severity string) string {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case playbackRebufferMinor, playbackRebufferMajor:
+		return strings.ToLower(strings.TrimSpace(severity))
+	default:
+		return "unknown"
+	}
+}
+
+func normalizePlaybackStageLabel(stage string) string {
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case playbackStagePlaybackInfo, playbackStageIntent, playbackStagePlaylist, playbackStageSegment, playbackStageStream:
+		return strings.ToLower(strings.TrimSpace(stage))
+	default:
+		return "unknown"
+	}
+}
+
+func normalizePlaybackCodeLabel(code string) string {
+	clean := strings.ToUpper(strings.TrimSpace(code))
+	switch clean {
+	case "RECORDING_PREPARING",
+		"UPSTREAM_UNAVAILABLE",
+		"CLAIM_MISMATCH",
+		"INVALID_INPUT",
+		"INVALID_CAPABILITIES",
+		"UNAUTHORIZED",
+		"FORBIDDEN",
+		"NOT_FOUND",
+		"REMOTE_PROBE_UNSUPPORTED",
+		"DECISION_AMBIGUOUS",
+		"ATTESTATION_UNAVAILABLE",
+		"ADMISSION_SESSIONS_FULL",
+		"ADMISSION_TRANSCODES_FULL",
+		"ADMISSION_NO_TUNERS",
+		"ADMISSION_ENGINE_DISABLED",
+		"ADMISSION_STATE_UNKNOWN",
+		"SERVICE_UNAVAILABLE",
+		"INTERNAL_ERROR",
+		"SESSION_NOT_FOUND",
+		"SESSION_GONE",
+		"V3_UNAVAILABLE",
+		"UNAVAILABLE":
+		return clean
+	default:
+		// Preserve numeric HTTP code if passed as string by a caller.
+		if _, err := strconv.Atoi(clean); err == nil {
+			return clean
+		}
+		return playbackCodeUnknown
+	}
+}

--- a/internal/metrics/playback_slo_gate_test.go
+++ b/internal/metrics/playback_slo_gate_test.go
@@ -1,0 +1,85 @@
+package metrics
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestMetrics_NoForbiddenHighCardinalityLabels(t *testing.T) {
+	forbidden := map[string]struct{}{
+		"request_id":   {},
+		"session_id":   {},
+		"recording_id": {},
+		"service_ref":  {},
+	}
+
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := filepath.Base(path)
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "._") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, filepath.Clean(path), nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) < 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			funcName := sel.Sel.Name
+			if !strings.HasSuffix(funcName, "Vec") {
+				return true
+			}
+			pkgIdent, ok := sel.X.(*ast.Ident)
+			if !ok || pkgIdent.Name != "promauto" {
+				return true
+			}
+
+			labels, ok := call.Args[1].(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			for _, elt := range labels.Elts {
+				lit, ok := elt.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				label, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					continue
+				}
+				if _, bad := forbidden[label]; bad {
+					pos := fset.Position(lit.Pos())
+					t.Errorf("%s:%d forbidden high-cardinality metric label: %s", pos.Filename, pos.Line, label)
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan metrics dir: %v", err)
+	}
+}

--- a/internal/metrics/playback_slo_test.go
+++ b/internal/metrics/playback_slo_test.go
@@ -1,0 +1,95 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func getHistogramCount(t *testing.T, hist prometheus.Observer) uint64 {
+	t.Helper()
+	h, ok := hist.(prometheus.Histogram)
+	if !ok {
+		t.Fatalf("observer is not a prometheus.Histogram")
+	}
+	metric := &dto.Metric{}
+	if err := h.Write(metric); err != nil {
+		t.Fatalf("write histogram metric: %v", err)
+	}
+	return metric.GetHistogram().GetSampleCount()
+}
+
+func TestPlaybackSLO_StartAndErrorNormalization(t *testing.T) {
+	startInitial := getCounterVecValue(t, playbackStartTotal, "unknown", "unknown")
+	IncPlaybackStart("custom_schema", "custom_mode")
+	startAfter := getCounterVecValue(t, playbackStartTotal, "unknown", "unknown")
+	if startAfter != startInitial+1 {
+		t.Fatalf("expected playback start unknown/unknown +1, got initial=%v after=%v", startInitial, startAfter)
+	}
+
+	errInitial := getCounterVecValue(t, playbackErrorTotal, "recording", "playback_info", "UNKNOWN")
+	IncPlaybackError("recording", "playback_info", "custom_code")
+	errAfter := getCounterVecValue(t, playbackErrorTotal, "recording", "playback_info", "UNKNOWN")
+	if errAfter != errInitial+1 {
+		t.Fatalf("expected playback error UNKNOWN +1, got initial=%v after=%v", errInitial, errAfter)
+	}
+}
+
+func TestPlaybackSLO_TTFFAndRebufferNormalization(t *testing.T) {
+	hist := playbackTTFFSeconds.WithLabelValues("live", "hlsjs", "ok")
+	before := getHistogramCount(t, hist)
+	ObservePlaybackTTFF("live", "hlsjs", "ok", 1.25)
+	after := getHistogramCount(t, hist)
+	if after != before+1 {
+		t.Fatalf("expected TTFF sample count +1, got before=%d after=%d", before, after)
+	}
+
+	rebufferInitial := getCounterVecValue(t, playbackRebufferTotal, "unknown", "unknown", "unknown")
+	IncPlaybackRebuffer("invalid_schema", "invalid_mode", "invalid_severity")
+	rebufferAfter := getCounterVecValue(t, playbackRebufferTotal, "unknown", "unknown", "unknown")
+	if rebufferAfter != rebufferInitial+1 {
+		t.Fatalf("expected rebuffer unknown labels +1, got initial=%v after=%v", rebufferInitial, rebufferAfter)
+	}
+}
+
+func TestPlaybackSLO_ErrorCodeAllowlist(t *testing.T) {
+	knownInitial := getCounterVecValue(t, playbackErrorTotal, "live", "intent", "ADMISSION_NO_TUNERS")
+	IncPlaybackError("live", "intent", "admission_no_tuners")
+	knownAfter := getCounterVecValue(t, playbackErrorTotal, "live", "intent", "ADMISSION_NO_TUNERS")
+	if knownAfter != knownInitial+1 {
+		t.Fatalf("expected known code counter +1, got initial=%v after=%v", knownInitial, knownAfter)
+	}
+
+	unknownInitial := getCounterVecValue(t, playbackErrorTotal, "live", "intent", "UNKNOWN")
+	IncPlaybackError("live", "intent", "totally_new_code")
+	unknownAfter := getCounterVecValue(t, playbackErrorTotal, "live", "intent", "UNKNOWN")
+	if unknownAfter != unknownInitial+1 {
+		t.Fatalf("expected unknown code counter +1, got initial=%v after=%v", unknownInitial, unknownAfter)
+	}
+}
+
+func TestPlaybackSLO_NoHighCardinalityLabels(t *testing.T) {
+	forbidden := []string{"request_id", "recording_id", "service_ref", "session_id"}
+	collectors := []prometheus.Collector{
+		playbackTTFFSeconds,
+		playbackRebufferTotal,
+		playbackErrorTotal,
+		playbackStartTotal,
+	}
+
+	for _, c := range collectors {
+		descCh := make(chan *prometheus.Desc, 10)
+		c.Describe(descCh)
+		close(descCh)
+		for desc := range descCh {
+			s := strings.ToLower(desc.String())
+			for _, bad := range forbidden {
+				if strings.Contains(s, bad) {
+					t.Fatalf("collector descriptor contains forbidden high-cardinality label %q: %s", bad, desc.String())
+				}
+			}
+		}
+	}
+}

--- a/internal/metrics/recordings_preparing.go
+++ b/internal/metrics/recordings_preparing.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	recordingsPreparingTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_recordings_preparing_total",
+		Help: "Total number of recordings playback preparing responses by probe state and blocked reason",
+	}, []string{"probe_state", "blocked_reason"})
+)
+
+// IncRecordingsPreparing records a preparing response with normalized labels.
+// Label allowlists are intentionally strict to cap cardinality:
+// probe_state ∈ {queued,in_flight,blocked,unknown}
+// blocked_reason ∈ {probe_disabled,probe_backoff,remote_probe_failed,none,unknown}
+// blocked_reason is forced to "none" unless probe_state is "blocked".
+func IncRecordingsPreparing(probeState, blockedReason string) {
+	stateLabel := normalizeRecordingProbeStateLabel(probeState)
+	reasonLabel := normalizeRecordingBlockedReasonLabel(stateLabel, blockedReason)
+	recordingsPreparingTotal.WithLabelValues(stateLabel, reasonLabel).Inc()
+}
+
+func normalizeRecordingProbeStateLabel(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "queued", "in_flight", "blocked":
+		return strings.ToLower(strings.TrimSpace(state))
+	default:
+		return "unknown"
+	}
+}
+
+func normalizeRecordingBlockedReasonLabel(state, reason string) string {
+	if state != "blocked" {
+		return "none"
+	}
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "", "none":
+		return "none"
+	case "probe_disabled", "probe_backoff", "remote_probe_failed":
+		return strings.ToLower(strings.TrimSpace(reason))
+	default:
+		return "unknown"
+	}
+}

--- a/internal/metrics/recordings_preparing_test.go
+++ b/internal/metrics/recordings_preparing_test.go
@@ -1,0 +1,79 @@
+package metrics
+
+import "testing"
+
+func TestIncRecordingsPreparing_IncrementsCanonicalLabels(t *testing.T) {
+	initial := getCounterVecValue(t, recordingsPreparingTotal, "blocked", "probe_disabled")
+	IncRecordingsPreparing("blocked", "probe_disabled")
+	actual := getCounterVecValue(t, recordingsPreparingTotal, "blocked", "probe_disabled")
+	if actual != initial+1 {
+		t.Fatalf("expected blocked/probe_disabled counter to increase by 1, got initial=%v actual=%v", initial, actual)
+	}
+}
+
+func TestIncRecordingsPreparing_NonBlockedForcesNoneReason(t *testing.T) {
+	initial := getCounterVecValue(t, recordingsPreparingTotal, "in_flight", "none")
+	IncRecordingsPreparing("in_flight", "probe_disabled")
+	actual := getCounterVecValue(t, recordingsPreparingTotal, "in_flight", "none")
+	if actual != initial+1 {
+		t.Fatalf("expected in_flight/none counter to increase by 1, got initial=%v actual=%v", initial, actual)
+	}
+}
+
+func TestIncRecordingsPreparing_NormalizesUnknowns(t *testing.T) {
+	initial := getCounterVecValue(t, recordingsPreparingTotal, "unknown", "none")
+	IncRecordingsPreparing("custom_state", "custom_reason")
+	actual := getCounterVecValue(t, recordingsPreparingTotal, "unknown", "none")
+	if actual != initial+1 {
+		t.Fatalf("expected unknown/none counter to increase by 1, got initial=%v actual=%v", initial, actual)
+	}
+
+	initialBlocked := getCounterVecValue(t, recordingsPreparingTotal, "blocked", "unknown")
+	IncRecordingsPreparing("blocked", "custom_reason")
+	actualBlocked := getCounterVecValue(t, recordingsPreparingTotal, "blocked", "unknown")
+	if actualBlocked != initialBlocked+1 {
+		t.Fatalf("expected blocked/unknown counter to increase by 1, got initial=%v actual=%v", initialBlocked, actualBlocked)
+	}
+}
+
+func TestIncRecordingsPreparing_ProbeStateAllowlist(t *testing.T) {
+	testCases := []struct {
+		inputState string
+		wantState  string
+	}{
+		{inputState: "queued", wantState: "queued"},
+		{inputState: "in_flight", wantState: "in_flight"},
+		{inputState: "blocked", wantState: "blocked"},
+		{inputState: "unexpected_state", wantState: "unknown"},
+	}
+
+	for _, tc := range testCases {
+		initial := getCounterVecValue(t, recordingsPreparingTotal, tc.wantState, "none")
+		IncRecordingsPreparing(tc.inputState, "none")
+		actual := getCounterVecValue(t, recordingsPreparingTotal, tc.wantState, "none")
+		if actual != initial+1 {
+			t.Fatalf("expected %s/none counter to increase by 1, got initial=%v actual=%v", tc.wantState, initial, actual)
+		}
+	}
+}
+
+func TestIncRecordingsPreparing_BlockedReasonAllowlist(t *testing.T) {
+	testCases := []struct {
+		inputReason string
+		wantReason  string
+	}{
+		{inputReason: "probe_disabled", wantReason: "probe_disabled"},
+		{inputReason: "probe_backoff", wantReason: "probe_backoff"},
+		{inputReason: "remote_probe_failed", wantReason: "remote_probe_failed"},
+		{inputReason: "unexpected_reason", wantReason: "unknown"},
+	}
+
+	for _, tc := range testCases {
+		initial := getCounterVecValue(t, recordingsPreparingTotal, "blocked", tc.wantReason)
+		IncRecordingsPreparing("blocked", tc.inputReason)
+		actual := getCounterVecValue(t, recordingsPreparingTotal, "blocked", tc.wantReason)
+		if actual != initial+1 {
+			t.Fatalf("expected blocked/%s counter to increase by 1, got initial=%v actual=%v", tc.wantReason, initial, actual)
+		}
+	}
+}


### PR DESCRIPTION
- Stellt die Boundary klar: `TruthProvider` klassifiziert nur, Probe-Orchestrierung liegt ausschließlich im `Resolver` (singleflight/TTL/backoff).
- Korrigiert Option-A-Semantik für impossible probe:
- `probeConfigured=false` -> `PREPARING + blocked + probe_disabled`
- `probeConfigured=true` -> `PREPARING + needsProbe` (nicht disabled)
- Vereinheitlicht Retry-After über SSOT-Constants (`playback.RetryAfterPreparingDefault=5`, `playback.RetryAfterPreparingBlockedDefault=30`) inkl. deterministischem Handler-Fallback.
- Terminale Fehler (`NotFound`, `Upstream`) propagieren jetzt `MediaTruth` (inkl. Metadata-Projection) für Handler/Observability statt leerem Payload.
- Test-Gates grün (`recordings`, `http/v3`, `playback`) inkl. Option-A-, Boundary- und Terminal-Truth-Regressionen.
