### PR TITLE
docs: rename docs/SECURITY.md to docs/SCANNER_GOVERNANCE.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,5 +35,5 @@ Please include:
 ## Security References
 
 - [Security invariants](docs/ops/SECURITY.md)
-- [Security and trust boundaries](docs/SECURITY.md)
+- [Scanner signal governance](docs/SCANNER_GOVERNANCE.md)
 - [Observability](docs/ops/OBSERVABILITY.md)

--- a/docs/ADR/002-config-precedence.md
+++ b/docs/ADR/002-config-precedence.md
@@ -31,6 +31,6 @@ We need deterministic, reviewable runtime behavior.
 
 ## References (Docs / Code)
 
-- Normative contract: `docs/SECURITY.md`, `docs/ops/CONTRACT_INVARIANTS.md`
+- Normative contract: `docs/SCANNER_GOVERNANCE.md`, `docs/ops/CONTRACT_INVARIANTS.md`
 - Env reading and snapshot build: `internal/config`
 - CI tripwire: `.github/workflows/lint.yml`

--- a/docs/HERMETICITY.md
+++ b/docs/HERMETICITY.md
@@ -225,7 +225,7 @@ This guarantee is **mechanically enforced**, not manually maintained:
 The hermetic build process is the foundation for our security trust model.
 By proving that our tools and code-generation paths are immutable and
 deterministic, we can safely optimize scanner signal for handwritten code.
-See [SECURITY.md](./SECURITY.md) for details on signal
+See [SCANNER_GOVERNANCE.md](./SCANNER_GOVERNANCE.md) for details on signal
 governance and generated code trust.
 
 ---

--- a/docs/SCANNER_GOVERNANCE.md
+++ b/docs/SCANNER_GOVERNANCE.md
@@ -1,6 +1,4 @@
-# Security & Trust Boundaries
-
-## Scanner Signal Governance
+# Scanner Signal Governance
 
 The scanner configuration is tuned to keep findings actionable while excluding
 immutable, machine-generated artifacts that cannot be fixed safely by hand.


### PR DESCRIPTION
## Summary

- `docs/SECURITY.md` is internal scanner-signal-governance documentation (gosec exclusions, generated-code trust, `#nosec` policy), not the public security policy.
- Three `SECURITY.md` files coexisted with overlapping names but different scopes:
  - `/SECURITY.md` — public reporting policy (untouched)
  - `/docs/SECURITY.md` — scanner signal governance (this rename)
  - `/docs/ops/SECURITY.md` — security operations runbook (untouched)
- Rename clarifies the file's actual scope and removes the visual clash with the public policy.

## Changes

- `git mv docs/SECURITY.md docs/SCANNER_GOVERNANCE.md`.
- Drop the redundant `# Security & Trust Boundaries` H1 — the file's only H2 (`## Scanner Signal Governance`) was the *de facto* file title; promote it.
- Three inbound link updates:
  - `/SECURITY.md:38` — label and target.
  - `/docs/ADR/002-config-precedence.md:34` — code-fence reference.
  - `/docs/HERMETICITY.md:228` — relative link inside `docs/`.

## Out of Scope

- `/SECURITY.md` and `/docs/ops/SECURITY.md` remain untouched.
- The relative link `[Security Operations](SECURITY.md)` in `docs/ops/README.md` resolves to `docs/ops/SECURITY.md` (sibling), not the renamed file — intentionally left alone.

## Test plan

- [ ] PR CI passes (`Docs Drift`, `Repo Hygiene` gates).
- [ ] No grep hit for `docs/SECURITY.md` or relative `./SECURITY.md` from `docs/HERMETICITY.md` remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)