### PR TITLE
webui: scrollbar polish, lazy images, route prefetch

### DIFF
--- a/frontend/webui/src/components/Navigation.tsx
+++ b/frontend/webui/src/components/Navigation.tsx
@@ -8,6 +8,7 @@ import { resolveHostEnvironment } from '../lib/hostBridge';
 import { resolveAppRouteContext } from '../lib/routeContext';
 import type { UiScale } from '../lib/uiScale';
 import { ROUTE_MAP, normalizePathname, type AppView } from '../routes';
+import { prefetchRoute } from '../routePrefetch';
 import styles from './Navigation.module.css';
 
 type NavSection = 'quick' | 'main' | 'footer';
@@ -342,6 +343,9 @@ export default function Navigation({ onLogout }: NavigationProps) {
       key={`${appearance}-${item.id}`}
       to={ROUTE_MAP[item.id]}
       onClick={(event) => { void handleNavItemClick(event, ROUTE_MAP[item.id], appearance); }}
+      onMouseEnter={() => prefetchRoute(item.id)}
+      onFocus={() => prefetchRoute(item.id)}
+      onTouchStart={() => prefetchRoute(item.id)}
       className={[
         styles.navItem,
         appearance === 'mobile' ? styles.mobileItem : null,

--- a/frontend/webui/src/components/Recordings.module.css
+++ b/frontend/webui/src/components/Recordings.module.css
@@ -310,6 +310,8 @@
 .recordingCard {
   position: relative;
   overflow: hidden;
+  content-visibility: auto;
+  contain-intrinsic-size: 0 320px;
 }
 
 .recordingCardFeatured .itemName {

--- a/frontend/webui/src/components/Recordings.module.css
+++ b/frontend/webui/src/components/Recordings.module.css
@@ -273,8 +273,27 @@
   grid-auto-columns: minmax(320px, 380px);
   overflow-x: auto;
   overscroll-behavior-x: contain;
-  padding-bottom: 6px;
+  padding-bottom: 10px;
   scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--accent-action) 45%, transparent) transparent;
+  scrollbar-gutter: stable;
+}
+
+.resumeShelf::-webkit-scrollbar {
+  height: 4px;
+}
+
+.resumeShelf::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.resumeShelf::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent-action) 45%, transparent);
+  border-radius: 4px;
+}
+
+.resumeShelf::-webkit-scrollbar-thumb:hover {
+  background: var(--accent-action-hover);
 }
 
 .grid {

--- a/frontend/webui/src/components/RecordingsList.tsx
+++ b/frontend/webui/src/components/RecordingsList.tsx
@@ -284,6 +284,8 @@ function RecordingPreviewArtwork({ recording, authToken }: { recording: Recordin
           data-testid="recording-thumbnail"
           src={resolvedThumbnailUrl}
           alt=""
+          loading="lazy"
+          decoding="async"
           draggable={false}
         />
       ) : null}

--- a/frontend/webui/src/features/epg/EPG.module.css
+++ b/frontend/webui/src/features/epg/EPG.module.css
@@ -392,6 +392,8 @@
   margin-bottom: 18px;
   padding-bottom: 18px;
   border-bottom: 1px solid var(--border-base);
+  content-visibility: auto;
+  contain-intrinsic-size: 0 104px;
 }
 
 .channelPlayable {

--- a/frontend/webui/src/features/epg/components/EpgChannelList.tsx
+++ b/frontend/webui/src/features/epg/components/EpgChannelList.tsx
@@ -308,6 +308,8 @@ function ChannelHeader({
           <img
             src={logo}
             alt={displayName}
+            loading="lazy"
+            decoding="async"
             onError={() => setImageFailed(true)}
           />
         ) : (

--- a/frontend/webui/src/features/player/components/V3Player.module.css
+++ b/frontend/webui/src/features/player/components/V3Player.module.css
@@ -675,6 +675,25 @@
   word-break: break-all;
   max-height: 200px;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, #ffffff 35%, transparent) transparent;
+}
+
+.errorDetailsContent::-webkit-scrollbar {
+  width: 4px;
+}
+
+.errorDetailsContent::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.errorDetailsContent::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, #ffffff 35%, transparent);
+  border-radius: 4px;
+}
+
+.errorDetailsContent::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, #ffffff 65%, transparent);
 }
 
 .errorDetailsPre {
@@ -2083,6 +2102,26 @@
   -webkit-overflow-scrolling: touch;
   touch-action: pan-y;
   padding-top: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, #ffffff 35%, transparent) transparent;
+  scrollbar-gutter: stable;
+}
+
+.container.surfaceTight .controlsHeader::-webkit-scrollbar {
+  width: 4px;
+}
+
+.container.surfaceTight .controlsHeader::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.container.surfaceTight .controlsHeader::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, #ffffff 35%, transparent);
+  border-radius: 4px;
+}
+
+.container.surfaceTight .controlsHeader::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, #ffffff 65%, transparent);
 }
 
 .container.surfaceTight .vodControls,

--- a/frontend/webui/src/features/player/components/V3Player.module.css
+++ b/frontend/webui/src/features/player/components/V3Player.module.css
@@ -676,7 +676,7 @@
   max-height: 200px;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, #ffffff 35%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-primary) 35%, transparent) transparent;
 }
 
 .errorDetailsContent::-webkit-scrollbar {
@@ -688,12 +688,12 @@
 }
 
 .errorDetailsContent::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, #ffffff 35%, transparent);
+  background: color-mix(in srgb, var(--text-primary) 35%, transparent);
   border-radius: 4px;
 }
 
 .errorDetailsContent::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, #ffffff 65%, transparent);
