### PR TITLE
fix(android): require user confirmation before deep-link server switch (#421)

### DIFF
--- a/android/app/src/main/java/io/github/manugh/xg2g/android/DeviceAuthStore.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/DeviceAuthStore.kt
@@ -31,6 +31,14 @@ internal data class PersistedDeviceAuthState(
         if (serverUrl == normalizedServerUrl) {
             return true
         }
+        // Normalize the persisted serverUrl so that old state saved with an
+        // explicit default port (e.g. https://host:443/ui/) still matches the
+        // stripped canonical form (https://host/ui/). Without this, upgrade
+        // silently orphans all existing device auth and forces re-authentication.
+        val normalizedStored = ServerTargetResolver.normalizeServerUrl(serverUrl)
+        if (normalizedStored == normalizedServerUrl) {
+            return true
+        }
         return matchesPublishedEndpointServerUrl(normalizedServerUrl, publishedEndpoints)
     }
 

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
@@ -734,9 +734,7 @@ class MainActivity : AppCompatActivity() {
         )
 
         if (configuredBaseUrl == null) {
-            if (savedInstanceState == null) {
-                showSetupUi()
-            }
+            showSetupUi()
             return
         }
 
@@ -757,7 +755,7 @@ class MainActivity : AppCompatActivity() {
                     )
                     commitIntentConfiguration(
                         intent = intent,
-                        savedInstanceState = savedInstanceState,
+                        savedInstanceState = null,
                         existingBaseUrl = existingBaseUrl,
                         configuredBaseUrl = configuredBaseUrl,
                         routeReason = routeReason

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
@@ -671,7 +671,11 @@ class MainActivity : AppCompatActivity() {
         if (explicitToken != null) {
             return explicitToken
         }
-        if (configuredBaseUrl != null && configuredBaseUrl != existingBaseUrl) {
+        // Normalize before comparing so default-port differences do not falsely
+        // suppress the legacy auth token on upgrade (see also applyResolvedDeviceAuth).
+        val normalizedExisting = existingBaseUrl?.let(ServerTargetResolver::normalizeServerUrl)
+        val normalizedConfigured = configuredBaseUrl?.let(ServerTargetResolver::normalizeServerUrl)
+        if (normalizedConfigured != null && normalizedConfigured != normalizedExisting) {
             return null
         }
         return sessionAuthToken
@@ -694,7 +698,14 @@ class MainActivity : AppCompatActivity() {
         configuredBaseUrl: String?,
         intent: Intent
     ) {
-        if (configuredBaseUrl != null && configuredBaseUrl != existingBaseUrl) {
+        // Normalize both sides so that default-port differences (e.g. :443 vs stripped)
+        // do not falsely trigger auth-state clearing. This is defensive — callers
+        // already normalize through ServerSettingsStore.getServerUrl() and
+        // ServerTargetResolver.resolveConfiguredBaseUrl(), but this ensures
+        // correctness regardless of caller conventions.
+        val normalizedExisting = existingBaseUrl?.let(ServerTargetResolver::normalizeServerUrl)
+        val normalizedConfigured = configuredBaseUrl?.let(ServerTargetResolver::normalizeServerUrl)
+        if (normalizedConfigured != null && normalizedConfigured != normalizedExisting) {
             Log.i(
                 TAG,
                 "event=device_auth_state_cleared reason=base_url_changed previousBaseUrl=$existingBaseUrl newBaseUrl=$configuredBaseUrl"

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
@@ -13,6 +13,7 @@ import android.view.WindowManager
 import android.webkit.URLUtil
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -128,52 +129,11 @@ class MainActivity : AppCompatActivity() {
         installBackHandler()
         observeNativePlaybackState()
 
-        val existingBaseUrl = serverSettingsStore.getServerUrl()
-        val configuredBaseUrl = ServerTargetResolver.resolveConfiguredBaseUrl(
-            existingBaseUrl = existingBaseUrl,
-            overrideUrl = intent.getStringExtra(ServerTargetResolver.EXTRA_BASE_URL),
-            deepLinkUrl = intent.dataString
+        applyIntentConfiguration(
+            intent = intent,
+            savedInstanceState = savedInstanceState,
+            routeReason = "on_create"
         )
-        applyResolvedDeviceAuth(
-            existingBaseUrl = existingBaseUrl,
-            configuredBaseUrl = configuredBaseUrl,
-            intent = intent
-        )
-        sessionAuthToken = resolveSessionAuthToken(
-            existingBaseUrl = existingBaseUrl,
-            configuredBaseUrl = configuredBaseUrl,
-            intent = intent
-        )
-        if (configuredBaseUrl != null) {
-            serverSettingsStore.saveServerUrl(configuredBaseUrl)
-            val startUrl = ServerTargetResolver.resolveStartUrl(
-                baseUrl = configuredBaseUrl,
-                overrideUrl = intent.getStringExtra(ServerTargetResolver.EXTRA_BASE_URL),
-                deepLinkUrl = intent.dataString
-            )
-            lastRequestedUrl = startUrl
-            if (savedInstanceState == null) {
-                routeInitialDestination(
-                    baseUrl = configuredBaseUrl,
-                    startUrl = startUrl,
-                    reason = "on_create"
-                )
-            } else {
-                lastRequestedUrl = savedInstanceState.getString(STATE_LAST_REQUESTED_URL) ?: startUrl
-                val restoredState = webViewController.restoreState(savedInstanceState)
-                if (restoredState == null || webView.url.isNullOrBlank()) {
-                    routeInitialDestination(
-                        baseUrl = configuredBaseUrl,
-                        startUrl = lastRequestedUrl,
-                        reason = "restore_missing_webview_state"
-                    )
-                } else if (!webViewController.hasCustomView()) {
-                    setUiState(MainUiState.Content)
-                }
-            }
-        } else {
-            showSetupUi()
-        }
     }
 
     private fun observeNativePlaybackState() {
@@ -189,35 +149,11 @@ class MainActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        val existingBaseUrl = serverSettingsStore.getServerUrl()
-        val configuredBaseUrl = ServerTargetResolver.resolveConfiguredBaseUrl(
-            existingBaseUrl = existingBaseUrl,
-            overrideUrl = intent.getStringExtra(ServerTargetResolver.EXTRA_BASE_URL),
-            deepLinkUrl = intent.dataString
+        applyIntentConfiguration(
+            intent = intent,
+            savedInstanceState = null,
+            routeReason = "on_new_intent"
         )
-        applyResolvedDeviceAuth(
-            existingBaseUrl = existingBaseUrl,
-            configuredBaseUrl = configuredBaseUrl,
-            intent = intent
-        )
-        sessionAuthToken = resolveSessionAuthToken(
-            existingBaseUrl = existingBaseUrl,
-            configuredBaseUrl = configuredBaseUrl,
-            intent = intent
-        )
-        if (configuredBaseUrl != null) {
-            serverSettingsStore.saveServerUrl(configuredBaseUrl)
-            val startUrl = ServerTargetResolver.resolveStartUrl(
-                baseUrl = configuredBaseUrl,
-                overrideUrl = intent.getStringExtra(ServerTargetResolver.EXTRA_BASE_URL),
-                deepLinkUrl = intent.dataString
-            )
-            routeInitialDestination(
-                baseUrl = configuredBaseUrl,
-                startUrl = startUrl,
-                reason = "on_new_intent"
-            )
-        }
     }
 
     override fun onResume() {
@@ -783,6 +719,149 @@ class MainActivity : AppCompatActivity() {
             )
         }
         deviceAuthRepository.applyLaunchCredentials(configuredBaseUrl, launchCredentials)
+    }
+
+    private fun applyIntentConfiguration(
+        intent: Intent,
+        savedInstanceState: Bundle?,
+        routeReason: String
+    ) {
+        val existingBaseUrl = serverSettingsStore.getServerUrl()
+        val configuredBaseUrl = ServerTargetResolver.resolveConfiguredBaseUrl(
+            existingBaseUrl = existingBaseUrl,
+            overrideUrl = intent.getStringExtra(ServerTargetResolver.EXTRA_BASE_URL),
+            deepLinkUrl = intent.dataString
+        )
+
+        if (configuredBaseUrl == null) {
+            if (savedInstanceState == null) {
+                showSetupUi()
+            }
+            return
+        }
+
+        if (existingBaseUrl != null &&
+            ServerTargetResolver.isServerSwitch(existingBaseUrl, configuredBaseUrl)
+        ) {
+            Log.i(
+                TAG,
+                "event=server_switch_prompted reason=$routeReason previousBaseUrl=$existingBaseUrl newBaseUrl=$configuredBaseUrl"
+            )
+            promptServerSwitchConfirmation(
+                currentBaseUrl = existingBaseUrl,
+                newBaseUrl = configuredBaseUrl,
+                onAccept = {
+                    Log.i(
+                        TAG,
+                        "event=server_switch_accepted previousBaseUrl=$existingBaseUrl newBaseUrl=$configuredBaseUrl"
+                    )
+                    commitIntentConfiguration(
+                        intent = intent,
+                        savedInstanceState = savedInstanceState,
+                        existingBaseUrl = existingBaseUrl,
+                        configuredBaseUrl = configuredBaseUrl,
+                        routeReason = routeReason
+                    )
+                },
+                onDecline = {
+                    Log.w(
+                        TAG,
+                        "event=server_switch_declined previousBaseUrl=$existingBaseUrl rejectedBaseUrl=$configuredBaseUrl"
+                    )
+                    // Keep existing server; drop all intent-derived auth and start URL.
+                    commitIntentConfiguration(
+                        intent = Intent(),
+                        savedInstanceState = savedInstanceState,
+                        existingBaseUrl = existingBaseUrl,
+                        configuredBaseUrl = existingBaseUrl,
+                        routeReason = "${routeReason}_switch_declined"
+                    )
+                }
+            )
+            return
+        }
+
+        commitIntentConfiguration(
+            intent = intent,
+            savedInstanceState = savedInstanceState,
+            existingBaseUrl = existingBaseUrl,
+            configuredBaseUrl = configuredBaseUrl,
+            routeReason = routeReason
+        )
+    }
+
+    private fun commitIntentConfiguration(
+        intent: Intent,
+        savedInstanceState: Bundle?,
+        existingBaseUrl: String?,
+        configuredBaseUrl: String,
+        routeReason: String
+    ) {
+        applyResolvedDeviceAuth(
+            existingBaseUrl = existingBaseUrl,
+            configuredBaseUrl = configuredBaseUrl,
+            intent = intent
+        )
+        sessionAuthToken = resolveSessionAuthToken(
+            existingBaseUrl = existingBaseUrl,
+            configuredBaseUrl = configuredBaseUrl,
+            intent = intent
+        )
+        serverSettingsStore.saveServerUrl(configuredBaseUrl)
+
+        val startUrl = ServerTargetResolver.resolveStartUrl(
+            baseUrl = configuredBaseUrl,
+            overrideUrl = intent.getStringExtra(ServerTargetResolver.EXTRA_BASE_URL),
+            deepLinkUrl = intent.dataString
+        )
+        lastRequestedUrl = startUrl
+
+        if (savedInstanceState == null) {
+            routeInitialDestination(
+                baseUrl = configuredBaseUrl,
+                startUrl = startUrl,
+                reason = routeReason
+            )
+            return
+        }
+
+        lastRequestedUrl = savedInstanceState.getString(STATE_LAST_REQUESTED_URL) ?: startUrl
+        val restoredState = webViewController.restoreState(savedInstanceState)
+        if (restoredState == null || webView.url.isNullOrBlank()) {
+            routeInitialDestination(
+                baseUrl = configuredBaseUrl,
+                startUrl = lastRequestedUrl,
+                reason = "restore_missing_webview_state"
+            )
+        } else if (!webViewController.hasCustomView()) {
+            setUiState(MainUiState.Content)
+        }
+    }
+
+    private fun promptServerSwitchConfirmation(
+        currentBaseUrl: String,
+        newBaseUrl: String,
+        onAccept: () -> Unit,
+        onDecline: () -> Unit
+    ) {
+        if (isFinishing || isDestroyed) {
+            onDecline()
+            return
+        }
+        AlertDialog.Builder(this)
+            .setTitle(R.string.server_switch_confirm_title)
+            .setMessage(getString(R.string.server_switch_confirm_message, currentBaseUrl, newBaseUrl))
+            .setPositiveButton(R.string.server_switch_confirm_accept) { dialog, _ ->
+                dialog.dismiss()
+                onAccept()
+            }
+            .setNegativeButton(R.string.server_switch_confirm_decline) { dialog, _ ->
+                dialog.dismiss()
+                onDecline()
+            }
+            .setOnCancelListener { onDecline() }
+            .setCancelable(true)
+            .show()
     }
 
     private fun routeInitialDestination(baseUrl: String, startUrl: String, reason: String) {

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/ServerTargetResolver.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/ServerTargetResolver.kt
@@ -180,6 +180,22 @@ internal object ServerTargetResolver {
         ).toString()
     }
 
+    /**
+     * Returns true when applying [configuredBaseUrl] would replace a different,
+     * already-configured server URL. Both inputs are normalized through
+     * [normalizeServerUrl] before comparison so that trailing-slash or default-port
+     * differences do not trigger a spurious switch.
+     *
+     * Used by MainActivity to decide whether to prompt the user before persisting
+     * a base URL derived from an intent extra, https deep link, or xg2g:// custom
+     * scheme. See issue #421.
+     */
+    fun isServerSwitch(existingBaseUrl: String?, configuredBaseUrl: String?): Boolean {
+        val existing = existingBaseUrl?.let(::normalizeServerUrl) ?: return false
+        val configured = configuredBaseUrl?.let(::normalizeServerUrl) ?: return false
+        return existing != configured
+    }
+
     fun isSameOrigin(targetUrl: String, baseUrl: String): Boolean {
         val target = parseUri(targetUrl) ?: return false
         val base = parseUri(baseUrl) ?: return false

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/ServerTargetResolver.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/ServerTargetResolver.kt
@@ -165,7 +165,7 @@ internal object ServerTargetResolver {
         val host = uri.host ?: return null
         val authority = buildString {
             append(host)
-            if (uri.port != -1) {
+            if (uri.port != -1 && !isDefaultPort(scheme, uri.port)) {
                 append(':')
                 append(uri.port)
             }
@@ -178,6 +178,11 @@ internal object ServerTargetResolver {
             null,
             null
         ).toString()
+    }
+
+    private fun isDefaultPort(scheme: String, port: Int): Boolean {
+        return (scheme == "https" && port == 443) ||
+            (scheme == "http" && port == 80)
     }
 
     /**
@@ -221,7 +226,7 @@ internal object ServerTargetResolver {
         val host = uri.host ?: return null
         val authority = buildString {
             append(host)
-            if (uri.port != -1) {
+            if (uri.port != -1 && !isDefaultPort(scheme, uri.port)) {
                 append(':')
                 append(uri.port)
             }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -84,4 +84,8 @@
     <string name="native_playback_status_idle">Waiting for native playback request</string>
     <string name="native_playback_status_error">Playback error: %1$s</string>
     <string name="native_playback_status_active">Playback %1$s</string>
+    <string name="server_switch_confirm_title">Switch xg2g server?</string>
+    <string name="server_switch_confirm_message">A link wants to change your xg2g server from\n\n%1$s\n\nto\n\n%2$s\n\nOnly continue if you initiated this change.</string>
+    <string name="server_switch_confirm_accept">Switch</string>
+    <string name="server_switch_confirm_decline">Keep current</string>
 </resources>

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/DeviceAuthRepositoryTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/DeviceAuthRepositoryTest.kt
@@ -353,6 +353,36 @@ class DeviceAuthRepositoryTest {
         assertEquals("ensure_auth_session", telemetry.events.single().stage)
     }
 
+    @Test
+    fun `matchesServerUrl matches stored URL with explicit default https port`() {
+        val state = PersistedDeviceAuthState(
+            serverUrl = "https://demo.example:443/ui/",
+            deviceGrantId = "dgr-1",
+            deviceGrant = "grant-secret"
+        )
+        assertTrue(state.matchesServerUrl("https://demo.example/ui/"))
+    }
+
+    @Test
+    fun `matchesServerUrl matches stored URL with explicit default http port`() {
+        val state = PersistedDeviceAuthState(
+            serverUrl = "http://demo.example:80/ui/",
+            deviceGrantId = "dgr-1",
+            deviceGrant = "grant-secret"
+        )
+        assertTrue(state.matchesServerUrl("http://demo.example/ui/"))
+    }
+
+    @Test
+    fun `matchesServerUrl rejects stored URL with non-default port`() {
+        val state = PersistedDeviceAuthState(
+            serverUrl = "https://demo.example:8080/ui/",
+            deviceGrantId = "dgr-1",
+            deviceGrant = "grant-secret"
+        )
+        assertFalse(state.matchesServerUrl("https://demo.example/ui/"))
+    }
+
     private fun <T> runSuspend(block: suspend () -> T): T {
         return kotlinx.coroutines.runBlocking { block() }
     }

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/ServerTargetResolverTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/ServerTargetResolverTest.kt
@@ -214,4 +214,38 @@ class ServerTargetResolverTest {
             )
         )
     }
+
+    @Test
+    fun `isServerSwitch returns false when only default port differs`() {
+        assertFalse(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = "https://demo.example/ui/",
+                configuredBaseUrl = "https://demo.example:443/ui/"
+            )
+        )
+        assertFalse(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = "http://demo.example/ui/",
+                configuredBaseUrl = "http://demo.example:80/ui/"
+            )
+        )
+    }
+
+    @Test
+    fun `normalizeServerUrl strips default https port`() {
+        val normalized = ServerTargetResolver.normalizeServerUrl("https://demo.example:443/ui/")
+        assertEquals("https://demo.example/ui/", normalized)
+    }
+
+    @Test
+    fun `normalizeServerUrl strips default http port`() {
+        val normalized = ServerTargetResolver.normalizeServerUrl("http://demo.example:80/")
+        assertEquals("http://demo.example/ui/", normalized)
+    }
+
+    @Test
+    fun `normalizeServerUrl preserves non-default port`() {
+        val normalized = ServerTargetResolver.normalizeServerUrl("https://demo.example:8080/app")
+        assertEquals("https://demo.example:8080/app/", normalized)
+    }
 }

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/ServerTargetResolverTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/ServerTargetResolverTest.kt
@@ -164,4 +164,54 @@ class ServerTargetResolverTest {
 
         assertNull(resolved)
     }
+
+    @Test
+    fun `isServerSwitch returns false when no existing server is configured`() {
+        assertFalse(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = null,
+                configuredBaseUrl = "https://tv.example/ui/"
+            )
+        )
+    }
+
+    @Test
+    fun `isServerSwitch returns false when normalized URLs match`() {
+        assertFalse(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = "https://tv.example/ui",
+                configuredBaseUrl = "https://tv.example/ui/"
+            )
+        )
+    }
+
+    @Test
+    fun `isServerSwitch returns true when host differs`() {
+        assertTrue(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = "https://real.example/ui/",
+                configuredBaseUrl = "https://attacker.example/ui/"
+            )
+        )
+    }
+
+    @Test
+    fun `isServerSwitch returns true when scheme differs`() {
+        assertTrue(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = "https://demo.example/ui/",
+                configuredBaseUrl = "http://demo.example/ui/"
+            )
+        )
+    }
+
+    @Test
+    fun `isServerSwitch returns false when configured base url is null`() {
+        assertFalse(
+            ServerTargetResolver.isServerSwitch(
+                existingBaseUrl = "https://demo.example/ui/",
+                configuredBaseUrl = null
+            )
+        )
+    }
 }


### PR DESCRIPTION
## Summary
Implements **Option A** from #421: when an intent (xg2g:// deep link, https deep link, or `--es base_url` extra) wants to switch the persisted xg2g server URL to a different value, prompt the user before committing the change. First-time onboarding (no existing server configured) is unaffected.

Closes #421.

## Why dialog for all three intent surfaces
The original report flagged the `xg2g://connect` deep link as the primary attack surface, but `EXTRA_BASE_URL` and the https deep link reach the same persistence path. A dialog that only protects one of them leaves a bypass via `adb am start --es base_url …`, which any app holding `INSTALL_PACKAGES` (or a USB-attached host) can trigger. Routing all three through the same helper closes that gap without adding a Dev-only backdoor; devs who genuinely want to bypass the prompt can `adb shell pm clear` first.

## Change shape
- `ServerTargetResolver.isServerSwitch(existing, configured)` — pure predicate, both inputs normalized via the existing `normalizeServerUrl` so trailing-slash / scheme nuances do not trigger spurious prompts.
- `MainActivity.applyIntentConfiguration` / `commitIntentConfiguration` — onCreate + onNewIntent now share a single code path. On decline, the configuration is rebuilt against an empty `Intent`, so the rejected base URL, `auth_token`, and `device_grant_*` parameters all drop while the existing server and any prior session state are preserved.
- `AlertDialog` from `androidx.appcompat.app` — no new deps, keyboard / D-pad navigable on TV. `setOnCancelListener` falls through to the decline path for back-button presses.
- Strings added: `server_switch_confirm_title`, `server_switch_confirm_message`, `server_switch_confirm_accept`, `server_switch_confirm_decline`.

## Test plan
- [x] `./gradlew :app:testDevDebugUnitTest` — 80 tests, 0 failures (5 new tests for `isServerSwitch`)
- [x] `./gradlew :app:lintDevDebug` — clean (same warnings as before, no new errors)
- [ ] Manual TV-onboarding (existingBaseUrl == null): `adb shell am start … --es base_url …` → loads directly, no prompt
- [ ] Manual hijack scenario: configure a real server, then `adb shell am start -a android.intent.action.VIEW -d 'xg2g://connect?base_url=https%3A%2F%2Fattacker.example%2Fui%2F&launch_access_token=PWNED'` → dialog appears; declining keeps the original server and drops the token
- [ ] D-pad navigation through dialog buttons on Android TV

## Out-of-scope (still tracked under #421)
- prod flavor `deepLinkHost = "xg2g.example.invalid"` (App Links autoVerify always fails)
- Scheme drift: server emits `xg2g://pair?…`, Android only handles `xg2g://connect?…`