### PR TITLE
fix: harden receiver playback startup and auth flows

### DIFF
--- a/backend/internal/config/loader_test.go
+++ b/backend/internal/config/loader_test.go
@@ -98,6 +98,33 @@ picons:
 	}
 }
 
+func TestLoadFromYAMLHLSReadySegments(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XG2G_STORE_PATH", t.TempDir())
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	yamlContent := `
+openWebIF:
+  baseUrl: http://custom.local
+hls:
+  readySegments: 5
+`
+
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0o600); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	loader := NewLoader(configPath, "1.0.0")
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+
+	if cfg.HLS.ReadySegments != 5 {
+		t.Fatalf("expected HLS.ReadySegments=5, got %d", cfg.HLS.ReadySegments)
+	}
+}
+
 func TestENVOverridesFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XG2G_STORE_PATH", t.TempDir())

--- a/backend/internal/config/merge_file.go
+++ b/backend/internal/config/merge_file.go
@@ -315,6 +315,9 @@ func (l *Loader) mergeFileHLS(dst *AppConfig, src *FileConfig) {
 		if src.HLS.SegmentSeconds > 0 {
 			dst.HLS.SegmentSeconds = src.HLS.SegmentSeconds
 		}
+		if src.HLS.ReadySegments > 0 {
+			dst.HLS.ReadySegments = src.HLS.ReadySegments
+		}
 	}
 }
 

--- a/backend/internal/control/http/v3/preflight_gate.go
+++ b/backend/internal/control/http/v3/preflight_gate.go
@@ -23,12 +23,12 @@ func enforcePreflight(ctx context.Context, w http.ResponseWriter, r *http.Reques
 		return false
 	}
 
-	sourceURL, err := resolvePreflightSourceURL(ctx, deps, serviceRef)
+	sourceRef, err := resolvePreflightSource(ctx, deps, serviceRef)
 	if err != nil {
 		return rejectPreflight(w, r, preflight.PreflightInternal, err)
 	}
 
