### PR TITLE
fix: validate preflight outbound urls before request

### DIFF
--- a/backend/internal/api/server_bootstrap.go
+++ b/backend/internal/api/server_bootstrap.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ManuGH/xg2g/internal/log"
 	"github.com/ManuGH/xg2g/internal/openwebif"
 	"github.com/ManuGH/xg2g/internal/platform/httpx"
+	platformnet "github.com/ManuGH/xg2g/internal/platform/net"
 	"github.com/ManuGH/xg2g/internal/recordings"
 )
 
@@ -37,8 +38,21 @@ func (s *Server) initPlaybackSubsystem(cfg config.AppConfig) error {
 		return fmt.Errorf("initialize vod manager: %w", err)
 	}
 	s.vodManager = vodMgr
-	s.preflightProvider = preflight.NewHTTPPreflightProvider(nil, cfg.Enigma2.PreflightTimeout)
+	s.preflightProvider = preflight.NewHTTPPreflightProvider(nil, cfg.Enigma2.PreflightTimeout, preflightOutboundPolicyFromConfig(cfg))
 	return nil
+}
+
+func preflightOutboundPolicyFromConfig(cfg config.AppConfig) platformnet.OutboundPolicy {
+	allow := cfg.Network.Outbound.Allow
+	return platformnet.OutboundPolicy{
+		Enabled: cfg.Network.Outbound.Enabled,
+		Allow: platformnet.OutboundAllowlist{
+			Hosts:   append([]string(nil), allow.Hosts...),
+			CIDRs:   append([]string(nil), allow.CIDRs...),
+			Ports:   append([]int(nil), allow.Ports...),
+			Schemes: append([]string(nil), allow.Schemes...),
+		},
+	}
 }
 
 func (s *Server) wireV3Subsystem(cfg config.AppConfig, cfgMgr *config.Manager) error {

--- a/backend/internal/control/vod/preflight/http_provider.go
+++ b/backend/internal/control/vod/preflight/http_provider.go
@@ -52,15 +52,16 @@ func (p *HTTPPreflightProvider) Check(ctx context.Context, src SourceRef) (Prefl
 		defer cancel()
 	}
 
-	validatedURL, err := platformnet.ValidateOutboundURL(ctx, src.URL, p.outboundPolicy)
+	validatedURL, err := platformnet.ParseValidatedOutboundURL(ctx, src.URL, p.outboundPolicy)
 	if err != nil {
 		return PreflightResult{Outcome: PreflightInternal}, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, validatedURL, nil)
-	if err != nil {
-		return PreflightResult{Outcome: PreflightInternal}, err
-	}
+	req := (&http.Request{
+		Method: http.MethodGet,
+		URL:    validatedURL,
+		Header: make(http.Header),
+	}).WithContext(ctx)
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/backend/internal/control/vod/preflight/http_provider.go
+++ b/backend/internal/control/vod/preflight/http_provider.go
@@ -8,16 +8,19 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	platformnet "github.com/ManuGH/xg2g/internal/platform/net"
 )
 
 // HTTPPreflightProvider checks source availability using HTTP requests.
 // Timeout is enforced via context.WithTimeout; http.Client.Timeout is left unset.
 type HTTPPreflightProvider struct {
-	client  *http.Client
-	timeout time.Duration
+	client         *http.Client
+	timeout        time.Duration
+	outboundPolicy platformnet.OutboundPolicy
 }
 
-func NewHTTPPreflightProvider(client *http.Client, timeout time.Duration) *HTTPPreflightProvider {
+func NewHTTPPreflightProvider(client *http.Client, timeout time.Duration, outboundPolicy platformnet.OutboundPolicy) *HTTPPreflightProvider {
 	if client == nil {
 		client = &http.Client{}
 	} else {
@@ -29,8 +32,9 @@ func NewHTTPPreflightProvider(client *http.Client, timeout time.Duration) *HTTPP
 		return http.ErrUseLastResponse
 	}
 	return &HTTPPreflightProvider{
-		client:  client,
-		timeout: timeout,
+		client:         client,
+		timeout:        timeout,
+		outboundPolicy: cloneOutboundPolicy(outboundPolicy),
 	}
 }
 
@@ -48,10 +52,12 @@ func (p *HTTPPreflightProvider) Check(ctx context.Context, src SourceRef) (Prefl
 		defer cancel()
 	}
 
-	// Invariant: src.URL is validated upstream by ValidateOutboundURL in preflight_gate.go.
-	// SSRF protection: scheme/host/port allowlist + DNS rebinding block.
-	// See: internal/platform/net/outbound.go, internal/control/http/v3/preflight_gate.go
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src.URL, nil)
+	validatedURL, err := platformnet.ValidateOutboundURL(ctx, src.URL, p.outboundPolicy)
+	if err != nil {
+		return PreflightResult{Outcome: PreflightInternal}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, validatedURL, nil)
 	if err != nil {
 		return PreflightResult{Outcome: PreflightInternal}, err
 	}
