### PR TITLE
test(procgroup): avoid racy process-group assertion

### DIFF
--- a/backend/internal/procgroup/procgroup_test.go
+++ b/backend/internal/procgroup/procgroup_test.go
@@ -40,11 +40,12 @@ func TestGroupKill(t *testing.T) {
 	err = process.Signal(syscall.Signal(0))
 	require.Error(t, err, "Parent process should be dead")
 
-	// 4. Verify no processes found in that PGID
-	// This is harder to check directly without scanning /proc or using pgrep
-	// but Signal(-pid, 0) should return ESRCH
-	err = syscall.Kill(-pgid, syscall.Signal(0))
-	require.Equal(t, syscall.ESRCH, err, "Process group should be dead")
+	// 4. Verify the process group eventually disappears.
+	// Child processes can briefly remain as zombies after the parent exits,
+	// so an immediate ESRCH is racy under slower CI/coverage runs.
+	require.Eventually(t, func() bool {
+		return syscall.Kill(-pgid, syscall.Signal(0)) == syscall.ESRCH
+	}, time.Second, 10*time.Millisecond, "Process group should be dead")
 }
 
 func TestKillGroupAlreadyGone(t *testing.T) {


### PR DESCRIPTION
Summary

- make procgroup group-death verification eventual instead of immediate
- avoid a Linux timing race where child processes can briefly remain visible after the parent exits
- stabilize the CI coverage path without changing procgroup runtime behavior

Verification

- make ci-pr
