### PR TITLE
refactor: untangle runtime lifecycle and planning paths

### DIFF
--- a/backend/internal/app/bootstrap/bootstrap.go
+++ b/backend/internal/app/bootstrap/bootstrap.go
@@ -49,6 +49,7 @@ type Container struct {
 	App           *daemon.App
 
 	snapshot         config.Snapshot
+	piconPool        *jobs.PiconPool
 	scanManager      *scan.Manager
 	verificationWork *verification.Worker
 
@@ -468,6 +469,10 @@ func (c *Container) Start(ctx context.Context) error {
 	}
 
 	c.startOnce.Do(func() {
+		if err := c.initPiconPool(ctx); err != nil {
+			c.Logger.Warn().Err(err).Msg("failed to initialize picon pool; background pre-warm disabled")
+		}
+
 		if c.scanManager != nil {
 			c.scanManager.AttachLifecycle(ctx)
 		}
@@ -486,6 +491,28 @@ func (c *Container) Start(ctx context.Context) error {
 		}
 	})
 
+	return nil
+}
+
+func (c *Container) initPiconPool(ctx context.Context) error {
+	if c == nil || c.snapshot.App.PiconBase == "" || c.piconPool != nil {
+		return nil
+	}
+
+	pool, err := jobs.NewPiconPoolForConfig(ctx, c.snapshot.App)
+	if err != nil {
+		return err
+	}
+	c.piconPool = pool
+	if c.Manager != nil {
+		c.Manager.RegisterShutdownHook("picon_pool_stop", func(context.Context) error {
+			pool.Stop()
+			return nil
+		})
+	}
+	if c.App != nil {
+		c.App.SetPiconPool(pool)
+	}
 	return nil
 }
 
