### PR TITLE
ci(release): pin GoReleaser binary to v2.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> 2" # pin to v2.x; bump intentionally when v3 ships
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace `version: latest` with `version: "~> 2"` in `.github/workflows/release.yml`
- add explicit intent comment: pin to v2.x and bump intentionally on v3

## Why
Using `latest` makes release builds non-reproducible and can break tagged releases on upstream major changes.

Closes #258
