### PR TITLE
android: configure production URLs and deep link support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ data/
 livetest-data/
 *.m3u
 *.xml
+!android/**/*.xml
 *.gz
 *.zip
 xg2g-main.zip

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,7 +17,9 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["appLabel"] = "xg2g"
         manifestPlaceholders["usesCleartextTraffic"] = "false"
-        buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.home.matrixcentral.de/ui/\"")
+        manifestPlaceholders["deepLinkScheme"] = "https"
+        manifestPlaceholders["deepLinkHost"] = "xg2g.example.invalid"
+        buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.example.invalid/ui/\"")
     }
 
     buildFeatures {
@@ -32,6 +34,8 @@ android {
             versionNameSuffix = "-dev"
             manifestPlaceholders["appLabel"] = "xg2g Dev"
             manifestPlaceholders["usesCleartextTraffic"] = "false"
+            manifestPlaceholders["deepLinkScheme"] = "https"
+            manifestPlaceholders["deepLinkHost"] = "xg2g.home.matrixcentral.de"
             buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.home.matrixcentral.de/ui/\"")
         }
         create("staging") {
@@ -40,12 +44,16 @@ android {
             versionNameSuffix = "-staging"
             manifestPlaceholders["appLabel"] = "xg2g Staging"
             manifestPlaceholders["usesCleartextTraffic"] = "false"
+            manifestPlaceholders["deepLinkScheme"] = "https"
+            manifestPlaceholders["deepLinkHost"] = "staging.example.invalid"
             buildConfigField("String", "DEFAULT_BASE_URL", "\"https://staging.example.invalid/ui/\"")
         }
         create("prod") {
             dimension = "environment"
             manifestPlaceholders["appLabel"] = "xg2g"
             manifestPlaceholders["usesCleartextTraffic"] = "false"
+            manifestPlaceholders["deepLinkScheme"] = "https"
+            manifestPlaceholders["deepLinkHost"] = "xg2g.example.invalid"
             buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.example.invalid/ui/\"")
         }
     }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         manifestPlaceholders["appLabel"] = "xg2g"
         manifestPlaceholders["usesCleartextTraffic"] = "false"
-        buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.example.invalid/ui/\"")
+        buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.home.matrixcentral.de/ui/\"")
     }
 
     buildFeatures {
@@ -31,8 +31,8 @@ android {
             applicationIdSuffix = ".dev"
             versionNameSuffix = "-dev"
             manifestPlaceholders["appLabel"] = "xg2g Dev"
-            manifestPlaceholders["usesCleartextTraffic"] = "true"
-            buildConfigField("String", "DEFAULT_BASE_URL", "\"http://10.0.2.2:8080/ui/\"")
+            manifestPlaceholders["usesCleartextTraffic"] = "false"
+            buildConfigField("String", "DEFAULT_BASE_URL", "\"https://xg2g.home.matrixcentral.de/ui/\"")
         }
         create("staging") {
             dimension = "environment"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,11 +12,22 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|smallestScreenSize|uiMode">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Deep Link Filter -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="xg2g.home.matrixcentral.de" />
+                <data android:pathPrefix="/ui" />
             </intent-filter>
         </activity>
     </application>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,14 +19,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Deep Link Filter -->
+            <!-- Deep Link Filter (Dynamic via Flavor) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="https" />
-                <data android:host="xg2g.home.matrixcentral.de" />
+                <data android:scheme="${deepLinkScheme}" />
+                <data android:host="${deepLinkHost}" />
                 <data android:pathPrefix="/ui" />
             </intent-filter>
         </activity>

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
@@ -33,6 +33,12 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        webView.loadUrl(resolveStartUrl())
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         webView.saveState(outState)
         super.onSaveInstanceState(outState)
@@ -68,7 +74,7 @@ class MainActivity : AppCompatActivity() {
                 request: WebResourceRequest
             ): Boolean {
                 val target = request.url
-                val baseHost = Uri.parse(resolveStartUrl()).host
+                val baseHost = Uri.parse(BuildConfig.DEFAULT_BASE_URL).host
 
                 return when {
                     target.scheme !in setOf("http", "https") -> {
@@ -99,6 +105,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun resolveStartUrl(): String {
+        val data = intent.dataString
+        if (data != null && data.startsWith("https://xg2g.home.matrixcentral.de/ui")) {
+            return data
+        }
+
         val overrideUrl = intent.getStringExtra(EXTRA_BASE_URL)?.trim().orEmpty()
         val raw = if (overrideUrl.isNotEmpty()) overrideUrl else BuildConfig.DEFAULT_BASE_URL
         return if (raw.endsWith("/")) raw else "$raw/"

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
@@ -74,7 +74,8 @@ class MainActivity : AppCompatActivity() {
                 request: WebResourceRequest
             ): Boolean {
                 val target = request.url
-                val baseHost = Uri.parse(BuildConfig.DEFAULT_BASE_URL).host
+                val baseUri = Uri.parse(BuildConfig.DEFAULT_BASE_URL)
+                val baseHost = baseUri.host
 
                 return when {
                     target.scheme !in setOf("http", "https") -> {
@@ -106,12 +107,16 @@ class MainActivity : AppCompatActivity() {
 
     private fun resolveStartUrl(): String {
         val data = intent.dataString
-        if (data != null && data.startsWith("https://xg2g.home.matrixcentral.de/ui")) {
+        val baseUrl = BuildConfig.DEFAULT_BASE_URL
+        val baseUri = Uri.parse(baseUrl)
+
+        // Check if intent data matches the configured base URL (including scheme, host, and path prefix)
+        if (data != null && baseUri.host != null && data.startsWith("${baseUri.scheme}://${baseUri.host}${baseUri.path}")) {
             return data
         }
 
         val overrideUrl = intent.getStringExtra(EXTRA_BASE_URL)?.trim().orEmpty()
-        val raw = if (overrideUrl.isNotEmpty()) overrideUrl else BuildConfig.DEFAULT_BASE_URL
+        val raw = if (overrideUrl.isNotEmpty()) overrideUrl else baseUrl
         return if (raw.endsWith("/")) raw else "$raw/"
     }
 


### PR DESCRIPTION
## Summary
- point Android production URL configuration at the production endpoints
- add Android deep link intent handling in the manifest and main activity
- keep the change scoped to the existing Android app wiring

## Testing
- Not run (not requested)