### PR TITLE
quality: nightly refactor-20260425-074634 (quality)

### DIFF
--- a/backend/internal/pipeline/profiles/resolve.go
+++ b/backend/internal/pipeline/profiles/resolve.go
@@ -221,12 +221,13 @@ func applyEnvH264GPUSettings(
 	qpKey string,
 	maxRateKey string,
 	bufSizeKey string,
+	defaultQP int,
 	defaultMaxRateK int,
 	defaultBufSizeK int,
 ) {
 	spec.HWAccel = hwaccel
 	spec.VideoCodec = "h264"
-	spec.VideoQP = envIntBounded(qpKey, 20, 10, 40)
+	spec.VideoQP = envIntBounded(qpKey, defaultQP, 10, 40)
 	spec.VideoMaxRateK = envIntBounded(maxRateKey, defaultMaxRateK, 4000, 60000)
 	spec.VideoBufSizeK = envIntBounded(bufSizeKey, defaultBufSizeK, 8000, 120000)
 }
@@ -407,6 +408,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 					"XG2G_SAFARI_VAAPI_QP",
 					"XG2G_SAFARI_VAAPI_MAXRATE_K",
 					"XG2G_SAFARI_VAAPI_BUFSIZE_K",
+					20,
 					20000,
 					40000,
 				)
@@ -448,6 +450,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 				"XG2G_SAFARI_DIRTY_VAAPI_QP",
 				"XG2G_SAFARI_DIRTY_MAXRATE_K",
 				"XG2G_SAFARI_DIRTY_BUFSIZE_K",
+				20,
 				20000,
 				40000,
 			)
@@ -458,6 +461,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 				"XG2G_SAFARI_DIRTY_VAAPI_QP",
 				"XG2G_SAFARI_DIRTY_MAXRATE_K",
 				"XG2G_SAFARI_DIRTY_BUFSIZE_K",
+				20,
 				20000,
 				40000,
 			)

--- a/backend/internal/pipeline/profiles/resolve.go
+++ b/backend/internal/pipeline/profiles/resolve.go
@@ -190,6 +190,47 @@ func requestedEncodeOnlyHWAccelProfile(backend GPUBackend, hwaccelMode HWAccelMo
 	return ""
 }
 
