### PR TITLE
fix(ffmpeg): treat startup markers as watchdog progress

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter.go
+++ b/backend/internal/infra/media/ffmpeg/adapter.go
@@ -491,6 +491,7 @@ func (a *LocalAdapter) monitorProcess(parentCtx context.Context, handle ports.Ru
 			if !firstFrameLogged {
 				if frame, ok := parseFFmpegFrameCount(line); ok && frame > 0 {
 					firstFrameLogged = true
+					wd.ObserveProgress()
 					a.writeFirstFrameMarker(sessionID)
 					a.Logger.Info().
 						Str("session_id", sessionID).
@@ -502,6 +503,7 @@ func (a *LocalAdapter) monitorProcess(parentCtx context.Context, handle ports.Ru
 			if !firstSegmentLogged {
 				if segmentPath, ok := extractStartupSegmentPath(line); ok {
 					firstSegmentLogged = true
+					wd.ObserveProgress()
 					a.Logger.Info().
 						Str("session_id", sessionID).
 						Str("startup_phase", "first_segment_write").

--- a/backend/internal/infra/media/ffmpeg/adapter_lifecycle_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_lifecycle_test.go
@@ -168,6 +168,52 @@ func TestMonitorProcess_KillsStalledProcessAndPreservesStallDetail(t *testing.T)
 	}
 }
 
+func TestMonitorProcess_FirstFramePreventsStartupTimeout(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg",
+		"",
+		t.TempDir(),
+		nil,
+		zerolog.New(io.Discard),
+		"",
+		"",
+		0,
+		1500*time.Millisecond,
+		false,
+		2*time.Second,
+		6,
+		150*time.Millisecond,
+		1200*time.Millisecond,
+		"",
+	)
+
+	cmd := exec.Command("sh", "-c", "printf 'frame=    1\\n' 1>&2; sleep 0.3")
+	stderr, err := cmd.StderrPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	handle := ports.RunHandle("session-startup-frame-123")
+	adapter.mu.Lock()
+	adapter.activeProcs[handle] = cmd
+	adapter.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		adapter.monitorProcess(context.Background(), handle, cmd, stderr, "session-startup-frame")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("monitorProcess did not finish in time")
+	}
+
+	status := adapter.Health(context.Background(), handle)
+	assert.False(t, status.Healthy)
+	assert.Equal(t, "process not found", status.Message)
+}
+
 func TestHealth_ExitedProcessInMapIsUnhealthyAndCleanedUp(t *testing.T) {
 	adapter := NewLocalAdapter(
 		"ffmpeg",

--- a/backend/internal/media/ffmpeg/watchdog/watchdog.go
+++ b/backend/internal/media/ffmpeg/watchdog/watchdog.go
@@ -121,13 +121,13 @@ func (w *Watchdog) ParseLine(line string) {
 		ms, _ := strconv.ParseInt(val, 10, 64)
 		if ms > w.lastOutTimeMs {
 			w.lastOutTimeMs = ms
-			w.recordHeartbeat()
+			w.recordParsedProgress()
 		}
 	case "total_size":
 		size, _ := strconv.ParseInt(val, 10, 64)
 		if size > w.lastTotalSize {
 			w.lastTotalSize = size
-			w.recordHeartbeat()
+			w.recordParsedProgress()
 		}
 	case "progress":
 		if val == "end" {
@@ -137,9 +137,26 @@ func (w *Watchdog) ParseLine(line string) {
 	}
 }
 
-func (w *Watchdog) recordHeartbeat() {
+// ObserveProgress records externally observed startup/runtime progress such as
+// first encoded frames or the first HLS segment write.
+func (w *Watchdog) ObserveProgress() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.recordExternalProgress()
+}
+
+func (w *Watchdog) recordParsedProgress() {
 	w.lastHeartbeat = w.clock.Now()
 	if !w.hasProgress && (w.lastOutTimeMs > 0 || w.lastTotalSize > 0) {
+		w.hasProgress = true
+		w.state = StateRunning
+		log.L().Debug().Msg("watchdog: meaningful progress detected")
+	}
+}
+
+func (w *Watchdog) recordExternalProgress() {
+	w.lastHeartbeat = w.clock.Now()
+	if !w.hasProgress {
 		w.hasProgress = true
 		w.state = StateRunning
 		log.L().Debug().Msg("watchdog: meaningful progress detected")

--- a/backend/internal/media/ffmpeg/watchdog/watchdog_test.go
+++ b/backend/internal/media/ffmpeg/watchdog/watchdog_test.go
@@ -105,7 +105,7 @@ func TestWatchdog_MeaningfulProgress(t *testing.T) {
 	w := New(2*time.Second, 5*time.Second)
 	w.clock = clock
 
-	// 1. Test out_time_ms vs total_size
+	// 1. Unknown log-like lines should not move the watchdog.
 	w.ParseLine("frame=10")
 	assert.Equal(t, StateStarting, w.State(), "frame= alone is not meaningful progress")
 
@@ -114,6 +114,17 @@ func TestWatchdog_MeaningfulProgress(t *testing.T) {
 
 	w.ParseLine("total_size=123")
 	assert.Equal(t, StateRunning, w.State(), "total_size > 0 IS meaningful progress")
+}
+
+func TestWatchdog_ObserveProgressTransitionsToRunning(t *testing.T) {
+	clock := &mockClock{now: time.Now()}
+	w := New(2*time.Second, 5*time.Second)
+	w.clock = clock
+
+	w.ObserveProgress()
+
+	assert.Equal(t, StateRunning, w.State())
+	assert.True(t, w.hasProgress)
 }
 
 func TestWatchdog_ParserRobustness(t *testing.T) {


### PR DESCRIPTION
## Summary
- treat first encoded frame and first HLS segment write as watchdog progress
- prevent false startup watchdog kills before ffmpeg emits the first -progress heartbeat
- cover the regression in watchdog and live adapter lifecycle tests

## Validation
- go test ./backend/internal/media/ffmpeg/watchdog
- go test ./backend/internal/infra/media/ffmpeg
