### PR TITLE
ci(security): run gitleaks on every push and PR

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -16,24 +16,6 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  secrets-scan:
-    name: Scan for Secrets (Gitleaks)
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # Latest stable
-        with:
-          fetch-depth: 0 # Full history for Gitleaks
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   scan-production-image:
     name: Scan Production Container (Pure Go)
     runs-on: ubuntu-24.04

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,6 +23,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      pull-requests: write
       security-events: write
     steps:
       - name: Checkout code

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,36 @@
+name: Security - Gitleaks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1" # weekly Monday
+
+concurrency:
+  group: repo-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Scan for Secrets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # Latest stable
+        with:
+          fetch-depth: 0 # Full history required
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,13 @@ repos:
       - id: go-mod-tidy
         name: Tidy Go modules
 
+  # Secret scanning (defense in depth — CI also runs gitleaks)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        name: Detect hardcoded secrets
+
   # Generic file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
## What

Move the gitleaks job out of `container-security.yml` into a dedicated workflow that runs on:

- `push` to any branch
- `pull_request` against `main`
- weekly schedule (Monday 04:23 UTC)
- manual dispatch

Plus add gitleaks as a `pre-commit` hook so secrets get caught locally before they hit the remote.

## Why

`container-security.yml` only fires on release tags (`v*.*.*`), so a leaked token in a feature branch wouldn't be detected until somebody cut a release — by which point it's long since in history. Secret-scanning needs to happen *before* publish, not at release time.

## Notes

- Action pin (`gitleaks/gitleaks-action@ff98106...`) is unchanged from the previous job — same SHA, same version (v2.3.9).
- `container-security.yml` keeps its container/trivy/sbom jobs, which is what its name actually implies.
- Pre-commit hook pinned to `v8.30.1`. Defense in depth; CI is still authoritative.

## Test plan

- [ ] CI green on this PR (gitleaks job runs and passes)
- [ ] Workflow shows up under Actions tab
- [ ] No regression on existing security workflows