### PR TITLE
ci: wire setup-go cache dependency paths

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           go-version-file: backend/go.mod
           cache: true
+          cache-dependency-path: backend/go.sum
 
       # Manual build for Go
       - name: Build Go

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # Latest stable
         with:
           go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
 
       - name: Install gosec (pinned)
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.11

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # Latest stable
         with:
           go-version-file: "backend/go.mod"
+          cache-dependency-path: backend/go.sum
         env:
           GOTOOLCHAIN: auto
 


### PR DESCRIPTION
Summary:
- add backend/go.sum as the cache dependency path for gosec
- add the same cache dependency path for govulncheck and CodeQL Go setup
- remove the noisy setup-go cache warning caused by the backend module layout