### PR TITLE
fix: restore iphone player controls

### DIFF
--- a/frontend/webui/src/features/player/components/V3Player.mobileControls.test.tsx
+++ b/frontend/webui/src/features/player/components/V3Player.mobileControls.test.tsx
@@ -110,7 +110,7 @@ describe('V3Player Mobile Controls', () => {
     vi.restoreAllMocks();
   });
 
-  it('keeps wrapper fullscreen on touch devices when native HLS is preferred', async () => {
+  it('uses native video fullscreen on touch devices when native HLS is preferred', async () => {
     const props = {
       src: 'http://example.com/playlist.m3u8',
       autoStart: true
@@ -125,9 +125,9 @@ describe('V3Player Mobile Controls', () => {
     fireEvent.click(fullscreenButton);
 
     const video = container.querySelector('video') as HTMLVideoElement;
-    expect(requestFullscreen).toHaveBeenCalledTimes(1);
-    expect(webkitEnterFullscreen).not.toHaveBeenCalled();
-    expect(video.controls).toBe(false);
+    expect(requestFullscreen).not.toHaveBeenCalled();
+    expect(webkitEnterFullscreen).toHaveBeenCalledTimes(1);
+    expect(video.controls).toBe(true);
     expect(screen.queryByRole('button', { name: /player\.dvrMode/i })).not.toBeInTheDocument();
   });
 

--- a/frontend/webui/src/features/player/usePlayerChrome.test.tsx
+++ b/frontend/webui/src/features/player/usePlayerChrome.test.tsx
@@ -1,0 +1,64 @@
+import { createRef, useRef, useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { usePlayerChrome } from './usePlayerChrome';
+import type { HlsInstanceRef, PlayerStatus } from '../../types/v3-player';
+
+function HookHarness({ shouldForceNativeMobileHls }: { shouldForceNativeMobileHls: () => boolean }) {
+  const containerRef = createRef<HTMLDivElement>();
+  const videoRef = createRef<HTMLVideoElement>();
+  const hlsRef = useRef<HlsInstanceRef>(null);
+  const userPauseIntentRef = useRef(false);
+  const lastDecodedRef = useRef(0);
+  const [, setStatus] = useState<PlayerStatus>('idle');
+
+  const chrome = usePlayerChrome({
+    autoStart: true,
+    containerRef,
+    videoRef,
+    hlsRef,
+    userPauseIntentRef,
+    lastDecodedRef,
+    playbackMode: 'LIVE',
+    durationSeconds: null,
+    canSeek: false,
+    startUnix: null,
+    setStatus,
+    allowNativeFullscreen: true,
+    shouldForceNativeMobileHls,
+    canUseDesktopWebKitFullscreen: () => false,
+  });
+
+  return (
+    <div ref={containerRef}>
+      <video ref={videoRef} data-testid="player-video" />
+      <button onClick={chrome.applyAutoplayMute} type="button">
+        mute
+      </button>
+    </div>
+  );
+}
+
+describe('usePlayerChrome', () => {
+  it('keeps autoplay audio enabled on the touch WebKit path', () => {
+    render(<HookHarness shouldForceNativeMobileHls={() => true} />);
+
+    const video = screen.getByTestId('player-video') as HTMLVideoElement;
+    video.muted = false;
+
+    fireEvent.click(screen.getByRole('button', { name: 'mute' }));
+
+    expect(video.muted).toBe(false);
+  });
+
+  it('still mutes autoplay when the touch WebKit path is not active', () => {
+    render(<HookHarness shouldForceNativeMobileHls={() => false} />);
+
+    const video = screen.getByTestId('player-video') as HTMLVideoElement;
+    video.muted = false;
+
+    fireEvent.click(screen.getByRole('button', { name: 'mute' }));
+
+    expect(video.muted).toBe(true);
+  });
+});

--- a/frontend/webui/src/features/player/usePlayerChrome.ts
+++ b/frontend/webui/src/features/player/usePlayerChrome.ts
@@ -107,6 +107,11 @@ export function usePlayerChrome({
   const lastNonZeroVolumeRef = useRef<number>(1);
   const idleTimerRef = useRef<number | null>(null);
 
+  const shouldUseTouchWebKitFullscreen = useCallback((videoEl?: VideoElementRef) => {
+    if (!videoEl?.webkitEnterFullscreen) return false;
+    return shouldForceNativeMobileHls(videoEl);
+  }, [shouldForceNativeMobileHls]);
+
   const formatClock = useCallback((value: number): string => {
     if (!Number.isFinite(value) || value < 0) return '--:--';
     const totalSeconds = Math.floor(value);
@@ -193,8 +198,19 @@ export function usePlayerChrome({
   const toggleFullscreen = useCallback(async () => {
     const video = videoRef.current;
     const container = containerRef.current;
+    const useTouchWebKitFullscreen = shouldUseTouchWebKitFullscreen(video);
 
     if (!document.fullscreenElement) {
+      if (video && useTouchWebKitFullscreen) {
+        try {
+          video.controls = true;
+          video.webkitEnterFullscreen?.();
+          return;
+        } catch (err) {
+          debugWarn('Touch WebKit fullscreen failed', err);
+        }
+      }
+
       if (allowNativeFullscreen && video && canUseDesktopWebKitFullscreen(video)) {
         try {
           video.controls = true;
@@ -229,7 +245,7 @@ export function usePlayerChrome({
     }
 
     await document.exitFullscreen();
-  }, [allowNativeFullscreen, canUseDesktopWebKitFullscreen, containerRef, videoRef]);
+  }, [allowNativeFullscreen, canUseDesktopWebKitFullscreen, containerRef, shouldUseTouchWebKitFullscreen, videoRef]);
 
   const enterDVRMode = useCallback(() => {
     const video = videoRef.current;
@@ -296,9 +312,15 @@ export function usePlayerChrome({
     if (!autoStart) return;
     const video = videoRef.current;
     if (!video) return;
+    // Keep iPhone/iPad hardware volume controls effective on the mobile WebKit path.
+    if (shouldForceNativeMobileHls(video)) {
+      video.muted = false;
+      setIsMuted(false);
+      return;
+    }
     video.muted = true;
     setIsMuted(true);
-  }, [autoStart, videoRef]);
+  }, [autoStart, shouldForceNativeMobileHls, videoRef]);
 
   const toggleStats = useCallback(() => {
     setShowStats((prev) => !prev);
@@ -527,6 +549,7 @@ export function usePlayerChrome({
       !!video &&
       typeof video.requestPictureInPicture === 'function';
     const fullscreenAvailable =
+      shouldUseTouchWebKitFullscreen(video) ||
       (allowNativeFullscreen && !!video?.webkitEnterFullscreen) ||
       !!container?.requestFullscreen ||
       (typeof document !== 'undefined' && document.fullscreenEnabled === true);
@@ -537,14 +560,16 @@ export function usePlayerChrome({
     setCanTogglePiP(pipAvailable);
     setCanToggleFullscreen(fullscreenAvailable);
     setCanAdjustVolume(volumeAvailable);
-  }, [allowNativeFullscreen, containerRef, shouldForceNativeMobileHls, videoRef]);
+  }, [allowNativeFullscreen, containerRef, shouldForceNativeMobileHls, shouldUseTouchWebKitFullscreen, videoRef]);
 
   useEffect(() => {
     const onFsChange = () => setIsFullscreen(!!document.fullscreenElement);
     const onPipChange = () => setIsPip(!!document.pictureInPictureElement);
 
     const video = videoRef.current;
-    const supportsWebkitFullscreen = allowNativeFullscreen && !!video?.webkitEnterFullscreen;
+    const supportsWebkitFullscreen =
+      !!video?.webkitEnterFullscreen &&
+      (allowNativeFullscreen || shouldUseTouchWebKitFullscreen(video));
 
     const onWebkitBeginFullscreen = () => {
       setIsFullscreen(true);
@@ -579,7 +604,7 @@ export function usePlayerChrome({
         }
       }
     };
-  }, [allowNativeFullscreen, videoRef]);
+  }, [allowNativeFullscreen, shouldUseTouchWebKitFullscreen, videoRef]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Summary
- use native WebKit fullscreen on touch iPhone/iPad playback instead of wrapper fullscreen
- keep startup audio available on the mobile WebKit path so hardware volume buttons work once native playback unveils
- cover the fullscreen preference and autoplay mute behavior with player regression tests

## Verification
- npm test -- --run src/features/player/components/V3Player.mobileControls.test.tsx src/features/player/components/V3Player.safari.test.tsx src/features/player/usePlayerChrome.test.tsx src/features/player/components/V3Player.volumeRestore.test.tsx
- npm run build
