### PR TITLE
fix(ffmpeg): drain stderr before wait

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter.go
+++ b/backend/internal/infra/media/ffmpeg/adapter.go
@@ -530,6 +530,9 @@ func (a *LocalAdapter) monitorProcess(parentCtx context.Context, handle ports.Ru
 
 	procErrCh := make(chan error, 1)
 	go func() {
+		// os/exec closes StderrPipe from Wait. Draining stderr first avoids
+		// dropping the final FFmpeg failure lines that Health surfaces later.
+		<-scanDone
 		procErrCh <- cmd.Wait()
 	}()
 


### PR DESCRIPTION
## Summary
- stop calling cmd.Wait before stderr from FFmpeg is fully drained
- preserve final FFmpeg failure lines for Health/process detail reporting
- address the flaky Coverage push failure seen after #306

## Verification
- go test ./backend/internal/infra/media/ffmpeg -run TestMonitorProcess_SurfacesMeaningfulExitDetail -count=200
- go test ./backend/internal/infra/media/ffmpeg -coverpkg=./... -coverprofile=/tmp/xg2g-coveragefix-ffmpeg.cover -count=20
