### PR TITLE
fix: escape systemd unit shell variables

### DIFF
--- a/backend/templates/docs/ops/xg2g.service.tmpl
+++ b/backend/templates/docs/ops/xg2g.service.tmpl
@@ -26,10 +26,10 @@ EnvironmentFile=/etc/xg2g/xg2g.env
 # These checks fail cleanly before any containers are touched and reject whitespace-only values.
 ExecStartPre=/bin/sh -eu -c '/usr/bin/docker info >/dev/null'
 ExecStartPre=/bin/sh -eu -c 'test -w /var/lib/xg2g'
-ExecStartPre=/bin/sh -eu -c 'h="${XG2G_E2_HOST:-}"; o="${XG2G_OWI_BASE:-}"; h="$(printf %s "$h" | tr -d "[:space:]")"; o="$(printf %s "$o" | tr -d "[:space:]")"; if [ -z "${h}${o}" ]; then echo "Missing XG2G_E2_HOST (legacy fallback: XG2G_OWI_BASE)" >&2; exit 1; fi; if [ -n "$h" ] && [ -n "$o" ] && [ "$h" != "$o" ]; then hm="$(printf %s "$h" | sed -E "s#(https?://)[^/@]+@#\\1#")"; om="$(printf %s "$o" | sed -E "s#(https?://)[^/@]+@#\\1#")"; echo "XG2G_E2_HOST and XG2G_OWI_BASE differ (E2_HOST=${hm}, OWI_BASE=${om})" >&2; exit 1; fi'
-ExecStartPre=/bin/sh -eu -c 't="${XG2G_API_TOKEN:-}"; t="$(printf %s "$t" | tr -d "[:space:]")"; test -n "$t"'
+ExecStartPre=/bin/sh -eu -c 'h="$${XG2G_E2_HOST:-}"; o="$${XG2G_OWI_BASE:-}"; h="$$(printf %%s "$$h" | tr -d "[:space:]")"; o="$$(printf %%s "$$o" | tr -d "[:space:]")"; if [ -z "$${h}$${o}" ]; then echo "Missing XG2G_E2_HOST (legacy fallback: XG2G_OWI_BASE)" >&2; exit 1; fi; if [ -n "$$h" ] && [ -n "$$o" ] && [ "$$h" != "$$o" ]; then hm="$$(printf %%s "$$h" | sed -E "s#(https?://)[^/@]+@#\\1#")"; om="$$(printf %%s "$$o" | sed -E "s#(https?://)[^/@]+@#\\1#")"; echo "XG2G_E2_HOST and XG2G_OWI_BASE differ (E2_HOST=$${hm}, OWI_BASE=$${om})" >&2; exit 1; fi'
+ExecStartPre=/bin/sh -eu -c 't="$${XG2G_API_TOKEN:-}"; t="$$(printf %%s "$$t" | tr -d "[:space:]")"; test -n "$$t"'
 # Fail-closed: XG2G_DECISION_SECRET required for live stream JWT signing (min 32 bytes).
-ExecStartPre=/bin/sh -eu -c 's="${XG2G_DECISION_SECRET:-}"; s="$(printf %s "$s" | tr -d "[:space:]")"; if [ -z "$s" ]; then echo "Missing XG2G_DECISION_SECRET (required for live stream JWT)" >&2; exit 1; fi; len="$(printf %s "$s" | wc -c)"; if [ "$len" -lt 32 ]; then echo "XG2G_DECISION_SECRET too short: need >= 32 bytes for HS256, got ${len}" >&2; exit 1; fi'
+ExecStartPre=/bin/sh -eu -c 's="$${XG2G_DECISION_SECRET:-}"; s="$$(printf %%s "$$s" | tr -d "[:space:]")"; if [ -z "$$s" ]; then echo "Missing XG2G_DECISION_SECRET (required for live stream JWT)" >&2; exit 1; fi; len="$$(printf %%s "$$s" | wc -c)"; if [ "$$len" -lt 32 ]; then echo "XG2G_DECISION_SECRET too short: need >= 32 bytes for HS256, got $${len}" >&2; exit 1; fi'
 
 # Fail-closed: ensure compose file is valid before touching containers
 ExecStartPre=/srv/xg2g/scripts/compose-xg2g.sh config -q

--- a/docs/ops/xg2g.service
+++ b/docs/ops/xg2g.service
@@ -27,10 +27,10 @@ EnvironmentFile=/etc/xg2g/xg2g.env
 # These checks fail cleanly before any containers are touched and reject whitespace-only values.
 ExecStartPre=/bin/sh -eu -c '/usr/bin/docker info >/dev/null'
 ExecStartPre=/bin/sh -eu -c 'test -w /var/lib/xg2g'
