### PR TITLE
chore(ci): fix Dependabot dirs + align GOTOOLCHAIN with go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # Go dependencies (Bundle everything into one PR)
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/backend"
     schedule:
       interval: "daily"
       time: "04:00"
@@ -21,7 +21,10 @@ updates:
 
   # WebUI dependencies (Bundle everything into one PR)
   - package-ecosystem: "npm"
-    directory: "/webui"
+    directories:
+      - "/"
+      - "/frontend/webui"
+      - "/backend/e2e/fixture-server"
     schedule:
       interval: "daily"
       time: "04:00"

--- a/mk/variables.mk
+++ b/mk/variables.mk
@@ -10,7 +10,7 @@ SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct 2>/dev/null || date -u +%s)
 export SOURCE_DATE_EPOCH
 export TZ := UTC
 export GOFLAGS := -trimpath -buildvcs=false -mod=vendor
-GOTOOLCHAIN ?= go1.25.9
+GOTOOLCHAIN ?= go1.25.10
 export GOTOOLCHAIN
 export GOWORK := off
 GO := go


### PR DESCRIPTION
Dependabot pointed at non-existent dirs (gomod / instead of /backend, npm /webui instead of /frontend/webui), so Go and WebUI deps never updated; point them at the real manifests. Align the GOTOOLCHAIN pin with go.mod (go1.25.10), which also unbreaks local make Go targets.