### PR TITLE
fix(ci): untrack test-results/.last-run.json (repo hygiene gate)

### DIFF
--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
## Root cause

`test-results/.last-run.json` was committed in a523da66, violating the Zero Tolerance repo hygiene gate (`gate-repo-hygiene` in mk/verify.mk).

## Failure

CI Nightly run #25299555124 — issue #401

## Fix

- `git rm --cached test-results/.last-run.json`
- `.gitignore` already contains `test-results/` and `**/test-results/` — no gitignore changes needed

## Verification

After the fix, `git ls-files test-results/` returns nothing, confirming the file is no longer tracked.