@@ -87,4 +93,16 @@ func (p *HTTPPreflightProvider) Check(ctx context.Context, src SourceRef) (Prefl
 		result.Outcome = PreflightInternal
 	}
 	return result, nil
+}
+
+func cloneOutboundPolicy(policy platformnet.OutboundPolicy) platformnet.OutboundPolicy {
+	return platformnet.OutboundPolicy{
+		Enabled: policy.Enabled,
+		Allow: platformnet.OutboundAllowlist{
+			Hosts:   append([]string(nil), policy.Allow.Hosts...),
+			CIDRs:   append([]string(nil), policy.Allow.CIDRs...),
+			Ports:   append([]int(nil), policy.Allow.Ports...),
+			Schemes: append([]string(nil), policy.Allow.Schemes...),
+		},
+	}
 }

--- a/backend/internal/control/vod/preflight/http_provider_test.go
+++ b/backend/internal/control/vod/preflight/http_provider_test.go
@@ -3,10 +3,15 @@ package preflight
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
+
+	platformnet "github.com/ManuGH/xg2g/internal/platform/net"
 )
 
 type errorRoundTripper struct {
@@ -24,12 +29,21 @@ func (ctxWaitRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	return nil, req.Context().Err()
 }
 
+type countingRoundTripper struct {
+	calls int
+}
+
+func (c *countingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	c.calls++
+	return nil, errors.New("unexpected network call")
+}
+
 func TestHTTPPreflightProvider_Unreachable(t *testing.T) {
 	provider := NewHTTPPreflightProvider(&http.Client{
 		Transport: errorRoundTripper{err: errors.New("dial error")},
-	}, 0)
+	}, 0, testOutboundPolicy(t, "http://127.0.0.1"))
 
