### PR TITLE
chore(templates): translate coverage_improvement.md issue template to English

### DIFF
--- a/.github/ISSUE_TEMPLATE/coverage_improvement.md
+++ b/.github/ISSUE_TEMPLATE/coverage_improvement.md
@@ -1,10 +1,14 @@
 ---
 name: "Coverage Improvement"
-about: "Gezielte Testabdeckung für eine Komponente erhöhen"
+about: "Increase targeted test coverage for a component"
 labels: ["coverage-improvement", "testing"]
 ---
 
-## Komponente
+> **Note**: This project follows an English-only policy.
+> Please write your issue in English to ensure it can be understood by all
+> contributors.
+
+## Component
 
 - [ ] api
 - [ ] proxy
@@ -13,53 +17,53 @@ labels: ["coverage-improvement", "testing"]
 - [ ] playlist
 - [ ] owi
 
-## Ist-/Soll-Coverage
+## Current / Target Coverage
 
-- **Ist:** <!-- z.B. 64.4% -->
-- **Ziel (PR):** <!-- z.B. +3..8 %-Pkt. oder API ≥70% -->
+- **Current:** <!-- e.g. 64.4% -->
+- **Target (PR):** <!-- e.g. +3..8 pp, or API ≥70% -->
 
-## Maßnahmen (ankreuzen)
+## Approach (check all that apply)
 
-- [ ] Interfaces extrahieren / Abhängigkeiten invertieren
-- [ ] Table-driven Tests für Handler
-- [ ] Circuit-Breaker State-Tests
-- [ ] Fake-FFmpeg / Fake-Prober
-- [ ] Fehlerpfade (Timeout, Exit≠0, leere Streams)
-- [ ] Contract-Test gegen Mock-OWI (CI-only)
-- [ ] I/O-Abstraktion (`io.Reader`/`io.Writer`)
-- [ ] Chaos-nahe Tests (Latenz, Upstream-Fehler)
+- [ ] Extract interfaces / invert dependencies
+- [ ] Table-driven tests for handlers
+- [ ] Circuit-breaker state tests
+- [ ] Fake FFmpeg / fake prober
+- [ ] Error paths (timeout, non-zero exit, empty streams)
+- [ ] Contract test against mock OpenWebIF (CI-only)
+- [ ] I/O abstraction (`io.Reader` / `io.Writer`)
+- [ ] Chaos-style tests (latency, upstream failure)
 
-## Test-Flags
+## Test Flags
 
-- [ ] unittests
+- [ ] unit tests
 - [ ] integration
 - [ ] contract
 
-## Abnahmekriterien
+## Acceptance Criteria
 
-- [ ] Patch ≥90%
-- [ ] Komponente +X %-Pkt.
-- [ ] Flaky-Rate <5%
-- [ ] CI-Zeit nicht erhöht (oder begründet)
-- [ ] Tests sind deterministisch (keine Sleeps)
+- [ ] Patch coverage ≥90%
+- [ ] Component coverage +X pp
+- [ ] Flaky rate <5%
+- [ ] CI time not increased (or justified)
+- [ ] Tests are deterministic (no sleeps)
 
-## Referenz
+## References
 
 - [Coverage workflow](../workflows/coverage.yml)
 - [CI Failure Playbook](../../docs/ops/CI_FAILURE_PLAYBOOK.md)
 
-## Implementierungsplan
+## Implementation Plan
 
-<!-- Beschreibe die konkreten Schritte: -->
+<!-- Describe the concrete steps: -->
 1.
 2.
 3.
 
 ## Definition of Done
 
-- [ ] Tests geschrieben und lokal erfolgreich
-- [ ] Coverage-Ziel erreicht (lokal mit `go tool cover`)
-- [ ] CI passing (alle Checks grün)
-- [ ] Codecov Patch Coverage ≥90%
-- [ ] Keine Flaky Tests (3x lokal ohne Fehler)
-- [ ] Code-Review approved
+- [ ] Tests written and passing locally
+- [ ] Coverage target reached (locally with `go tool cover`)
+- [ ] CI passing (all checks green)
+- [ ] Codecov patch coverage ≥90%
+- [ ] No flaky tests (3x locally without failure)
+- [ ] Code review approved


### PR DESCRIPTION
## Summary

- The other three issue templates (`bug_report.md`, `feature_request.md`, `tech_review.md`) carry an explicit "this project follows an English-only policy" note.
- `coverage_improvement.md` was the only German-language template — "Komponente", "Maßnahmen", "Abnahmekriterien", "Definition of Done" section bodies, etc.
- This silently broke the policy for external contributors arriving via "New issue → Coverage Improvement" and raised the barrier for non-German speakers.

## Changes

Translation preserves structure and section semantics:

| German | English |
| --- | --- |
| Komponente | Component |
| Ist-/Soll-Coverage | Current / Target Coverage |
| Maßnahmen | Approach (check all that apply) |
| Test-Flags | Test Flags |
| Abnahmekriterien | Acceptance Criteria |
| Referenz | References |
| Implementierungsplan | Implementation Plan |
| Definition of Done | Definition of Done (unchanged) |

Added the same English-only policy preamble used by the other three templates for consistency.

Labels (`coverage-improvement`, `testing`) and form-config metadata are unchanged. Internal links (`../workflows/coverage.yml`, `../../docs/ops/CI_FAILURE_PLAYBOOK.md`) remain valid — targets are not renamed in this change.

## Test plan

- [ ] PR CI passes — only a template file change, no code paths affected.
- [ ] Manual visual check via "New issue → Coverage Improvement" picks up the English version on the next render (will land after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)