### PR TITLE
docs: clean onboarding and repo-root references

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Tier-1 compliant with Apple HLS Guidelines.
 
 ## Documentation
 
-- 🚀 [Start Here (10 Minutes)](NEW_HERE.md) - First-commit onboarding path
+- 🚀 [Start Here (10 Minutes)](backend/NEW_HERE.md) - First-commit onboarding path
 - 📘 [Architecture Overview](docs/arch/ARCHITECTURE.md) - Complete system
   explanation
 - 📋 [ADRs](docs/ADR/) - Design decisions and trade-offs
@@ -85,7 +85,7 @@ Tier-1 compliant with Apple HLS Guidelines.
   from [backend/api/openapi.yaml](backend/api/openapi.yaml)
 - ⚙️ [Configuration Guide](docs/guides/CONFIGURATION.md)
 - 🏗️ [Development Guide](docs/guides/DEVELOPMENT.md)
-- 🧭 [Workflow Guide](WORKFLOW.md) - Branching, testing, and deployment flow
+- 🧭 [Workflow Guide](backend/WORKFLOW.md) - Branching, testing, and deployment flow
 - 🩺 [CI Failure Playbook](docs/ops/CI_FAILURE_PLAYBOOK.md) - Triage guide for
   failing gates
 

--- a/backend/BUILD.md
+++ b/backend/BUILD.md
@@ -6,7 +6,7 @@ This document captures the technical requirements and targets for building and d
 
 | Component | Policy / Requirement |
 | :--- | :--- |
-| **Go** | Source of Truth: `go.mod`. Required version: `1.25.6`. |
+| **Go** | Source of Truth: `backend/go.mod`. Required language version: `1.25`; pinned toolchain: `go1.25.7`. |
 | **FFmpeg** | Required for HLS/Transcoding. Version: `6.x` or `7.x`. |
 | **Docker** | Required for containerized build/deploy. Supports `buildx`. |
 | **Make** | Used as the orchestration layer for all dev tasks. |
@@ -17,11 +17,11 @@ Base command: `make [target]`
 
 | Target | Description |
 | :--- | :--- |
-| `build` | Compiles the `xg2g` binary to `./bin/` |
+| `build` | Compiles the offline-safe backend binary to `./bin/xg2g`. |
+| `ui-build` | Builds `frontend/webui/` and copies the bundle into `backend/internal/control/http/dist/`. |
 | `docker-build` | Builds the Docker image (AMD64) with `--load` |
 | `test` | Runs unit and fast integration tests |
-| `lint` | Executes `golangci-lint` and documentation linters |
-| `clean` | Purges `./bin/`, logs, and temporary test data |
+| `lint` | Executes `golangci-lint`, WebUI linting, and design contract checks |
 
 ## 3. Deployment Posture
 
@@ -31,4 +31,4 @@ Base command: `make [target]`
 - **Network**: Exposes HTTP service (default `:8088`).
 
 > [!IMPORTANT]
-> Always verify the `go.mod` version before local compilation to ensure toolchain alignment with CI.
+> Always verify `backend/go.mod` and the root `mk/variables.mk` toolchain pin before local compilation to stay aligned with CI.

--- a/backend/NEW_HERE.md
+++ b/backend/NEW_HERE.md
@@ -5,21 +5,20 @@ This is the fastest path to understand and run xg2g as a new contributor.
 ## 1. Read Order (3 files)
 
 1. `README.md` - Product scope and quickstart
-2. `WORKFLOW.md` - Branching and PR rules
+2. `backend/WORKFLOW.md` - Branching and PR rules
 3. `docs/arch/PACKAGE_LAYOUT.md` - Where code belongs
 
-## 2. First Local Run
+## 2. First Local Check
 
 ```bash
-make hooks
-make check-env
 make build
+go test ./...
 ```
 
 Optional WebUI dev loop:
 
 ```bash
-cd webui
+cd frontend/webui
 npm ci
 npm run dev
 ```
