### PR TITLE
[codex] add host fingerprints to decision audit

### DIFF
--- a/backend/cmd/daemon/storage_decision_report_cmd.go
+++ b/backend/cmd/daemon/storage_decision_report_cmd.go
@@ -32,6 +32,7 @@ const (
 	reportTruthSourceFallback      = "fallback"
 	reportTruthSourceUnresolved    = "unresolved"
 	reportTruthSourceEventInactive = "event_inactive"
+	reportUnknownHost              = "unknown_host"
 )
 
 type storageDecisionReportOptions struct {
@@ -52,6 +53,7 @@ type storageDecisionReport struct {
 	Bouquet     string                       `json:"bouquet,omitempty"`
 	Filters     storageDecisionReportFilters `json:"filters"`
 	Summary     storageDecisionReportSummary `json:"summary"`
+	Warnings    []string                     `json:"warnings,omitempty"`
 	Rows        []storageDecisionReportRow   `json:"rows"`
 }
 
@@ -75,6 +77,10 @@ type storageDecisionReportSummary struct {
 	TruthSourceFallback      int `json:"truthSourceFallback"`
 	TruthSourceUnresolved    int `json:"truthSourceUnresolved"`
 	TruthSourceEventInactive int `json:"truthSourceEventInactive"`
+	DistinctHostFingerprints int `json:"distinctHostFingerprints"`
+	DistinctBasisHostPairs   int `json:"distinctBasisHostPairs"`
+	BasisHashesWithMultiHost int `json:"basisHashesWithMultiHost"`
+	UnknownHostRows          int `json:"unknownHostRows"`
 }
 
 type storageDecisionReportRow struct {
@@ -94,6 +100,7 @@ type storageDecisionReportRow struct {
 	ClientFamily         string                                 `json:"clientFamily,omitempty"`
 	ClientCapsSource     string                                 `json:"clientCapsSource,omitempty"`
 	ClientCapsSourceCode string                                 `json:"clientCapsSourceCode,omitempty"`
+	HostFingerprint      string                                 `json:"hostFingerprint,omitempty"`
 	RequestedIntent      string                                 `json:"requestedIntent,omitempty"`
 	EffectiveIntent      string                                 `json:"effectiveIntent,omitempty"`
 	Mode                 string                                 `json:"mode,omitempty"`
@@ -111,6 +118,7 @@ type storageDecisionAuditRow struct {
 	Origin           string
 	ClientFamily     string
 	ClientCapsSource string
+	HostFingerprint  string
 	RequestedIntent  string
 	EffectiveIntent  string
 	Mode             string
@@ -283,6 +291,7 @@ func buildStorageDecisionReport(opts storageDecisionReportOptions) (storageDecis
 	})
 
 	report.Summary = summarizeStorageDecisionReport(report.Rows)
+	report.Warnings = buildStorageDecisionReportWarnings(report.Summary)
 	return report, nil
 }
 
@@ -313,6 +322,7 @@ func buildStorageDecisionReportRow(service read.Service, capability scan.Capabil
 	row.DecisionOrigin = decisionRow.Origin
 	row.ClientCapsSourceCode = decisionRow.ClientCapsSource
 	row.ClientCapsSource = presentClientCapsSource(decisionRow.ClientCapsSource)
+	row.HostFingerprint = presentHostFingerprint(decisionRow.HostFingerprint)
 	row.RequestedIntent = decisionRow.RequestedIntent
 	row.EffectiveIntent = decisionRow.EffectiveIntent
 	row.ModeCode = decisionRow.Mode
@@ -333,6 +343,9 @@ func summarizeStorageDecisionReport(rows []storageDecisionReportRow) storageDeci
 	servicesSeen := make(map[string]bool)
 	servicesWithDecision := make(map[string]bool)
 	serviceTruthCounted := make(map[string]bool)
+	hostFingerprintsSeen := make(map[string]bool)
+	basisHostPairs := make(map[string]bool)
+	basisHosts := make(map[string]map[string]bool)
 
 	for _, row := range rows {
 		if !servicesSeen[row.ServiceRef] {
@@ -341,6 +354,20 @@ func summarizeStorageDecisionReport(rows []storageDecisionReportRow) storageDeci
 		}
 		if row.DecisionPresent {
 			servicesWithDecision[row.ServiceRef] = true
+			hostFingerprint := presentHostFingerprint(row.HostFingerprint)
+			hostFingerprintsSeen[hostFingerprint] = true
+			if hostFingerprint == reportUnknownHost {
+				summary.UnknownHostRows++
+			}
+			if row.BasisHash != "" {
+				basisHostPairs[row.BasisHash+"\x00"+hostFingerprint] = true
+				if hostFingerprint != reportUnknownHost {
+					if _, ok := basisHosts[row.BasisHash]; !ok {
+						basisHosts[row.BasisHash] = make(map[string]bool)
+					}
+					basisHosts[row.BasisHash][hostFingerprint] = true
+				}
+			}
 		}
 		if !serviceTruthCounted[row.ServiceRef] {
 			serviceTruthCounted[row.ServiceRef] = true
@@ -369,7 +396,22 @@ func summarizeStorageDecisionReport(rows []storageDecisionReportRow) storageDeci
 
 	summary.ServicesWithDecision = len(servicesWithDecision)
 	summary.ServicesWithoutDecision = summary.ServicesTotal - summary.ServicesWithDecision
+	summary.DistinctHostFingerprints = len(hostFingerprintsSeen)
+	summary.DistinctBasisHostPairs = len(basisHostPairs)
+	for _, hosts := range basisHosts {
+		if len(hosts) > 1 {
+			summary.BasisHashesWithMultiHost++
+		}
+	}
 	return summary
+}
+
+func buildStorageDecisionReportWarnings(summary storageDecisionReportSummary) []string {
+	warnings := make([]string, 0, 1)
+	if summary.UnknownHostRows > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d decision row(s) are bucketed as %s; these rows predate decision_audit schema v4 or were written without host fingerprints", summary.UnknownHostRows, reportUnknownHost))
+	}
+	return warnings
 }
 
 func renderStorageDecisionReportTable(w io.Writer, report storageDecisionReport) {
@@ -387,7 +429,7 @@ func renderStorageDecisionReportTable(w io.Writer, report storageDecisionReport)
 			report.Filters.SubjectKind,
 		)
 	}
-	_, _ = fmt.Fprintf(w, "Summary:   services=%d rows=%d with_decision=%d without_decision=%d truth_complete=%d truth_incomplete=%d truth_missing=%d truth_event_inactive=%d\n\n",
+	_, _ = fmt.Fprintf(w, "Summary:   services=%d rows=%d with_decision=%d without_decision=%d truth_complete=%d truth_incomplete=%d truth_missing=%d truth_event_inactive=%d host_fingerprints=%d basis_host_pairs=%d multi_host_basis=%d unknown_host_rows=%d\n",
 		report.Summary.ServicesTotal,
 		report.Summary.RowsTotal,
 		report.Summary.ServicesWithDecision,
@@ -396,16 +438,24 @@ func renderStorageDecisionReportTable(w io.Writer, report storageDecisionReport)
 		report.Summary.TruthIncomplete,
 		report.Summary.TruthMissing,
 		report.Summary.TruthEventInactive,
+		report.Summary.DistinctHostFingerprints,
+		report.Summary.DistinctBasisHostPairs,
+		report.Summary.BasisHashesWithMultiHost,
+		report.Summary.UnknownHostRows,
 	)
+	for _, warning := range report.Warnings {
+		_, _ = fmt.Fprintf(w, "Warning:   %s\n", warning)
+	}
+	_, _ = fmt.Fprintln(w)
 
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "SERVICE_REF\tCHANNEL\tBOUQUET\tTRUTH_SOURCE\tTRUTH_STATUS\tORIGIN\tCLIENT\tCAPS_SOURCE\tREQUESTED_INTENT\tEFFECTIVE_INTENT\tMODE\tTARGET_PROFILE\tREASONS\tCHANGED_AT")
+	_, _ = fmt.Fprintln(tw, "SERVICE_REF\tCHANNEL\tBOUQUET\tTRUTH_SOURCE\tTRUTH_STATUS\tORIGIN\tCLIENT\tCAPS_SOURCE\tHOST_FINGERPRINT\tREQUESTED_INTENT\tEFFECTIVE_INTENT\tMODE\tTARGET_PROFILE\tREASONS\tCHANGED_AT")
 	for _, row := range report.Rows {
 		changedAt := ""
 		if row.ChangedAt != nil {
 			changedAt = row.ChangedAt.Format(time.RFC3339)
 		}
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			row.ServiceRef,
 			row.ChannelName,
 			row.Bouquet,
@@ -414,6 +464,7 @@ func renderStorageDecisionReportTable(w io.Writer, report storageDecisionReport)
 			emptyDash(row.DecisionOrigin),
 			emptyDash(row.ClientFamily),
 			emptyDash(row.ClientCapsSource),
+			emptyDash(row.HostFingerprint),
 			emptyDash(row.RequestedIntent),
 			emptyDash(row.EffectiveIntent),
 			emptyDash(row.Mode),
@@ -587,7 +638,7 @@ func queryDecisionCurrentRows(db *sql.DB, columns map[string]bool, serviceRef st
 	var args []any
 	// #nosec G202 -- dynamic fragments are fixed internal column expressions selected from an allowlist, not user input.
 	query := `
-	SELECT service_ref, ` + sqliteSelectExpr(columns, "origin") + `, client_family, requested_intent, resolved_intent, ` + sqliteSelectExpr(columns, "client_caps_source") + `, mode, target_profile_json, reasons_json, basis_hash, changed_at_ms, last_seen_at_ms
+	SELECT service_ref, ` + sqliteSelectExpr(columns, "origin") + `, client_family, requested_intent, resolved_intent, ` + sqliteSelectExpr(columns, "client_caps_source") + `, ` + sqliteSelectExpr(columns, "host_fingerprint") + `, mode, target_profile_json, reasons_json, basis_hash, changed_at_ms, last_seen_at_ms
 	FROM decision_current
 	WHERE service_ref = ? AND subject_kind = 'live'
 	`
@@ -619,6 +670,7 @@ func queryDecisionCurrentRows(db *sql.DB, columns map[string]bool, serviceRef st
 		var decisionOrigin sql.NullString
 		var effectiveIntent sql.NullString
 		var clientCapsSource sql.NullString
+		var hostFingerprint sql.NullString
 		var targetProfileJSON sql.NullString
 		var reasonsJSON string
 		var changedAtMS int64
@@ -630,6 +682,7 @@ func queryDecisionCurrentRows(db *sql.DB, columns map[string]bool, serviceRef st
 			&row.RequestedIntent,
 			&effectiveIntent,
 			&clientCapsSource,
+			&hostFingerprint,
 			&row.Mode,
 			&targetProfileJSON,
 			&reasonsJSON,
@@ -651,6 +704,9 @@ func queryDecisionCurrentRows(db *sql.DB, columns map[string]bool, serviceRef st
 		}
 		if clientCapsSource.Valid {
 			row.ClientCapsSource = clientCapsSource.String
+		}
+		if hostFingerprint.Valid {
+			row.HostFingerprint = hostFingerprint.String
 		}
 		if targetProfileJSON.Valid && strings.TrimSpace(targetProfileJSON.String) != "" {
 			var targetProfile playbackprofile.TargetPlaybackProfile
@@ -678,6 +734,13 @@ func queryDecisionCurrentRows(db *sql.DB, columns map[string]bool, serviceRef st
 		return nil, err
 	}
 	return out, nil
+}
+
+func presentHostFingerprint(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return reportUnknownHost
+	}
+	return value
 }
 
 func normalizeDecisionReportOrigin(value string) string {

--- a/backend/cmd/daemon/storage_decision_report_cmd_test.go
+++ b/backend/cmd/daemon/storage_decision_report_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/ManuGH/xg2g/internal/pipeline/scan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
 func TestBuildStorageDecisionReport_JoinsPlaylistTruthAndCurrentDecisions(t *testing.T) {
@@ -380,6 +382,142 @@ func TestBuildStorageDecisionReport_ClassifiesInactiveEventFeedSeparately(t *tes
 	assert.Equal(t, 1, report.Summary.TruthEventInactive)
 	assert.Equal(t, 1, report.Summary.TruthSourceEventInactive)
 	assert.Equal(t, 3, report.Summary.TruthSourceUnresolved)
+}
+
+func TestSummarizeStorageDecisionReportTracksHostBuckets(t *testing.T) {
+	rows := []storageDecisionReportRow{
+		{
+			ServiceRef:      "svc-1",
+			TruthSource:     reportTruthSourceScan,
+			TruthStatus:     reportTruthComplete,
+			DecisionPresent: true,
+			BasisHash:       "basis-a",
+			HostFingerprint: "df1:host-a",
+		},
+		{
+			ServiceRef:      "svc-2",
+			TruthSource:     reportTruthSourceScan,
+			TruthStatus:     reportTruthComplete,
+			DecisionPresent: true,
+			BasisHash:       "basis-a",
+			HostFingerprint: "df1:host-b",
+		},
+		{
+			ServiceRef:      "svc-3",
+			TruthSource:     reportTruthSourceFallback,
+			TruthStatus:     reportTruthIncomplete,
+			DecisionPresent: true,
+			BasisHash:       "basis-c",
+		},
+	}
+
+	summary := summarizeStorageDecisionReport(rows)
+	require.Equal(t, 3, summary.DistinctHostFingerprints)
+	require.Equal(t, 3, summary.DistinctBasisHostPairs)
+	require.Equal(t, 1, summary.BasisHashesWithMultiHost)
+	require.Equal(t, 1, summary.UnknownHostRows)
+
+	warnings := buildStorageDecisionReportWarnings(summary)
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], reportUnknownHost)
+}
+
+func TestRenderStorageDecisionReportTableIncludesHostFingerprintWarnings(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	report := storageDecisionReport{
+		GeneratedAt: now,
+		DataDir:     "/tmp/xg2g",
+		Playlist:    "playlist.m3u8",
+		Filters: storageDecisionReportFilters{
+			SubjectKind: "live",
+		},
+		Summary: storageDecisionReportSummary{
+			ServicesTotal:            1,
+			RowsTotal:                1,
+			ServicesWithDecision:     1,
+			DistinctHostFingerprints: 1,
+			DistinctBasisHostPairs:   1,
+			UnknownHostRows:          1,
+		},
+		Warnings: []string{"1 decision row(s) are bucketed as unknown_host"},
+		Rows: []storageDecisionReportRow{
+			{
+				ServiceRef:       "svc-1",
+				ChannelName:      "Sky Sport Austria 1",
+				Bouquet:          "Sports",
+				TruthSource:      reportTruthSourceScan,
+				TruthStatus:      reportTruthComplete,
+				DecisionPresent:  true,
+				DecisionOrigin:   "runtime",
+				ClientFamily:     "safari_native",
+				ClientCapsSource: "runtime",
+				HostFingerprint:  reportUnknownHost,
+				RequestedIntent:  "quality",
+				EffectiveIntent:  "quality",
+				Mode:             "transcode",
+				BasisHash:        "basis-a",
+				ChangedAt:        &now,
+			},
+		},
+	}
+
+	var out strings.Builder
+	renderStorageDecisionReportTable(&out, report)
+
+	rendered := out.String()
+	require.Contains(t, rendered, "HOST_FINGERPRINT")
+	require.Contains(t, rendered, "unknown_host")
+	require.Contains(t, rendered, "Warning:")
+}
+
+func TestQueryDecisionCurrentRows_ReadsOptionalHostFingerprint(t *testing.T) {
+	db, err := sql.Open("sqlite", t.TempDir()+"/decision_audit.sqlite")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+	CREATE TABLE decision_current (
+		service_ref TEXT NOT NULL,
+		subject_kind TEXT NOT NULL,
+		origin TEXT NOT NULL,
+		client_family TEXT NOT NULL,
+		requested_intent TEXT NOT NULL,
+		basis_hash TEXT NOT NULL,
+		truth_hash TEXT NOT NULL,
+		output_hash TEXT NOT NULL,
+		mode TEXT NOT NULL,
+		selected_container TEXT NOT NULL,
+		selected_video_codec TEXT NOT NULL,
+		selected_audio_codec TEXT NOT NULL,
+		target_profile_json TEXT,
+		reasons_json TEXT NOT NULL,
+		shadow_json TEXT,
+		resolved_intent TEXT,
+		host_pressure_band TEXT,
+		client_caps_source TEXT,
+		device_type TEXT,
+		host_fingerprint TEXT,
+		changed_at_ms INTEGER NOT NULL,
+		last_seen_at_ms INTEGER NOT NULL
+	);
+	INSERT INTO decision_current (
+		service_ref, subject_kind, origin, client_family, requested_intent, basis_hash, truth_hash, output_hash,
+		mode, selected_container, selected_video_codec, selected_audio_codec, target_profile_json, reasons_json,
+		shadow_json, resolved_intent, host_pressure_band, client_caps_source, device_type, host_fingerprint, changed_at_ms, last_seen_at_ms
+	) VALUES (
+		'1:0:1:2B66:3F3:1:C00000:0:0:0:', 'live', 'runtime', 'safari_native', 'quality', 'basis-a', 'truth-a', 'output-a',
+		'transcode', 'fmp4', 'h264', 'aac', NULL, '[]', NULL, 'quality', 'normal', 'runtime', 'web', 'df1:host-a', 1000, 1000
+	);
+	`)
+	require.NoError(t, err)
+
+	columns, err := loadSQLiteColumnSet(db, "decision_current")
+	require.NoError(t, err)
+
+	rows, err := queryDecisionCurrentRows(db, columns, "1:0:1:2B66:3F3:1:C00000:0:0:0:", "safari_native", "quality", "runtime")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "df1:host-a", rows[0].HostFingerprint)
 }
 
 func testPremiumPlaylist() string {

--- a/backend/internal/control/http/v3/recordings/capability_registry.go
+++ b/backend/internal/control/http/v3/recordings/capability_registry.go
@@ -17,6 +17,12 @@ import (
 	"github.com/ManuGH/xg2g/internal/pipeline/scan"
 )
 
+type requestHostContext struct {
+	Snapshot            capreg.HostSnapshot
+	DecisionFingerprint string
+	BuiltAt             time.Time
+}
+
 func (s *Service) applyCapabilityRegistryFallback(ctx context.Context, req PlaybackInfoRequest) PlaybackInfoRequest {
 	registry := s.deps.CapabilityRegistry()
 	if registry == nil {
@@ -49,13 +55,22 @@ func (s *Service) applyCapabilityRegistryFallback(ctx context.Context, req Playb
 	return req
 }
 
-func (s *Service) rememberCapabilitySnapshots(ctx context.Context, sourceRef string, req PlaybackInfoRequest, truth playback.MediaTruth, resolved capabilities.PlaybackCapabilities) (string, string, string) {
+func (s *Service) buildRequestHostContext(ctx context.Context) requestHostContext {
+	hostSnapshot := hostSnapshotForRequest(s.deps.HostRuntime(ctx))
+	return requestHostContext{
+		Snapshot:            hostSnapshot,
+		DecisionFingerprint: hostSnapshot.DecisionFingerprint(),
+		BuiltAt:             hostSnapshot.UpdatedAt,
+	}
+}
+
+func (s *Service) rememberCapabilitySnapshots(ctx context.Context, hostContext requestHostContext, sourceRef string, req PlaybackInfoRequest, truth playback.MediaTruth, resolved capabilities.PlaybackCapabilities) (string, string, string) {
 	registry := s.deps.CapabilityRegistry()
 	if registry == nil {
 		return "", "", ""
 	}
 
-	hostSnapshot := hostSnapshotForRequest(s.deps.HostRuntime(ctx))
+	hostSnapshot := hostContext.Snapshot
 	hostFingerprint := hostSnapshot.Identity.Fingerprint()
 	if err := registry.RememberHost(ctx, hostSnapshot); err != nil {
 		log.L().Warn().Err(err).Str("requestId", req.RequestID).Msg("capability registry host snapshot failed")

--- a/backend/internal/control/http/v3/recordings/playback_info.go
+++ b/backend/internal/control/http/v3/recordings/playback_info.go
@@ -57,6 +57,7 @@ func (s *Service) ResolvePlaybackInfo(ctx context.Context, req PlaybackInfoReque
 		req.Headers,
 		req.Capabilities,
 	)
+	hostContext := s.buildRequestHostContext(ctx)
 
 	input := buildDecisionInput(
 		req,
@@ -85,8 +86,8 @@ func (s *Service) ResolvePlaybackInfo(ctx context.Context, req PlaybackInfoReque
 	alignAutoCodecDecision(req, resolvedCaps, dec)
 	alignLiveNativePackaging(req, resolvedCaps, dec)
 	alignRecordingNativePackaging(req, resolvedCaps, dec)
-	hostFingerprint, deviceFingerprint, sourceFingerprint := s.rememberCapabilitySnapshots(ctx, sourceRef, req, truth, resolvedCaps)
-	s.recordDecisionAudit(ctx, sourceRef, req, resolvedCaps, input, dec)
+	hostFingerprint, deviceFingerprint, sourceFingerprint := s.rememberCapabilitySnapshots(ctx, hostContext, sourceRef, req, truth, resolvedCaps)
+	s.recordDecisionAudit(ctx, hostContext, sourceRef, req, resolvedCaps, input, dec)
 	s.recordCapabilityObservation(ctx, sourceRef, req, truth, resolvedCaps, dec, hostFingerprint, deviceFingerprint, sourceFingerprint)
 
 	return PlaybackInfoResult{
@@ -161,7 +162,7 @@ func (s *Service) resolveSubjectTruth(ctx context.Context, req PlaybackInfoReque
 	}
 }
 
-func (s *Service) recordDecisionAudit(ctx context.Context, sourceRef string, req PlaybackInfoRequest, resolvedCaps capabilities.PlaybackCapabilities, input decision.DecisionInput, dec *decision.Decision) {
+func (s *Service) recordDecisionAudit(ctx context.Context, hostContext requestHostContext, sourceRef string, req PlaybackInfoRequest, resolvedCaps capabilities.PlaybackCapabilities, input decision.DecisionInput, dec *decision.Decision) {
 	sink := s.deps.DecisionAuditSink()
 	if sink == nil || dec == nil {
 		return
@@ -179,6 +180,7 @@ func (s *Service) recordDecisionAudit(ctx context.Context, sourceRef string, req
 		ClientFamily:     clientFamily,
 		ClientCapsSource: resolvedCaps.ClientCapsSource,
 		DeviceType:       resolvedCaps.DeviceType,
+		HostFingerprint:  hostContext.DecisionFingerprint,
 		DecidedAt:        time.Now().UTC(),
 	}, input, dec)
 	if err != nil {

--- a/backend/internal/control/recordings/capreg/store.go
+++ b/backend/internal/control/recordings/capreg/store.go
@@ -60,6 +60,18 @@ type HostSnapshot struct {
 	UpdatedAt           time.Time
 }
 
+type decisionFingerprintInput struct {
+	Version      string                          `json:"version"`
+	OSName       string                          `json:"osName,omitempty"`
+	OSVersion    string                          `json:"osVersion,omitempty"`
+	Architecture string                          `json:"architecture,omitempty"`
+	EncoderKeys  []decisionFingerprintEncoderKey `json:"encoderKeys,omitempty"`
+}
+
+type decisionFingerprintEncoderKey struct {
+	Codec string `json:"codec"`
+}
+
 type ReceiverContext struct {
 	Platform            string `json:"platform,omitempty"`
 	Brand               string `json:"brand,omitempty"`
@@ -103,6 +115,36 @@ func (s SourceSnapshot) Fingerprint() string {
 		"interlaced":   canonical.Interlaced,
 		"problemFlags": canonical.ProblemFlags,
 		"receiver":     canonical.ReceiverContext,
+	})
+}
+
+func (s HostSnapshot) DecisionFingerprint() string {
+	canonical := canonicalHostSnapshot(s)
+	if canonical.Identity.OSName == "" && canonical.Identity.OSVersion == "" && canonical.Identity.Architecture == "" && len(canonical.EncoderCapabilities) == 0 {
+		return ""
+	}
+	keys := make([]decisionFingerprintEncoderKey, 0, len(canonical.EncoderCapabilities))
+	seen := make(map[string]struct{}, len(canonical.EncoderCapabilities))
+	for _, capability := range canonical.EncoderCapabilities {
+		codec := normalizeToken(capability.Codec)
+		if codec == "" {
+			continue
+		}
+		if _, ok := seen[codec]; ok {
+			continue
+		}
+		seen[codec] = struct{}{}
+		keys = append(keys, decisionFingerprintEncoderKey{Codec: codec})
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].Codec < keys[j].Codec
+	})
+	return "df1:" + sha256JSON(decisionFingerprintInput{
+		Version:      "df1",
+		OSName:       canonical.Identity.OSName,
+		OSVersion:    canonical.Identity.OSVersion,
+		Architecture: canonical.Identity.Architecture,
+		EncoderKeys:  keys,
 	})
 }
 

--- a/backend/internal/control/recordings/capreg/store_test.go
+++ b/backend/internal/control/recordings/capreg/store_test.go
@@ -1,0 +1,56 @@
+package capreg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostSnapshotDecisionFingerprint_UsesStableHostClass(t *testing.T) {
+	base := HostSnapshot{
+		Identity: HostIdentity{
+			Hostname:     "host-a",
+			OSName:       "Linux",
+			OSVersion:    "6.9 ",
+			Architecture: "amd64",
+		},
+		EncoderCapabilities: []EncoderCapability{
+			{Codec: "hevc", Verified: true, AutoEligible: false, ProbeElapsedMS: 51},
+			{Codec: "h264", Verified: false, AutoEligible: true, ProbeElapsedMS: 12},
+		},
+		UpdatedAt: time.Unix(1_700_000_000, 0).UTC(),
+	}
+
+	changedRuntime := base
+	changedRuntime.Identity.Hostname = "host-b"
+	changedRuntime.UpdatedAt = time.Unix(1_800_000_000, 0).UTC()
+	changedRuntime.EncoderCapabilities = []EncoderCapability{
+		{Codec: "h264", Verified: true, AutoEligible: false, ProbeElapsedMS: 999},
+		{Codec: "hevc", Verified: false, AutoEligible: true, ProbeElapsedMS: 1},
+	}
+
+	baseFingerprint := base.DecisionFingerprint()
+	require.NotEmpty(t, baseFingerprint)
+	require.Contains(t, baseFingerprint, "df1:")
+	require.Equal(t, baseFingerprint, changedRuntime.DecisionFingerprint())
+}
+
+func TestHostSnapshotDecisionFingerprint_ChangesWhenHostClassChanges(t *testing.T) {
+	base := HostSnapshot{
+		Identity: HostIdentity{
+			OSName:       "linux",
+			OSVersion:    "6.9",
+			Architecture: "amd64",
+		},
+		EncoderCapabilities: []EncoderCapability{
+			{Codec: "hevc"},
+			{Codec: "h264"},
+		},
+	}
+
+	withAV1 := base
+	withAV1.EncoderCapabilities = append(withAV1.EncoderCapabilities, EncoderCapability{Codec: "av1"})
+
+	require.NotEqual(t, base.DecisionFingerprint(), withAV1.DecisionFingerprint())
+}

--- a/backend/internal/control/recordings/decision/event.go
+++ b/backend/internal/control/recordings/decision/event.go
@@ -14,12 +14,16 @@ import (
 )
 
 type Event struct {
-	ServiceRef       string                                 `json:"serviceRef"`
-	SubjectKind      string                                 `json:"subjectKind"`
-	Origin           string                                 `json:"origin"`
-	ClientFamily     string                                 `json:"clientFamily"`
-	ClientCapsSource string                                 `json:"clientCapsSource,omitempty"`
-	DeviceType       string                                 `json:"deviceType,omitempty"`
+	ServiceRef       string `json:"serviceRef"`
+	SubjectKind      string `json:"subjectKind"`
+	Origin           string `json:"origin"`
+	ClientFamily     string `json:"clientFamily"`
+	ClientCapsSource string `json:"clientCapsSource,omitempty"`
+	DeviceType       string `json:"deviceType,omitempty"`
+	// HostFingerprint is forensic metadata only. It MUST NOT be mixed into
+	// BasisHash because cross-host decision comparison depends on BasisHash
+	// remaining host-independent.
+	HostFingerprint  string                                 `json:"hostFingerprint,omitempty"`
 	RequestedIntent  string                                 `json:"requestedIntent,omitempty"`
 	ResolvedIntent   string                                 `json:"resolvedIntent,omitempty"`
 	Mode             Mode                                   `json:"mode"`
@@ -41,6 +45,7 @@ type EventMetadata struct {
 	ClientFamily     string
 	ClientCapsSource string
 	DeviceType       string
+	HostFingerprint  string
 	DecidedAt        time.Time
 }
 
@@ -89,6 +94,7 @@ func BuildEvent(meta EventMetadata, input DecisionInput, dec *Decision) (Event, 
 		ClientFamily:     normalizeTokenOrUnknown(meta.ClientFamily),
 		ClientCapsSource: normalize.Token(meta.ClientCapsSource),
 		DeviceType:       normalize.Token(firstNonEmpty(meta.DeviceType, input.Capabilities.DeviceType)),
+		HostFingerprint:  normalizeHostFingerprint(meta.HostFingerprint),
 		RequestedIntent:  string(playbackprofile.NormalizeRequestedIntent(string(input.RequestedIntent))),
 		ResolvedIntent:   normalize.Token(dec.Trace.ResolvedIntent),
 		Mode:             dec.Mode,
@@ -129,6 +135,7 @@ func (e Event) Normalized() Event {
 	e.ClientFamily = normalizeTokenOrUnknown(e.ClientFamily)
 	e.ClientCapsSource = normalize.Token(e.ClientCapsSource)
 	e.DeviceType = normalize.Token(e.DeviceType)
+	e.HostFingerprint = normalizeHostFingerprint(e.HostFingerprint)
 	e.RequestedIntent = string(playbackprofile.NormalizeRequestedIntent(e.RequestedIntent))
 	e.ResolvedIntent = normalize.Token(e.ResolvedIntent)
 	e.Selected = normalizeSelected(e.Selected)
@@ -250,6 +257,10 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func normalizeHostFingerprint(value string) string {
+	return strings.TrimSpace(value)
 }
 
 func sha256Hex(payload []byte) string {

--- a/backend/internal/control/recordings/decision/event_test.go
+++ b/backend/internal/control/recordings/decision/event_test.go
@@ -1,0 +1,78 @@
+package decision
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/playbackprofile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEvent_BasisHashIgnoresHostFingerprint(t *testing.T) {
+	input := DecisionInput{
+		Source: Source{
+			Container:  "ts",
+			VideoCodec: "h264",
+			AudioCodec: "aac",
+			Width:      1920,
+			Height:     1080,
+			FPS:        50,
+		},
+		Capabilities: Capabilities{
+			Version:     3,
+			Containers:  []string{"hls"},
+			VideoCodecs: []string{"h264"},
+			AudioCodecs: []string{"aac"},
+			SupportsHLS: true,
+			DeviceType:  "web",
+		},
+		Policy: Policy{
+			AllowTranscode: true,
+			Host:           HostPolicy{PressureBand: playbackprofile.HostPressureNormal},
+		},
+		RequestedIntent: playbackprofile.IntentQuality,
+		APIVersion:      "v3.1",
+		RequestID:       "req-1",
+	}
+	decision := &Decision{
+		Mode: ModeTranscode,
+		Selected: SelectedFormats{
+			Container:  "fmp4",
+			VideoCodec: "h264",
+			AudioCodec: "aac",
+		},
+		Reasons: []ReasonCode{ReasonVideoCodecNotSupported},
+		Trace: Trace{
+			RequestedIntent:  "quality",
+			ResolvedIntent:   "quality",
+			HostPressureBand: string(playbackprofile.HostPressureNormal),
+		},
+	}
+
+	eventA, err := BuildEvent(EventMetadata{
+		ServiceRef:       "1:0:1:2B66:3F3:1:C00000:0:0:0:",
+		SubjectKind:      "live",
+		Origin:           OriginRuntime,
+		ClientFamily:     "safari_native",
+		ClientCapsSource: "runtime",
+		DeviceType:       "web",
+		HostFingerprint:  "df1:host-a",
+		DecidedAt:        time.Unix(1_700_000_000, 0).UTC(),
+	}, input, decision)
+	require.NoError(t, err)
+
+	eventB, err := BuildEvent(EventMetadata{
+		ServiceRef:       "1:0:1:2B66:3F3:1:C00000:0:0:0:",
+		SubjectKind:      "live",
+		Origin:           OriginRuntime,
+		ClientFamily:     "safari_native",
+		ClientCapsSource: "runtime",
+		DeviceType:       "web",
+		HostFingerprint:  "df1:host-b",
+		DecidedAt:        time.Unix(1_700_000_000, 0).UTC(),
+	}, input, decision)
+	require.NoError(t, err)
+
+	require.Equal(t, eventA.BasisHash, eventB.BasisHash)
+	require.NotEqual(t, eventA.HostFingerprint, eventB.HostFingerprint)
+}

--- a/backend/internal/control/recordings/decision/sqlite_audit_store.go
+++ b/backend/internal/control/recordings/decision/sqlite_audit_store.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	auditSchemaVersion       = 3
+	auditSchemaVersion       = 4
 	historyRetention         = 30 * 24 * time.Hour
 	historyEntriesPerKey     = 20
 	defaultUnknownEventValue = "unknown"
@@ -57,7 +57,7 @@ func (s *SqliteAuditStore) migrate() error {
 
 	switch {
 	case currentVersion <= 0:
-		if err := createAuditSchemaV3(tx); err != nil {
+		if err := createAuditSchemaV4(tx); err != nil {
 			return err
 		}
 	case currentVersion == 1:
@@ -67,12 +67,22 @@ func (s *SqliteAuditStore) migrate() error {
 		if err := migrateAuditSchemaV2ToV3(tx); err != nil {
 			return err
 		}
+		if err := migrateAuditSchemaV3ToV4(tx); err != nil {
+			return err
+		}
 	case currentVersion == 2:
 		if err := migrateAuditSchemaV2ToV3(tx); err != nil {
 			return err
 		}
+		if err := migrateAuditSchemaV3ToV4(tx); err != nil {
+			return err
+		}
+	case currentVersion == 3:
+		if err := migrateAuditSchemaV3ToV4(tx); err != nil {
+			return err
+		}
 	default:
-		if err := createAuditSchemaV3(tx); err != nil {
+		if err := createAuditSchemaV4(tx); err != nil {
 			return err
 		}
 	}
@@ -86,7 +96,7 @@ func (s *SqliteAuditStore) migrate() error {
 	return tx.Commit()
 }
 
-func createAuditSchemaV3(tx *sql.Tx) error {
+func createAuditSchemaV4(tx *sql.Tx) error {
 	if _, err := tx.Exec(`
 	CREATE TABLE IF NOT EXISTS decision_current (
 		service_ref TEXT NOT NULL,
@@ -108,6 +118,7 @@ func createAuditSchemaV3(tx *sql.Tx) error {
 		host_pressure_band TEXT,
 		client_caps_source TEXT,
 		device_type TEXT,
+		host_fingerprint TEXT,
 		changed_at_ms INTEGER NOT NULL,
 		last_seen_at_ms INTEGER NOT NULL,
 		PRIMARY KEY (service_ref, subject_kind, origin, client_family, requested_intent)
@@ -135,11 +146,14 @@ func createAuditSchemaV3(tx *sql.Tx) error {
 		host_pressure_band TEXT,
 		client_caps_source TEXT,
 		device_type TEXT,
+		host_fingerprint TEXT,
 		decided_at_ms INTEGER NOT NULL
 	);
 	CREATE INDEX IF NOT EXISTS idx_decision_history_key_time
 		ON decision_history(service_ref, subject_kind, origin, client_family, requested_intent, decided_at_ms DESC, id DESC);
 	CREATE INDEX IF NOT EXISTS idx_decision_history_decided_at ON decision_history(decided_at_ms);
+	CREATE INDEX IF NOT EXISTS idx_decision_history_host_fingerprint ON decision_history(host_fingerprint);
+	CREATE INDEX IF NOT EXISTS idx_decision_history_basis_host ON decision_history(basis_hash, host_fingerprint);
 	`); err != nil {
 		return err
 	}
@@ -156,7 +170,7 @@ func migrateAuditSchemaV1ToV2(tx *sql.Tx) error {
 		return err
 	}
 	if currentHasOrigin && historyHasOrigin {
-		return createAuditSchemaV3(tx)
+		return nil
 	}
 
 	if _, err := tx.Exec(`
@@ -248,7 +262,7 @@ func migrateAuditSchemaV1ToV2(tx *sql.Tx) error {
 		return err
 	}
 
-	return createAuditSchemaV3(tx)
+	return nil
 }
 
 func migrateAuditSchemaV2ToV3(tx *sql.Tx) error {
@@ -272,7 +286,31 @@ func migrateAuditSchemaV2ToV3(tx *sql.Tx) error {
 		}
 	}
 
-	return createAuditSchemaV3(tx)
+	return nil
+}
+
+func migrateAuditSchemaV3ToV4(tx *sql.Tx) error {
+	currentHasHostFingerprint, err := tableHasColumn(tx, "decision_current", "host_fingerprint")
+	if err != nil {
+		return err
+	}
+	if !currentHasHostFingerprint {
+		if _, err := tx.Exec(`ALTER TABLE decision_current ADD COLUMN host_fingerprint TEXT`); err != nil {
+			return err
+		}
+	}
+
+	historyHasHostFingerprint, err := tableHasColumn(tx, "decision_history", "host_fingerprint")
+	if err != nil {
+		return err
+	}
+	if !historyHasHostFingerprint {
+		if _, err := tx.Exec(`ALTER TABLE decision_history ADD COLUMN host_fingerprint TEXT`); err != nil {
+			return err
+		}
+	}
+
+	return createAuditSchemaV4(tx)
 }
 
 func tableHasColumn(tx *sql.Tx, table string, column string) (bool, error) {
@@ -380,8 +418,8 @@ func upsertCurrentAuditRow(ctx context.Context, tx *sql.Tx, event Event, changed
 		`INSERT INTO decision_current (
 			service_ref, subject_kind, origin, client_family, requested_intent, basis_hash, truth_hash, output_hash,
 			mode, selected_container, selected_video_codec, selected_audio_codec, target_profile_json, reasons_json,
-			shadow_json, resolved_intent, host_pressure_band, client_caps_source, device_type, changed_at_ms, last_seen_at_ms
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			shadow_json, resolved_intent, host_pressure_band, client_caps_source, device_type, host_fingerprint, changed_at_ms, last_seen_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(service_ref, subject_kind, origin, client_family, requested_intent) DO UPDATE SET
 			basis_hash = excluded.basis_hash,
 			truth_hash = excluded.truth_hash,
@@ -397,6 +435,7 @@ func upsertCurrentAuditRow(ctx context.Context, tx *sql.Tx, event Event, changed
 			host_pressure_band = excluded.host_pressure_band,
 			client_caps_source = excluded.client_caps_source,
 			device_type = excluded.device_type,
+			host_fingerprint = excluded.host_fingerprint,
 			changed_at_ms = excluded.changed_at_ms,
 			last_seen_at_ms = excluded.last_seen_at_ms`,
 		event.ServiceRef,
@@ -418,6 +457,7 @@ func upsertCurrentAuditRow(ctx context.Context, tx *sql.Tx, event Event, changed
 		normalizeNullableToken(event.HostPressureBand),
 		normalizeNullableToken(event.ClientCapsSource),
 		normalizeNullableToken(event.DeviceType),
+		normalizeNullableToken(event.HostFingerprint),
 		changedAtMS,
 		lastSeenAtMS,
 	)
@@ -435,8 +475,8 @@ func insertAuditHistory(ctx context.Context, tx *sql.Tx, event Event, decidedAtM
 		`INSERT INTO decision_history (
 			service_ref, subject_kind, origin, client_family, requested_intent, basis_hash, truth_hash, output_hash,
 			mode, selected_container, selected_video_codec, selected_audio_codec, target_profile_json, reasons_json,
-			shadow_json, resolved_intent, host_pressure_band, client_caps_source, device_type, decided_at_ms
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			shadow_json, resolved_intent, host_pressure_band, client_caps_source, device_type, host_fingerprint, decided_at_ms
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		event.ServiceRef,
 		normalizeSubjectKind(event.SubjectKind),
 		normalizeEventOrigin(event.Origin),
@@ -456,6 +496,7 @@ func insertAuditHistory(ctx context.Context, tx *sql.Tx, event Event, decidedAtM
 		normalizeNullableToken(event.HostPressureBand),
 		normalizeNullableToken(event.ClientCapsSource),
 		normalizeNullableToken(event.DeviceType),
+		normalizeNullableToken(event.HostFingerprint),
 		decidedAtMS,
 	)
 	return err

--- a/backend/internal/control/recordings/decision/sqlite_audit_store_test.go
+++ b/backend/internal/control/recordings/decision/sqlite_audit_store_test.go
@@ -206,6 +206,26 @@ func TestSqliteAuditStore_ShadowDivergenceAlwaysPersistsHistoryPerRequest(t *tes
 	require.Equal(t, []string{"codec_mismatch"}, shadow.NewReasons)
 }
 
+func TestSqliteAuditStore_PersistsHostFingerprint(t *testing.T) {
+	store, err := NewSqliteAuditStore(filepath.Join(t.TempDir(), "decision_audit.sqlite"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.DB.Close()) }()
+
+	event := testDecisionEvent(time.Now().UTC(), "basis-host", "output-host")
+	event.HostFingerprint = "df1:host-class"
+	require.NoError(t, store.Record(context.Background(), event))
+
+	var currentHostFingerprint string
+	err = store.DB.QueryRow(`SELECT host_fingerprint FROM decision_current LIMIT 1`).Scan(&currentHostFingerprint)
+	require.NoError(t, err)
+	require.Equal(t, event.HostFingerprint, currentHostFingerprint)
+
+	var historyHostFingerprint string
+	err = store.DB.QueryRow(`SELECT host_fingerprint FROM decision_history LIMIT 1`).Scan(&historyHostFingerprint)
+	require.NoError(t, err)
+	require.Equal(t, event.HostFingerprint, historyHostFingerprint)
+}
+
 func TestSqliteAuditStore_MigratesV1RowsToRuntimeOrigin(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "decision_audit.sqlite")
 	db, err := sql.Open("sqlite", dbPath)
@@ -305,6 +325,95 @@ func TestSqliteAuditStore_MigratesV1RowsToRuntimeOrigin(t *testing.T) {
 	historyHasShadow, err := tableHasColumn(tx, "decision_history", "shadow_json")
 	require.NoError(t, err)
 	require.True(t, historyHasShadow)
+
+	currentHasHostFingerprint, err := tableHasColumn(tx, "decision_current", "host_fingerprint")
+	require.NoError(t, err)
+	require.True(t, currentHasHostFingerprint)
+
+	historyHasHostFingerprint, err := tableHasColumn(tx, "decision_history", "host_fingerprint")
+	require.NoError(t, err)
+	require.True(t, historyHasHostFingerprint)
+
+	require.True(t, tableHasIndex(t, tx, "idx_decision_history_host_fingerprint"))
+	require.True(t, tableHasIndex(t, tx, "idx_decision_history_basis_host"))
+}
+
+func TestSqliteAuditStore_MigratesV3RowsToHostFingerprintSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "decision_audit.sqlite")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+	PRAGMA user_version = 3;
+	CREATE TABLE decision_current (
+		service_ref TEXT NOT NULL,
+		subject_kind TEXT NOT NULL,
+		origin TEXT NOT NULL,
+		client_family TEXT NOT NULL,
+		requested_intent TEXT NOT NULL,
+		basis_hash TEXT NOT NULL,
+		truth_hash TEXT NOT NULL,
+		output_hash TEXT NOT NULL,
+		mode TEXT NOT NULL,
+		selected_container TEXT NOT NULL,
+		selected_video_codec TEXT NOT NULL,
+		selected_audio_codec TEXT NOT NULL,
+		target_profile_json TEXT,
+		reasons_json TEXT NOT NULL,
+		shadow_json TEXT,
+		resolved_intent TEXT,
+		host_pressure_band TEXT,
+		client_caps_source TEXT,
+		device_type TEXT,
+		changed_at_ms INTEGER NOT NULL,
+		last_seen_at_ms INTEGER NOT NULL,
+		PRIMARY KEY (service_ref, subject_kind, origin, client_family, requested_intent)
+	);
+	CREATE TABLE decision_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		service_ref TEXT NOT NULL,
+		subject_kind TEXT NOT NULL,
+		origin TEXT NOT NULL,
+		client_family TEXT NOT NULL,
+		requested_intent TEXT NOT NULL,
+		basis_hash TEXT NOT NULL,
+		truth_hash TEXT NOT NULL,
+		output_hash TEXT NOT NULL,
+		mode TEXT NOT NULL,
+		selected_container TEXT NOT NULL,
+		selected_video_codec TEXT NOT NULL,
+		selected_audio_codec TEXT NOT NULL,
+		target_profile_json TEXT,
+		reasons_json TEXT NOT NULL,
+		shadow_json TEXT,
+		resolved_intent TEXT,
+		host_pressure_band TEXT,
+		client_caps_source TEXT,
+		device_type TEXT,
+		decided_at_ms INTEGER NOT NULL
+	);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	store, err := NewSqliteAuditStore(dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.DB.Close()) }()
+
+	tx, err := store.DB.Begin()
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	currentHasHostFingerprint, err := tableHasColumn(tx, "decision_current", "host_fingerprint")
+	require.NoError(t, err)
+	require.True(t, currentHasHostFingerprint)
+
+	historyHasHostFingerprint, err := tableHasColumn(tx, "decision_history", "host_fingerprint")
+	require.NoError(t, err)
+	require.True(t, historyHasHostFingerprint)
+
+	require.True(t, tableHasIndex(t, tx, "idx_decision_history_host_fingerprint"))
+	require.True(t, tableHasIndex(t, tx, "idx_decision_history_basis_host"))
 }
 
 func testDecisionEvent(decidedAt time.Time, basisHash, outputHash string) Event {
@@ -315,6 +424,7 @@ func testDecisionEvent(decidedAt time.Time, basisHash, outputHash string) Event 
 		ClientFamily:     "safari",
 		ClientCapsSource: "runtime_plus_family",
 		DeviceType:       "tv",
+		HostFingerprint:  "df1:test-host",
 		RequestedIntent:  "quality",
 		ResolvedIntent:   "quality",
 		Mode:             ModeTranscode,
@@ -358,4 +468,21 @@ func countDecisionHistoryRows(t *testing.T, store *SqliteAuditStore) int {
 
 func timeLabel(i int) string {
 	return fmt.Sprintf("%02d", i)
+}
+
+func tableHasIndex(t *testing.T, tx *sql.Tx, name string) bool {
+	t.Helper()
+	rows, err := tx.Query(`SELECT name FROM sqlite_master WHERE type = 'index'`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var indexName string
+		require.NoError(t, rows.Scan(&indexName))
+		if indexName == name {
+			return true
+		}
+	}
+	require.NoError(t, rows.Err())
+	return false
 }


### PR DESCRIPTION
## What changed

This PR threads a stable host-class fingerprint into the live playback decision audit path.

It adds a versioned `df1:` host decision fingerprint, persists it in `decision_audit.sqlite`, threads it through the playback info runtime path, and surfaces host-bucket information in the storage decision report.

## Why

The decision audit already records `basis_hash`, but that hash must stay host-independent so identical semantic inputs can be compared across hosts.

`host_fingerprint` therefore lives next to `basis_hash`, not inside it. That keeps cross-host decision comparison possible while still making divergence clustering by host class available.

## Scope kept intentionally small

This PR does not:

- add a `/system/host` endpoint
- add a cached host fingerprint provider or invalidation contract
- backfill old audit rows
- introduce a provider abstraction for host inventory
- change decision semantics or mix host state into `basis_hash`

## User/developer impact

- live decision audit rows can now be grouped by stable host class
- report output shows `host_fingerprint`, `unknown_host` rows, and multi-host basis buckets
- shadow/divergence analysis can distinguish host effects from input effects

## Validation

- `go test ./backend/internal/control/recordings/capreg`
- `go test ./backend/internal/control/recordings/decision`
- `go test ./backend/internal/control/http/v3/recordings`
- `go test ./backend/cmd/daemon`
