### PR TITLE
test: fix go coverage report regressions

### DIFF
--- a/backend/internal/api/http_preparing_test.go
+++ b/backend/internal/api/http_preparing_test.go
@@ -21,7 +21,8 @@ func (m *MockPreparingServer) GetEpg(w http.ResponseWriter, r *http.Request, par
 }
 func (m *MockPreparingServer) CreateIntent(w http.ResponseWriter, r *http.Request)         {}
 func (m *MockPreparingServer) PostLivePlaybackInfo(w http.ResponseWriter, r *http.Request) {}
-func (m *MockPreparingServer) GetLogs(w http.ResponseWriter, r *http.Request)              {}
+func (m *MockPreparingServer) GetLogs(w http.ResponseWriter, r *http.Request, params v3.GetLogsParams) {
+}
 func (m *MockPreparingServer) GetReceiverCurrent(w http.ResponseWriter, r *http.Request)   {}
 func (m *MockPreparingServer) GetRecordings(w http.ResponseWriter, r *http.Request, params v3.GetRecordingsParams) {
 }

--- a/backend/testdata/contract/p4_1/golden/03_transcode_video_hevc_to_h264.expected.json
+++ b/backend/testdata/contract/p4_1/golden/03_transcode_video_hevc_to_h264.expected.json
@@ -32,11 +32,14 @@
 							"packaging": "ts",
 							"video": {
 								"codec": "h264",
-								"mode": "transcode"
+								"crf": 23,
+								"mode": "transcode",
+								"preset": "fast"
 							}
 						},
 						"trace": {
 							"inputHash": "8b31fee5fefb74a59f36781cb5ea9067f2da1eef990abb2b19d4d9a642d8ef3f",
+							"qualityRung": "compatible_video_h264_crf23_fast",
 							"requestId": "stub-request-id",
 							"resolvedIntent": "compatible",
 							"ruleHits": [
@@ -50,7 +53,8 @@
 								{
 									"code": "video_codec_not_supported_by_client"
 								}
-							]
+							],
+							"videoQualityRung": "compatible_video_h264_crf23_fast"
 						}
 					},
 					"status": 200

--- a/backend/testdata/contract/p4_1/golden/04_transcode_audio_ac3_to_aac.expected.json
+++ b/backend/testdata/contract/p4_1/golden/04_transcode_audio_ac3_to_aac.expected.json
@@ -39,6 +39,7 @@
 							}
 						},
 						"trace": {
+							"audioQualityRung": "compatible_audio_aac_256_stereo",
 							"inputHash": "29c6be0eff30d880c33a0e423e2c43720047cc263e5f798aeabb4d8a4c336e83",
 							"qualityRung": "compatible_audio_aac_256_stereo",
 							"requestId": "stub-request-id",


### PR DESCRIPTION
## Summary
- update the preparing API test mock to match the current v3 GetLogs signature
- refresh the two p4_1 golden snapshots with the new quality rung fields
- restore the failing Go Coverage Report after PR #295 merged

## Verification
- go test ./... (from backend)