@@ -35,16 +34,16 @@ If that is too heavy locally, use this narrower path first:
 ```bash
 make lint
 go test ./...
-cd webui && npm run test
+cd frontend/webui && npm run test
 ```
 
 ## 4. Where To Change What
 
-- API and handlers: `internal/control/http/v3/`
-- Playback/session domain behavior: `internal/control/` and `internal/domain/`
-- App wiring/bootstrap: `internal/app/bootstrap/`
-- Frontend: `webui/src/`
-- Contracts and invariants: `docs/ops/`, `docs/arch/`, `contracts/`
+- API and handlers: `backend/internal/control/http/v3/`
+- Playback/session domain behavior: `backend/internal/control/` and `backend/internal/domain/`
+- App wiring/bootstrap: `backend/internal/app/bootstrap/`
+- Frontend: `frontend/webui/src/`
+- Contracts and invariants: `docs/ops/`, `docs/arch/`, `backend/contracts/`
 
 ## 5. If CI Fails
 
@@ -52,9 +51,9 @@ Start here: `docs/ops/CI_FAILURE_PLAYBOOK.md`
 
 Common checks you can run locally:
 
-- `./scripts/check-go-toolchain.sh`
-- `./scripts/check-ui-contract.sh`
-- `cd webui && npm run verify:client-wrapper`
+- `./backend/scripts/check-go-toolchain.sh`
+- `./backend/scripts/check-ui-contract.sh`
+- `cd frontend/webui && npm run verify:client-wrapper`
 
 ## 6. Contributor Notes
 

--- a/backend/WORKFLOW.md
+++ b/backend/WORKFLOW.md
@@ -14,7 +14,7 @@ git checkout -b codex/<feature>
 
 ## Shared SMB Hygiene (Required)
 
-- Run once per clone: `make hooks` (installs `pre-commit` + `pre-push` hooks).
+- Run once per clone: `pip install pre-commit && pre-commit install --hook-type pre-commit --hook-type pre-push`.
 - The pre-push hook blocks:
   - direct pushes from `main`
   - branches not descending from `origin/main` (unrelated-history safety)
@@ -50,7 +50,7 @@ go test ./...
 go test ./...
 # build/run as needed
 make build
-./xg2g --config /path/to/config.yaml
+./bin/xg2g --config /path/to/config.yaml
 ```
 
 ### WebUI (Dev Mode)
@@ -58,13 +58,13 @@ make build
 The WebUI can run independently via Vite (fast reload) while the backend runs separately:
 
 ```bash
-cd webui
+cd frontend/webui
 npm install
 npm run dev
 ```
 
 - Dev server: `http://<host>:5173/ui/`
-- API is proxied to `http://localhost:8080` by default (see `webui/vite.config.js`).
+- API is proxied to `http://localhost:8080` by default (see `frontend/webui/vite.config.js`).
 - In dev, run the backend on **8080**. In compose/prod the backend is typically **8088**.
 - You can restart the WebUI without touching the backend.
 

--- a/backend/templates/README.md.tmpl
+++ b/backend/templates/README.md.tmpl
@@ -74,7 +74,7 @@ Tier-1 compliant with Apple HLS Guidelines.
 
 ## Documentation
 
-- 🚀 [Start Here (10 Minutes)](NEW_HERE.md) - First-commit onboarding path
+- 🚀 [Start Here (10 Minutes)](backend/NEW_HERE.md) - First-commit onboarding path
 - 📘 [Architecture Overview](docs/arch/ARCHITECTURE.md) - Complete system
   explanation
 - 📋 [ADRs](docs/ADR/) - Design decisions and trade-offs
@@ -84,7 +84,7 @@ Tier-1 compliant with Apple HLS Guidelines.
   from [backend/api/openapi.yaml](backend/api/openapi.yaml)
 - ⚙️ [Configuration Guide](docs/guides/CONFIGURATION.md)
 - 🏗️ [Development Guide](docs/guides/DEVELOPMENT.md)
-- 🧭 [Workflow Guide](WORKFLOW.md) - Branching, testing, and deployment flow
+- 🧭 [Workflow Guide](backend/WORKFLOW.md) - Branching, testing, and deployment flow
 - 🩺 [CI Failure Playbook](docs/ops/CI_FAILURE_PLAYBOOK.md) - Triage guide for
   failing gates
 

