### PR TITLE
docs(api): publish OpenAPI reference via GitHub Pages

### DIFF
--- a/.github/workflows/api-docs-pages.yml
+++ b/.github/workflows/api-docs-pages.yml
@@ -1,0 +1,57 @@
+name: API Docs (GitHub Pages)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "backend/api/openapi.yaml"
+      - "docs/api/**"
+      - ".github/workflows/api-docs-pages.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: repo-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build API Docs Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # Latest stable
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build static API docs site
+        run: |
+          set -euo pipefail
+          rm -rf _site
+          mkdir -p _site
+          cp docs/api/index.html _site/index.html
+          cp backend/api/openapi.yaml _site/openapi.yaml
+          touch _site/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy API Docs
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Tier-1 compliant with Apple HLS Guidelines.
 - 📋 [ADRs](docs/ADR/) - Design decisions and trade-offs
 - 🔍 [Repository Audit](docs/arch/AUDIT_REPO_STRUCTURE.md) - Repository
   structure orientation
+- 🌐 [API Reference (GitHub Pages)](https://manugh.github.io/xg2g/) - Generated
+  from [backend/api/openapi.yaml](backend/api/openapi.yaml)
 - ⚙️ [Configuration Guide](docs/guides/CONFIGURATION.md)
 - 🏗️ [Development Guide](docs/guides/DEVELOPMENT.md)
 - 🧭 [Workflow Guide](WORKFLOW.md) - Branching, testing, and deployment flow

--- a/backend/templates/README.md.tmpl
+++ b/backend/templates/README.md.tmpl
@@ -79,6 +79,8 @@ Tier-1 compliant with Apple HLS Guidelines.
 - 📋 [ADRs](docs/ADR/) - Design decisions and trade-offs
 - 🔍 [Repository Audit](docs/arch/AUDIT_REPO_STRUCTURE.md) - Repository
   structure orientation
+- 🌐 [API Reference (GitHub Pages)](https://manugh.github.io/xg2g/) - Generated
+  from [backend/api/openapi.yaml](backend/api/openapi.yaml)
 - ⚙️ [Configuration Guide](docs/guides/CONFIGURATION.md)
 - 🏗️ [Development Guide](docs/guides/DEVELOPMENT.md)
 - 🧭 [Workflow Guide](WORKFLOW.md) - Branching, testing, and deployment flow

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,12 @@ and decision logic is the **Spec Index**:
 
 👉 **[SPEC_INDEX.md](decision/SPEC_INDEX.md)**
 
+## 🌐 API Reference
+
+- Published API docs (GitHub Pages): **[xg2g API Reference](https://manugh.github.io/xg2g/)**
+- In-repo Redoc entrypoint: [docs/api/index.html](api/index.html)
+- OpenAPI source of truth: [backend/api/openapi.yaml](../backend/api/openapi.yaml)
+
 ---
 
 ## 📚 Documentation Structure

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>xg2g API Reference</title>
+    <meta
+      name="description"
+      content="xg2g OpenAPI reference for the v3 API, published via GitHub Pages."
+    />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        background: #f5f8fb;
+        color: #1a2433;
+      }
+
+      .topbar {
+        background: linear-gradient(120deg, #1b4f72 0%, #21618c 60%, #2e86c1 100%);
+        color: #fff;
+        padding: 20px 24px;
+      }
+
+      .topbar h1 {
+        margin: 0 0 8px;
+        font-size: 1.5rem;
+        line-height: 1.2;
+      }
+
+      .topbar p {
+        margin: 0;
+        opacity: 0.92;
+      }
+
+      .topbar a {
+        color: #d6ecff;
+      }
+
+      .topbar a:hover {
+        color: #fff;
+      }
+
+      main {
+        min-height: calc(100vh - 96px);
+      }
+    </style>
+  </head>
+  <body>
+    <header class="topbar">
+      <h1>xg2g API Reference</h1>
+      <p>
+        OpenAPI v3 documentation for <code>/api/v3</code>. Source:
+        <a href="https://github.com/ManuGH/xg2g/blob/main/backend/api/openapi.yaml"
+          >backend/api/openapi.yaml</a
+        >
+      </p>
+    </header>
+    <main>
+      <redoc spec-url="./openapi.yaml" hide-download-button></redoc>
+    </main>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -18,6 +18,9 @@
         font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
         background: #f5f8fb;
         color: #1a2433;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
       }
 
       .topbar {
@@ -46,7 +49,13 @@
       }
 
       main {
-        min-height: calc(100vh - 96px);
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+      }
+
+      main > redoc {
+        flex: 1 1 auto;
       }
     </style>
   </head>
@@ -63,6 +72,6 @@
     <main>
       <redoc spec-url="./openapi.yaml" hide-download-button></redoc>
     </main>
-    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+    <script src="https://cdn.redoc.ly/redoc/v2.1.5/bundles/redoc.standalone.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Pages workflow to publish API docs from `backend/api/openapi.yaml`
- add `docs/api/index.html` with Redoc UI and serve `openapi.yaml` as part of the Pages artifact
- update documentation entrypoints with a prominent API reference link:
  - `docs/README.md`
  - `backend/templates/README.md.tmpl`
  - generated `README.md`

## Workflow behavior
- triggers on push to `main` when API docs sources change
- supports manual runs via `workflow_dispatch`
- deploys only from `main`

## Notes
- docs link verification script currently reports pre-existing broken links in unrelated docs files
