### PR TITLE
test(webui): harden player journey fetch waits

### DIFF
--- a/frontend/webui/tests/player-session.journey.test.tsx
+++ b/frontend/webui/tests/player-session.journey.test.tsx
@@ -173,6 +173,8 @@ type PlayerFetchScenario = {
   heartbeatBody?: Record<string, unknown>;
 };
 
+const PLAYER_NETWORK_WAIT_MS = 3_000;
+
 function installPlayerFetchMock(scenario: PlayerFetchScenario = {}) {
   const sessionId = 'sess-journey-1';
   const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
@@ -268,12 +270,16 @@ describe('Player session journeys', () => {
     await screen.findByText('EPG launcher ready');
     fireEvent.click(screen.getByRole('button', { name: 'Launch player' }));
 
+    await screen.findByRole('button', { name: /player\.closePlayer|Close Player/i });
+    await screen.findByText('Journey Channel');
+
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /player\.closePlayer|Close Player/i })).toBeInTheDocument();
-      expect(screen.getByText('Journey Channel')).toBeInTheDocument();
       expect(findFetchCall(fetchMock, '/intents')).toBeDefined();
+    }, { timeout: PLAYER_NETWORK_WAIT_MS });
+
+    await waitFor(() => {
       expect(findFetchCall(fetchMock, '/sessions/sess-journey-1')).toBeDefined();
-    });
+    }, { timeout: PLAYER_NETWORK_WAIT_MS });
   });
 
   it('routes a player 401 start intent to the session-expired auth surface', async () => {


### PR DESCRIPTION
Summary:
- harden the live player journey test against slow CI runs
- separate UI assertions from network-call assertions in the EPG start journey
- give the /intents and session fetch waits an explicit timeout instead of relying on the default waitFor window

Verification:
- cd frontend/webui && npm test -- --run tests/player-session.journey.test.tsx
- repeated the targeted journey test 20x locally
- make webui-test

Why:
The failing gate was webui-test in tests/player-session.journey.test.tsx, where the start journey expected the /intents fetch inside the default waitFor timeout. That path is close to the limit locally and can miss under slower CI scheduling even though the player flow is correct.