### PR TITLE
security(ci): fix CodeQL SARIF upload sub-action usage

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -71,7 +71,7 @@ jobs:
           ignore-unfixed: false
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e
         if: always()
         with:
           sarif_file: "trivy-results.sarif"
@@ -189,7 +189,7 @@ jobs:
           scanners: "secret,misconfig"
 
       - name: Upload filesystem scan to GitHub Security
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v3.27.9
+        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v3.27.9
         if: always()
         with:
           sarif_file: "trivy-fs-results.sarif"


### PR DESCRIPTION
## Summary
- replace incorrect `github/codeql-action/init` usage with `github/codeql-action/upload-sarif` in `.github/workflows/container-security.yml`
- apply fix to both SARIF upload steps:
  - production image Trivy SARIF upload
  - filesystem Trivy SARIF upload

## Context
Issue #259 reports multiple wrong CodeQL sub-action usages. In current branch state, the concrete reproducible misuse is in `container-security.yml`; `release.yml` currently has no CodeQL SARIF upload/analyze steps.

Closes #259
