### PR TITLE
ci: opt workflows into node24 actions runtime

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -12,6 +12,9 @@ concurrency:
   group: repo-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   secrets-scan:
     name: Scan for Secrets (Gitleaks)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   TRIVY_SEVERITY: CRITICAL,HIGH
 
 jobs:


### PR DESCRIPTION
## Summary
- opt the Trivy workflow into the Node 24 GitHub Actions runtime
- opt the container-security workflow into the same runtime to keep the Trivy/buildx path aligned

## Context
- GitHub Actions warned in CI that Node.js 20 actions will be forced to Node 24 starting 2026-06-02 and removed on 2026-09-16
- this uses the runner opt-in flag GitHub recommends, without broad workflow churn