-	res, err := provider.Check(ctx, preflight.SourceRef{URL: sourceURL})
+	res, err := provider.Check(ctx, sourceRef)
 	outcome := res.Outcome
 	if err != nil || outcome == "" {
 		return rejectPreflight(w, r, preflight.PreflightInternal, err)
@@ -39,41 +39,71 @@ func enforcePreflight(ctx context.Context, w http.ResponseWriter, r *http.Reques
 	return rejectPreflight(w, r, outcome, err)
 }
 
-func resolvePreflightSourceURL(ctx context.Context, deps sessionsModuleDeps, serviceRef string) (string, error) {
+func resolvePreflightSource(ctx context.Context, deps sessionsModuleDeps, serviceRef string) (preflight.SourceRef, error) {
 	cfg := deps.cfg
 	snap := deps.snap
 
 	serviceRef = strings.TrimSpace(serviceRef)
 	if serviceRef == "" {
-		return "", fmt.Errorf("serviceRef empty")
+		return preflight.SourceRef{}, fmt.Errorf("serviceRef empty")
 	}
 
 	if u, ok := platformnet.ParseDirectHTTPURL(serviceRef); ok {
-		if err := validatePreflightOutboundURL(ctx, u.String(), outboundPolicyFromConfig(cfg)); err != nil {
-			return "", err
+		src, err := buildPreflightSourceRef(u.String())
+		if err != nil {
+			return preflight.SourceRef{}, err
 		}
-		return u.String(), nil
+		if err := validatePreflightOutboundURL(ctx, src.URL, outboundPolicyFromConfig(cfg)); err != nil {
+			return preflight.SourceRef{}, err
+		}
+		return src, nil
 	}
 
 	if deps.receiver == nil {
-		return "", fmt.Errorf("receiver control factory unavailable")
+		return preflight.SourceRef{}, fmt.Errorf("receiver control factory unavailable")
 	}
 	receiver := deps.receiver(cfg, snap)
 	streamer, ok := receiver.(streamURLProvider)
 	if !ok {
-		return "", fmt.Errorf("stream url provider unavailable")
+		return preflight.SourceRef{}, fmt.Errorf("stream url provider unavailable")
 	}
 	rawURL, err := streamer.StreamURL(ctx, serviceRef, "")
 	if err != nil {
-		return "", err
+		return preflight.SourceRef{}, err
+	}
+	src, err := buildPreflightSourceRef(rawURL)
+	if err != nil {
+		return preflight.SourceRef{}, err
+	}
+	if src.Username == "" && strings.TrimSpace(cfg.Enigma2.Username) != "" {
+		src.Username = cfg.Enigma2.Username
+		src.Password = cfg.Enigma2.Password
 	}
 	// Defense in depth: validate receiver-derived URLs against outbound policy.
 	// Even though Enigma2.BaseURL is admin-controlled, we apply the same SSRF
 	// protection (scheme/host/port allowlist + DNS rebinding block) for consistency.
-	if err := validatePreflightOutboundURL(ctx, rawURL, outboundPolicyFromConfig(cfg)); err != nil {
-		return "", err
+	if err := validatePreflightOutboundURL(ctx, src.URL, outboundPolicyFromConfig(cfg)); err != nil {
+		return preflight.SourceRef{}, err
 	}
-	return rawURL, nil
+	return src, nil
+}
+
+func buildPreflightSourceRef(rawURL string) (preflight.SourceRef, error) {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return preflight.SourceRef{}, err
+	}
+
+	src := preflight.SourceRef{}
+	if parsed.User != nil {
+		src.Username = parsed.User.Username()
+		src.Password, _ = parsed.User.Password()
+	}
+
+	sanitizedURL := *parsed
+	sanitizedURL.User = nil
+	src.URL = sanitizedURL.String()
+	return src, nil
 }
 
 func validatePreflightOutboundURL(ctx context.Context, rawURL string, policy platformnet.OutboundPolicy) error {

--- a/backend/internal/control/http/v3/preflight_gate_test.go
+++ b/backend/internal/control/http/v3/preflight_gate_test.go
@@ -14,7 +14,7 @@ type preflightReceiverAdapter struct {
 	*openwebif.Client
 }
 
-func TestResolvePreflightSourceURL_AllowsReceiverURLWithUserinfo(t *testing.T) {
+func TestResolvePreflightSource_UsesReceiverAuthWithoutEmbeddingUserinfo(t *testing.T) {
 	cfg := config.AppConfig{}
 	cfg.Enigma2.BaseURL = "http://10.10.55.64"
 	cfg.Enigma2.StreamPort = 17999
@@ -38,7 +38,9 @@ func TestResolvePreflightSourceURL_AllowsReceiverURLWithUserinfo(t *testing.T) {
 		},
 	}
 
-	got, err := resolvePreflightSourceURL(context.Background(), deps, "1:0:19:11:6:85:C00000:0:0:0:")
+	got, err := resolvePreflightSource(context.Background(), deps, "1:0:19:11:6:85:C00000:0:0:0:")
 	require.NoError(t, err)
-	require.Equal(t, "http://root:Kiddy99@10.10.55.64:17999/1:0:19:11:6:85:C00000:0:0:0:", got)
+	require.Equal(t, "http://10.10.55.64:17999/1:0:19:11:6:85:C00000:0:0:0:", got.URL)
+	require.Equal(t, "root", got.Username)
+	require.Equal(t, "Kiddy99", got.Password)
 }

--- a/backend/internal/control/http/v3/preflight_gate_test.go
+++ b/backend/internal/control/http/v3/preflight_gate_test.go
@@ -10,36 +10,16 @@ import (
 	"github.com/ManuGH/xg2g/internal/openwebif"
 )
 
-type mockPreflightReceiver struct {
-	streamURL string
-}
-
-func (m mockPreflightReceiver) AddTimer(ctx context.Context, sRef string, begin, end int64, name, desc string) error {
-	return nil
-}
-
-func (m mockPreflightReceiver) DeleteTimer(ctx context.Context, sRef string, begin, end int64) error {
-	return nil
-}
-
-func (m mockPreflightReceiver) UpdateTimer(ctx context.Context, oldSRef string, oldBegin, oldEnd int64, newSRef string, newBegin, newEnd int64, name, description string, enabled bool) error {
-	return nil
-}
-
-func (m mockPreflightReceiver) GetTimers(ctx context.Context) ([]openwebif.Timer, error) {
-	return nil, nil
-}
-
-func (m mockPreflightReceiver) DetectTimerChange(ctx context.Context) (openwebif.TimerChangeCap, error) {
-	return openwebif.TimerChangeCap{}, nil
-}
-
-func (m mockPreflightReceiver) StreamURL(ctx context.Context, ref, name string) (string, error) {
-	return m.streamURL, nil
+type preflightReceiverAdapter struct {
+	*openwebif.Client
 }
 
 func TestResolvePreflightSourceURL_AllowsReceiverURLWithUserinfo(t *testing.T) {
 	cfg := config.AppConfig{}
+	cfg.Enigma2.BaseURL = "http://10.10.55.64"
+	cfg.Enigma2.StreamPort = 17999
+	cfg.Enigma2.Username = "root"
+	cfg.Enigma2.Password = "Kiddy99"
 	cfg.Network.Outbound.Enabled = true
 	cfg.Network.Outbound.Allow.CIDRs = []string{"10.10.55.64/32"}
 	cfg.Network.Outbound.Allow.Schemes = []string{"http"}
@@ -49,8 +29,11 @@ func TestResolvePreflightSourceURL_AllowsReceiverURLWithUserinfo(t *testing.T) {
 		cfg:  cfg,
 		snap: config.BuildSnapshot(cfg, config.DefaultEnv()),
 		receiver: func(cfg config.AppConfig, snap config.Snapshot) ReceiverControl {
-			return mockPreflightReceiver{
-				streamURL: "http://root:Kiddy99@10.10.55.64:17999/1:0:19:11:6:85:C00000:0:0:0:",
+			return preflightReceiverAdapter{
+				Client: openwebif.NewWithPort(cfg.Enigma2.BaseURL, cfg.Enigma2.StreamPort, openwebif.Options{
+					Username: cfg.Enigma2.Username,
+					Password: cfg.Enigma2.Password,
+				}),
 			}
 		},
 	}

--- a/backend/internal/control/vod/preflight/http_provider.go
+++ b/backend/internal/control/vod/preflight/http_provider.go
@@ -56,12 +56,14 @@ func (p *HTTPPreflightProvider) Check(ctx context.Context, src SourceRef) (Prefl
 	if err != nil {
 		return PreflightResult{Outcome: PreflightInternal}, err
 	}
-
 	req := (&http.Request{
 		Method: http.MethodGet,
 		URL:    validatedURL,
 		Header: make(http.Header),
 	}).WithContext(ctx)
+	if src.Username != "" {
+		req.SetBasicAuth(src.Username, src.Password)
+	}
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/backend/internal/control/vod/preflight/http_provider_test.go
+++ b/backend/internal/control/vod/preflight/http_provider_test.go
@@ -236,3 +236,30 @@ func testAllowedCIDRs(host string) []string {
 	}
 	return nil
 }
+
+func TestHTTPPreflightProvider_SetsBasicAuthFromSourceRef(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			t.Fatal("expected basic auth on preflight request")
+		}
+		if username != "root" || password != "secret" {
+			t.Fatalf("unexpected basic auth credentials: %q / %q", username, password)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	provider := NewHTTPPreflightProvider(srv.Client(), 0, testOutboundPolicy(t, srv.URL))
+	res, err := provider.Check(context.Background(), SourceRef{
+		URL:      srv.URL + "/stream?" + url.Values{"ref": []string{"1:0:1:"}}.Encode(),
+		Username: "root",
+		Password: "secret",
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if res.Outcome != PreflightOK {
+		t.Fatalf("expected outcome %q, got %q", PreflightOK, res.Outcome)
+	}
+}

--- a/backend/internal/control/vod/preflight/types.go
+++ b/backend/internal/control/vod/preflight/types.go
@@ -17,7 +17,9 @@ const (
 )
 
 type SourceRef struct {
-	URL string
+	URL      string
+	Username string
+	Password string
 }
 
 // PreflightResult conveys the semantic outcome (Outcome) and any upstream HTTP status.

--- a/backend/internal/openwebif/client.go
+++ b/backend/internal/openwebif/client.go
@@ -1274,7 +1274,7 @@ func (c *Client) StreamURL(ctx context.Context, ref, name string) (string, error
 		return u, nil
 	}
 
-	return buildDirectTSStreamURL(parsed, ref, c.port)
+	return buildDirectTSStreamURL(parsed, ref, c.port, c.username, c.password)
 }
 
 func parseOpenWebIFBaseURL(rawBase string) (*url.URL, error) {
@@ -1312,9 +1312,7 @@ func buildWebIFStreamURL(parsed *url.URL, ref, name, username, password string) 
 		Path:     "/web/stream.m3u",
 		RawQuery: q.Encode(),
 	}
-	if username != "" {
-		u.User = url.UserPassword(username, password)
-	}
+	setStreamURLUser(u, username, password)
 	return u.String(), nil
 }
 
@@ -1337,7 +1335,7 @@ func buildDirectStreamOverrideURL(rawStreamBase, ref string) (string, bool) {
 	return u.String(), true
 }
 
-func buildDirectTSStreamURL(parsed *url.URL, ref string, streamPort int) (string, error) {
+func buildDirectTSStreamURL(parsed *url.URL, ref string, streamPort int, username, password string) (string, error) {
 	host, err := resolveDirectTSHost(parsed, streamPort)
 	if err != nil {
 		return "", err
@@ -1348,7 +1346,14 @@ func buildDirectTSStreamURL(parsed *url.URL, ref string, streamPort int) (string
 		Host:   host,
 		Path:   "/" + ref,
 	}
+	setStreamURLUser(u, username, password)
 	return u.String(), nil
+}
+
+func setStreamURLUser(u *url.URL, username, password string) {
+	if username != "" {
+		u.User = url.UserPassword(username, password)
+	}
 }
 
 func resolveDirectTSHost(parsed *url.URL, streamPort int) (string, error) {

--- a/backend/internal/openwebif/client.go
+++ b/backend/internal/openwebif/client.go
@@ -1274,7 +1274,7 @@ func (c *Client) StreamURL(ctx context.Context, ref, name string) (string, error
 		return u, nil
 	}
 
-	return buildDirectTSStreamURL(parsed, ref, c.port, c.username, c.password)
+	return buildDirectTSStreamURL(parsed, ref, c.port)
 }
 
 func parseOpenWebIFBaseURL(rawBase string) (*url.URL, error) {
@@ -1312,7 +1312,9 @@ func buildWebIFStreamURL(parsed *url.URL, ref, name, username, password string) 
 		Path:     "/web/stream.m3u",
 		RawQuery: q.Encode(),
 	}
-	setStreamURLUser(u, username, password)
+	if username != "" {
+		u.User = url.UserPassword(username, password)
+	}
 	return u.String(), nil
 }
 
@@ -1335,7 +1337,7 @@ func buildDirectStreamOverrideURL(rawStreamBase, ref string) (string, bool) {
 	return u.String(), true
 }
 
-func buildDirectTSStreamURL(parsed *url.URL, ref string, streamPort int, username, password string) (string, error) {
+func buildDirectTSStreamURL(parsed *url.URL, ref string, streamPort int) (string, error) {
 	host, err := resolveDirectTSHost(parsed, streamPort)
 	if err != nil {
 		return "", err
@@ -1346,14 +1348,7 @@ func buildDirectTSStreamURL(parsed *url.URL, ref string, streamPort int, usernam
 		Host:   host,
 		Path:   "/" + ref,
 	}
-	setStreamURLUser(u, username, password)
 	return u.String(), nil
-}
-
-func setStreamURLUser(u *url.URL, username, password string) {
-	if username != "" {
-		u.User = url.UserPassword(username, password)
-	}
 }
 
 func resolveDirectTSHost(parsed *url.URL, streamPort int) (string, error) {

--- a/backend/internal/openwebif/client_test.go
+++ b/backend/internal/openwebif/client_test.go
@@ -191,7 +191,7 @@ func TestStreamURLInvalidStreamBaseOverrideFallsBack(t *testing.T) {
 	}
 }
 
-func TestStreamURLDirectIncludesCredentials(t *testing.T) {
+func TestStreamURLDirectDoesNotIncludeCredentials(t *testing.T) {
 	ref := "1:0:19:1334:3EF:1:C00000:0:0:0:"
 	client := NewWithPort("http://receiver.local", 19000, Options{
 		Username: "root",
@@ -208,15 +208,8 @@ func TestStreamURLDirectIncludesCredentials(t *testing.T) {
 		t.Fatalf("failed to parse URL %q: %v", got, err)
 	}
 
-	if parsed.User == nil {
-		t.Fatal("expected direct stream URL to include userinfo")
-	}
-	if parsed.User.Username() != "root" {
-		t.Fatalf("username: want %q, got %q", "root", parsed.User.Username())
-	}
-	password, ok := parsed.User.Password()
-	if !ok || password != "secret" {
-		t.Fatalf("password: want %q, got %q (ok=%v)", "secret", password, ok)
+	if parsed.User != nil {
+		t.Fatalf("expected direct stream URL without userinfo, got %q", got)
 	}
 }
 

--- a/backend/internal/openwebif/client_test.go
+++ b/backend/internal/openwebif/client_test.go
@@ -191,6 +191,35 @@ func TestStreamURLInvalidStreamBaseOverrideFallsBack(t *testing.T) {
 	}
 }
 
+func TestStreamURLDirectIncludesCredentials(t *testing.T) {
+	ref := "1:0:19:1334:3EF:1:C00000:0:0:0:"
+	client := NewWithPort("http://receiver.local", 19000, Options{
+		Username: "root",
+		Password: "secret",
+	})
+
+	got, err := client.StreamURL(context.Background(), ref, "ignored-name")
+	if err != nil {
+		t.Fatalf("StreamURL returned error: %v", err)
+	}
+
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("failed to parse URL %q: %v", got, err)
+	}
+
+	if parsed.User == nil {
+		t.Fatal("expected direct stream URL to include userinfo")
+	}
+	if parsed.User.Username() != "root" {
+		t.Fatalf("username: want %q, got %q", "root", parsed.User.Username())
+	}
+	password, ok := parsed.User.Password()
+	if !ok || password != "secret" {
+		t.Fatalf("password: want %q, got %q (ok=%v)", "secret", password, ok)
+	}
+}
+
 func TestAbout(t *testing.T) {
 	mock := NewMockServer()
 	defer mock.Close()


### PR DESCRIPTION
## Summary
- unblock authenticated receiver stream preflight and direct playback resolution
- add configurable live playlist readiness and quick-start HLS sizing wiring
- fix frontend auth/resume initialization timing and refresh generated docs/config artifacts

## Validation
- go test ./internal/openwebif
- go test ./internal/config
- go test ./internal/control/http/v3 -run 'TestResolvePreflightSourceURL_AllowsReceiverURLWithUserinfo'

## Notes
- TestRaceSafety_ParallelIntents is a pre-existing flake and not part of this change set