+func newResolvedSpec(name string) model.ProfileSpec {
+	return model.ProfileSpec{
+		Name:                name,
+		PolicyModeHint:      ports.RuntimeModeUnknown,
+		EffectiveModeSource: ports.RuntimeModeSourceResolve,
+	}
+}
+
+func applyDVRWindow(spec *model.ProfileSpec, dvrWindowSec int) {
+	if dvrWindowSec > 0 {
+		spec.DVRWindowSec = dvrWindowSec
+	}
+}
+
+func safariFamilyContainer(isSafari bool) string {
+	if isSafari {
+		return "mpegts"
+	}
+	return "fmp4"
+}
+
+func interlacedOrUnknown(cap *scan.Capability) bool {
+	return cap == nil || cap.Interlaced
+}
+
+func applyEnvH264GPUSettings(
+	spec *model.ProfileSpec,
+	hwaccel string,
+	qpKey string,
+	maxRateKey string,
+	bufSizeKey string,
+	defaultMaxRateK int,
+	defaultBufSizeK int,
+) {
+	spec.HWAccel = hwaccel
+	spec.VideoCodec = "h264"
+	spec.VideoQP = envIntBounded(qpKey, 20, 10, 40)
+	spec.VideoMaxRateK = envIntBounded(maxRateKey, defaultMaxRateK, 4000, 60000)
+	spec.VideoBufSizeK = envIntBounded(bufSizeKey, defaultBufSizeK, 8000, 120000)
+}
+
 // NormalizeRequestedProfileID maps known aliases to the stable internal profile IDs
 // without collapsing unknown inputs to auto.
 func NormalizeRequestedProfileID(requested string) string {
@@ -304,11 +345,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 	// Frontend now controls profile switching explicitly based on fullscreen state
 	// This ensures inline playback uses custom controls, fullscreen uses native DVR
 
-	spec := model.ProfileSpec{
-		Name:                canonical,
-		PolicyModeHint:      ports.RuntimeModeUnknown,
-		EffectiveModeSource: ports.RuntimeModeSourceResolve,
-	}
+	spec := newResolvedSpec(canonical)
 
 	switch canonical {
 	case ProfileCopy:
@@ -324,9 +361,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		spec.PolicyModeHint = ports.RuntimeModeCopy
 		spec.TranscodeVideo = false // Default to copy (passthrough) for original quality
 		spec.AudioBitrateK = 192    // FORCE AAC: Browsers cannot decode MP2/AC3 natively
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileAndroid:
 		spec.PolicyModeHint = ports.RuntimeModeCopy
 		// Android native player (ExoPlayer): video copy + AAC transcode.
@@ -334,9 +369,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		spec.TranscodeVideo = false
 		spec.Container = "mpegts"
 		spec.AudioBitrateK = 192
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileSafari:
 		// Smart Profile Logic
 		if cap != nil && !cap.Interlaced {
@@ -346,11 +379,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 			// reuse the safari family (for example Android native_hls) prefer fMP4.
 			spec.TranscodeVideo = false
 			spec.PolicyModeHint = ports.RuntimeModeCopy
-			if isSafari {
-				spec.Container = "mpegts"
-			} else {
-				spec.Container = "fmp4"
-			}
+			spec.Container = safariFamilyContainer(isSafari)
 			spec.AudioBitrateK = 192
 			// HWAccel disabled for passthrough
 		} else {
@@ -362,11 +391,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 			// transcode output. Keep classic MPEG-TS HLS there as the safer
 			// browser-native HLS path; app-native or non-Safari clients that
 			// resolve through the safari family can stay on fMP4.
-			if isSafari {
-				spec.Container = "mpegts"
-			} else {
-				spec.Container = "fmp4"
-			}
+			spec.Container = safariFamilyContainer(isSafari)
 			spec.AudioBitrateK = 192
 
 			// HWAccel Decision (respects override)
@@ -376,11 +401,15 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 				// GPU acceleration uses an explicit VAAPI QP target as the primary
 				// quality knob. The bitrate fields remain available as optional
 				// safety ceilings in the FFmpeg builder.
-				spec.HWAccel = requestedHWAccelProfile(gpuBackend, hwaccelMode)
-				spec.VideoCodec = "h264"
-				spec.VideoQP = envIntBounded("XG2G_SAFARI_VAAPI_QP", 20, 10, 40)
-				spec.VideoMaxRateK = envIntBounded("XG2G_SAFARI_VAAPI_MAXRATE_K", 20000, 4000, 60000)
-				spec.VideoBufSizeK = envIntBounded("XG2G_SAFARI_VAAPI_BUFSIZE_K", 40000, 8000, 120000)
+				applyEnvH264GPUSettings(
+					&spec,
+					requestedHWAccelProfile(gpuBackend, hwaccelMode),
+					"XG2G_SAFARI_VAAPI_QP",
+					"XG2G_SAFARI_VAAPI_MAXRATE_K",
+					"XG2G_SAFARI_VAAPI_BUFSIZE_K",
+					20000,
+					40000,
+				)
 			} else {
 				// CPU fallback keeps the Safari-compatible H.264 live path, while
 				// retaining the quality rung's CRF and overriding the preset to a
@@ -395,9 +424,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		}
 
 		spec.LLHLS = false
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileSafariDirty:
 		spec.PolicyModeHint = ports.RuntimeModeSafe
 		// Robust recovery profile for dirty DVB inputs.
@@ -406,11 +433,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		// Browser Safari has shown black-video / freeze regressions on dirty live
 		// transcodes packaged as fMP4. Keep TS HLS there; other MSE clients can
 		// stay on fMP4.
-		if isSafari {
-			spec.Container = "mpegts"
-		} else {
-			spec.Container = "fmp4"
-		}
+		spec.Container = safariFamilyContainer(isSafari)
 		spec.AudioBitrateK = envIntBounded("XG2G_SAFARI_DIRTY_AUDIO_BITRATE_K", 192, 96, 384)
 
 		// Dirty DVB sources need finer-grained control than a simple CPU/GPU split.
@@ -419,17 +442,25 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		// full        -> full VAAPI decode/deinterlace/encode path
 		switch resolveSafariDirtyHWMode(gpuBackend, hwaccelMode) {
 		case safariDirtyHWModeFull:
-			spec.HWAccel = requestedHWAccelProfile(gpuBackend, hwaccelMode)
-			spec.VideoCodec = "h264"
-			spec.VideoQP = envIntBounded("XG2G_SAFARI_DIRTY_VAAPI_QP", 20, 10, 40)
-			spec.VideoMaxRateK = envIntBounded("XG2G_SAFARI_DIRTY_MAXRATE_K", 20000, 4000, 60000)
-			spec.VideoBufSizeK = envIntBounded("XG2G_SAFARI_DIRTY_BUFSIZE_K", 40000, 8000, 120000)
+			applyEnvH264GPUSettings(
+				&spec,
+				requestedHWAccelProfile(gpuBackend, hwaccelMode),
+				"XG2G_SAFARI_DIRTY_VAAPI_QP",
+				"XG2G_SAFARI_DIRTY_MAXRATE_K",
+				"XG2G_SAFARI_DIRTY_BUFSIZE_K",
+				20000,
+				40000,
+			)
 		case safariDirtyHWModeEncodeOnly:
-			spec.HWAccel = requestedEncodeOnlyHWAccelProfile(gpuBackend, hwaccelMode)
-			spec.VideoCodec = "h264"
-			spec.VideoQP = envIntBounded("XG2G_SAFARI_DIRTY_VAAPI_QP", 20, 10, 40)
-			spec.VideoMaxRateK = envIntBounded("XG2G_SAFARI_DIRTY_MAXRATE_K", 20000, 4000, 60000)
-			spec.VideoBufSizeK = envIntBounded("XG2G_SAFARI_DIRTY_BUFSIZE_K", 40000, 8000, 120000)
+			applyEnvH264GPUSettings(
+				&spec,
+				requestedEncodeOnlyHWAccelProfile(gpuBackend, hwaccelMode),
+				"XG2G_SAFARI_DIRTY_VAAPI_QP",
+				"XG2G_SAFARI_DIRTY_MAXRATE_K",
+				"XG2G_SAFARI_DIRTY_BUFSIZE_K",
+				20000,
+				40000,
+			)
 		default:
 			// CPU fallback prioritizes startup stability and sustained playback over
 			// "best quality" defaults. Dirty 1080i feeds can stall badly on hosts
@@ -442,9 +473,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		}
 
 		spec.LLHLS = false
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileSafariDVR:
 		spec.PolicyModeHint = ports.RuntimeModeHQ25
 		spec.TranscodeVideo = true
@@ -452,9 +481,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		spec.LLHLS = true
 		applyH264VideoLadder(&spec, playbackprofile.VideoRungForIntent(playbackprofile.IntentCompatible))
 		spec.AudioBitrateK = 192
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileH264FMP4:
 		spec.PolicyModeHint = ports.RuntimeModeHQ25
 		// Always transcode to H.264 with fMP4 segments.
@@ -463,7 +490,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		spec.Container = "fmp4"
 		spec.AudioBitrateK = 192
 
-		if cap == nil || cap.Interlaced {
+		if interlacedOrUnknown(cap) {
 			spec.Deinterlace = true
 		}
 
@@ -482,17 +509,13 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 			spec.VideoBufSizeK = 16000
 		}
 
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileDVR:
 		spec.PolicyModeHint = ports.RuntimeModeHQ25
 		spec.TranscodeVideo = true
 		spec.Deinterlace = true
 		applyH264VideoLadder(&spec, playbackprofile.VideoRungForIntent(playbackprofile.IntentCompatible))
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileSafariHEVC:
 		spec.PolicyModeHint = ports.RuntimeModeHQ25
 		// Experimental: HEVC Live Transcoding (CPU)
@@ -501,12 +524,8 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		// MPEG-TS HLS; app-native clients can still use fMP4.
 		spec.TranscodeVideo = true
 		spec.VideoCodec = "hevc"
-		if isSafari {
-			spec.Container = "mpegts"
-		} else {
-			spec.Container = "fmp4"
-		}
-		spec.Deinterlace = cap == nil || cap.Interlaced
+		spec.Container = safariFamilyContainer(isSafari)
+		spec.Deinterlace = interlacedOrUnknown(cap)
 		spec.VideoCRF = 22        // Conservative start for x265
 		spec.VideoMaxRateK = 5000 // Strict VBV Cap
 		spec.VideoBufSizeK = 10000
@@ -520,14 +539,10 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		// HEVC live issue is tied to fMP4 packaging, not the encoder itself.
 		spec.TranscodeVideo = true
 		spec.VideoCodec = "hevc"
-		if isSafari {
-			spec.Container = "mpegts"
-		} else {
-			spec.Container = "fmp4"
-		}
+		spec.Container = safariFamilyContainer(isSafari)
 		// Respect existing scan truth so progressive HEVC candidates do not enter
 		// the conservative interlaced path and get downgraded to H.264 before launch.
-		spec.Deinterlace = cap == nil || cap.Interlaced
+		spec.Deinterlace = interlacedOrUnknown(cap)
 		spec.VideoQP = envIntBounded("XG2G_SAFARI_HEVC_VAAPI_QP", 20, 10, 40)
 		spec.VideoMaxRateK = 5000 // VBV Cap
 		spec.VideoBufSizeK = 10000
@@ -550,7 +565,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		spec.TranscodeVideo = true
 		spec.VideoCodec = "hevc"
 		spec.Container = "fmp4"
-		spec.Deinterlace = cap == nil || cap.Interlaced
+		spec.Deinterlace = interlacedOrUnknown(cap)
 		spec.LLHLS = true // Enable Low-Latency HLS with 0.5s part-segments
 		spec.VideoQP = envIntBounded("XG2G_SAFARI_HEVC_VAAPI_QP", 20, 10, 40)
 		spec.VideoMaxRateK = 5000
@@ -566,9 +581,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 			spec.VideoCRF = 22
 		}
 
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileAV1HW:
 		spec.PolicyModeHint = ports.RuntimeModeHQ25
 		// GPU-Accelerated AV1 (VAAPI).
@@ -582,7 +595,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 		}
 		// Respect existing scan truth so progressive services do not enter the
 		// conservative interlaced startup path and get downgraded before launch.