--- a/docs/CI_CONTRACT.md
+++ b/docs/CI_CONTRACT.md
@@ -8,8 +8,8 @@ All developers must verify these gates locally before pushing.
 | CI Job | Local Command | Description |
 | :--- | :--- | :--- |
 | `lint` | `make lint` | Runs `golangci-lint`. |
-| `check-deprecations` | `python3 scripts/check_deprecations.py` | Registry validation. |
-| `complexity-check` | `gocyclo -over 20 ./internal ./cmd` | Complexity limit. |
+| `check-deprecations` | `python3 backend/scripts/check_deprecations.py` | Registry validation. |
+| `complexity-check` | `cd backend && gocyclo -over 20 ./internal ./cmd` | Complexity limit. |
 | `openapi-drift` | `make generate && git diff --exit-code` | Spec sync check. |
 | `docs-drift` | `./hack/verify-docs-drift.sh` | Rendered-docs drift gate (clean tree). |
 
@@ -21,13 +21,13 @@ All developers must verify these gates locally before pushing.
 | `Integration` | `make smoke-test` | Local daemon run. |
 | `validate-config` | `make validate` | Config validation. |
 | `schema-validate` | `make schema-validate` | JSON Schema check. |
-| `Phase4 wrapper boundary` | `cd webui && npm run verify:client-wrapper` | Enforces no direct `client-ts/*.gen` imports outside wrapper. |
+| `Phase4 wrapper boundary` | `cd frontend/webui && npm run verify:client-wrapper` | Enforces no direct `client-ts/*.gen` imports outside wrapper. |
 
 ## 3. Build Sanity
 
 | CI Job | Local Command | Description |
 | :--- | :--- | :--- |
-| `build` | `go build ./cmd/daemon` | Pure Go compilation (CGO disabled). |
+| `build` | `make build` | Pure Go compilation (CGO disabled). |
 | `multi-platform` | `make build-all` | Cross-compilation. |
 
 ## 4. Environment Invariants

--- a/docs/HERMETICITY.md
+++ b/docs/HERMETICITY.md
@@ -39,9 +39,9 @@ No warm cache masking missing vendored dependencies.
 
 All build-time tools hermetically vendored:
 
-- Tools declared in [`tools.go`](../../tools.go)
-- Vendored in `vendor/github.com/oapi-codegen/`
-- Verified via `vendor/modules.txt` (canonical source)
+- Tools declared in [`backend/tools.go`](../backend/tools.go)
+- Vendored in `backend/vendor/github.com/oapi-codegen/`
+- Verified via `backend/vendor/modules.txt` (canonical source)
 
 ### 5. No External Tool Installation
 
@@ -69,7 +69,7 @@ Generated code (deterministic output)
 
 ### CTO Gate: Contract Enforcement
 
-**Script**: [`scripts/ci/ctogate_hermetic_codegen.sh`](../../scripts/ci/ctogate_hermetic_codegen.sh)
+**Script**: [`backend/scripts/ci/ctogate_hermetic_codegen.sh`](../backend/scripts/ci/ctogate_hermetic_codegen.sh)
 
 - **Allow-list**: Codegen steps must use `make generate` only
 - **Global forbid**: Blocks direct `oapi-codegen`, `go install`, `curl`/`wget` invocations
@@ -126,7 +126,7 @@ GOPROXY=off GOSUMDB=off GOVCS=*:off GOTOOLCHAIN=local \
 
 # Verify determinism
 make generate
-git diff --exit-code -- internal/api internal/control/http/v3
+git diff --exit-code -- backend/internal/api backend/internal/control/http/v3
 
 # Verify hermetic invariants
 make verify-hermetic-codegen
@@ -134,7 +134,7 @@ make verify-hermetic-codegen
 
 ### CI Proof
 
-See [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) - step
+See [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) - step
 "Hermetic Build Proof (Adversarial-Grade)"
 
 Every push proves the guarantee under adversarial conditions.

