### PR TITLE
fix(ci): align python tooling venv path with Makefile

### DIFF
--- a/backend/scripts/bootstrap-python-tools.sh
+++ b/backend/scripts/bootstrap-python-tools.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "${BACKEND_DIR}/.." && pwd)"
 VENV_DIR="${REPO_ROOT}/.venv"
-REQ_FILE="${REPO_ROOT}/scripts/requirements-python-tools.txt"
+REQ_FILE="${BACKEND_DIR}/scripts/requirements-python-tools.txt"
 STAMP_FILE="${VENV_DIR}/.xg2g-python-tools.sha256"
 
 if ! command -v python3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fix path mismatch causing **CI Nightly to fail every run since at least 2026-04-30** (12+ consecutive failures, issues #406, #407, #408, #410, #413, #414, #418).
- `bootstrap-python-tools.sh` creates the venv at `backend/.venv`, but `mk/variables.mk` resolves `PYTHON_TOOLS := .venv/bin/python3` relative to the Make CWD (repo root). `gate-v3-contract` therefore fails with `make: .venv/bin/python3: No such file or directory` (run 25648755840).
- Split path resolution in the bootstrap script into `BACKEND_DIR` (for `scripts/requirements-python-tools.txt`) and a real `REPO_ROOT` one level up, so the venv lands at `<repo>/.venv` where Make expects it.

## Test plan
- [ ] CI Nightly run completes `gate-v3-contract` step successfully
- [ ] `make gate-v3-contract` succeeds on a clean checkout (with `python3-venv` available)
- [ ] `make verify-purity` (other consumer of `$(PYTHON_TOOLS)`) still passes

Closes #418