-		spec.Deinterlace = cap == nil || cap.Interlaced
+		spec.Deinterlace = interlacedOrUnknown(cap)
 		spec.VideoMaxRateK = 6000
 		spec.VideoBufSizeK = 12000
 		spec.AudioBitrateK = 192
@@ -595,9 +608,7 @@ func Resolve(requested, userAgent string, dvrWindowSec int, cap *scan.Capability
 			spec.HWAccel = requestedEncodeOnlyHWAccelProfile(gpuBackend, hwaccelMode)
 		}
 
-		if dvrWindowSec > 0 {
-			spec.DVRWindowSec = dvrWindowSec
-		}
+		applyDVRWindow(&spec, dvrWindowSec)
 	case ProfileRepair:
 		spec.PolicyModeHint = ports.RuntimeModeSafe
 		// RESCUE MODE: Force Transcode to repair timestamps/GOP


### PR DESCRIPTION
## OpenClaw quality/hardening summary

Board decision:
- CTO: Prefer the profile resolver slice because `Resolve` is a central playback policy function; small helper extraction improves long-term understandability without changing product behavior.
- Staff Engineer: The previous function repeated Safari-family container selection, DVR-window guards, interlaced checks, and env-backed H.264 GPU assignments across profile cases; centralizing those keeps cases focused on profile policy.
- Maintainer: One production file, existing style, no generated/noise files, and no schema or API changes.
- Product Engineer: No intended user-visible behavior change; this is product hardening by making future profile edits safer.
- QA Lead: Existing profile matrix/hwaccel tests and backend-wide Go tests cover the resolver outputs touched here.
- DX/Platform Lead: Helper names document repeated policy concepts (`safariFamilyContainer`, `interlacedOrUnknown`, `applyDVRWindow`) for easier future reviews.
- SRE/Operations: Runtime knobs and environment variable names are preserved; the VAAPI/H.264 env-backed settings are now grouped in one helper.
- Performance Pragmatist: No performance feature work; only minor branch/assignment consolidation.
- Release Manager: Small one-commit PR with low conflict risk and a clear rollback path.
- Reviewer: Diff should be easy to review: helper extraction plus direct call-site replacements.