+  background: color-mix(in srgb, var(--text-primary) 65%, transparent);
 }
 
 .errorDetailsPre {
@@ -2103,7 +2103,7 @@
   touch-action: pan-y;
   padding-top: 12px;
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, #ffffff 35%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--text-primary) 35%, transparent) transparent;
   scrollbar-gutter: stable;
 }
 
@@ -2116,12 +2116,12 @@
 }
 
 .container.surfaceTight .controlsHeader::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, #ffffff 35%, transparent);
+  background: color-mix(in srgb, var(--text-primary) 35%, transparent);
   border-radius: 4px;
 }
 
 .container.surfaceTight .controlsHeader::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, #ffffff 65%, transparent);
+  background: color-mix(in srgb, var(--text-primary) 65%, transparent);
 }
 
 .container.surfaceTight .vodControls,

--- a/frontend/webui/src/index.css
+++ b/frontend/webui/src/index.css
@@ -445,24 +445,45 @@ a:hover {
 }
 
 /* Custom Scrollbar */
+:root {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--accent-action) 55%, transparent) transparent;
+}
+
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--bg-input);
-  border-radius: 10px;
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--accent-action);
-  border-radius: 10px;
-  border: 2px solid var(--bg-input);
+  background: color-mix(in srgb, var(--accent-action) 55%, transparent);
+  border-radius: 8px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--accent-action-hover);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    scrollbar-color: var(--accent-action) var(--bg-input);
+  }
+
+  ::-webkit-scrollbar-track {
+    background: var(--bg-input);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: var(--accent-action);
+  }
 }
 
 /* Hide scrollbar (utility) */

--- a/frontend/webui/src/routePrefetch.ts
+++ b/frontend/webui/src/routePrefetch.ts
@@ -1,0 +1,23 @@
+import type { AppView } from './routes';
+
+const prefetchMap: Record<AppView, () => Promise<unknown>> = {
+  dashboard: () => import('./components/Dashboard'),
+  epg: () => import('./features/epg/EPG'),
+  timers: () => import('./features/epg/EPG'),
+  recordings: () => import('./components/RecordingsList'),
+  series: () => import('./components/RecordingsList'),
+  files: () => import('./components/Settings'),
+  logs: () => import('./components/Settings'),
+  settings: () => import('./components/Settings'),
+  system: () => import('./features/system/SystemInfo'),
+};
+
+const prefetched = new Set<AppView>();
+
+export function prefetchRoute(view: AppView): void {
+  if (prefetched.has(view)) return;
+  prefetched.add(view);
+  prefetchMap[view]().catch(() => {
+    prefetched.delete(view);
+  });
+}


### PR DESCRIPTION
## Summary

Three focused WebUI passes, each landed as its own commit so the PR can be split or rolled back surgically.

- **`959b0ee0` style: scrollbar styling refinement**
  Global scrollbar shrinks from 10 px solid-accent to 8 px half-transparent thumb on transparent track. The Recordings resume shelf and the player's `surfaceTight` controls header / error details box get dedicated overlay overrides so the accent-coloured scrollbar no longer breaks the video chrome. `scrollbar-gutter: stable` on the shelf and tight player header prevents layout jumps when the scrollbar appears. `prefers-contrast: more` falls back to solid accent on filled track for accessibility.

- **`bd6ca4bd` a11y: lazy-load list images**
  `loading="lazy"` + `decoding="async"` on the channel logos in `EpgChannelList` and the recording thumbnails in `RecordingsList`. Both render in long scrolling lists where eager image loading delays initial paint and wastes bandwidth on offscreen rows.
  Note: the original commit on `integration/v3.4.9-lxc110` also added `aria-label` to the LIVE/DVR buttons in `V3Player.tsx`, but `origin/main` already covers that via the `V3PlayerView` refactor at `V3PlayerView.tsx:232` — that portion was dropped on rebase.

- **`776ca7ef` perf: prefetch lazy routes on hover, skip offscreen list render**
  Small `prefetchRoute` helper maps every nav view onto its dynamic `import()`; `Navigation.tsx` invokes it via `onMouseEnter`, `onFocus`, and `onTouchStart`. Lazy-loaded routes start fetching before the click lands, eliminating the Suspense spinner flash on every navigation. `content-visibility: auto` with conservative `contain-intrinsic-size` is added to `.recordingCard` and `.channel` so the browser skips render+layout for items outside the scroll viewport. `scrollIntoView` and focus traversal continue to work because the UA materializes a `content-visibility: auto` element on demand.

## Test plan

- [ ] Open the app in a narrow viewport; verify the player's `surfaceTight` mobile controls header does not horizontally jump when its 4 px scrollbar appears.
- [ ] Confirm the Recordings resume shelf shows a thin overlay scrollbar (~4 px) and that bottom card content is not overlapped by it.
- [ ] Toggle OS-level High Contrast; verify the scrollbar track + thumb become solid (accent / `--bg-input`).
- [ ] Open `/recordings` with a large library; confirm thumbnails below the fold are not requested until scrolled near.
- [ ] Open `/epg`; confirm channel logos load lazily.
- [ ] Hover (or tab) over the nav items for `Dashboard`, `EPG`, `Recordings`, `Settings`, `System`; watch the network tab — the route chunk should be requested before the click.
- [ ] Scroll a long Recordings library; verify `content-visibility: auto` is in effect via DevTools (offscreen `.recordingCard` should have `contain-intrinsic-size` measured rendering) and that `scrollIntoView`-based jumps still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)