### PR TITLE
Security: central request-body size backstop + prove PIN-unlock throttle

### DIFF
--- a/backend/internal/api/server_routes_wiring.go
+++ b/backend/internal/api/server_routes_wiring.go
@@ -51,6 +51,8 @@ func (s *Server) newRouter() chi.Router {
 		RateLimitGlobalRPS: s.cfg.RateLimitGlobal,
 		RateLimitBurst:     s.cfg.RateLimitBurst,
 		RateLimitWhitelist: s.cfg.RateLimitWhitelist,
+
+		MaxRequestBodyBytes: middleware.DefaultMaxRequestBodyBytes,
 	})
 	return r
 }

--- a/backend/internal/control/http/v3/exposure_security_test.go
+++ b/backend/internal/control/http/v3/exposure_security_test.go
@@ -55,6 +55,48 @@ func TestExposureSecurityMiddlewareRateLimitsSensitiveClasses(t *testing.T) {
 	}
 }
 
+// TestExposureSecurityMiddlewareThrottlesHouseholdPINUnlock proves the PIN
+// unlock endpoint is brute-force throttled by default: PostHouseholdUnlock
+// carries the dedicated "auth" rate-limit class, and the middleware blocks once
+// the configured per-IP attempt budget is spent. This is the load-bearing proof
+// that the guardrail fires (the throttle existed but was previously unproven).
+func TestExposureSecurityMiddlewareThrottlesHouseholdPINUnlock(t *testing.T) {
+	srv := NewServer(config.AppConfig{
+		RateLimitEnabled: true,
+		RateLimitAuth:    2,
+	}, nil, nil)
+	policy, ok := authz.ExposurePolicyForOperation("PostHouseholdUnlock")
+	if !ok {
+		t.Fatal("missing PostHouseholdUnlock exposure policy")
+	}
+	if policy.RateLimitClass != authz.ExposureRateLimitAuth {
+		t.Fatalf("PostHouseholdUnlock rate-limit class = %q, want %q", policy.RateLimitClass, authz.ExposureRateLimitAuth)
+	}
+
+	handler := srv.ExposureSecurityMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for i := 0; i < 2; i++ {
+		req := exposureRequest("PostHouseholdUnlock", policy)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("attempt %d status = %d, want %d (throttled too early)", i, w.Code, http.StatusNoContent)
+		}
+	}
+
+	req := exposureRequest("PostHouseholdUnlock", policy)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("PIN unlock not throttled after budget: status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if got := w.Header().Get("X-RateLimit-Class"); got != string(authz.ExposureRateLimitAuth) {
+		t.Fatalf("rate-limit class header = %q, want %q", got, string(authz.ExposureRateLimitAuth))
+	}
+}
+
 func exposureRequest(operationID string, policy authz.ExposurePolicy) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/api/v3/pairing/start", nil)
 	req.RemoteAddr = "203.0.113.10:55000"

