### PR TITLE
fix(security): M3U injection + Android media foreground-service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- media3 MediaSessionService runs as a foreground service for the playback
+         notification. targetSdk 34+ throws (MissingForegroundServiceTypeException /
+         SecurityException) unless both the permission and a foregroundServiceType
+         are declared. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <!-- Declare Android TV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
@@ -71,7 +78,8 @@
 
         <service
             android:name=".playback.service.PlaybackService"
-            android:exported="false">
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
             </intent-filter>

--- a/backend/internal/playlist/m3u.go
+++ b/backend/internal/playlist/m3u.go
@@ -25,24 +25,53 @@ type Item struct {
 	ServiceRef string // Internal use: store original sRef for EPG fetching
 }
 
+// sanitizeM3UField neutralises values that flow from the upstream box
+// (channel/bouquet names, logos) into a single-line #EXTINF record. M3U has no
+// attribute-escaping standard, so a raw double quote would break out of a
+// quoted attribute and a CR/LF would split the line and inject a fake URL or
+// entry. Strip CR/LF and other control characters, replace the quote, and trim.
+func sanitizeM3UField(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteByte(' ')
+		case r == '"':
+			b.WriteByte('\'')
+		case r < 0x20 || r == 0x7f:
+			// drop remaining control characters
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
 // WriteM3U writes an M3U playlist to the given writer.
 func WriteM3U(w io.Writer, items []Item, publicURL string, xTvgURL string) error {
 	buf := &bytes.Buffer{}
 	// Optional x-tvg-url header attribute for clients that auto-load EPG
 	if epgURL := strings.TrimSpace(xTvgURL); epgURL != "" {
 		// Some players support x-tvg-url (unofficial but widely used)
-		fmt.Fprintf(buf, `#EXTM3U x-tvg-url="%s"`+"\n", epgURL)
+		fmt.Fprintf(buf, `#EXTM3U x-tvg-url="%s"`+"\n", sanitizeM3UField(epgURL))
 	} else {
 		buf.WriteString("#EXTM3U\n")
 	}
 	for _, it := range items {
+		// Upstream channel/bouquet metadata is untrusted; sanitise before it is
+		// interpolated into the quoted attributes or the display name.
+		name := sanitizeM3UField(it.Name)
+		group := sanitizeM3UField(it.Group)
+		tvgID := sanitizeM3UField(it.TvgID)
+
 		// Build attributes dynamically to omit tvg-chno when unset and include tvg-name
 		attrs := bytes.Buffer{}
 		// tvg-chno only when > 0
 		if it.TvgChNo > 0 {
 			fmt.Fprintf(&attrs, `tvg-chno="%d" `, it.TvgChNo)
 		}
-		fmt.Fprintf(&attrs, `tvg-id="%s" `, it.TvgID)
+		fmt.Fprintf(&attrs, `tvg-id="%s" `, tvgID)
 
 		// Handle Logo URL (prepend publicURL if set and logo is relative)
 		logo := it.TvgLogo
@@ -51,14 +80,14 @@ func WriteM3U(w io.Writer, items []Item, publicURL string, xTvgURL string) error
 			base := strings.TrimRight(publicURL, "/")
 			logo = base + logo
 		}
-		fmt.Fprintf(&attrs, `tvg-logo="%s" `, logo)
+		fmt.Fprintf(&attrs, `tvg-logo="%s" `, sanitizeM3UField(logo))
 
-		fmt.Fprintf(&attrs, `group-title="%s" `, it.Group)
+		fmt.Fprintf(&attrs, `group-title="%s" `, group)
 		// tvg-name duplicates channel name to improve EPG mapping in some clients
-		fmt.Fprintf(&attrs, `tvg-name="%s"`, it.Name)
+		fmt.Fprintf(&attrs, `tvg-name="%s"`, name)
 
-		fmt.Fprintf(buf, `#EXTINF:-1 %s,%s`+"\n", attrs.String(), it.Name)
-		buf.WriteString(it.URL + "\n")
+		fmt.Fprintf(buf, `#EXTINF:-1 %s,%s`+"\n", attrs.String(), name)
+		buf.WriteString(sanitizeM3UField(it.URL) + "\n")
 	}
 	_, err := io.Copy(w, buf)
 	return err

--- a/backend/internal/playlist/m3u_injection_test.go
+++ b/backend/internal/playlist/m3u_injection_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package playlist
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestWriteM3UNeutralizesInjection proves that CR/LF and double quotes in
+// upstream-controlled channel/bouquet names cannot split the #EXTINF record
+// (injecting a fake URL/entry) or break out of a quoted attribute.
+func TestWriteM3UNeutralizesInjection(t *testing.T) {
+	var buf bytes.Buffer
+	items := []Item{{
+		Name:  "Evil\" tvg-logo=\"x\nhttp://attacker.example/inject.ts\n#EXTINF:-1,Fake",
+		Group: "Grp\"\nstuff",
+		TvgID: "id\nx",
+		URL:   "http://box/stream.ts",
+	}}
+
+	if err := WriteM3U(&buf, items, "", ""); err != nil {
+		t.Fatalf("WriteM3U: %v", err)
+	}
+	out := buf.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	// Header + exactly one #EXTINF + exactly one URL line. Any injected newline
+	// would produce extra lines here.
+	if len(lines) != 3 {
+		t.Fatalf("newline injection split the record; want 3 lines, got %d:\n%s", len(lines), out)
+	}
+	if lines[0] != "#EXTM3U" {
+		t.Errorf("line 0 = %q, want #EXTM3U", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "#EXTINF:-1 ") {
+		t.Errorf("line 1 is not an EXTINF record: %q", lines[1])
+	}
+	if lines[2] != "http://box/stream.ts" {
+		t.Errorf("URL line = %q; injection must not replace the real stream URL", lines[2])
+	}
+	// The raw quote from the name must be neutralised (no attribute breakout).
+	if strings.Contains(out, `Evil"`) {
+		t.Error("raw double quote from the channel name survived (attribute breakout)")
+	}
+	if !strings.Contains(out, "Evil'") {
+		t.Error("expected the channel-name double quote to be replaced with a single quote")
+	}
+}
+
+func TestSanitizeM3UField(t *testing.T) {
+	cases := map[string]string{
+		"plain":            "plain",
+		"a\nb":             "a b",
+		"a\r\nb":           "a  b",
+		"a\tb":             "a b",
+		`say "hi"`:         "say 'hi'",
+		"ctrl\x00char":     "ctrlchar",
+		"  trim me  ":      "trim me",
+	}
+	for in, want := range cases {
+		if got := sanitizeM3UField(in); got != want {
+			t.Errorf("sanitizeM3UField(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Sanitise upstream channel/bouquet names before the M3U (a quote or CR/LF could inject attributes or a fake URL into the playlist consumed by Plex/Threadfin/Jellyfin). Declare the media foregroundServiceType + FOREGROUND_SERVICE permissions so the Android playback service does not crash on Android 14+.