--- a/docs/TECHNICAL_DEBT.md
+++ b/docs/TECHNICAL_DEBT.md
@@ -44,7 +44,7 @@ This document tracks known issues that are not blockers for release but require 
 ### 4. WebUI Generated Client Wrapper Discipline
 
 - **Status**: Completed on 2026-02-19.
-- **Result**: Added `webui/src/client-ts/wrapper.ts`, removed direct `client-ts/*.gen` imports in product code, and added typed RFC7807 mapping tests (`webui/src/client-ts/wrapper.test.ts`).
+- **Result**: Added `frontend/webui/src/client-ts/wrapper.ts`, removed direct `client-ts/*.gen` imports in product code, and added typed RFC7807 mapping tests (`frontend/webui/src/client-ts/wrapper.test.ts`).
 - **Follow-up**: Preserve the wrapper boundary for all new API call sites and keep error mapping contract tests in CI.
 
 ### 5. Go Toolchain Directive Normalization
@@ -56,5 +56,5 @@ This document tracks known issues that are not blockers for release but require 
 ### 6. CI Wrapper Boundary Drift
 
 - **Status**: Completed on 2026-02-19.
-- **Result**: Centralized boundary check in `webui/scripts/verify-client-wrapper-boundary.sh` and reused it across PR/CI/nightly workflows to avoid regex drift.
+- **Result**: Centralized boundary check in `frontend/webui/scripts/verify-client-wrapper-boundary.sh` and reused it across PR/CI/nightly workflows to avoid regex drift.
 - **Follow-up**: Keep all future WebUI API-boundary checks delegated to this script (single source of truth).

--- a/docs/arch/ARCHITECTURE.md
+++ b/docs/arch/ARCHITECTURE.md
@@ -771,9 +771,9 @@ PASS  # All tests green
 1. [docs/arch/ARCHITECTURE.md](ARCHITECTURE.md) (this doc) – System overview
 2. [docs/arch/ENIGMA2_STREAMING_TOPOLOGY.md](ENIGMA2_STREAMING_TOPOLOGY.md) – Production Enigma2 integration
 3. [docs/arch/PACKAGE_LAYOUT.md](PACKAGE_LAYOUT.md) – Layering rules
-4. [internal/app/bootstrap/bootstrap.go](../../internal/app/bootstrap/bootstrap.go) – Wiring truth
+4. [backend/internal/app/bootstrap/bootstrap.go](../../backend/internal/app/bootstrap/bootstrap.go) – Wiring truth
 5. [api/openapi.yaml](../../api/openapi.yaml) – API contract
-6. [internal/validate/imports_test.go](../../internal/validate/imports_test.go) – Layering enforcement
+6. [backend/internal/validate/imports_test.go](../../backend/internal/validate/imports_test.go) – Layering enforcement
 
 ---
 

--- a/docs/arch/AUDIT_REPO_STRUCTURE.md
+++ b/docs/arch/AUDIT_REPO_STRUCTURE.md
@@ -16,8 +16,8 @@ authoritative.
 - Build, test, and release workflows are highly gate-driven (`Makefile`,
   `.github/workflows/`).
 - Runtime operations and governance policy are documented under `docs/ops/`.
-- WebUI is developed in `webui/` and embedded into `internal/control/http/dist`
-  for backend serving.
+- WebUI is developed in `frontend/webui/` and embedded into
+  `backend/internal/control/http/dist/` for backend serving.
 
 ## Source Of Truth Documents
 
@@ -28,7 +28,7 @@ authoritative.
 - Operator and governance posture:
   `docs/ops/EXTERNAL_AUDIT_MODE.md`
 - Development and contribution flow:
-  `WORKFLOW.md`
+  `backend/WORKFLOW.md`
 
 ## Scope Notes
 

--- a/docs/dev/LOG_HYGIENE_TICKET.md
+++ b/docs/dev/LOG_HYGIENE_TICKET.md
@@ -15,14 +15,14 @@ Reduce expected, non-actionable stderr/warn output in WebUI tests without global
 ## Implemented
 
 - Added opt-in helper:
-  - `webui/tests/helpers/consoleNoise.ts`
+  - `frontend/webui/tests/helpers/consoleNoise.ts`
 - Applied targeted suppression in migrated live-flow tests:
-  - `webui/tests/V3Player.seal.test.tsx`
-  - `webui/src/components/V3Player.serviceRef.test.tsx`
-  - `webui/tests/contracts/v3player.intent-keys.contract.test.tsx`
+  - `frontend/webui/tests/V3Player.seal.test.tsx`
+  - `frontend/webui/src/components/V3Player.serviceRef.test.tsx`
+  - `frontend/webui/tests/contracts/v3player.intent-keys.contract.test.tsx`
 - Applied targeted suppression in remaining noisy V3Player suites:
-  - `webui/tests/V3Player.contract.test.tsx`
-  - `webui/tests/V3Player.errors.test.tsx`
+  - `frontend/webui/tests/V3Player.contract.test.tsx`
+  - `frontend/webui/tests/V3Player.errors.test.tsx`
 
 Suppressed patterns (expected noise only):
 
@@ -34,6 +34,6 @@ Suppressed patterns (expected noise only):
 
 ## Follow-up Candidates
 
-- `webui/tests/contracts/v3player.failclosed.test.tsx` produced no additional stderr noise in targeted run, so no allowlist was added.
+- `frontend/webui/tests/contracts/v3player.failclosed.test.tsx` produced no additional stderr noise in targeted run, so no allowlist was added.
 - Optional product/test harness improvement:
   - ensure teardown stop-intent uses absolute URL in jsdom tests to eliminate `/api/v3/intents` relative URL warnings at source.

--- a/docs/guides/REFERENCE.md
+++ b/docs/guides/REFERENCE.md
@@ -5,7 +5,7 @@ configuration files, and health endpoints.
 
 > [!NOTE]
 > For architectural details, see [ARCHITECTURE.md](../arch/ARCHITECTURE.md). For
-> build/deploy facts, see [BUILD.md](../../BUILD.md).
+> build/deploy facts, see [backend/BUILD.md](../../backend/BUILD.md).
 
 ## 1. Environment Variables
 
@@ -21,7 +21,7 @@ Precedence: **Environment Variables** > **Configuration File** > **Defaults**.
 | `XG2G_API_TOKEN` | Primary admin bearer token | - |
 | `XG2G_API_TOKEN_SCOPES`| Scopes for primary token (CSV) | `v3:read,v3:write` |
 | `XG2G_API_TOKENS` | Multi-token JSON list | `[{"token":"...","scopes":...}]` |
-| `XG2G_API_DISABLE_LEGACY_TOKEN_SOURCES` | Disable legacy `X-API-Token` header/cookie auth vectors | `false` |
+| `XG2G_API_DISABLE_LEGACY_TOKEN_SOURCES` | Disable legacy `X-API-Token` header/cookie auth vectors | `true` |
 
 ### V3 Streaming Engine
 
@@ -48,10 +48,9 @@ Precedence: **Environment Variables** > **Configuration File** > **Defaults**.
 | `XG2G_E2_BACKOFF` | `200ms` | Initial retry backoff |
 | `XG2G_E2_MAX_BACKOFF` | `30s` | Max retry backoff duration (canonical) |
 | `XG2G_E2_STREAM_PORT` | `8001` | Deprecated direct stream port override (canonical) |
-| `XG2G_E2_USE_WEBIF_STREAMS` | `true` | Prefer `/web/stream.m3u` URL path |
+| `XG2G_E2_USE_WEBIF_STREAMS` | `false` | Prefer `/web/stream.m3u` URL path |
 | `XG2G_E2_RESPONSE_HEADER_TIMEOUT` | `10s` | HTTP response header timeout |
 | `XG2G_E2_TUNE_TIMEOUT` | `10s` | Tune timeout before fallback/error |