--- a/backend/internal/control/middleware/bodylimit.go
+++ b/backend/internal/control/middleware/bodylimit.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package middleware
+
+import "net/http"
+
+// DefaultMaxRequestBodyBytes is the canonical ceiling for inbound request
+// bodies on the control API. It is a backstop, not a tight quota: every real
+// control payload (config blobs, EPG service lists, intents) is far smaller, so
+// the cap only trips on abusive or runaway requests. Endpoints that need a
+// tighter bound (e.g. /intents) wrap their own MaxBytesReader inside this one.
+const DefaultMaxRequestBodyBytes int64 = 4 << 20 // 4 MiB
+
+// MaxBodyBytes caps the size of inbound request bodies to limit bytes. It wraps
+// r.Body with http.MaxBytesReader so that any handler reading past the ceiling
+// fails its decode instead of buffering unbounded input — bounding memory use
+// across every endpoint without per-handler wiring. A limit <= 0 disables the
+// cap (passthrough).
+func MaxBodyBytes(limit int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if limit <= 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Body != nil {
+				r.Body = http.MaxBytesReader(w, r.Body, limit)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/control/middleware/bodylimit_test.go
+++ b/backend/internal/control/middleware/bodylimit_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMaxBodyBytesRejectsOversizedBody proves the guardrail fires: a body past
+// the cap fails the handler's read, while a body within the cap passes.
+func TestMaxBodyBytesRejectsOversizedBody(t *testing.T) {
+	const limit = 16
+	handler := MaxBodyBytes(limit)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			http.Error(w, "too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	small := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("12345"))
+	wSmall := httptest.NewRecorder()
+	handler.ServeHTTP(wSmall, small)
+	if wSmall.Code != http.StatusOK {
+		t.Fatalf("within-cap body status = %d, want %d", wSmall.Code, http.StatusOK)
+	}
+
+	big := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(make([]byte, limit+1)))
+	wBig := httptest.NewRecorder()
+	handler.ServeHTTP(wBig, big)
+	if wBig.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body status = %d, want %d", wBig.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+// TestMaxBodyBytesDisabledPassesThrough proves a non-positive limit is an
+// explicit opt-out, not an accidental zero-byte cap.
+func TestMaxBodyBytesDisabledPassesThrough(t *testing.T) {
+	handler := MaxBodyBytes(0)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n, err := io.Copy(io.Discard, r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if n == 0 {
+			http.Error(w, "empty", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	big := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(make([]byte, 1<<20)))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, big)
+	if w.Code != http.StatusOK {
+		t.Fatalf("passthrough status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+// TestApplyStackInstallsBodyLimit proves the cap is actually wired into the
+// canonical stack when configured. A GET carries the body so the CSRF guard
+// (safe-method) lets the request through to the body-reading handler.
+func TestApplyStackInstallsBodyLimit(t *testing.T) {
+	r := NewRouter(StackConfig{MaxRequestBodyBytes: 16})
+	r.Get("/echo", func(w http.ResponseWriter, req *http.Request) {
+		if _, err := io.ReadAll(req.Body); err != nil {
+			http.Error(w, "too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/echo", bytes.NewReader(make([]byte, 64)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body through stack status = %d, want %d", resp.StatusCode, http.StatusRequestEntityTooLarge)
+	}
+}

--- a/backend/internal/control/middleware/stack.go
+++ b/backend/internal/control/middleware/stack.go
@@ -37,6 +37,9 @@ type StackConfig struct {
 	RateLimitGlobalRPS int
 	RateLimitBurst     int
 	RateLimitWhitelist []string
+
+	// MaxRequestBodyBytes caps the size of inbound request bodies (0 disables).
+	MaxRequestBodyBytes int64
 }
 
 // NewRouter constructs a chi router with the canonical middleware stack applied.
@@ -52,6 +55,10 @@ func ApplyStack(r chi.Router, cfg StackConfig) {
 	r.Use(Recoverer)
 	// 2. RequestID (correlation early)
 	r.Use(RequestID)
+	// 2b. Body-size backstop (bound memory before any handler reads the body)
+	if cfg.MaxRequestBodyBytes > 0 {
+		r.Use(MaxBodyBytes(cfg.MaxRequestBodyBytes))
+	}
 	// 3. CORS (so OPTIONS and browser clients behave)
 	if cfg.EnableCORS {
 		r.Use(CORS(cfg.AllowedOrigins, cfg.CORSAllowCredentials))


### PR DESCRIPTION
Two small hardening items from the recent security pass over the backend. Additive only — no existing production logic changed.

## Request-body size backstop

Only `/intents` capped its request body (`MaxBytesReader`, 1 MiB); 16 other control handlers decoded `r.Body` unbounded, and one did a raw `io.ReadAll(r.Body)`. Rather than patch each handler, this adds a `MaxBodyBytes` middleware to the canonical ingress stack (`StackConfig.MaxRequestBodyBytes`) and wires it on the API server at a generous **4 MiB** backstop.

- It's a backstop, not a quota: real payloads (config blobs, EPG service lists) are far smaller, so the limit only trips on abusive/runaway requests. Picked 4 MiB deliberately so no legitimate request can hit it.
- `/intents` keeps its tighter 1 MiB inner cap.
- Single `ApplyStack` caller (the API server), so no proxy path is affected.

## PIN-unlock throttle — test only

While auditing I suspected the PIN unlock endpoint lacked brute-force protection. It doesn't: `PostHouseholdUnlock` already carries the dedicated `auth` exposure rate-limit class (10/min per client IP by default). No code change — but there was no test proving the throttle actually fires. This adds that proof.

## Tests

- oversized body → rejected (413); `limit <= 0` → passthrough; `ApplyStack` installs the cap.
- PIN unlock: the operation's policy through `ExposureSecurityMiddleware` under default config blocks once the per-IP budget is spent.

Verified green across `middleware`, `api`, `v3` (+ subpackages) and `test/integration`; `go vet` clean.