### PR TITLE
fix(ci): exclude package-main binaries from test-cover -coverpkg

### DIFF
--- a/mk/quality.mk
+++ b/mk/quality.mk
@@ -43,7 +43,10 @@ test-race: ## Run tests with race detection
 test-cover: ## Run tests with coverage reporting
 	@echo "Running tests with coverage..."
 	@mkdir -p $(ARTIFACTS_DIR)
-	@cd $(BACKEND_DIR) && $(RESOLVE_GO_BIN_SH) && GOTOOLCHAIN=local "$$GO_BIN" test -count=1 -timeout=$(GO_TEST_COVER_TIMEOUT) -covermode=atomic -coverprofile=../$(ARTIFACTS_DIR)/coverage.out -coverpkg=./... ./...
+	@cd $(BACKEND_DIR) && $(RESOLVE_GO_BIN_SH) && \
+	  COVERPKG="$$(GOTOOLCHAIN=local "$$GO_BIN" list ./internal/... ./test/... 2>/dev/null | paste -sd, -)"; \
+	  if [ -z "$$COVERPKG" ]; then COVERPKG="./internal/..."; fi; \
+	  GOTOOLCHAIN=local "$$GO_BIN" test -count=1 -timeout=$(GO_TEST_COVER_TIMEOUT) -covermode=atomic -coverprofile=../$(ARTIFACTS_DIR)/coverage.out -coverpkg="$$COVERPKG" ./...
 	@$(RESOLVE_GO_BIN_SH) && GOTOOLCHAIN=local "$$GO_BIN" tool cover -html=$(ARTIFACTS_DIR)/coverage.out -o $(ARTIFACTS_DIR)/coverage.html
 	@echo "Coverage report generated: $(ARTIFACTS_DIR)/coverage.html"
 	@$(RESOLVE_GO_BIN_SH) && GOTOOLCHAIN=local "$$GO_BIN" tool cover -func=$(ARTIFACTS_DIR)/coverage.out | tail -1


### PR DESCRIPTION
## Summary

- CI Nightly (`ci-v2.yml` → `make ci-nightly` → `quality-gates-online` → `test-cover`) has been failing every night for **20+ consecutive days** (since at least 2026-04-28) with:
  ```
  cover: no required module provides package github.com/ManuGH/xg2g/cmd/configgen
  make: *** [mk/quality.mk:47: test-cover] Error 2
  ```
- Root cause: `-coverpkg=./...` instruments `package main` binaries (`cmd/configgen`, `cmd/tools/verify-bin`, `cmd/gencert`, `cmd/generate-capability-fixtures`, `scripts/`, `tools/`). Their entries land in `coverage.out`; `go tool cover -html` then runs from the repo root (no `cd backend`) and fails to resolve those module paths.
- Fix: build `-coverpkg` dynamically from `go list ./internal/... ./test/...`, robust against missing `./test/...` (falls back to `./internal/...`). One file, four-line diff in `mk/quality.mk`.

## Expected Coverage Drift

`cmd/...` packages with their own unit tests drop out of the aggregated coverpkg scope:

| Package | Drop-out contribution |
|---|---|
| `cmd/daemon` | 6.8% local statements |
| `cmd/v3probe` | 0.4% |
| `cmd/validate` | 0.1% |
| `cmd/xg2g-soak` | 0.1% |

Their unit tests still run via `./...` — only their cross-package coverage contribution to the aggregated `total:` line is removed. Repo `COVERAGE_MIN` thresholds may need a small downward adjustment if they were calibrated to the broken-but-formerly-passing baseline; the threshold gate is at `.github/workflows/coverage.yml`, currently using `vars.COVERAGE_MIN`.

## Out of Scope

- **CI Nightly / CI Deep Scheduled consolidation** (commit `95fe5739` started this). `ci-v2.yml`, the nightly failure alert job, and the issue routing are intentionally left unchanged. That consolidation needs a gate-mapping table (`ci-v2.yml` job → `ci-deep-scheduled.yml` replacement OR deliberately dropped) and belongs in a separate PR.

## Local Verification Limitation

The maintainer host's Go 1.25.9 toolchain ships without the `covdata` binary (source-only in `pkg/tool/linux_amd64/`), so `make test-cover` locally emits `go: no such tool "covdata"`. CI runners install a complete SDK via `setup-go`, so this is not a CI concern. What is verified locally:

- `go list ./internal/... ./test/...` produces a valid coverpkg list.
- Build annotations `# github.com/ManuGH/xg2g/cmd/...`, `# .../scripts`, `# .../tools` no longer appear in test output after the change (verified diff of pre-/post-fix logs).

Final verification of the actual CI failure mode will land via the PR's own CI run.

## Test plan

- [ ] PR CI passes on this branch (`Go Coverage Report` / `coverage.yml` is the canary — it uses the same broken-pre-fix command directly and should remain green since the `coverage.yml` invocation is in `cd backend` context).
- [ ] Next CI Nightly schedule (`ci-v2.yml`, cron `17 2 * * *` UTC) reaches `test-cover` step green.
- [ ] Coverage threshold gate in `coverage.yml` does not trip on the slightly lower `total:` number (recheck `COVERAGE_MIN` if alert fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)