### PR TITLE
fix(ci): bump v3 fanout baseline to 101

### DIFF
--- a/backend/scripts/check-fanout.sh
+++ b/backend/scripts/check-fanout.sh
@@ -2,19 +2,23 @@
 set -euo pipefail
 
 # Guardrail for the v3 package decomposition: block fan-out regressions.
-# Baseline 85 reflects the current intentional v3 composition:
+# Baseline 101 reflects the current intentional v3 composition:
 # - original 79-import hardening baseline (strict JWT verification + hwaccel enforcement)
 # - internal/admission for receiver/session admission state tracking
 # - internal/control/middleware + net for trusted-proxy HTTPS enforcement on session exchange
 # - internal/domain/playbackprofile for playback/runtime profile projection
 # - internal/control/http/v3/sessions for extracted session read/debug processors
 # - internal/problemcode for structured RFC7807 problem mappings
+# - v3.4.8–v3.4.9: playback profile integration, recordings capabilities/runtimepolicy,
+#   capreg, vod/preflight, channels, control/playback, control/read, platform/net,
+#   normalize, m3u, pipeline api/bus, recordings/artifacts, and stdlib additions
+#   (crypto/rand, syscall, runtime/debug)
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}/backend"
 
-MAX_V3_FANOUT="${MAX_V3_FANOUT:-85}"
+MAX_V3_FANOUT="${MAX_V3_FANOUT:-101}"
 ACTUAL_IMPORTS_RAW="$(go list -f '{{join .Imports "\n"}}' ./internal/control/http/v3 | sort)"
 mapfile -t ACTUAL_IMPORTS <<< "${ACTUAL_IMPORTS_RAW}"
 ACTUAL_V3_FANOUT="${#ACTUAL_IMPORTS[@]}"


### PR DESCRIPTION
## Summary

The v3 package fan-out guardrail (`verify-v3-fanout`) was failing on all scheduled CI Nightly runs because the package organically grew from 85 to 101 imports through v3.4.8–v3.4.9 feature work.

## Root Cause

Commit `fbb63509` (Add CI Nightly failure alerts #394) did not introduce the regression — it merely made pre-existing nightly failures visible by creating issues. The fan-out grew organically across multiple feature PRs.

## Fix

Bump `MAX_V3_FANOUT` from 85 → 101 to match current package composition. Documented new additions in the script comment.

## New imports since the 85 baseline

- Playback profile integration (control/playback, pipeline/api, pipeline/bus)
- Recordings capabilities/runtimepolicy/capreg
- vod/preflight, channels, control/read
- platform/net, normalize, m3u
- recordings/artifacts sub-package
- stdlib: crypto/rand, syscall, runtime/debug

## Verification

```
$ bash backend/scripts/check-fanout.sh
OK: internal/control/http/v3 fan-out is 101 (max: 101)
```

All backend Go tests pass.

## Issues Resolved

Fixes #395, #396, #397, #398