-ExecStartPre=/bin/sh -eu -c 'h="${XG2G_E2_HOST:-}"; o="${XG2G_OWI_BASE:-}"; h="$(printf %s "$h" | tr -d "[:space:]")"; o="$(printf %s "$o" | tr -d "[:space:]")"; if [ -z "${h}${o}" ]; then echo "Missing XG2G_E2_HOST (legacy fallback: XG2G_OWI_BASE)" >&2; exit 1; fi; if [ -n "$h" ] && [ -n "$o" ] && [ "$h" != "$o" ]; then hm="$(printf %s "$h" | sed -E "s#(https?://)[^/@]+@#\\1#")"; om="$(printf %s "$o" | sed -E "s#(https?://)[^/@]+@#\\1#")"; echo "XG2G_E2_HOST and XG2G_OWI_BASE differ (E2_HOST=${hm}, OWI_BASE=${om})" >&2; exit 1; fi'
-ExecStartPre=/bin/sh -eu -c 't="${XG2G_API_TOKEN:-}"; t="$(printf %s "$t" | tr -d "[:space:]")"; test -n "$t"'
+ExecStartPre=/bin/sh -eu -c 'h="$${XG2G_E2_HOST:-}"; o="$${XG2G_OWI_BASE:-}"; h="$$(printf %%s "$$h" | tr -d "[:space:]")"; o="$$(printf %%s "$$o" | tr -d "[:space:]")"; if [ -z "$${h}$${o}" ]; then echo "Missing XG2G_E2_HOST (legacy fallback: XG2G_OWI_BASE)" >&2; exit 1; fi; if [ -n "$$h" ] && [ -n "$$o" ] && [ "$$h" != "$$o" ]; then hm="$$(printf %%s "$$h" | sed -E "s#(https?://)[^/@]+@#\\1#")"; om="$$(printf %%s "$$o" | sed -E "s#(https?://)[^/@]+@#\\1#")"; echo "XG2G_E2_HOST and XG2G_OWI_BASE differ (E2_HOST=$${hm}, OWI_BASE=$${om})" >&2; exit 1; fi'
+ExecStartPre=/bin/sh -eu -c 't="$${XG2G_API_TOKEN:-}"; t="$$(printf %%s "$$t" | tr -d "[:space:]")"; test -n "$$t"'
 # Fail-closed: XG2G_DECISION_SECRET required for live stream JWT signing (min 32 bytes).
-ExecStartPre=/bin/sh -eu -c 's="${XG2G_DECISION_SECRET:-}"; s="$(printf %s "$s" | tr -d "[:space:]")"; if [ -z "$s" ]; then echo "Missing XG2G_DECISION_SECRET (required for live stream JWT)" >&2; exit 1; fi; len="$(printf %s "$s" | wc -c)"; if [ "$len" -lt 32 ]; then echo "XG2G_DECISION_SECRET too short: need >= 32 bytes for HS256, got ${len}" >&2; exit 1; fi'
+ExecStartPre=/bin/sh -eu -c 's="$${XG2G_DECISION_SECRET:-}"; s="$$(printf %%s "$$s" | tr -d "[:space:]")"; if [ -z "$$s" ]; then echo "Missing XG2G_DECISION_SECRET (required for live stream JWT)" >&2; exit 1; fi; len="$$(printf %%s "$$s" | wc -c)"; if [ "$$len" -lt 32 ]; then echo "XG2G_DECISION_SECRET too short: need >= 32 bytes for HS256, got $${len}" >&2; exit 1; fi'
 
 # Fail-closed: ensure compose file is valid before touching containers
 ExecStartPre=/srv/xg2g/scripts/compose-xg2g.sh config -q


### PR DESCRIPTION
## Summary
- escape shell variable references in the canonical systemd unit template
- escape `printf` specifiers so systemd does not consume `%s`
- keep the generated docs unit in sync with the fixed template

## Why
Deploying the current canonical `docs/ops/xg2g.service` to a live host breaks `ExecStartPre` because systemd consumes `${...}`, `$var`, and `%s` before `/bin/sh -c` sees them. This was reproduced during the `v3.4.3` host rollout and required a host-side hotfix before restart would succeed.

## Validation
- `systemd-analyze verify /tmp/xg2g-unit-escaping/docs/ops/xg2g.service`
- live host restart succeeded after applying the equivalent escaped unit