-	res, err := provider.Check(context.Background(), SourceRef{URL: "http://example.invalid"})
+	res, err := provider.Check(context.Background(), SourceRef{URL: "http://127.0.0.1"})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -44,12 +58,12 @@ func TestHTTPPreflightProvider_Unreachable(t *testing.T) {
 func TestHTTPPreflightProvider_Timeout(t *testing.T) {
 	provider := NewHTTPPreflightProvider(&http.Client{
 		Transport: ctxWaitRoundTripper{},
-	}, 0)
+	}, 0, testOutboundPolicy(t, "http://127.0.0.1"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
-	res, err := provider.Check(ctx, SourceRef{URL: "http://example.invalid"})
+	res, err := provider.Check(ctx, SourceRef{URL: "http://127.0.0.1"})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -64,12 +78,12 @@ func TestHTTPPreflightProvider_Timeout(t *testing.T) {
 func TestHTTPPreflightProvider_CanceledContext(t *testing.T) {
 	provider := NewHTTPPreflightProvider(&http.Client{
 		Transport: ctxWaitRoundTripper{},
-	}, 0)
+	}, 0, testOutboundPolicy(t, "http://127.0.0.1"))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	res, err := provider.Check(ctx, SourceRef{URL: "http://example.invalid"})
+	res, err := provider.Check(ctx, SourceRef{URL: "http://127.0.0.1"})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -105,7 +119,7 @@ func TestHTTPPreflightProvider_StatusMapping(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			provider := NewHTTPPreflightProvider(srv.Client(), 0)
+			provider := NewHTTPPreflightProvider(srv.Client(), 0, testOutboundPolicy(t, srv.URL))
 			res, err := provider.Check(context.Background(), SourceRef{URL: srv.URL})
 			if err != nil {
 				t.Fatalf("expected nil error, got %v", err)
@@ -133,7 +147,7 @@ func TestHTTPPreflightProvider_NoRedirect(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	provider := NewHTTPPreflightProvider(srv.Client(), 0)
+	provider := NewHTTPPreflightProvider(srv.Client(), 0, testOutboundPolicy(t, srv.URL))
 	res, err := provider.Check(context.Background(), SourceRef{URL: srv.URL})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
@@ -147,4 +161,78 @@ func TestHTTPPreflightProvider_NoRedirect(t *testing.T) {
 	if res.HTTPStatus != http.StatusFound {
 		t.Fatalf("expected status %d, got %d", http.StatusFound, res.HTTPStatus)
 	}
+}
+
+func TestHTTPPreflightProvider_RejectsDisallowedURLBeforeRequest(t *testing.T) {
+	transport := &countingRoundTripper{}
+	provider := NewHTTPPreflightProvider(&http.Client{
+		Transport: transport,
+	}, 0, platformnet.OutboundPolicy{
+		Enabled: true,
+		Allow: platformnet.OutboundAllowlist{
+			Hosts:   []string{"example.com"},
+			Ports:   []int{443},
+			Schemes: []string{"https"},
+		},
+	})
+
+	res, err := provider.Check(context.Background(), SourceRef{URL: "http://127.0.0.1"})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if res.Outcome != PreflightInternal {
+		t.Fatalf("expected outcome %q, got %q", PreflightInternal, res.Outcome)
+	}
+	if transport.calls != 0 {
+		t.Fatalf("expected no network call, got %d", transport.calls)
+	}
+}
+
+func testOutboundPolicy(t *testing.T, rawURL string) platformnet.OutboundPolicy {
+	t.Helper()
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse test url: %v", err)
+	}
+	host := u.Hostname()
+
+	port := 0
+	switch u.Scheme {
+	case "http":
+		port = 80
+	case "https":
+		port = 443
+	}
+	if u.Port() != "" {
+		var parseErr error
+		port, parseErr = parsePort(u.Port())
+		if parseErr != nil {
+			t.Fatalf("parse port: %v", parseErr)
+		}
+	}
+
+	return platformnet.OutboundPolicy{
+		Enabled: true,
+		Allow: platformnet.OutboundAllowlist{
+			Hosts:   []string{host},
+			CIDRs:   testAllowedCIDRs(host),
+			Ports:   []int{port},
+			Schemes: []string{u.Scheme},
+		},
+	}
+}
+
+func parsePort(raw string) (int, error) {
+	if raw == "" {
+		return 0, errors.New("empty port")
+	}
+	return strconv.Atoi(raw)
+}
+
+func testAllowedCIDRs(host string) []string {
+	if ip := net.ParseIP(host); ip != nil {
+		return []string{ip.String()}
+	}
+	return nil
 }

--- a/backend/internal/platform/net/outbound.go
+++ b/backend/internal/platform/net/outbound.go
@@ -75,69 +75,69 @@ func NormalizeHost(raw string) (string, error) {
 	return strings.ToLower(ascii), nil
 }
 
-// ValidateOutboundURL verifies a URL against the outbound policy and returns a normalized URL string.
-func ValidateOutboundURL(ctx context.Context, raw string, policy OutboundPolicy) (string, error) {
+// ParseValidatedOutboundURL verifies a URL against the outbound policy and returns a normalized URL.
+func ParseValidatedOutboundURL(ctx context.Context, raw string, policy OutboundPolicy) (*url.URL, error) {
 	if !policy.Enabled {
-		return "", ErrOutboundDisabled
+		return nil, ErrOutboundDisabled
 	}
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
-		return "", fmt.Errorf("outbound url empty")
+		return nil, fmt.Errorf("outbound url empty")
 	}
 	u, err := url.Parse(trimmed)
 	if err != nil {
-		return "", fmt.Errorf("invalid url: %w", err)
+		return nil, fmt.Errorf("invalid url: %w", err)
 	}
 	if u.Scheme == "" {
-		return "", fmt.Errorf("missing url scheme")
+		return nil, fmt.Errorf("missing url scheme")
 	}
 	if u.Host == "" {
-		return "", fmt.Errorf("missing url host")
+		return nil, fmt.Errorf("missing url host")
 	}
 	if u.User != nil {
-		return "", fmt.Errorf("userinfo not allowed")
+		return nil, fmt.Errorf("userinfo not allowed")
 	}
 	if u.Fragment != "" {
-		return "", fmt.Errorf("fragments not allowed")
+		return nil, fmt.Errorf("fragments not allowed")
 	}
 
 	scheme := strings.ToLower(u.Scheme)
 	if !schemeAllowed(policy.Allow.Schemes, scheme) {
-		return "", fmt.Errorf("scheme %q not allowed", scheme)
+		return nil, fmt.Errorf("scheme %q not allowed", scheme)
 	}
 
 	port, err := urlPort(u, scheme)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if !portAllowed(policy.Allow.Ports, port) {
-		return "", fmt.Errorf("port %d not allowed", port)
+		return nil, fmt.Errorf("port %d not allowed", port)
 	}
 
 	host, err := NormalizeHost(u.Hostname())
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	allowedHosts, err := normalizeHostAllowlist(policy.Allow.Hosts)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	allowedCIDRs, err := parseCIDRAllowlist(policy.Allow.CIDRs)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	ips, err := resolveHostIPs(ctx, host)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	_, hostAllowed := allowedHosts[host]
 	ipAllowed := false
 	for _, ip := range ips {
 		if isBlockedIP(ip) && !ipInCIDRs(ip, allowedCIDRs) {
-			return "", fmt.Errorf("blocked ip %s", ip.String())
+			return nil, fmt.Errorf("blocked ip %s", ip.String())
 		}
 		if ipInCIDRs(ip, allowedCIDRs) {
 			ipAllowed = true
@@ -145,10 +145,21 @@ func ValidateOutboundURL(ctx context.Context, raw string, policy OutboundPolicy)
 	}
 
 	if !hostAllowed && !ipAllowed {
-		return "", ErrOutboundNotAllowed
+		return nil, ErrOutboundNotAllowed
 	}
 
-	u.Host = joinHostPort(host, u.Port())
+	normalized := *u
+	normalized.Scheme = scheme
+	normalized.Host = joinHostPort(host, u.Port())
+	return &normalized, nil
+}
+
+// ValidateOutboundURL verifies a URL against the outbound policy and returns a normalized URL string.
+func ValidateOutboundURL(ctx context.Context, raw string, policy OutboundPolicy) (string, error) {
+	u, err := ParseValidatedOutboundURL(ctx, raw, policy)
+	if err != nil {
+		return "", err
+	}
 	return u.String(), nil
 }
 

--- a/backend/internal/platform/net/outbound_test.go
+++ b/backend/internal/platform/net/outbound_test.go
@@ -165,3 +165,22 @@ func TestValidateOutboundURL(t *testing.T) {
 		})
 	}
 }
+
+func TestParseValidatedOutboundURL(t *testing.T) {
+	policy := OutboundPolicy{
+		Enabled: true,
+		Allow: OutboundAllowlist{
+			Hosts:   []string{"192.0.2.10"},
+			Ports:   []int{80},
+			Schemes: []string{"http"},
+		},
+	}
+
+	u, err := ParseValidatedOutboundURL(context.Background(), "http://192.0.2.10./stream.ts?profile=main", policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := u.String(), "http://192.0.2.10/stream.ts?profile=main"; got != want {
+		t.Fatalf("expected normalized url %q, got %q", want, got)
+	}
+}


### PR DESCRIPTION
## Summary
- validate preflight URLs inside the HTTP preflight provider before building the outbound request
- wire the server's outbound allowlist policy into the provider instead of relying only on upstream callers
- add direct tests for allowed local test targets and blocked disallowed targets

## Why
CodeQL alert #2230 () flags  because the provider built a request directly from  and only relied on upstream validation. This change makes the provider enforce the outbound policy itself before any request is created.

## Verification
- FAIL	./internal/control/vod/preflight [setup failed]
FAIL
- FAIL	./internal/api [setup failed]
FAIL

Refs: code scanning alert #2230