-| `XG2G_E2_AUTH_MODE` | `inherit` | Auth behavior (`inherit|none|explicit`) |
 | `XG2G_E2_RATE_LIMIT` | - | Optional per-session rate limit |
 | `XG2G_E2_RATE_BURST` | - | Optional burst for rate limiting |
 | `XG2G_E2_USER_AGENT` | - | Optional User-Agent override |

--- a/docs/ops/DURATION_TRUTH.md
+++ b/docs/ops/DURATION_TRUTH.md
@@ -90,10 +90,10 @@ Observability contract:
 ## Mechanical Gates
 
 - Gate F (No UI guessing):
-  - `webui/tests/contracts/v3player.duration-truth-gate.test.ts`
+  - `frontend/webui/tests/contracts/v3player.duration-truth-gate.test.ts`
 - Gate K (No Duration Guessing, repo-wide UI policy):
-  - `npm --prefix webui run gate:no-duration-guessing`
-  - `webui/scripts/no-duration-guessing.mjs`
+  - `npm --prefix frontend/webui run gate:no-duration-guessing`
+  - `frontend/webui/scripts/no-duration-guessing.mjs`
 - Gate G/H (deterministic resolver + clamp):
   - `internal/control/recordings/duration_truth_resolver_test.go`
 - Gate I (DTO schema stability):

--- a/docs/ops/SAFARI_AUDIT.md
+++ b/docs/ops/SAFARI_AUDIT.md
@@ -39,8 +39,8 @@ Hard proof that Safari playback is capability-driven and fail-closed:
 
 ### Gate W — No UA Sniffing (mechanical)
 
-- Script: `webui/scripts/no-ua-sniffing.mjs`
-- Fails on `navigator.userAgent/platform/vendor/appVersion` in runtime `webui/src/**`.
+- Script: `frontend/webui/scripts/no-ua-sniffing.mjs`
+- Fails on `navigator.userAgent/platform/vendor/appVersion` in runtime `frontend/webui/src/**`.
 - Tests/stories/generated client are excluded.
 - Allowlist comment for telemetry-only tags: `ua-telemetry-only`.
 
@@ -52,7 +52,7 @@ Hard proof that Safari playback is capability-driven and fail-closed:
   - `direct_mp4|deny` => no HLS engine
 - Additional availability check:
   - if mapped engine is not available in measured capabilities, fail-closed.
-- Contract test: `webui/tests/contracts/v3player.mode-bridge.test.ts`.
+- Contract test: `frontend/webui/tests/contracts/v3player.mode-bridge.test.ts`.
 
 ### Gate Y — HLS MIME + Playlist Sanity (server-side)
 

--- a/docs/ops/THIN_CLIENT_AUDIT.md
+++ b/docs/ops/THIN_CLIENT_AUDIT.md
@@ -14,11 +14,11 @@ Hard proof that WebUI acts as API client #1:
 
 Audited paths:
 
-- `webui/src/components/V3Player.tsx`
-- `webui/src/features/resume/useResume.ts`
-- `webui/src/components/Config.tsx`
-- `webui/src/client-ts/**`
-- `webui/tests/contracts/**` (contract gates)
+- `frontend/webui/src/components/V3Player.tsx`
+- `frontend/webui/src/features/resume/useResume.ts`
+- `frontend/webui/src/components/Config.tsx`
+- `frontend/webui/src/client-ts/**`
+- `frontend/webui/tests/contracts/**` (contract gates)
 
 Search patterns used:
 
@@ -45,14 +45,14 @@ Forbidden client logic:
 
 ## Non-SDK Fetch Inventory
 
-Findings from `rg "fetch\\(" webui/src`:
+Findings from `rg "fetch\\(" frontend/webui/src`:
 
-1. `webui/src/components/Config.tsx`
+1. `frontend/webui/src/components/Config.tsx`
    - `/healthz` (`GET`): non-JSON liveness polling after restart. Allowed.
    - `/internal/setup/validate` (`POST` JSON): internal bootstrap endpoint not in generated SDK.
      - Marked: `raw-fetch-justified: internal setup bootstrap endpoint is not part of typed public SDK surface.`
 