Chosen slice: Profile resolver refactor: split repeated profile-case construction helpers out of `backend/internal/pipeline/profiles/resolve.go` without changing `Resolve` outputs.

Why this slice: It improves a high-value product-code path while staying bounded to one coherent Go file and relying on strong existing resolver tests.

Rejected alternatives:
- FFmpeg adapter test builders: useful but test-only and less product-code impact.
- Playback info test builders: useful but test-only and larger fixture surface.
- WebUI player/recordings refactors: potentially valuable but larger TSX surfaces with higher accidental UI risk.
- Refresh job refactor: already completed in PR #388.

Expected quality/hardening gain: Reduced duplicated policy plumbing in central playback profile resolution, making future profile changes easier to review and less error-prone.

Risk: Accidental changes to profile defaults, Safari/native container choice, DVR propagation, interlaced handling, or hardware encoder knobs.

Stop condition used: Completed the helper extraction in one file; stopped before broad behavior changes, generated files, frontend refactors, or additional slices.

## Quality/hardening scorecard

| Category | Before | After | Evidence |
|---|---:|---:|---|
| Readability | 6.6 | 7.2 | Repeated concepts now have explicit helper names instead of inline conditionals across many switch cases. |
| Simplicity | 6.4 | 6.9 | `Resolve` case bodies shed repeated DVR/container/interlaced/H.264 GPU assignment details. |
| Cohesion | 6.3 | 6.8 | Cross-cutting construction rules sit near resolver helpers; profile cases focus more on policy differences. |
| Duplication | 5.8 | 6.8 | Removed repeated `dvrWindowSec > 0`, Safari `mpegts`/`fmp4`, `cap == nil || cap.Interlaced`, and env-backed H.264 GPU blocks. |
| Testability | 7.8 | 7.8 | Behavior is still covered by existing package matrix/hwaccel tests; no new seams needed. |
| Correctness hardening | 7.2 | 7.2 | No intended logic change; hardening comes from reducing future copy/paste drift. |
| CI reliability | 7.4 | 7.4 | No CI script changes; backend-wide tests pass locally. |
| Behavior safety | 8.2 | 8.3 | Existing resolver tests stayed green before/after; helper replacements preserve constants/env keys. |
| Product polish | 7.0 | 7.0 | No direct user-facing product change. |
| DX/Operations | 6.7 | 7.0 | Env-backed GPU setting assignments are grouped, making runtime knob review/debug easier. |

