### PR TITLE
Fix frontend auth and resume hook effects

### DIFF
--- a/frontend/webui/src/components/V3Player.tsx
+++ b/frontend/webui/src/components/V3Player.tsx
@@ -346,7 +346,7 @@ function V3Player(props: V3PlayerProps) {
   useResume({
     recordingId: activeRecordingId || undefined,
     duration: durationSeconds,
-    videoElement: videoRef.current,
+    videoRef,
     isPlaying,
     isSeekable: canSeek
   });

--- a/frontend/webui/src/context/AppContext.test.tsx
+++ b/frontend/webui/src/context/AppContext.test.tsx
@@ -1,0 +1,43 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppProvider } from './AppContext';
+
+const { setClientAuthToken } = vi.hoisted(() => ({
+  setClientAuthToken: vi.fn()
+}));
+
+vi.mock('../lib/clientWrapper', () => ({
+  setClientAuthToken
+}));
+
+vi.mock('../utils/tokenStorage', () => ({
+  clearStoredToken: vi.fn(),
+  getStoredToken: vi.fn(() => 'stored-token'),
+  setStoredToken: vi.fn()
+}));
+
+describe('AppProvider', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not initialize auth token during render', async () => {
+    let callsDuringRender = -1;
+
+    function RenderProbe() {
+      callsDuringRender = setClientAuthToken.mock.calls.length;
+      return <div>probe</div>;
+    }
+
+    render(
+      <AppProvider>
+        <RenderProbe />
+      </AppProvider>
+    );
+
+    expect(callsDuringRender).toBe(0);
+    await waitFor(() => {
+      expect(setClientAuthToken).toHaveBeenCalledWith('stored-token');
+    });
+  });
+});

--- a/frontend/webui/src/context/AppContext.tsx
+++ b/frontend/webui/src/context/AppContext.tsx
@@ -1,6 +1,6 @@
 // Application Context - Centralized State Management with TypeScript
 
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
 import { flushSync } from 'react-dom';
 import { getServices, getServicesBouquets, getSystemConfig } from '../client-ts';
 import { setClientAuthToken } from '../lib/clientWrapper';
@@ -44,13 +44,13 @@ export function AppProvider({ children }: AppProviderProps) {
   const [initializing, setInitializing] = useState<boolean>(true);
   const [dataLoaded, setDataLoaded] = useState<boolean>(false);
 
-  // Initialize client with stored token on mount (Address Phase 1/13 Refactor gap)
-  useCallback(() => {
+  // Initialize client with stored token after mount to avoid render-time side effects.
+  useEffect(() => {
     const storedToken = getStoredToken();
     if (storedToken) {
       setClientAuthToken(storedToken);
     }
-  }, [])();
+  }, []);
 
   // Actions
   const setToken = useCallback((newToken: string) => {

--- a/frontend/webui/src/features/resume/useResume.test.tsx
+++ b/frontend/webui/src/features/resume/useResume.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useResume } from './useResume';
+
+const { saveResume } = vi.hoisted(() => ({
+  saveResume: vi.fn()
+}));
+
+vi.mock('./api', () => ({
+  saveResume
+}));
+
+function ResumeHarness() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useResume({
+    recordingId: 'rec-123',
+    duration: 120,
+    videoRef,
+    isPlaying: false,
+    isSeekable: true
+  });
+
+  return <video ref={videoRef} />;
+}
+
+describe('useResume', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('binds video listeners from the ref after mount', async () => {
+    const { container } = render(<ResumeHarness />);
+    const video = container.querySelector('video');
+
+    expect(video).not.toBeNull();
+    Object.defineProperty(video, 'currentTime', {
+      configurable: true,
+      value: 42,
+      writable: true
+    });
+
+    fireEvent.pause(video as HTMLVideoElement);
+
+    await waitFor(() => {
+      expect(saveResume).toHaveBeenCalledWith('rec-123', {
+        position: 42,
+        total: 120,
+        finished: false
+      });
+    });
+  });
+});

--- a/frontend/webui/src/features/resume/useResume.ts
+++ b/frontend/webui/src/features/resume/useResume.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback, type RefObject } from 'react';
 import { saveResume } from './api';
 import { debugWarn, formatError } from '../../utils/logging';
 
@@ -8,12 +8,12 @@ const JUMP_THRESHOLD = 30;
 interface UseResumeProps {
   recordingId?: string;
   duration?: number | null;
-  videoElement: HTMLVideoElement | null;
+  videoRef: RefObject<HTMLVideoElement | null>;
   isPlaying: boolean;
   isSeekable?: boolean;
 }
 
-export function useResume({ recordingId, duration, videoElement, isPlaying, isSeekable = true }: UseResumeProps) {
+export function useResume({ recordingId, duration, videoRef, isPlaying, isSeekable = true }: UseResumeProps) {
   const lastSavedTime = useRef<number>(0);
   const saveTimerRef = useRef<number | null>(null);
   const finishedRef = useRef(false);
@@ -24,6 +24,7 @@ export function useResume({ recordingId, duration, videoElement, isPlaying, isSe
   }, [recordingId]);
 
   const save = useCallback(async (forceFinished: boolean = false) => {
+    const videoElement = videoRef.current;
     if (!recordingId || !videoElement) return;
     if (!isSeekable) return;
 
@@ -52,7 +53,7 @@ export function useResume({ recordingId, duration, videoElement, isPlaying, isSe
     } catch (err) {
       debugWarn('[useResume] Failed to save resume state', formatError(err));
     }
-  }, [recordingId, videoElement, duration, isSeekable]);
+  }, [recordingId, videoRef, duration, isSeekable]);
 
   // Periodic Save
   useEffect(() => {
@@ -78,6 +79,7 @@ export function useResume({ recordingId, duration, videoElement, isPlaying, isSe
 
   // Event Listeners (Pause, Ended, Seeking)
   useEffect(() => {
+    const videoElement = videoRef.current;
     if (!videoElement || !recordingId || !isSeekable) return;
 
     const handlePause = () => save();
@@ -105,5 +107,5 @@ export function useResume({ recordingId, duration, videoElement, isPlaying, isSe
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [videoElement, recordingId, isSeekable, save]);
+  }, [videoRef, recordingId, isSeekable, save]);
 }


### PR DESCRIPTION
## Summary
- move stored auth token initialization out of the render path into a mount effect
- pass the video ref object into useResume so listener registration reads the current element after mount
- add regression tests for both fixes

## Verification
- npm test
- npm run type-check