-2. `webui/src/components/V3Player.tsx`
+2. `frontend/webui/src/components/V3Player.tsx`
    - `/sessions/{id}/feedback` (`POST` JSON)
    - `/intents` (`POST` JSON; stop/start)
    - `/live/stream-info` (`POST` JSON)
@@ -64,11 +64,11 @@ Findings from `rg "fetch\\(" webui/src`:
 
 - Duration truth remains DTO-first (`durationMs`, `isSeekable`, reasons) and guarded by Gate K.
 - Live mode bridge is centralized:
-  - `webui/src/components/v3playerModeBridge.ts`
+  - `frontend/webui/src/components/v3playerModeBridge.ts`
   - exhaustive backend mode table
   - fail-closed default for missing/invalid/unsupported modes
 - RFC7807 parsing is centralized:
-  - `webui/src/lib/httpProblem.ts`
+  - `frontend/webui/src/lib/httpProblem.ts`
   - `V3Player` consumes `assertOkOrProblem` / `parseProblemResponse` for live/session API errors
 - V3Player consumes backend mode via the bridge and throws on contract drift (no implicit fallback mode).
 - V3Player validates mapped engine availability from measured capabilities and fails closed on mismatch.
@@ -76,8 +76,8 @@ Findings from `rg "fetch\\(" webui/src`:
   - `useResume` now receives `isSeekable`
   - no resume-save side effects when server reports `isSeekable=false`
 - Legacy client decision helper was moved out of runtime source:
-  - from `webui/src/contracts/PolicyEngine.ts`
-  - to `webui/tests/contracts/helpers/PolicyEngine.ts` (test-only)
+  - from `frontend/webui/src/contracts/PolicyEngine.ts`
+  - to `frontend/webui/tests/contracts/helpers/PolicyEngine.ts` (test-only)
 
 ## Mechanical Gates
 
@@ -94,15 +94,15 @@ Findings from `rg "fetch\\(" webui/src`:
 `make gate-webui` now executes:
 
 1. `scripts/ci_gate_webui_audit.sh`
-2. `npm --prefix webui run gate:no-appledouble`
-3. `npm --prefix webui run gate:no-duration-guessing`
-4. `npm --prefix webui run gate:no-client-decision-engine`
-5. `npm --prefix webui run gate:no-ua-sniffing`
-6. `npm --prefix webui run gate:no-seek-resume-guessing`
-7. `npm --prefix webui run gate:no-raw-json-fetch`
-8. `npm --prefix webui run gate:no-raw-error-text`
-9. `npm --prefix webui run gate:mode-bridge`
-10. `npm --prefix webui run gate:seekable-contract`
+2. `npm --prefix frontend/webui run gate:no-appledouble`
+3. `npm --prefix frontend/webui run gate:no-duration-guessing`
+4. `npm --prefix frontend/webui run gate:no-client-decision-engine`
+5. `npm --prefix frontend/webui run gate:no-ua-sniffing`
+6. `npm --prefix frontend/webui run gate:no-seek-resume-guessing`
+7. `npm --prefix frontend/webui run gate:no-raw-json-fetch`
+8. `npm --prefix frontend/webui run gate:no-raw-error-text`
+9. `npm --prefix frontend/webui run gate:mode-bridge`
+10. `npm --prefix frontend/webui run gate:seekable-contract`
 
 ## Status
 

--- a/docs/webui/TELEMETRY_INDEX.md
+++ b/docs/webui/TELEMETRY_INDEX.md
@@ -1,6 +1,6 @@
 # Telemetry Traceability Index
 
-This document maps system states to the Normative Telemetry Events defined in `contracts/telemetry.schema.json`.
+This document maps system states to the Normative Telemetry Events defined in `backend/contracts/telemetry.schema.json`.
 
 ## Contract Consumption (`ui.contract.consumed`)
 


### PR DESCRIPTION
## Summary
- fix broken onboarding and workflow links from the repo root docs
- align doc examples and paths with the current monorepo layout (backend and frontend/webui)
- correct reference-guide defaults for legacy token sources and useWebIFStreams

## Verification
- ./hack/verify-docs-drift.sh --allow-dirty
- git diff --check