@@ -528,7 +555,7 @@ func (c *Container) Run(ctx context.Context, stop context.CancelFunc) error {
 func (c *Container) runInitialRefresh(ctx context.Context) {
 	time.Sleep(100 * time.Millisecond)
 	c.Logger.Info().Msg("performing initial data refresh (background)")
-	st, err := jobs.Refresh(ctx, c.snapshot)
+	st, err := jobs.RefreshWithOptions(ctx, c.snapshot, jobs.WithPiconPool(c.piconPool))
 	if err != nil {
 		c.Logger.Error().Err(err).Msg("initial data refresh failed")
 		c.Logger.Warn().Msg("→ Channels will be empty until manual refresh via /api/refresh")

--- a/backend/internal/app/bootstrap/picon_pool_runtime_test.go
+++ b/backend/internal/app/bootstrap/picon_pool_runtime_test.go
@@ -1,0 +1,48 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/daemon"
+	"github.com/ManuGH/xg2g/internal/log"
+)
+
+type recordingManager struct {
+	hooks []string
+}
+
+func (m *recordingManager) Start(context.Context) error    { return nil }
+func (m *recordingManager) Shutdown(context.Context) error { return nil }
+func (m *recordingManager) RegisterShutdownHook(name string, _ daemon.ShutdownHook) {
+	m.hooks = append(m.hooks, name)
+}
+
+func TestContainerInitPiconPoolRegistersShutdownHook(t *testing.T) {
+	tmp := t.TempDir()
+	mgr := &recordingManager{}
+	c := &Container{
+		Logger:  log.WithComponent("test"),
+		Manager: mgr,
+		snapshot: config.BuildSnapshot(config.AppConfig{
+			DataDir:   tmp,
+			PiconBase: "http://example.com",
+			Enigma2: config.Enigma2Settings{
+				BaseURL: "http://receiver.local",
+			},
+		}, config.DefaultEnv()),
+	}
+
+	if err := c.initPiconPool(context.Background()); err != nil {
+		t.Fatalf("initPiconPool returned error: %v", err)
+	}
+	if c.piconPool == nil {
+		t.Fatal("expected picon pool to be initialized")
+	}
+	defer c.piconPool.Stop()
+
+	if len(mgr.hooks) != 1 || mgr.hooks[0] != "picon_pool_stop" {
+		t.Fatalf("shutdown hooks = %v, want [picon_pool_stop]", mgr.hooks)
+	}
+}

--- a/backend/internal/control/http/v3/intents/service.go
+++ b/backend/internal/control/http/v3/intents/service.go
@@ -27,6 +27,27 @@ type Service struct {
 	deps Deps
 }
 
+type startHardwareState struct {
+	hasGPU       bool
+	av1Verified  bool
+	hevcVerified bool
+	h264Verified bool
+}
+
+type startProfileResolution struct {
+	requestedPlaybackMode string
+	publicRequestProfile  string
+	effectiveProfileID    string
+	profileSpec           model.ProfileSpec
+	operatorSnapshot      profiles.OperatorOverrideSnapshot
+	hostPressureBand      playbackprofile.HostPressureBand
+	hostOverrideApplied   bool
+	bucket                string
+	idempotencyKey        string
+	resolvedIntent        string
+	degradedFrom          string
+}
+
 func NewService(deps Deps) *Service {
 	return &Service{deps: deps}
 }
@@ -45,20 +66,72 @@ func (s *Service) ProcessIntent(ctx context.Context, intent Intent) (*Result, *E
 func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Error) {
 	store := s.deps.SessionStore()
 	bus := s.deps.EventBus()
-
-	// Smart Profile Lookup
-	var cap *scan.Capability
-	if scanner := s.deps.ChannelScanner(); scanner != nil {
-		if c, found := scanner.GetCapability(intent.ServiceRef); found {
-			cap = &c
-		}
+	capability := s.lookupStartCapability(intent.ServiceRef)
+	hardwareState := detectStartHardwareState()
+	hwaccelMode, err := s.resolveStartHWAccelMode(intent, hardwareState)
+	if err != nil {
+		return nil, err
+	}
+	reqProfileID, requestedPlaybackMode, err := s.resolveRequestedStartProfile(intent, hwaccelMode)
+	if err != nil {
+		return nil, err
+	}
+	resolution, err := s.resolveStartProfile(ctx, intent, capability, hardwareState, hwaccelMode, reqProfileID, requestedPlaybackMode)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.checkStartAdmission(ctx, intent, resolution.profileSpec); err != nil {
+		return nil, err
 	}
 
-	hasGPU := hardware.IsVAAPIReady()
-	av1Verified := hardware.IsVAAPIEncoderReady("av1_vaapi")
-	hevcVerified := hardware.IsVAAPIEncoderReady("hevc_vaapi")
-	h264Verified := hardware.IsVAAPIEncoderReady("h264_vaapi")
+	hwaccelEffective, hwaccelReason, encoderBackend := deriveStartHWAccelSummary(resolution.profileSpec, hwaccelMode, hardwareState.hasGPU)
+	s.logStartProfileResolution(intent, resolution, hardwareState, hwaccelMode, hwaccelEffective, hwaccelReason, encoderBackend)
 
+	if !s.deps.HasTunerSlots() {
+		s.deps.RecordIntent(string(model.IntentTypeStreamStart), "phase0", "no_slots")
+		return nil, &Error{Kind: ErrorNoTunerSlots, Message: "no tuner slots configured", RetryAfter: "10"}
+	}
+
+	phaseLabel := "phase2"
+	session := s.buildStartSession(intent, resolution)
+	if replay, err := s.persistStartSession(ctx, intent, store, session, resolution.idempotencyKey, phaseLabel); err != nil {
+		return nil, err
+	} else if replay != nil {
+		return replay, nil
+	}
+	if err := s.publishStartSession(ctx, intent, bus, resolution.effectiveProfileID, phaseLabel); err != nil {
+		return nil, err
+	}
+
+	intent.Logger.Info().Msg("intent accepted")
+	s.deps.RecordIntent(string(model.IntentTypeStreamStart), phaseLabel, "accepted")
+
+	return &Result{
+		SessionID:     intent.SessionID,
+		Status:        "accepted",
+		CorrelationID: intent.CorrelationID,
+	}, nil
+}
+
+func (s *Service) lookupStartCapability(serviceRef string) *scan.Capability {
+	if scanner := s.deps.ChannelScanner(); scanner != nil {
+		if capability, found := scanner.GetCapability(serviceRef); found {
+			return &capability
+		}
+	}
+	return nil
+}
+
+func detectStartHardwareState() startHardwareState {
+	return startHardwareState{
+		hasGPU:       hardware.IsVAAPIReady(),
+		av1Verified:  hardware.IsVAAPIEncoderReady("av1_vaapi"),
+		hevcVerified: hardware.IsVAAPIEncoderReady("hevc_vaapi"),
+		h264Verified: hardware.IsVAAPIEncoderReady("h264_vaapi"),
+	}
+}
+
+func (s *Service) resolveStartHWAccelMode(intent Intent, hw startHardwareState) (profiles.HWAccelMode, *Error) {
 	hwaccelMode := profiles.HWAccelAuto
 	if hwaccel := normalize.Token(intent.Params["hwaccel"]); hwaccel != "" {
 		switch hwaccel {
@@ -70,37 +143,41 @@ func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Er
 			hwaccelMode = profiles.HWAccelAuto
 		default:
 			s.deps.RecordIntent(string(model.IntentTypeStreamStart), "phase0", "invalid_hwaccel")
-			return nil, &Error{
+			return "", &Error{
 				Kind:    ErrorInvalidInput,
 				Message: fmt.Sprintf("invalid hwaccel value: %q (must be auto, force, or off)", hwaccel),
 			}
 		}
 	}
 
-	if hwaccelMode == profiles.HWAccelForce && !hasGPU {
+	if hwaccelMode == profiles.HWAccelForce && !hw.hasGPU {
 		reason := "no /dev/dri/renderD128"
 		if hardware.HasVAAPI() {
 			reason = "VAAPI preflight encode test failed"
 		}
 		s.deps.RecordIntent(string(model.IntentTypeStreamStart), "phase0", "hwaccel_unavailable")
-		return nil, &Error{
+		return "", &Error{
 			Kind:    ErrorInvalidInput,
 			Message: fmt.Sprintf("hwaccel=force requested but GPU not available (%s)", reason),
 		}
 	}
 
+	return hwaccelMode, nil
+}
+
+func (s *Service) resolveRequestedStartProfile(intent Intent, hwaccelMode profiles.HWAccelMode) (string, string, *Error) {
 	reqProfileID := "universal"
 	requestedPlaybackMode := normalize.Token(intent.Params["playback_mode"])
 	if requestedPlaybackMode != "" {
 		_, keyLabel, resultLabel, tokenErr := resolvePlaybackDecisionToken(intent.Params)
 		if tokenErr != nil {
 			s.deps.IncLivePlaybackKey(keyLabel, resultLabel)
-			return nil, &Error{Kind: ErrorInvalidInput, Message: tokenErr.Error()}
+			return "", "", &Error{Kind: ErrorInvalidInput, Message: tokenErr.Error()}
 		}
 		s.deps.IncLivePlaybackKey(keyLabel, resultLabel)
 		mappedProfile, mapErr := mapPlaybackModeToProfile(requestedPlaybackMode)
 		if mapErr != nil {
-			return nil, &Error{Kind: ErrorInvalidInput, Message: mapErr.Error()}
+			return "", "", &Error{Kind: ErrorInvalidInput, Message: mapErr.Error()}
 		}
 		reqProfileID = mappedProfile
 		if requestedPlaybackMode == "transcode" {
@@ -108,86 +185,94 @@ func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Er
 				reqProfileID = picked
 			}
 		}
-	} else if p := normalize.Token(intent.Params["profile"]); p != "" {
-		reqProfileID = p
-	} else if picked := pickProfileForCodecs(intent.Params["codecs"], hwaccelMode); picked != "" {
-		reqProfileID = picked
+		return reqProfileID, requestedPlaybackMode, nil
 	}
-	publicRequestProfile := profiles.PublicProfileName(reqProfileID)
-	operatorCfg := s.deps.PlaybackOperator()
-	effectiveProfileID, operatorSnapshot := profiles.ResolveRequestedProfileWithSourceOperatorOverride(reqProfileID, string(intent.Mode), intent.ServiceRef, operatorCfg)
-	effectiveProfileID = profiles.NormalizeRequestedProfileID(effectiveProfileID)
-	operatorActive := operatorSnapshot.ForcedIntent != playbackprofile.IntentUnknown || operatorSnapshot.MaxQualityRung != playbackprofile.RungUnknown
-	hostPressure := s.deps.HostPressure(ctx)
-	hostPressureBand := playbackprofile.NormalizeHostPressureBand(string(hostPressure.EffectiveBand))
-	hostOverrideApplied := false
+	if profileID := normalize.Token(intent.Params["profile"]); profileID != "" {
+		return profileID, "", nil
+	}
+	if picked := pickProfileForCodecs(intent.Params["codecs"], hwaccelMode); picked != "" {
+		return picked, "", nil
+	}
+	return reqProfileID, "", nil
+}
 
-	bucket := "0"
-	if intent.StartMs != nil && *intent.StartMs > 0 {
-		bucket = fmt.Sprintf("%d", *intent.StartMs/1000)
+func (s *Service) resolveStartProfile(ctx context.Context, intent Intent, capability *scan.Capability, hw startHardwareState, hwaccelMode profiles.HWAccelMode, reqProfileID, requestedPlaybackMode string) (startProfileResolution, *Error) {
+	resolution := startProfileResolution{
+		requestedPlaybackMode: requestedPlaybackMode,
+		publicRequestProfile:  profiles.PublicProfileName(reqProfileID),
 	}
-	idempotencyKey := ComputeIdemKey(model.IntentTypeStreamStart, intent.ServiceRef, effectiveProfileID, bucket)
+	operatorCfg := s.deps.PlaybackOperator()
+	resolution.effectiveProfileID, resolution.operatorSnapshot = profiles.ResolveRequestedProfileWithSourceOperatorOverride(reqProfileID, string(intent.Mode), intent.ServiceRef, operatorCfg)
+	resolution.effectiveProfileID = profiles.NormalizeRequestedProfileID(resolution.effectiveProfileID)
+	resolution.hostPressureBand = playbackprofile.NormalizeHostPressureBand(string(s.deps.HostPressure(ctx).EffectiveBand))
+	resolution.bucket = "0"
+	if intent.StartMs != nil && *intent.StartMs > 0 {
+		resolution.bucket = fmt.Sprintf("%d", *intent.StartMs/1000)
+	}
+	resolution.idempotencyKey = ComputeIdemKey(model.IntentTypeStreamStart, intent.ServiceRef, resolution.effectiveProfileID, resolution.bucket)
 
 	profileUserAgent := intent.UserAgent
 	if requestedPlaybackMode != "" {
 		profileUserAgent = ""
 	}
-
 	resolveProfileSpec := func(profileID string) model.ProfileSpec {
-		resolveHasGPU := hasGPU
-		switch profileID {
-		case profiles.ProfileAV1HW:
-			resolveHasGPU = av1Verified
-		case profiles.ProfileSafariHEVCHW, profiles.ProfileSafariHEVCHWLL:
-			resolveHasGPU = hevcVerified
-		case profiles.ProfileH264FMP4:
-			resolveHasGPU = h264Verified
-		}
-		return profiles.Resolve(profileID, profileUserAgent, int(s.deps.DVRWindow().Seconds()), cap, resolveHasGPU, hwaccelMode)
+		return s.resolveProfileSpec(profileID, profileUserAgent, capability, hw, hwaccelMode)
 	}
-
-	profileSpec := resolveProfileSpec(effectiveProfileID)
-	if cappedSpec, changed := profiles.ApplyMaxQualityRung(profileSpec, operatorSnapshot.MaxQualityRung); changed {
-		profileSpec = cappedSpec
-		operatorSnapshot.OverrideApplied = true
+	resolution.profileSpec = resolveProfileSpec(resolution.effectiveProfileID)
+	if cappedSpec, changed := profiles.ApplyMaxQualityRung(resolution.profileSpec, resolution.operatorSnapshot.MaxQualityRung); changed {
+		resolution.profileSpec = cappedSpec
+		resolution.operatorSnapshot.OverrideApplied = true
 	}
+	operatorActive := resolution.operatorSnapshot.ForcedIntent != playbackprofile.IntentUnknown || resolution.operatorSnapshot.MaxQualityRung != playbackprofile.RungUnknown
 	if !operatorActive {
-		if downgradedProfileID, changed := profiles.ApplyHostPressureOverride(effectiveProfileID, hostPressureBand); changed {
-			effectiveProfileID = downgradedProfileID
-			profileSpec = resolveProfileSpec(effectiveProfileID)
-			hostOverrideApplied = true
+		if downgradedProfileID, changed := profiles.ApplyHostPressureOverride(resolution.effectiveProfileID, resolution.hostPressureBand); changed {
+			resolution.effectiveProfileID = downgradedProfileID
+			resolution.profileSpec = resolveProfileSpec(resolution.effectiveProfileID)
+			resolution.hostOverrideApplied = true
 		}
 	}
-	if requiredEncoder, ok := requiredVerifiedVAAPIEncoderForProfile(effectiveProfileID); ok {
+	if requiredEncoder, ok := requiredVerifiedVAAPIEncoderForProfile(resolution.effectiveProfileID); ok {
 		if hwaccelMode == profiles.HWAccelOff {
 			s.deps.RecordIntent(string(model.IntentTypeStreamStart), "phase0", "hw_profile_conflict")
-			return nil, &Error{
+			return startProfileResolution{}, &Error{
 				Kind:    ErrorInvalidInput,
-				Message: fmt.Sprintf("profile %q requires verified hardware acceleration; hwaccel=off is incompatible", effectiveProfileID),
+				Message: fmt.Sprintf("profile %q requires verified hardware acceleration; hwaccel=off is incompatible", resolution.effectiveProfileID),
 			}
 		}
 		if !hardware.IsVAAPIEncoderReady(requiredEncoder) {
 			s.deps.RecordIntent(string(model.IntentTypeStreamStart), "phase0", "hw_profile_unavailable")
-			return nil, &Error{
+			return startProfileResolution{}, &Error{
 				Kind:    ErrorInvalidInput,
-				Message: fmt.Sprintf("profile %q requires verified %s on this host", effectiveProfileID, requiredEncoder),
+				Message: fmt.Sprintf("profile %q requires verified %s on this host", resolution.effectiveProfileID, requiredEncoder),
 			}
 		}
 	}
-	resolvedIntent := profiles.PublicProfileName(profileSpec.Name)
-	degradedFrom := ""
-	if publicRequestProfile != "" && resolvedIntent != "" && publicRequestProfile != resolvedIntent {
-		degradedFrom = publicRequestProfile
+	resolution.resolvedIntent = profiles.PublicProfileName(resolution.profileSpec.Name)
+	if resolution.publicRequestProfile != "" && resolution.resolvedIntent != "" && resolution.publicRequestProfile != resolution.resolvedIntent {
+		resolution.degradedFrom = resolution.publicRequestProfile
 	}
+	return resolution, nil
+}
 
+func (s *Service) resolveProfileSpec(profileID, userAgent string, capability *scan.Capability, hw startHardwareState, hwaccelMode profiles.HWAccelMode) model.ProfileSpec {
+	resolveHasGPU := hw.hasGPU
+	switch profileID {
+	case profiles.ProfileAV1HW:
+		resolveHasGPU = hw.av1Verified
+	case profiles.ProfileSafariHEVCHW, profiles.ProfileSafariHEVCHWLL:
+		resolveHasGPU = hw.hevcVerified
+	case profiles.ProfileH264FMP4:
+		resolveHasGPU = hw.h264Verified
+	}
+	return profiles.Resolve(profileID, userAgent, int(s.deps.DVRWindow().Seconds()), capability, resolveHasGPU, hwaccelMode)
+}
+
+func (s *Service) checkStartAdmission(ctx context.Context, intent Intent, profileSpec model.ProfileSpec) *Error {
 	controller := s.deps.AdmissionController()
 	if controller == nil {
-		return nil, &Error{Kind: ErrorAdmissionUnavailable}
+		return &Error{Kind: ErrorAdmissionUnavailable}
 	}
-
-	runtimeState := s.deps.AdmissionRuntimeState(ctx)
-	wantsTranscode := profileSpec.TranscodeVideo
-	decision := controller.Check(ctx, admission.Request{WantsTranscode: wantsTranscode}, runtimeState)
+	decision := controller.Check(ctx, admission.Request{WantsTranscode: profileSpec.TranscodeVideo}, s.deps.AdmissionRuntimeState(ctx))
 	if !decision.Allow {
 		if decision.Problem != nil {
 			s.deps.RecordReject(decision.Problem.Code)
@@ -210,73 +295,70 @@ func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Er
 			Msg("admission rejected")
 
 		s.deps.RecordIntent(string(model.IntentTypeStreamStart), "admission", problemCode)
-		return nil, &Error{Kind: ErrorAdmissionRejected, RetryAfter: retryAfter, AdmissionProblem: decision.Problem}
+		return &Error{Kind: ErrorAdmissionRejected, RetryAfter: retryAfter, AdmissionProblem: decision.Problem}
 	}
-
 	s.deps.RecordAdmit()
+	return nil
+}
 
-	var hwaccelEffective, hwaccelReason, encoderBackend string
+func deriveStartHWAccelSummary(profileSpec model.ProfileSpec, hwaccelMode profiles.HWAccelMode, hasGPU bool) (effective, reason, backend string) {
 	if profileSpec.TranscodeVideo {
 		if profiles.IsGPUBackedProfile(profileSpec.HWAccel) {
-			hwaccelEffective = "gpu"
-			encoderBackend = "vaapi"
+			effective = "gpu"
+			backend = "vaapi"
 			if hwaccelMode == profiles.HWAccelForce {
-				hwaccelReason = "forced"
+				reason = "forced"
 			} else {
-				hwaccelReason = "auto_has_gpu"
+				reason = "auto_has_gpu"
 			}
-		} else {
-			hwaccelEffective = "cpu"
-			encoderBackend = profileSpec.VideoCodec
-			if hwaccelMode == profiles.HWAccelOff {
-				hwaccelReason = "user_disabled"
-			} else if !hasGPU {
-				hwaccelReason = "no_gpu_available"
-			} else {
-				hwaccelReason = "profile_cpu_only"
-			}
+			return effective, reason, backend
 		}
-	} else {
-		hwaccelEffective = "off"
-		hwaccelReason = "passthrough"
-		encoderBackend = "none"
+		effective = "cpu"
+		backend = profileSpec.VideoCodec
+		if hwaccelMode == profiles.HWAccelOff {
+			reason = "user_disabled"
+		} else if !hasGPU {
+			reason = "no_gpu_available"
+		} else {
+			reason = "profile_cpu_only"
+		}
+		return effective, reason, backend
 	}
+	return "off", "passthrough", "none"
+}
 
+func (s *Service) logStartProfileResolution(intent Intent, resolution startProfileResolution, hw startHardwareState, hwaccelMode profiles.HWAccelMode, hwaccelEffective, hwaccelReason, encoderBackend string) {
 	intent.Logger.Info().
 		Str("ua", intent.UserAgent).
-		Str("profile", profileSpec.Name).
-		Str("profile_public", publicRequestProfile).
-		Str("profile_effective", effectiveProfileID).
-		Int("dvr_window_sec", profileSpec.DVRWindowSec).
-		Str("idem_key", idempotencyKey).
-		Bool("gpu_available", hasGPU).
+		Str("profile", resolution.profileSpec.Name).
+		Str("profile_public", resolution.publicRequestProfile).
+		Str("profile_effective", resolution.effectiveProfileID).
+		Int("dvr_window_sec", resolution.profileSpec.DVRWindowSec).
+		Str("idem_key", resolution.idempotencyKey).
+		Bool("gpu_available", hw.hasGPU).
 		Str("hwaccel_requested", string(hwaccelMode)).
 		Str("hwaccel_effective", hwaccelEffective).
 		Str("hwaccel_reason", hwaccelReason).
-		Str("operator_force_intent", playbackprofile.PublicIntentName(operatorSnapshot.ForcedIntent)).
-		Str("operator_max_quality_rung", string(operatorSnapshot.MaxQualityRung)).
-		Bool("operator_disable_client_fallback", operatorSnapshot.DisableClientFallback).
-		Bool("operator_override_applied", operatorSnapshot.OverrideApplied).
-		Str("host_pressure_band", string(hostPressureBand)).
-		Bool("host_override_applied", hostOverrideApplied).
+		Str("operator_force_intent", playbackprofile.PublicIntentName(resolution.operatorSnapshot.ForcedIntent)).
+		Str("operator_max_quality_rung", string(resolution.operatorSnapshot.MaxQualityRung)).
+		Bool("operator_disable_client_fallback", resolution.operatorSnapshot.DisableClientFallback).
+		Bool("operator_override_applied", resolution.operatorSnapshot.OverrideApplied).
+		Str("host_pressure_band", string(resolution.hostPressureBand)).
+		Bool("host_override_applied", resolution.hostOverrideApplied).
 		Str("encoder_backend", encoderBackend).
-		Str("video_codec", profileSpec.VideoCodec).
-		Str("container", profileSpec.Container).
-		Bool("llhls", profileSpec.LLHLS).
+		Str("video_codec", resolution.profileSpec.VideoCodec).
+		Str("container", resolution.profileSpec.Container).
+		Bool("llhls", resolution.profileSpec.LLHLS).
 		Msg("intent profile resolved")
+}
 
-	if !s.deps.HasTunerSlots() {
-		s.deps.RecordIntent(string(model.IntentTypeStreamStart), "phase0", "no_slots")
-		return nil, &Error{Kind: ErrorNoTunerSlots, Message: "no tuner slots configured", RetryAfter: "10"}
-	}
-
-	phaseLabel := "phase2"
+func buildStartRequestParams(intent Intent, resolution startProfileResolution) map[string]string {
 	requestParams := map[string]string{
-		"profile": effectiveProfileID,
-		"bucket":  bucket,
+		"profile": resolution.effectiveProfileID,
+		"bucket":  resolution.bucket,
 	}
-	if requestedPlaybackMode != "" {
-		requestParams[model.CtxKeyClientPath] = requestedPlaybackMode
+	if resolution.requestedPlaybackMode != "" {
+		requestParams[model.CtxKeyClientPath] = resolution.requestedPlaybackMode
 	}
 	if clientFamily := normalize.Token(intent.Params[model.CtxKeyClientFamily]); clientFamily != "" {
 		requestParams[model.CtxKeyClientFamily] = clientFamily
@@ -296,42 +378,49 @@ func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Er
 	if intent.Mode != "" {
 		requestParams[model.CtxKeyMode] = intent.Mode
 	}
+	return requestParams
+}
 
-	var operatorTrace *model.PlaybackOperatorTrace
-	if operatorSnapshot.OverrideApplied || operatorSnapshot.ForcedIntent != playbackprofile.IntentUnknown || operatorSnapshot.MaxQualityRung != playbackprofile.RungUnknown || operatorSnapshot.DisableClientFallback {
-		operatorTrace = &model.PlaybackOperatorTrace{
-			ForcedIntent:           playbackprofile.PublicIntentName(operatorSnapshot.ForcedIntent),
-			MaxQualityRung:         string(operatorSnapshot.MaxQualityRung),
-			ClientFallbackDisabled: operatorSnapshot.DisableClientFallback,
-			RuleName:               operatorSnapshot.RuleName,
-			RuleScope:              operatorSnapshot.RuleScope,
-			OverrideApplied:        operatorSnapshot.OverrideApplied,
-		}
+func buildStartOperatorTrace(snapshot profiles.OperatorOverrideSnapshot) *model.PlaybackOperatorTrace {
+	if !snapshot.OverrideApplied && snapshot.ForcedIntent == playbackprofile.IntentUnknown && snapshot.MaxQualityRung == playbackprofile.RungUnknown && !snapshot.DisableClientFallback {
+		return nil
 	}
+	return &model.PlaybackOperatorTrace{
+		ForcedIntent:           playbackprofile.PublicIntentName(snapshot.ForcedIntent),
+		MaxQualityRung:         string(snapshot.MaxQualityRung),
+		ClientFallbackDisabled: snapshot.DisableClientFallback,
+		RuleName:               snapshot.RuleName,
+		RuleScope:              snapshot.RuleScope,
+		OverrideApplied:        snapshot.OverrideApplied,
+	}
+}
 
-	videoQualityRung := model.TraceVideoQualityRungFromProfile(profileSpec)
-
+func (s *Service) buildStartSession(intent Intent, resolution startProfileResolution) *model.SessionRecord {
+	videoQualityRung := model.TraceVideoQualityRungFromProfile(resolution.profileSpec)
 	session := lifecycle.NewSessionRecord(time.Now())
 	session.SessionID = intent.SessionID
 	session.ServiceRef = intent.ServiceRef
-	session.Profile = profileSpec
+	session.Profile = resolution.profileSpec
 	session.CorrelationID = intent.CorrelationID
 	session.LeaseExpiresAtUnix = time.Now().Add(s.deps.SessionLeaseTTL()).Unix()
 	session.HeartbeatInterval = int(s.deps.SessionHeartbeatInterval().Seconds())
-	session.ContextData = requestParams
+	session.ContextData = buildStartRequestParams(intent, resolution)
 	session.PlaybackTrace = &model.PlaybackTrace{
-		RequestProfile:      publicRequestProfile,
-		RequestedIntent:     publicRequestProfile,
-		ResolvedIntent:      resolvedIntent,
+		RequestProfile:      resolution.publicRequestProfile,
+		RequestedIntent:     resolution.publicRequestProfile,
+		ResolvedIntent:      resolution.resolvedIntent,
 		QualityRung:         videoQualityRung,
 		VideoQualityRung:    videoQualityRung,
-		DegradedFrom:        degradedFrom,
-		ClientPath:          requestedPlaybackMode,
-		Operator:            operatorTrace,
-		HostPressureBand:    string(hostPressureBand),
-		HostOverrideApplied: hostOverrideApplied,
+		DegradedFrom:        resolution.degradedFrom,
+		ClientPath:          resolution.requestedPlaybackMode,
+		Operator:            buildStartOperatorTrace(resolution.operatorSnapshot),
+		HostPressureBand:    string(resolution.hostPressureBand),
+		HostOverrideApplied: resolution.hostOverrideApplied,
 	}
+	return session
+}
 
+func (s *Service) persistStartSession(ctx context.Context, intent Intent, store SessionStore, session *model.SessionRecord, idempotencyKey, phaseLabel string) (*Result, *Error) {
 	persisted := false
 	for attempt := 0; attempt < startReplayRecoveryAttempts; attempt++ {
 		existingID, exists, err := store.PutSessionWithIdempotency(ctx, session, idempotencyKey, admissionLeaseTTL)
@@ -365,13 +454,17 @@ func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Er
 			intent.Logger.Warn().Str("existing_sid", existingID).Int("attempt", attempt+1).Msg("discarded stale idempotent replay for terminal session")
 		}
 	}
-	if !persisted {
-		err := fmt.Errorf("stale idempotency mapping persisted after %d attempts", startReplayRecoveryAttempts)
-		intent.Logger.Error().Err(err).Str("idem_key", idempotencyKey).Msg("failed to refresh stale idempotency mapping")
-		s.deps.RecordIntent(string(model.IntentTypeStreamStart), phaseLabel, "store_error")
-		return nil, &Error{Kind: ErrorStoreUnavailable, Message: "failed to refresh stale intent mapping", Cause: err}
+	if persisted {
+		return nil, nil
 	}
 
+	err := fmt.Errorf("stale idempotency mapping persisted after %d attempts", startReplayRecoveryAttempts)
+	intent.Logger.Error().Err(err).Str("idem_key", idempotencyKey).Msg("failed to refresh stale idempotency mapping")
+	s.deps.RecordIntent(string(model.IntentTypeStreamStart), phaseLabel, "store_error")
+	return nil, &Error{Kind: ErrorStoreUnavailable, Message: "failed to refresh stale intent mapping", Cause: err}
+}
+
+func (s *Service) publishStartSession(ctx context.Context, intent Intent, bus EventBus, effectiveProfileID, phaseLabel string) *Error {
 	evt := model.StartSessionEvent{
 		Type:          model.EventStartSession,
 		SessionID:     intent.SessionID,
@@ -388,18 +481,10 @@ func (s *Service) processStart(ctx context.Context, intent Intent) (*Result, *Er
 		intent.Logger.Error().Err(err).Msg("failed to publish start event")
 		s.deps.RecordPublish("session.start", "error")
 		s.deps.RecordIntent(string(model.IntentTypeStreamStart), phaseLabel, "publish_error")
-		return nil, &Error{Kind: ErrorPublishUnavailable, Message: "failed to publish event", Cause: err}
+		return &Error{Kind: ErrorPublishUnavailable, Message: "failed to publish event", Cause: err}
 	}
 	s.deps.RecordPublish("session.start", "ok")
-
-	intent.Logger.Info().Msg("intent accepted")
-	s.deps.RecordIntent(string(model.IntentTypeStreamStart), phaseLabel, "accepted")
-
-	return &Result{
-		SessionID:     intent.SessionID,
-		Status:        "accepted",
-		CorrelationID: intent.CorrelationID,
-	}, nil
+	return nil
 }
 
 func (s *Service) processStop(ctx context.Context, intent Intent) (*Result, *Error) {

--- a/backend/internal/daemon/app.go
+++ b/backend/internal/daemon/app.go
@@ -30,6 +30,7 @@ type App struct {
 	manager      Manager
 	cfgHolder    *config.ConfigHolder
 	apiServer    *api.Server
+	piconPool    *jobs.PiconPool
 	proxyOnly    bool
 	reloadSignal os.Signal
 }
@@ -44,6 +45,10 @@ func NewApp(logger zerolog.Logger, manager Manager, cfgHolder *config.ConfigHold
 		proxyOnly:    proxyOnly,
 		reloadSignal: syscall.SIGHUP,
 	}
+}
+
+func (a *App) SetPiconPool(pool *jobs.PiconPool) {
+	a.piconPool = pool
 }
 
 // Run starts all owned background subsystems and blocks until ctx is cancelled or a fatal error occurs.
@@ -169,7 +174,7 @@ func (a *App) Run(ctx context.Context) error {
 						}
 
 						a.logger.Info().Msg("Starting scheduled EPG refresh")
-						if st, err := jobs.Refresh(ctx, *snap); err != nil {
+						if st, err := jobs.RefreshWithOptions(ctx, *snap, jobs.WithPiconPool(a.piconPool)); err != nil {
 							a.logger.Error().Err(err).Msg("Scheduled EPG refresh failed")
 						} else {
 							a.logger.Info().Msg("Scheduled EPG refresh completed")

--- a/backend/internal/infra/media/ffmpeg/plan_builder.go
+++ b/backend/internal/infra/media/ffmpeg/plan_builder.go
@@ -37,6 +37,12 @@ type outputPlan struct {
 	args []string
 }
 
+type liveSegmentLayout struct {
+	segmentDurationSec     int
+	initSegmentDurationSec int
+	listSize               int
+}
+
 func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inputURL string) ([]string, error) {
 	codecPhase, err := a.planCodec(spec)
 	if err != nil {
@@ -289,23 +295,58 @@ func (a *LocalAdapter) planInput(spec ports.StreamSpec, inputURL string) (inputP
 }
 
 func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec, input inputPlan, codec codecPlan) (outputPlan, error) {
-	segmentDurationSec := a.SegmentSeconds
-	initSegmentDurationSec := 0
-	if strings.EqualFold(strings.TrimSpace(spec.Profile.Name), "safari_dirty") && segmentDurationSec > safariDirtyHLSTimeSec {
-		segmentDurationSec = safariDirtyHLSTimeSec
-		initSegmentDurationSec = safariDirtyHLSInitTimeSec
-		if initSegmentDurationSec > segmentDurationSec {
-			initSegmentDurationSec = segmentDurationSec
+	layout, err := a.planLiveSegmentLayout(spec)
+	if err != nil {
+		return outputPlan{}, err
+	}
+	fps := a.resolveLiveFPS(ctx, spec, input.inputURL)
+	spec = a.applySafariRuntimeRemuxOverride(ctx, spec, input.inputURL)
+	gop := fps * layout.segmentDurationSec
+
+	out := outputPlan{}
+	out.args = append(out.args,
+		"-map", "0:v:0?",
+		"-map", "0:a:0?",
+	)
+
+	out.args = a.buildLiveVideoOutputArgs(out.args, spec, codec, gop, layout.segmentDurationSec)
+	out.args = appendLiveAudioArgs(out.args, spec)
+	out.args = a.appendLiveHLSArgs(out.args, spec, layout)
+	out.args = append(out.args, a.prepareLiveOutputPath(spec.SessionID))
+
+	return out, nil
+}
+
+func (a *LocalAdapter) planLiveSegmentLayout(spec ports.StreamSpec) (liveSegmentLayout, error) {
+	layout := liveSegmentLayout{
+		segmentDurationSec: a.SegmentSeconds,
+		listSize:           10,
+	}
+	if strings.EqualFold(strings.TrimSpace(spec.Profile.Name), "safari_dirty") && layout.segmentDurationSec > safariDirtyHLSTimeSec {
+		layout.segmentDurationSec = safariDirtyHLSTimeSec
+		layout.initSegmentDurationSec = safariDirtyHLSInitTimeSec
+		if layout.initSegmentDurationSec > layout.segmentDurationSec {
+			layout.initSegmentDurationSec = layout.segmentDurationSec
 		}
 	}
-	if segmentDurationSec <= 0 {
-		return outputPlan{}, fmt.Errorf("invalid hls segment seconds: %d", segmentDurationSec)
+	if layout.segmentDurationSec <= 0 {
+		return liveSegmentLayout{}, fmt.Errorf("invalid hls segment seconds: %d", layout.segmentDurationSec)
 	}
+	if a.DVRWindow > 0 {
+		layout.listSize = int(math.Ceil(a.DVRWindow.Seconds() / float64(layout.segmentDurationSec)))
+		if layout.listSize < 3 {
+			layout.listSize = 3
+		}
+	}
+	return layout, nil
+}
+
+func (a *LocalAdapter) defaultLiveFPS(spec ports.StreamSpec, inputURL string) int {
 	fps := a.FPSFallback
 	if fps <= 0 {
 		fps = 25
 	}
-	if (spec.Source.Type != ports.SourceTuner && !isStreamRelayURL(input.inputURL)) && !spec.Profile.Deinterlace {
+	if (spec.Source.Type != ports.SourceTuner && !isStreamRelayURL(inputURL)) && !spec.Profile.Deinterlace {
 		fps = 30
 	}
 	if spec.Profile.Deinterlace || strings.EqualFold(strings.TrimSpace(spec.Profile.Name), "safari_dirty") {
@@ -314,197 +355,206 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 	if fps <= 0 {
 		fps = 25
 	}
+	return fps
+}
 
-	sourceKey := fpsCacheKey(spec.Source, input.inputURL)
-	skipProbe := false
-	if isStreamRelayURL(input.inputURL) {
-		skipProbe = true
+func (a *LocalAdapter) resolveLiveFPS(ctx context.Context, spec ports.StreamSpec, inputURL string) int {
+	fps := a.defaultLiveFPS(spec, inputURL)
+	sourceKey := fpsCacheKey(spec.Source, inputURL)
+	if resolved, skipProbe := a.resolveSkippedLiveFPS(ctx, spec, inputURL, sourceKey, fps); skipProbe {
+		return resolved
+	}
+	return a.resolveProbedLiveFPS(ctx, spec, inputURL, sourceKey, fps)
+}
+
+func (a *LocalAdapter) resolveSkippedLiveFPS(ctx context.Context, spec ports.StreamSpec, inputURL, sourceKey string, fallback int) (int, bool) {
+	if isStreamRelayURL(inputURL) {
 		logEvt := a.Logger.Info().
 			Str("session_id", spec.SessionID).
 			Str("startup_phase", "fps_probe_skipped_streamrelay").
 			Str("source_key", sourceKey).
-			Str("input_url", sanitizeURLForLog(input.inputURL))
-		if sourceKey != "" {
-			if cachedFPS, ok := a.getLastKnownFPS(sourceKey); ok && cachedFPS >= a.FPSMin && cachedFPS <= a.FPSMax {
-				fps = cachedFPS
-				logEvt.Int("cached_fps", cachedFPS).
-					Msg("skipping fps probe for stream relay input; using cached fps")
-			} else {
-				logEvt.Int("fallback_fps", fps).
-					Msg("skipping fps probe for stream relay input; using fallback fps")
-			}
-		} else {
-			logEvt.Int("fallback_fps", fps).
-				Msg("skipping fps probe for stream relay input; using fallback fps")
+			Str("input_url", sanitizeURLForLog(inputURL))
+		if cachedFPS, ok := a.cachedFPS(sourceKey); ok {
+			logEvt.Int("cached_fps", cachedFPS).
+				Msg("skipping fps probe for stream relay input; using cached fps")
+			return cachedFPS, true
 		}
+		logEvt.Int("fallback_fps", fallback).
+			Msg("skipping fps probe for stream relay input; using fallback fps")
+		return fallback, true
 	}
-	if !skipProbe && sourceKey != "" {
-		if cachedFPS, ok := a.getLastKnownFPS(sourceKey); ok && cachedFPS >= a.FPSMin && cachedFPS <= a.FPSMax {
-			a.Logger.Info().
-				Str("session_id", spec.SessionID).
-				Str("startup_phase", "fps_cache_available").
-				Str("source_key", sourceKey).
-				Int("cached_fps", cachedFPS).
-				Msg("fps cache available before probe")
-			if a.SkipFPSProbeOnCache {
-				warmupSucceeded := true
-				if a.SkipFPSProbeWarmup > 0 && isHTTPInputURL(input.inputURL) {
-					a.Logger.Info().
-						Str("session_id", spec.SessionID).
-						Str("startup_phase", "fps_probe_warmup_started").
-						Str("source_key", sourceKey).
-						Str("input_url", sanitizeURLForLog(input.inputURL)).
-						Dur("warmup_duration", a.SkipFPSProbeWarmup).
-						Msg("starting cache-hit stream warmup")
-					warmupResult, warmupErr := a.warmupInputStream(ctx, input.inputURL, a.SkipFPSProbeWarmup)
-					warmupEvt := a.Logger.Info().
-						Str("session_id", spec.SessionID).
-						Str("startup_phase", "fps_probe_warmup_finished").
-						Str("source_key", sourceKey).
-						Str("input_url", sanitizeURLForLog(input.inputURL)).
-						Int("warmup_bytes", warmupResult.bytes).
-						Int("http_status", warmupResult.httpStatus).
-						Int64("latency_ms", warmupResult.latencyMs)
-					if warmupErr != nil {
-						warmupEvt = warmupEvt.Err(warmupErr)
-						warmupSucceeded = false
-					}
-					warmupEvt.Msg("cache-hit stream warmup finished")
-				}
-				if warmupSucceeded {
-					fps = cachedFPS
-					skipProbe = true
-					a.Logger.Info().
-						Str("session_id", spec.SessionID).
-						Str("startup_phase", "fps_probe_skipped").
-						Str("source_key", sourceKey).
-						Int("cached_fps", cachedFPS).
-						Msg("skipping fps probe because cached fps is available")
-				} else {
-					a.Logger.Warn().
-						Str("session_id", spec.SessionID).
-						Str("startup_phase", "fps_probe_skip_aborted").
-						Str("source_key", sourceKey).
-						Int("cached_fps", cachedFPS).
-						Msg("cache-hit stream warmup failed, falling back to fps probe")
-				}
-			}
-		}
+	if sourceKey == "" {
+		return fallback, false
 	}
-	if !skipProbe {
-		a.Logger.Info().
-			Str("session_id", spec.SessionID).
-			Str("startup_phase", "fps_probe_started").
-			Str("source_key", sourceKey).
-			Str("input_url", sanitizeURLForLog(input.inputURL)).
-			Msg("fps probe started")
-		detected, basis, err := a.probeFPS(ctx, input.inputURL)
-		probeEvt := a.Logger.Info().
-			Str("session_id", spec.SessionID).
-			Str("startup_phase", "fps_probe_finished").
-			Str("source_key", sourceKey).
-			Str("input_url", sanitizeURLForLog(input.inputURL))
-		if err != nil {
-			probeEvt = probeEvt.Err(err)
-		} else {
-			probeEvt = probeEvt.Int("detected_fps", detected).Str("fps_basis", basis)
-		}
-		probeEvt.Msg("fps probe finished")
-		if err == nil && detected >= a.FPSMin && detected <= a.FPSMax {
-			fps = detected
-			if sourceKey != "" {
-				a.setLastKnownFPS(sourceKey, detected)
-			}
-			a.Logger.Debug().
-				Str("sessionId", spec.SessionID).
-				Int("fps", fps).
-				Str("fps_basis", basis).
-				Str("url", sanitizeURLForLog(input.inputURL)).
-				Msg("detected input fps")
-		} else {
-			if err == nil {
-				err = fmt.Errorf("detected fps out of range: %d", detected)
-			}
-			if sourceKey != "" {
-				if cachedFPS, ok := a.getLastKnownFPS(sourceKey); ok && cachedFPS >= a.FPSMin && cachedFPS <= a.FPSMax {
-					fps = cachedFPS
-					a.Logger.Warn().
-						Str("sessionId", spec.SessionID).
-						Err(err).
-						Int("cached_fps", cachedFPS).
-						Str("fps_basis", "last_known_source").
-						Str("source_key", sourceKey).
-						Int("fps_min", a.FPSMin).
-						Int("fps_max", a.FPSMax).
-						Str("url", sanitizeURLForLog(input.inputURL)).
-						Msg("fps detection failed, using last known source fps")
-				} else {
-					a.Logger.Warn().
-						Str("sessionId", spec.SessionID).
-						Err(err).
-						Int("fallback_fps", fps).
-						Int("fps_min", a.FPSMin).
-						Int("fps_max", a.FPSMax).
-						Str("url", sanitizeURLForLog(input.inputURL)).
-						Msg("fps detection failed, using fallback")
-				}
-			} else {
-				a.Logger.Warn().
-					Str("sessionId", spec.SessionID).
-					Err(err).
-					Int("fallback_fps", fps).
-					Int("fps_min", a.FPSMin).
-					Int("fps_max", a.FPSMax).
-					Str("url", sanitizeURLForLog(input.inputURL)).
-					Msg("fps detection failed, using fallback")
-			}
-		}
+	cachedFPS, ok := a.cachedFPS(sourceKey)
+	if !ok {
+		return fallback, false
 	}
+	a.Logger.Info().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_cache_available").
+		Str("source_key", sourceKey).
+		Int("cached_fps", cachedFPS).
+		Msg("fps cache available before probe")
+	if !a.SkipFPSProbeOnCache {
+		return fallback, false
+	}
+	if a.shouldAbortCachedFPSSkip(ctx, spec, inputURL, sourceKey, cachedFPS) {
+		return fallback, false
+	}
+	a.Logger.Info().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_probe_skipped").
+		Str("source_key", sourceKey).
+		Int("cached_fps", cachedFPS).
+		Msg("skipping fps probe because cached fps is available")
+	return cachedFPS, true
+}
 
-	gop := fps * segmentDurationSec
-	listSize := 10
-	if a.DVRWindow > 0 {
-		listSize = int(math.Ceil(a.DVRWindow.Seconds() / float64(segmentDurationSec)))
-		if listSize < 3 {
-			listSize = 3
-		}
+func (a *LocalAdapter) shouldAbortCachedFPSSkip(ctx context.Context, spec ports.StreamSpec, inputURL, sourceKey string, cachedFPS int) bool {
+	if a.SkipFPSProbeWarmup <= 0 || !isHTTPInputURL(inputURL) {
+		return false
 	}
-
-	out := outputPlan{}
-	out.args = append(out.args,
-		"-map", "0:v:0?",
-		"-map", "0:a:0?",
-	)
-
-	if a.shouldPreferSafariRuntimeRemux(ctx, spec, input.inputURL) {
-		spec.Profile.TranscodeVideo = false
-		spec.Profile.Deinterlace = false
-		// Native Safari is tolerant on MPEG-TS HLS, but remuxed broadcast H.264
-		// inside fMP4 has shown audio-only / black-video failures in production.
-		// Keep the runtime-remux optimization, but package it as classic TS HLS.
-		spec.Profile.Container = "mpegts"
-		if spec.Profile.AudioBitrateK <= 0 {
-			spec.Profile.AudioBitrateK = 192
-		}
+	a.Logger.Info().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_probe_warmup_started").
+		Str("source_key", sourceKey).
+		Str("input_url", sanitizeURLForLog(inputURL)).
+		Dur("warmup_duration", a.SkipFPSProbeWarmup).
+		Msg("starting cache-hit stream warmup")
+	warmupResult, warmupErr := a.warmupInputStream(ctx, inputURL, a.SkipFPSProbeWarmup)
+	warmupEvt := a.Logger.Info().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_probe_warmup_finished").
+		Str("source_key", sourceKey).
+		Str("input_url", sanitizeURLForLog(inputURL)).
+		Int("warmup_bytes", warmupResult.bytes).
+		Int("http_status", warmupResult.httpStatus).
+		Int64("latency_ms", warmupResult.latencyMs)
+	if warmupErr != nil {
+		warmupEvt = warmupEvt.Err(warmupErr)
 	}
+	warmupEvt.Msg("cache-hit stream warmup finished")
+	if warmupErr == nil {
+		return false
+	}
+	a.Logger.Warn().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_probe_skip_aborted").
+		Str("source_key", sourceKey).
+		Int("cached_fps", cachedFPS).
+		Msg("cache-hit stream warmup failed, falling back to fps probe")
+	return true
+}
 
-	if !spec.Profile.TranscodeVideo && !usesLegacyCPUDefaults(spec, codec.resolvedCodec) {
-		out.args = a.buildCopyVideoArgs(out.args, spec)
-	} else if codec.useVAAPI {
-		if codec.fullVAAPI {
-			out.args = a.buildVaapiVideoArgs(out.args, spec, codec.resolvedCodec, gop, segmentDurationSec)
-		} else {
-			out.args = a.buildVaapiEncodeOnlyVideoArgs(out.args, spec, codec.resolvedCodec, gop, segmentDurationSec)
-		}
+func (a *LocalAdapter) resolveProbedLiveFPS(ctx context.Context, spec ports.StreamSpec, inputURL, sourceKey string, fallback int) int {
+	a.Logger.Info().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_probe_started").
+		Str("source_key", sourceKey).
+		Str("input_url", sanitizeURLForLog(inputURL)).
+		Msg("fps probe started")
+	detected, basis, err := a.probeFPS(ctx, inputURL)
+	probeEvt := a.Logger.Info().
+		Str("session_id", spec.SessionID).
+		Str("startup_phase", "fps_probe_finished").
+		Str("source_key", sourceKey).
+		Str("input_url", sanitizeURLForLog(inputURL))
+	if err != nil {
+		probeEvt = probeEvt.Err(err)
 	} else {
-		out.args = a.buildCPUVideoArgs(out.args, spec, codec.resolvedCodec, gop, segmentDurationSec)
+		probeEvt = probeEvt.Int("detected_fps", detected).Str("fps_basis", basis)
 	}
+	probeEvt.Msg("fps probe finished")
+	if err == nil && a.isValidFPS(detected) {
+		if sourceKey != "" {
+			a.setLastKnownFPS(sourceKey, detected)
+		}
+		a.Logger.Debug().
+			Str("sessionId", spec.SessionID).
+			Int("fps", detected).
+			Str("fps_basis", basis).
+			Str("url", sanitizeURLForLog(inputURL)).
+			Msg("detected input fps")
+		return detected
+	}
+	if err == nil {
+		err = fmt.Errorf("detected fps out of range: %d", detected)
+	}
+	if cachedFPS, ok := a.cachedFPS(sourceKey); ok {
+		a.Logger.Warn().
+			Str("sessionId", spec.SessionID).
+			Err(err).
+			Int("cached_fps", cachedFPS).
+			Str("fps_basis", "last_known_source").
+			Str("source_key", sourceKey).
+			Int("fps_min", a.FPSMin).
+			Int("fps_max", a.FPSMax).
+			Str("url", sanitizeURLForLog(inputURL)).
+			Msg("fps detection failed, using last known source fps")
+		return cachedFPS
+	}
+	a.Logger.Warn().
+		Str("sessionId", spec.SessionID).
+		Err(err).
+		Int("fallback_fps", fallback).
+		Int("fps_min", a.FPSMin).
+		Int("fps_max", a.FPSMax).
+		Str("url", sanitizeURLForLog(inputURL)).
+		Msg("fps detection failed, using fallback")
+	return fallback
+}
 
+func (a *LocalAdapter) cachedFPS(sourceKey string) (int, bool) {
+	if sourceKey == "" {
+		return 0, false
+	}
+	cachedFPS, ok := a.getLastKnownFPS(sourceKey)
+	if !ok || !a.isValidFPS(cachedFPS) {
+		return 0, false
+	}
+	return cachedFPS, true
+}
+
+func (a *LocalAdapter) isValidFPS(fps int) bool {
+	return fps >= a.FPSMin && fps <= a.FPSMax
+}
+
+func (a *LocalAdapter) applySafariRuntimeRemuxOverride(ctx context.Context, spec ports.StreamSpec, inputURL string) ports.StreamSpec {
+	if !a.shouldPreferSafariRuntimeRemux(ctx, spec, inputURL) {
+		return spec
+	}
+	spec.Profile.TranscodeVideo = false
+	spec.Profile.Deinterlace = false
+	// Native Safari is tolerant on MPEG-TS HLS, but remuxed broadcast H.264
+	// inside fMP4 has shown audio-only / black-video failures in production.
+	// Keep the runtime-remux optimization, but package it as classic TS HLS.
+	spec.Profile.Container = "mpegts"
+	if spec.Profile.AudioBitrateK <= 0 {
+		spec.Profile.AudioBitrateK = 192
+	}
+	return spec
+}
+
+func (a *LocalAdapter) buildLiveVideoOutputArgs(args []string, spec ports.StreamSpec, codec codecPlan, gop, segmentDurationSec int) []string {
+	if !spec.Profile.TranscodeVideo && !usesLegacyCPUDefaults(spec, codec.resolvedCodec) {
+		return a.buildCopyVideoArgs(args, spec)
+	}
+	if codec.useVAAPI {
+		if codec.fullVAAPI {
+			return a.buildVaapiVideoArgs(args, spec, codec.resolvedCodec, gop, segmentDurationSec)
+		}
+		return a.buildVaapiEncodeOnlyVideoArgs(args, spec, codec.resolvedCodec, gop, segmentDurationSec)
+	}
+	return a.buildCPUVideoArgs(args, spec, codec.resolvedCodec, gop, segmentDurationSec)
+}
+
+func appendLiveAudioArgs(args []string, spec ports.StreamSpec) []string {
 	audioBitrate := "192k"
 	if spec.Profile.AudioBitrateK > 0 {
 		audioBitrate = fmt.Sprintf("%dk", spec.Profile.AudioBitrateK)
 	}
-	out.args = append(out.args,
+	return append(args,
 		"-c:a", "aac",
 		"-b:a", audioBitrate,
 		"-ac", "2",
@@ -512,41 +562,43 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 		"-sn",
 		"-f", "hls",
 	)
+}
 
+func (a *LocalAdapter) appendLiveHLSArgs(args []string, spec ports.StreamSpec, layout liveSegmentLayout) []string {
 	segmentType := "mpegts"
 	segmentFilename := filepath.Join(a.HLSRoot, "sessions", spec.SessionID, "seg_%06d.ts")
 	if strings.EqualFold(strings.TrimSpace(spec.Profile.Container), "fmp4") {
 		segmentType = "fmp4"
 		segmentFilename = filepath.Join(a.HLSRoot, "sessions", spec.SessionID, "seg_%06d.m4s")
 	}
-
-	out.args = append(out.args,
-		"-hls_time", strconv.Itoa(segmentDurationSec),
-		"-hls_list_size", strconv.Itoa(listSize),
+	args = append(args,
+		"-hls_time", strconv.Itoa(layout.segmentDurationSec),
+		"-hls_list_size", strconv.Itoa(layout.listSize),
 		"-hls_flags", "delete_segments+append_list+independent_segments+program_date_time",
 		"-hls_segment_type", segmentType,
 		"-hls_segment_filename", segmentFilename,
 	)
 	if segmentType == "fmp4" {
-		out.args = append(out.args, "-hls_fmp4_init_filename", "init.mp4")
+		args = append(args, "-hls_fmp4_init_filename", "init.mp4")
 	}
-	if initSegmentDurationSec > 0 {
-		out.args = append(out.args, "-hls_init_time", strconv.Itoa(initSegmentDurationSec))
+	if layout.initSegmentDurationSec > 0 {
+		args = append(args, "-hls_init_time", strconv.Itoa(layout.initSegmentDurationSec))
 	}
+	return args
+}
 
-	outputPath := filepath.Join(a.HLSRoot, "sessions", spec.SessionID, "index.m3u8")
+func (a *LocalAdapter) prepareLiveOutputPath(sessionID string) string {
+	outputPath := filepath.Join(a.HLSRoot, "sessions", sessionID, "index.m3u8")
 	_ = os.MkdirAll(filepath.Dir(outputPath), 0755) // #nosec G301
-	if markerPath := ports.SessionFirstFrameMarkerPath(a.HLSRoot, spec.SessionID); markerPath != "" {
+	if markerPath := ports.SessionFirstFrameMarkerPath(a.HLSRoot, sessionID); markerPath != "" {
 		_ = os.Remove(markerPath)
 	}
 	a.Logger.Info().
-		Str("session_id", spec.SessionID).
+		Str("session_id", sessionID).
 		Str("startup_phase", "output_dir_ready").
 		Str("output_path", outputPath).
 		Msg("output directory ready")
-	out.args = append(out.args, outputPath)
-
-	return out, nil
+	return outputPath
 }
 
 func (a *LocalAdapter) shouldPreferSafariRuntimeRemux(ctx context.Context, spec ports.StreamSpec, inputURL string) bool {

--- a/backend/internal/jobs/picon_pool.go
+++ b/backend/internal/jobs/picon_pool.go
@@ -58,7 +58,7 @@ type PiconPool struct {
 }
 
 func NewPiconPool(upstreamBase, piconDir string, cfg PiconPoolConfig) *PiconPool {
-	return NewPiconPoolWithContext(nil, upstreamBase, piconDir, cfg)
+	return NewPiconPoolWithContext(context.Background(), upstreamBase, piconDir, cfg)
 }
 
 func NewPiconPoolWithContext(rootCtx context.Context, upstreamBase, piconDir string, cfg PiconPoolConfig) *PiconPool {

--- a/backend/internal/jobs/picon_pool.go
+++ b/backend/internal/jobs/picon_pool.go
@@ -6,6 +6,7 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -56,50 +57,11 @@ type PiconPool struct {
 	stopOnce sync.Once
 }
 
-var (
-	globalPool     *PiconPool
-	globalPoolOnce sync.Once
-)
-
-// InitPiconPool initializes the global PiconPool singleton.
-func InitPiconPool(cfg config.AppConfig) {
-	globalPoolOnce.Do(func() {
-		upstreamBase := cfg.PiconBase
-		if upstreamBase == "" {
-			upstreamBase = cfg.Enigma2.BaseURL
-		}
-
-		piconDir := filepath.Join(cfg.DataDir, "picons")
-		if err := os.MkdirAll(piconDir, 0750); err != nil {
-			log.Error().Err(err).Msg("Picon: failed to create cache dir, worker pool will likely fail")
-		}
-
-		// Defaults
-		conf := PiconPoolConfig{
-			Workers:       8,
-			QueueSize:     512,
-			NegTTL:        10 * time.Minute,
-			ClientTimeout: 30 * time.Second,
-		}
-
-		globalPool = NewPiconPool(upstreamBase, piconDir, conf)
-		globalPool.Start()
-		log.Info().
-			Int("workers", conf.Workers).
-			Int("queue_size", conf.QueueSize).
-			Msg("Picon: Global worker pool initialized")
-	})
-}
-
-// GetPiconPool returns the global singleton, taking care to initialize it logic safely.
-func GetPiconPool(cfg config.AppConfig) *PiconPool {
-	// Always call Init to ensure Once has run, handling the race where globalPool is nil
-	// but Init is running elsewhere.
-	InitPiconPool(cfg)
-	return globalPool
-}
-
 func NewPiconPool(upstreamBase, piconDir string, cfg PiconPoolConfig) *PiconPool {
+	return NewPiconPoolWithContext(nil, upstreamBase, piconDir, cfg)
+}
+
+func NewPiconPoolWithContext(rootCtx context.Context, upstreamBase, piconDir string, cfg PiconPoolConfig) *PiconPool {
 	// Ensure defaults if zero (double safety)
 	if cfg.Workers <= 0 {
 		cfg.Workers = 8
@@ -107,8 +69,18 @@ func NewPiconPool(upstreamBase, piconDir string, cfg PiconPoolConfig) *PiconPool
 	if cfg.QueueSize <= 0 {
 		cfg.QueueSize = 512
 	}
+	if cfg.NegTTL <= 0 {
+		cfg.NegTTL = 10 * time.Minute
+	}
+	if cfg.ClientTimeout <= 0 {
+		cfg.ClientTimeout = 30 * time.Second
+	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	parent := context.Background()
+	if rootCtx != nil {
+		parent = rootCtx
+	}
+	ctx, cancel := context.WithCancel(parent)
 
 	return &PiconPool{
 		upstreamBase: upstreamBase,
@@ -122,6 +94,31 @@ func NewPiconPool(upstreamBase, piconDir string, cfg PiconPoolConfig) *PiconPool
 		neg:          make(map[string]time.Time),
 		negTTL:       cfg.NegTTL,
 	}
+}
+
+func NewPiconPoolForConfig(rootCtx context.Context, cfg config.AppConfig) (*PiconPool, error) {
+	if rootCtx == nil {
+		return nil, fmt.Errorf("picon pool context is nil")
+	}
+
+	upstreamBase := cfg.PiconBase
+	if upstreamBase == "" {
+		upstreamBase = cfg.Enigma2.BaseURL
+	}
+
+	piconDir := filepath.Join(cfg.DataDir, "picons")
+	if err := os.MkdirAll(piconDir, 0750); err != nil {
+		return nil, fmt.Errorf("create picon cache dir: %w", err)
+	}
+
+	pool := NewPiconPoolWithContext(rootCtx, upstreamBase, piconDir, PiconPoolConfig{})
+	pool.Start()
+	log.Info().
+		Int("workers", pool.workers).
+		Int("queue_size", cap(pool.jobs)).
+		Str("cache_dir", piconDir).
+		Msg("Picon: worker pool initialized")
+	return pool, nil
 }
 
 func (p *PiconPool) Start() {

--- a/backend/internal/jobs/picons.go
+++ b/backend/internal/jobs/picons.go
@@ -8,25 +8,21 @@ import (
 	"context"
 	"strings"
 
-	"github.com/ManuGH/xg2g/internal/config"
 	"github.com/ManuGH/xg2g/internal/playlist"
 	"github.com/rs/zerolog/log"
 )
 
 // PrewarmPicons downloads all missing picons in the background
-func PrewarmPicons(ctx context.Context, cfg config.AppConfig, items []playlist.Item) {
+func PrewarmPicons(ctx context.Context, pool *PiconPool, items []playlist.Item) {
+	if pool == nil {
+		log.Debug().Msg("Picon: pre-warm skipped because no worker pool is configured")
+		return
+	}
+
 	log.Info().Int("count", len(items)).Msg("Picon: Starting background pre-warm")
 
 	refs := extractPiconRefs(items)
 	log.Info().Int("unique_picons", len(refs)).Msg("Picon: Identified unique picons to warm")
-
-	// Get (or init) global pool
-	// Note: Ideally InitPiconPool is called at app startup to ensure workers are running,
-	// but this lazy getter handles it if not.
-	pool := GetPiconPool(cfg)
-
-	// We don't start/stop the pool here anymore (it's global/long-lived).
-	// We just enqueue jobs.
 
 	var enq, dropped int
 	for ref := range refs {

--- a/backend/internal/jobs/refresh.go
+++ b/backend/internal/jobs/refresh.go
@@ -54,11 +54,36 @@ type Status struct {
 	Error string `json:"error,omitempty"`
 }
 
-// Refresh performs the complete refresh cycle: fetch bouquets → services → write M3U + XMLTV
-//
+type RefreshOption func(*refreshOptions)
 
-//nolint:gocyclo // Complex orchestration function with validation, requires sequential operations
+type refreshOptions struct {
+	piconPool *PiconPool
+}
+
+func WithPiconPool(pool *PiconPool) RefreshOption {
+	return func(opts *refreshOptions) {
+		opts.piconPool = pool
+	}
+}
+
+func buildRefreshOptions(opts []RefreshOption) refreshOptions {
+	var cfg refreshOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+
 func Refresh(ctx context.Context, snap config.Snapshot) (*Status, error) {
+	return RefreshWithOptions(ctx, snap)
+}
+
+// RefreshWithOptions performs the complete refresh cycle: fetch bouquets → services → write M3U + XMLTV.
+//
+//nolint:gocyclo // Complex orchestration function with validation, requires sequential operations
+func RefreshWithOptions(ctx context.Context, snap config.Snapshot, opts ...RefreshOption) (*Status, error) {
 	// Start tracing span for the entire refresh job
 	tracer := telemetry.Tracer("xg2g.jobs")
 	ctx, span := tracer.Start(ctx, "job.refresh",
@@ -68,6 +93,7 @@ func Refresh(ctx context.Context, snap config.Snapshot) (*Status, error) {
 
 	cfg := snap.App
 	rt := snap.Runtime
+	refreshOpts := buildRefreshOptions(opts)
 
 	startTime := time.Now()
 
@@ -84,7 +110,7 @@ func Refresh(ctx context.Context, snap config.Snapshot) (*Status, error) {
 		return nil, err
 	}
 
-	opts := openwebif.Options{
+	owiOpts := openwebif.Options{
 		Timeout:         cfg.Enigma2.Timeout,
 		MaxRetries:      cfg.Enigma2.Retries,
 		Backoff:         cfg.Enigma2.Backoff,
@@ -96,7 +122,7 @@ func Refresh(ctx context.Context, snap config.Snapshot) (*Status, error) {
 
 		HTTPMaxConnsPerHost: rt.OpenWebIF.HTTPMaxConnsPerHost,
 	}
-	client := openwebif.NewWithPort(cfg.Enigma2.BaseURL, cfg.Enigma2.StreamPort, opts)
+	client := openwebif.NewWithPort(cfg.Enigma2.BaseURL, cfg.Enigma2.StreamPort, owiOpts)
 
 	// Fetch bouquets with tracing
 	span.AddEvent("fetching bouquets")
@@ -276,7 +302,11 @@ func Refresh(ctx context.Context, snap config.Snapshot) (*Status, error) {
 
 	// Trigger background picon pre-warm (don't block refresh)
 	if cfg.PiconBase != "" {
-		go PrewarmPicons(ctx, cfg, items)
+		if refreshOpts.piconPool != nil {
+			go PrewarmPicons(ctx, refreshOpts.piconPool, items)
+		} else {
+			logger.Debug().Msg("skipping picon pre-warm because no runtime picon pool is configured")
+		}
 	}
 
 	// Generate M3U

--- a/backend/internal/jobs/refresh_integration_test.go
+++ b/backend/internal/jobs/refresh_integration_test.go
@@ -13,7 +13,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ManuGH/xg2g/internal/config"
 )
@@ -82,4 +84,119 @@ func TestRefresh_IntegrationSuccess(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(tmp, "xmltv.xml")); err != nil {
 		t.Fatalf("xmltv.xml not written: %v", err)
 	}
+}
+
+func TestRefresh_DoesNotPrewarmPiconsWithoutRuntimePool(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/bouquets", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"bouquets": [][]string{{"1:7:TEST:REF:", "Favourites"}},
+		})
+	})
+	mux.HandleFunc("/api/getservices", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"services": []map[string]string{
+				{"servicename": "Chan A", "servicereference": "1:0:19:AAA:1:1:C00000:0:0:0:"},
+			},
+		})
+	})
+	mux.HandleFunc("/picon/", func(http.ResponseWriter, *http.Request) {
+		t.Fatalf("unexpected picon fetch without configured runtime pool")
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	cfg := config.AppConfig{
+		DataDir:   tmp,
+		PiconBase: srv.URL,
+		Enigma2: config.Enigma2Settings{
+			BaseURL:    srv.URL,
+			StreamPort: 8001,
+		},
+		Bouquet: "Favourites",
+	}
+
+	snap := config.BuildSnapshot(cfg, config.ReadOSRuntimeEnvOrDefault())
+	status, err := Refresh(context.Background(), snap)
+	if err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if status == nil || status.Channels != 1 {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmp, "picons")); !os.IsNotExist(err) {
+		t.Fatalf("picon cache dir should not exist without runtime pool, err=%v", err)
+	}
+}
+
+func TestRefresh_WithRuntimePoolPrewarmsPicons(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/bouquets", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"bouquets": [][]string{{"1:7:TEST:REF:", "Favourites"}},
+		})
+	})
+	serviceRef := "1:0:19:AAA:1:1:C00000:0:0:0:"
+	mux.HandleFunc("/api/getservices", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"services": []map[string]string{
+				{"servicename": "Chan A", "servicereference": serviceRef},
+			},
+		})
+	})
+	mux.HandleFunc("/picon/", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, ".png") {
+			t.Fatalf("unexpected picon path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("fake-png"))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tmp := t.TempDir()
+	cfg := config.AppConfig{
+		DataDir:   tmp,
+		PiconBase: srv.URL,
+		Enigma2: config.Enigma2Settings{
+			BaseURL:    srv.URL,
+			StreamPort: 8001,
+		},
+		Bouquet: "Favourites",
+	}
+
+	pool, err := NewPiconPoolForConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewPiconPoolForConfig returned error: %v", err)
+	}
+	defer pool.Stop()
+
+	snap := config.BuildSnapshot(cfg, config.ReadOSRuntimeEnvOrDefault())
+	status, err := RefreshWithOptions(context.Background(), snap, WithPiconPool(pool))
+	if err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if status == nil || status.Channels != 1 {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+
+	storeRef := strings.TrimRight(strings.ReplaceAll(serviceRef, ":", "_"), "_")
+	wantFile := filepath.Join(tmp, "picons", storeRef+".png")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(wantFile); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	t.Fatalf("expected prewarmed picon file %q", wantFile)
 }


### PR DESCRIPTION
## Summary
- bind the picon worker pool to the runtime lifecycle instead of hidden global startup
- split FFmpeg live-output planning into focused helpers for segment layout, fps resolution, safari overrides and HLS output
- split v3 start-intent processing into explicit phases for profile resolution, admission, session persistence and publish

## Testing
- go test ./backend/internal/jobs ./backend/internal/app/bootstrap ./backend/internal/daemon ./backend/internal/infra/media/ffmpeg ./backend/internal/control/http/v3/intents ./backend/internal/control/http/v3