### PR TITLE
ci(coverage): add coverage workflow and badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,99 @@
+name: Coverage
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**/*.go"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "mk/**"
+      - ".github/workflows/coverage.yml"
+      - "Makefile"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**/*.go"
+      - "backend/go.mod"
+      - "backend/go.sum"
+      - "mk/**"
+      - ".github/workflows/coverage.yml"
+      - "Makefile"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-coverage:
+    name: Go Coverage Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      GOTOOLCHAIN: auto
+      TZ: UTC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Go
+        uses: actions/setup-go@def8c394e3ad351a79bc93815e4a585520fe993b # v6
+        with:
+          go-version-file: backend/go.mod
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Run coverage
+        id: coverage
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cd backend
+          go test ./... -count=1 -timeout=20m \
+            -covermode=atomic \
+            -coverprofile=../artifacts/coverage.out \
+            -coverpkg=./...
+          go tool cover -func=../artifacts/coverage.out | tee ../artifacts/coverage.txt
+          go tool cover -html=../artifacts/coverage.out -o ../artifacts/coverage.html
+
+          total="$(go tool cover -func=../artifacts/coverage.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')"
+          if [[ -z "${total}" ]]; then
+            echo "failed to extract total coverage" >&2
+            exit 1
+          fi
+          echo "total=${total}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Coverage Report"
+            echo
+            echo "- Total Go coverage: **${total}%**"
+            echo "- Artifact: \`coverage-report\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce coverage threshold
+        if: vars.COVERAGE_MIN != ''
+        run: |
+          set -euo pipefail
+          total="${{ steps.coverage.outputs.total }}"
+          minimum="${{ vars.COVERAGE_MIN }}"
+          awk -v t="${total}" -v m="${minimum}" 'BEGIN {
+            if ((t + 0) < (m + 0)) {
+              printf("coverage gate failed: total %.2f%% < minimum %.2f%%\n", t, m)
+              exit 1
+            }
+          }'
+          echo "Coverage gate passed: ${total}% >= ${minimum}%"
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v4.4.3
+        if: always()
+        with:
+          name: coverage-report
+          path: |
+            artifacts/coverage.out
+            artifacts/coverage.txt
+            artifacts/coverage.html
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # xg2g - Next Gen to Go
 
 [![CI](https://github.com/ManuGH/xg2g/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ManuGH/xg2g/actions/workflows/ci.yml)
+[![Coverage](https://github.com/ManuGH/xg2g/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/ManuGH/xg2g/actions/workflows/coverage.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ManuGH/xg2g)](https://goreportcard.com/report/github.com/ManuGH/xg2g)
 [![License](https://img.shields.io/badge/license-PolyForm%20NC-blue)](LICENSE)
 

--- a/backend/templates/README.md.tmpl
+++ b/backend/templates/README.md.tmpl
@@ -1,6 +1,7 @@
 # xg2g - Next Gen to Go
 
 [![CI](https://github.com/ManuGH/xg2g/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ManuGH/xg2g/actions/workflows/ci.yml)
+[![Coverage](https://github.com/ManuGH/xg2g/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/ManuGH/xg2g/actions/workflows/coverage.yml)
 [![Release](https://img.shields.io/github/v/release/ManuGH/xg2g)](https://github.com/ManuGH/xg2g/releases)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ManuGH/xg2g)](https://goreportcard.com/report/github.com/ManuGH/xg2g)
 [![License](https://img.shields.io/badge/license-PolyForm%20NC-blue)](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # xg2g Documentation Portal
 
+[![Coverage](https://github.com/ManuGH/xg2g/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/ManuGH/xg2g/actions/workflows/coverage.yml)
+
 Welcome to the normative documentation for xg2g.
 To ensure consistency and "Operator-Grade" quality,
 all documentation follows a strict hierarchy.


### PR DESCRIPTION
## Summary
- add a dedicated `Coverage` workflow (`.github/workflows/coverage.yml`)
- run Go test coverage for backend packages and publish artifacts:
  - `artifacts/coverage.out`
  - `artifacts/coverage.txt`
  - `artifacts/coverage.html`
- add coverage summary to GitHub job summary
- add optional coverage gate via repo variable `COVERAGE_MIN`
- add coverage badge to README and README template

## Trigger model
- `pull_request` on `main` for backend-related changes
- `push` on `main` for backend-related changes
- `workflow_dispatch`

## Notes
- This is non-blocking by default; threshold enforcement is opt-in using `COVERAGE_MIN`.