Weighted overall:
- Before: 6.94
- After: 7.24
- Delta: +0.30

Quality/hardening thesis: Make central playback profile resolution safer to maintain by naming and centralizing repeated construction rules without changing resolved profile behavior.

## Changed areas

- `backend/internal/pipeline/profiles/resolve.go`
  - Added `newResolvedSpec`, `applyDVRWindow`, `safariFamilyContainer`, `interlacedOrUnknown`, and `applyEnvH264GPUSettings`.
  - Replaced repeated inline policy plumbing in profile cases with those helpers.

## Behavior safety

No intentional product behavior change. The refactor preserves existing constants, environment variable keys, default values, bitrate/QP bounds, profile names, container choices, and DVR propagation rules.

## Gates

- ✅ Baseline targeted: `cd backend && go test ./internal/pipeline/profiles`
- ✅ Post-change targeted: `cd backend && go test ./internal/pipeline/profiles`
- ✅ Diff hygiene: `git diff --check`
- ✅ Broader Go gate from `oc-xg2g-verify`: `go test ./...` under `backend`
- ⚠️ Full `oc-xg2g-verify` did not complete locally because frontend lint could not start: `sh: 1: eslint: not found` (local frontend dependencies/node_modules absent). This PR is Go-only, so the backend-wide gate is the justified narrower gate.

## Next human decision

Review the draft PR and either merge after GitHub checks are green, or request a narrower helper shape if preferred.
