### PR TITLE
docs(community): add code of conduct and improve templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and Ideas
+    url: https://github.com/ManuGH/xg2g/issues/new?labels=question
+    about: Use a `question` issue for Q&A and architecture ideas.
+  - name: Security Report (Private)
+    url: https://github.com/ManuGH/xg2g/security/advisories/new
+    about: Report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and Ideas
-    url: https://github.com/ManuGH/xg2g/issues/new?labels=question
-    about: Use a `question` issue for Q&A and architecture ideas.
+    url: https://github.com/ManuGH/xg2g/discussions
+    about: Use Discussions for Q&A, architecture ideas, and show-and-tell.
   - name: Security Report (Private)
     url: https://github.com/ManuGH/xg2g/security/advisories/new
     about: Report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,44 @@
+---
+name: Good First Issue Candidate
+about: Maintainer template for newcomer-friendly tasks
+title: "[Good First Issue] "
+labels: ["good first issue", "help wanted"]
+assignees: ""
+---
+
+## Summary
+
+One-paragraph description of the task and why it matters.
+
+## Why this is newcomer-friendly
+
+- [ ] Small scope (can be done in one PR)
+- [ ] Low architectural risk
+- [ ] Existing code examples to follow
+- [ ] Acceptance criteria are objective
+
+## Context
+
+Relevant files, docs, and prior discussions:
+
+- File(s):
+- Docs:
+- Related issue/PR:
+
+## Implementation hints
+
+Concrete starting points for contributors:
+
+1. 
+2. 
+3. 
+
+## Acceptance criteria
+
+- [ ] Behavior is correct and tested
+- [ ] CI checks pass
+- [ ] Documentation updated if needed
+
+## Out of scope
+
+State explicitly what should not be changed in this issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,39 @@
 # Pull Request
 
-## Description
+## Summary
 
-Briefly describe the objective and technical approach.
+Describe what changed and why.
 
 ## Scope
 
 - In scope:
-- Non-goals:
+- Out of scope:
 
-## Observability
+## Risk and Rollout
 
-- SLO/alert signal metric:
-- Supporting metrics/logs/traces:
-
-## Change Type
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Breaking change
-- [ ] Documentation / Refactoring
+- Risk level: low / medium / high
+- Rollout or migration notes:
+- Fallback plan:
 
 ## Verification
 
-- [ ] `make test` passed
-- [ ] `make lint` passed
-- [ ] Manual verification evidence (logs/screenshots) attached
+Commands and evidence used to verify this change:
 
-## Documentation
+```bash
+# example:
+make test
+make lint
+```
 
-- [ ] Modified [REFERENCE.md](docs/guides/REFERENCE.md) (if changed config)
-- [ ] Updated [ARCHITECTURE.md](ARCHITECTURE.md) (if changed design)
+- Manual checks (if applicable):
+- Logs/screenshots (if applicable):
+
+## Checklist
+
+- [ ] Tests added/updated for changed behavior
+- [ ] Documentation updated (if needed)
+- [ ] No secrets or credentials introduced
+- [ ] Backward compatibility considered (or break documented)
 
 ## Related Issues
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,92 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+our community a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the community and project
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to behavior they deem inappropriate, threatening, offensive, or
+harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and also applies when an
+individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately via:
+
+- GitHub Security Advisory draft:
+  https://github.com/ManuGH/xg2g/security/advisories/new
+
+All reports will be reviewed and investigated promptly and fairly.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining
+consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction:
+   Community Impact: Use of inappropriate language or other behavior deemed
+   unprofessional or unwelcome.
+   Consequence: A private, written warning from maintainers, providing clarity
+   around the nature of the violation and an explanation of why the behavior
+   was inappropriate.
+2. Warning:
+   Community Impact: A violation through a single incident or series of
+   actions.
+   Consequence: A warning with consequences for continued behavior. No
+   interaction with the people involved for a specified period.
+3. Temporary Ban:
+   Community Impact: A serious violation of community standards, including
+   sustained inappropriate behavior.
+   Consequence: A temporary ban from any interaction or public communication
+   with the community for a specified period.
+4. Permanent Ban:
+   Community Impact: Demonstrating a pattern of violation of community
+   standards, including sustained inappropriate behavior, harassment, or
+   aggression.
+   Consequence: A permanent ban from any sort of public interaction within the
+   project.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! This guide will help you get started with contributing to xg2g.
 
 ## Community Channels
 
-- Questions and ideas: GitHub Issues with label `question`
+- Questions and ideas: [GitHub Discussions](https://github.com/ManuGH/xg2g/discussions)
 - Feature proposals: GitHub Issues with label `enhancement`
 - Bugs and feature requests: GitHub Issues
 - Security reports: [GitHub Security Advisories](https://github.com/ManuGH/xg2g/security/advisories/new)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ Welcome! This guide will help you get started with contributing to xg2g.
 - Questions and ideas: GitHub Issues with label `question`
 - Feature proposals: GitHub Issues with label `enhancement`
 - Bugs and feature requests: GitHub Issues
-- Security reports: GitHub Security Advisories
-  (`https://github.com/ManuGH/xg2g/security/advisories/new`)
+- Security reports: [GitHub Security Advisories](https://github.com/ManuGH/xg2g/security/advisories/new)
 
 If you want to start with a small task, look for issues labeled:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 Welcome! This guide will help you get started with contributing to xg2g.
 
+## Community Channels
+
+- Questions and ideas: GitHub Issues with label `question`
+- Feature proposals: GitHub Issues with label `enhancement`
+- Bugs and feature requests: GitHub Issues
+- Security reports: GitHub Security Advisories
+  (`https://github.com/ManuGH/xg2g/security/advisories/new`)
+
+If you want to start with a small task, look for issues labeled:
+
+- `good first issue`
+- `help wanted`
+
 ## Quick Start (5 Minutes)
 
 1.  **Clone the repository**:
@@ -38,7 +51,7 @@ The project is organized into a monorepo with a clear separation between backend
 ## Development Workflow
 
 ### Backend (Go)
-The backend is located in [backend/](file:///root/xg2g/backend/).
+The backend is located in [backend/](backend/).
 To run the daemon directly:
 ```bash
 cd backend
@@ -50,7 +63,7 @@ make dev
 ```
 
 ### Frontend (WebUI)
-Located in [frontend/webui/](file:///root/xg2g/frontend/webui/).
+Located in [frontend/webui/](frontend/webui/).
 ```bash
 cd frontend/webui
 npm ci
@@ -85,6 +98,10 @@ Before submitting a Pull Request, please ensure:
 - [ ] Documentation is updated (if applicable).
 - [ ] No regression markers (`FIXME`, `TODO`) left in production code.
 - [ ] Commit messages follow the project convention.
+
+## Code of Conduct
+
+Please read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 By contributing, you agree that your contributions will be licensed under the project's [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- add a repository `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1 adapted)
- improve contributor guidance in `CONTRIBUTING.md` (community channels, newcomer labels, CoC reference)
- add issue template config (`.github/ISSUE_TEMPLATE/config.yml`) with explicit contact routes
- add a maintainer-focused `Good First Issue Candidate` template pre-labeled with `good first issue` and `help wanted`
- tighten PR template to require summary, scope, risk/rollout, and verification evidence

## Notes
- `good first issue` and `help wanted` labels already exist in the repository
- enabling GitHub Discussions via API is currently blocked by repo permissions (`FORBIDDEN`)
