### PR TITLE
fix(ci): install ripgrep on CI Nightly runner and add grep fallback

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -66,6 +66,17 @@ jobs:
           fi
           ffmpeg -version
 
+      - name: Install ripgrep
+        run: |
+          set -euo pipefail
+          if command -v rg >/dev/null 2>&1; then
+            echo "rg already installed on runner"
+          else
+            sudo apt-get update
+            sudo apt-get install -y ripgrep
+          fi
+          rg --version
+
       - name: Run nightly gates
         run: make ci-nightly
 

--- a/frontend/webui/scripts/verify-no-hls-startup-policy-client-usage.sh
+++ b/frontend/webui/scripts/verify-no-hls-startup-policy-client-usage.sh
@@ -7,8 +7,13 @@ cd "$ROOT_DIR"
 PATTERN='\b(startupMode|startupHeadroomSec|startupReasons)\b'
 ALLOW_TAG='xg2g:allow-startup-policy-debug'
 
-if ! command -v rg >/dev/null 2>&1; then
-  echo "❌ rg is required for verify-no-hls-startup-policy-client-usage.sh"
+if command -v rg >/dev/null 2>&1; then
+  SEARCH_TOOL="rg"
+elif command -v grep >/dev/null 2>&1; then
+  echo "⚠️  rg not found; falling back to grep -rnE"
+  SEARCH_TOOL="grep"
+else
+  echo "❌ Neither rg nor grep found; cannot proceed."
   exit 1
 fi
 
@@ -26,7 +31,11 @@ if [ "${#scan_targets[@]}" -eq 0 ]; then
   exit 0
 fi
 
-matches="$(rg -n -- "$PATTERN" "${scan_targets[@]}" || true)"
+if [ "$SEARCH_TOOL" = "rg" ]; then
+  matches="$(rg -n -- "$PATTERN" "${scan_targets[@]}" || true)"
+else
+  matches="$(grep -rnE -- "$PATTERN" "${scan_targets[@]}" || true)"
+fi
 
 if [ -z "$matches" ]; then
   echo "✅ HLS startup policy debug fields are not used in product WebUI code."


### PR DESCRIPTION
## Root cause

The ubuntu-24.04 runner image (20260513.135.3) lacks `rg` (ripgrep), causing `verify-no-hls-startup-policy-client-usage.sh` to fail hard:

```
❌ rg is required for verify-no-hls-startup-policy-client-usage.sh
make: *** [mk/verify.mk:91: gate-webui] Error 1
```

## Fix

1. **Install ripgrep in the CI workflow** — Added an install step in `ci-v2.yml` right after the existing ffmpeg install, using `sudo apt-get install ripgrep`.
2. **Add grep fallback** — The script now falls back to `grep -rnE` when `rg` is unavailable, improving robustness.

## Verification

- All Go backend tests pass: `oc-xg2g-verify /root/xg2g-ci-deep`

Fixes: #430