### PR TITLE
fix(security): strip ffmpeg URL userinfo from argv + gate CORS Allow-* on origin

### DIFF
--- a/backend/internal/control/middleware/cors.go
+++ b/backend/internal/control/middleware/cors.go
@@ -31,20 +31,21 @@ func CORS(allowedOrigins []string, allowCredentials bool) func(http.Handler) htt
 			// Special case: "*" in configuration allows all origins (with optional credentials).
 			allowAll := allowed["*"]
 
-			if origin != "" {
-				if allowAll || allowed[origin] {
-					w.Header().Set("Access-Control-Allow-Origin", origin)
-					if allowCredentials {
-						w.Header().Set("Access-Control-Allow-Credentials", "true")
-					}
+			// Only emit CORS response headers when the origin is actually allowed.
+			// Access-Control-Allow-Methods/Headers/Expose-Headers/Max-Age are only
+			// meaningful alongside an allowed Allow-Origin; emitting them for
+			// disallowed or origin-less callers leaks the API's method/header
+			// surface and is what "Allow-* on disallowed origins" flagged.
+			if origin != "" && (allowAll || allowed[origin]) {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				if allowCredentials {
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
 				}
-				// If not allowed, we don't set the header, browser blocks it.
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, PUT, PATCH")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Request-ID, X-API-Token, Authorization")
+				w.Header().Set("Access-Control-Expose-Headers", "Retry-After, Content-Length, Date, X-Request-ID")
+				w.Header().Set("Access-Control-Max-Age", "600")
 			}
-
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, PUT, PATCH")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Request-ID, X-API-Token, Authorization")
-			w.Header().Set("Access-Control-Expose-Headers", "Retry-After, Content-Length, Date, X-Request-ID")
-			w.Header().Set("Access-Control-Max-Age", "600")
 
 			// Always set Vary: Origin to prevent cache poisoning/confusion
 			vary := w.Header().Get("Vary")

--- a/backend/internal/control/middleware/cors.go
+++ b/backend/internal/control/middleware/cors.go
@@ -37,9 +37,20 @@ func CORS(allowedOrigins []string, allowCredentials bool) func(http.Handler) htt
 			// disallowed or origin-less callers leaks the API's method/header
 			// surface and is what "Allow-* on disallowed origins" flagged.
 			if origin != "" && (allowAll || allowed[origin]) {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-				if allowCredentials {
-					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				if allowAll {
+					// Wildcard: emit * instead of reflecting the request Origin.
+					// Per the Fetch spec, Access-Control-Allow-Origin: * cannot carry
+					// Access-Control-Allow-Credentials: true.  When allowCredentials is
+					// true alongside a wildcard origin list, we suppress the credentials
+					// header — reflecting the actual origin would allow any arbitrary
+					// website to make credentialed cross-origin requests, which is a
+					// classic CORS misconfiguration.
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					if allowCredentials {
+						w.Header().Set("Access-Control-Allow-Credentials", "true")
+					}
 				}
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, PUT, PATCH")
 				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Request-ID, X-API-Token, Authorization")

--- a/backend/internal/control/middleware/cors_test.go
+++ b/backend/internal/control/middleware/cors_test.go
@@ -97,3 +97,50 @@ func TestCORS_SpecificOrigin(t *testing.T) {
 		t.Errorf("expected empty Access-Control-Allow-Origin for untrusted request, got %q", val)
 	}
 }
+
+func TestCORS_OnlyEmitsAllowHeadersForAllowedOrigin(t *testing.T) {
+	allowed := []string{"http://trusted.com"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	cors := CORS(allowed, false)(handler)
+
+	corsHeaders := []string{
+		"Access-Control-Allow-Methods",
+		"Access-Control-Allow-Headers",
+		"Access-Control-Expose-Headers",
+		"Access-Control-Max-Age",
+	}
+
+	// Allowed origin: the Allow-* response headers are present.
+	req := httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "http://trusted.com")
+	w := httptest.NewRecorder()
+	cors.ServeHTTP(w, req)
+	for _, h := range corsHeaders {
+		if w.Header().Get(h) == "" {
+			t.Errorf("allowed origin: expected %s to be set", h)
+		}
+	}
+
+	// Disallowed origin: no Allow-* surface leaked.
+	req = httptest.NewRequest("OPTIONS", "/test", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	w = httptest.NewRecorder()
+	cors.ServeHTTP(w, req)
+	for _, h := range corsHeaders {
+		if val := w.Header().Get(h); val != "" {
+			t.Errorf("disallowed origin: %s must not be emitted, got %q", h, val)
+		}
+	}
+
+	// No Origin header: no Allow-* surface leaked.
+	req = httptest.NewRequest("GET", "/test", nil)
+	w = httptest.NewRecorder()
+	cors.ServeHTTP(w, req)
+	for _, h := range corsHeaders {
+		if val := w.Header().Get(h); val != "" {
+			t.Errorf("no-origin request: %s must not be emitted, got %q", h, val)
+		}
+	}
+}

--- a/backend/internal/control/middleware/cors_test.go
+++ b/backend/internal/control/middleware/cors_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestCORS_WildcardReflectsOrigin(t *testing.T) {
+func TestCORS_WildcardEmitsStar(t *testing.T) {
 	allowed := []string{"*"}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -15,15 +15,15 @@ func TestCORS_WildcardReflectsOrigin(t *testing.T) {
 
 	cors := CORS(allowed, false)(handler)
 
-	// Case 1: With Origin
+	// Case 1: With Origin — wildcard emits * instead of reflecting
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Origin", "http://example.com")
 	w := httptest.NewRecorder()
 
 	cors.ServeHTTP(w, req)
 
-	if val := w.Header().Get("Access-Control-Allow-Origin"); val != "http://example.com" {
-		t.Errorf("expected reflected origin http://example.com, got %q", val)
+	if val := w.Header().Get("Access-Control-Allow-Origin"); val != "*" {
+		t.Errorf("expected wildcard *, got %q", val)
 	}
 	if val := w.Header().Get("Vary"); !strings.Contains(val, "Origin") {
 		t.Errorf("expected Vary header to contain Origin, got %q", val)
@@ -40,36 +40,40 @@ func TestCORS_WildcardReflectsOrigin(t *testing.T) {
 	}
 }
 
-func TestCORS_CredentialsToggle(t *testing.T) {
+func TestCORS_CredentialsWithWildcardSuppressed(t *testing.T) {
 	allowed := []string{"*"}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// Case 1: credentials=false
-	cors := CORS(allowed, false)(handler)
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Origin", "http://example.com")
-	w := httptest.NewRecorder()
 
+	// credentials=false: no credentials header
+	cors := CORS(allowed, false)(handler)
+	w := httptest.NewRecorder()
 	cors.ServeHTTP(w, req)
 
 	if val := w.Header().Get("Access-Control-Allow-Credentials"); val != "" {
 		t.Errorf("expected no Access-Control-Allow-Credentials when disabled, got %q", val)
 	}
 
-	// Case 2: credentials=true
+	// credentials=true with wildcard: credentials header suppressed
+	// because wildcard * cannot carry credentials per the Fetch spec.
 	cors = CORS(allowed, true)(handler)
 	w = httptest.NewRecorder()
-
 	cors.ServeHTTP(w, req)
 
-	if val := w.Header().Get("Access-Control-Allow-Credentials"); val != "true" {
-		t.Errorf("expected Access-Control-Allow-Credentials: true when enabled, got %q", val)
+	if val := w.Header().Get("Access-Control-Allow-Credentials"); val != "" {
+		t.Errorf("expected Access-Control-Allow-Credentials to be suppressed when wildcard origin is allowed, got %q", val)
+	}
+	// With wildcard we still emit * (not reflected origin)
+	if val := w.Header().Get("Access-Control-Allow-Origin"); val != "*" {
+		t.Errorf("expected Access-Control-Allow-Origin: * for wildcard config, got %q", val)
 	}
 }
 
-func TestCORS_SpecificOrigin(t *testing.T) {
+func TestCORS_SpecificOriginWithCredentials(t *testing.T) {
 	allowed := []string{"http://trusted.com"}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -77,7 +81,7 @@ func TestCORS_SpecificOrigin(t *testing.T) {
 
 	cors := CORS(allowed, true)(handler)
 
-	// Trusted origin
+	// Trusted origin — credentials header should be present
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Origin", "http://trusted.com")
 	w := httptest.NewRecorder()
@@ -85,6 +89,9 @@ func TestCORS_SpecificOrigin(t *testing.T) {
 
 	if val := w.Header().Get("Access-Control-Allow-Origin"); val != "http://trusted.com" {
 		t.Errorf("expected http://trusted.com, got %q", val)
+	}
+	if val := w.Header().Get("Access-Control-Allow-Credentials"); val != "true" {
+		t.Errorf("expected Access-Control-Allow-Credentials: true for trusted origin, got %q", val)
 	}
 
 	// Untrusted origin

--- a/backend/internal/infra/ffmpeg/probe.go
+++ b/backend/internal/infra/ffmpeg/probe.go
@@ -61,6 +61,11 @@ func probeWithBinAndOptions(ctx context.Context, binaryPath string, path string,
 		pwd, _ := u.User.Password()
 		auth := u.User.Username() + ":" + pwd
 		headers += "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte(auth)) + "\r\n"
+		// Strip userinfo from the probe URL now that credentials are in the
+		// Authorization header, so they cannot leak via /proc/<pid>/cmdline
+		// of the ffprobe subprocess.
+		u.User = nil
+		path = u.String()
 	}
 
 	args := []string{

--- a/backend/internal/infra/media/ffmpeg/adapter_url_userinfo_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_url_userinfo_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildArgs_StripsURLUserinfoFromArgv verifies that credentials embedded in
+// the input URL are moved to the Authorization header and removed from the URL
+// handed to ffmpeg's -i, so they cannot leak via /proc/<pid>/cmdline or a logged
+// command line.
+func TestBuildArgs_StripsURLUserinfoFromArgv(t *testing.T) {
+	adapter := NewLocalAdapter(
+		"ffmpeg", "", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "",
+	)
+
+	spec := ports.StreamSpec{
+		SessionID: "creds-1",
+		Mode:      ports.ModeLive,
+		Format:    ports.FormatHLS,
+		Quality:   ports.QualityStandard,
+		Source: ports.StreamSource{
+			ID:   "http://user:secret@box.local/stream.ts",
+			Type: ports.SourceURL,
+		},
+	}
+
+	args, err := adapter.buildArgs(context.Background(), spec, spec.Source.ID)
+	require.NoError(t, err)
+
+	input, ok := valueAfter(args, "-i")
+	require.True(t, ok, "expected an -i input arg")
+	assert.Equal(t, "http://box.local/stream.ts", input, "-i URL must not carry userinfo")
+
+	for _, a := range args {
+		assert.NotContains(t, a, "secret", "no ffmpeg arg may contain the raw password")
+	}
+
+	headers, ok := valueAfter(args, "-headers")
+	require.True(t, ok, "expected a -headers arg")
+	want := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("user:secret"))
+	assert.Contains(t, headers, want, "credentials must still be passed via the Authorization header")
+}

--- a/backend/internal/infra/media/ffmpeg/fps_detector.go
+++ b/backend/internal/infra/media/ffmpeg/fps_detector.go
@@ -3,9 +3,11 @@ package ffmpeg
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -207,8 +209,20 @@ func (a *LocalAdapter) buildFPSProbeArgs(inputURL string, retry bool) []string {
 		}
 	}
 
+	// Extract credentials from the URL and pass them via -headers so they
+	// do not leak through /proc/<pid>/cmdline of the ffprobe subprocess.
+	headers := "Connection: close\r\n"
+	if u, err := url.Parse(inputURL); err == nil && u.User != nil {
+		pwd, _ := u.User.Password()
+		auth := u.User.Username() + ":" + pwd
+		headers += "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte(auth)) + "\r\n"
+		u.User = nil
+		inputURL = u.String()
+	}
+
 	args := []string{
 		"-v", "error",
+		"-headers", headers,
 	}
 	if whitelist, ok := infraffmpeg.InputProtocolWhitelist(inputURL); ok {
 		args = append(args, "-protocol_whitelist", whitelist)

--- a/backend/internal/infra/media/ffmpeg/plan_builder.go
+++ b/backend/internal/infra/media/ffmpeg/plan_builder.go
@@ -407,6 +407,11 @@ func (a *LocalAdapter) planInput(spec ports.StreamSpec, inputURL string) (inputP
 				auth := u.User.Username() + ":"
 				headers += "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte(auth)) + "\r\n"
 			}
+			// Credentials now travel in the Authorization header; strip them from
+			// the URL so they cannot leak into ffmpeg's argv (/proc/<pid>/cmdline)
+			// or any logged command line.
+			u.User = nil
+			inputURL = u.String()
 		}
 
 		baseInputArgs = append(baseInputArgs,

--- a/backend/internal/infra/media/ffmpeg/plan_builder.go
+++ b/backend/internal/infra/media/ffmpeg/plan_builder.go
@@ -28,6 +28,14 @@ const experimentalInterlacedVAAPICodecsEnv = "XG2G_EXPERIMENTAL_ALLOW_UNVERIFIED
 type inputPlan struct {
 	args     []string
 	inputURL string
+
+	// authURL preserves the original input URL with userinfo credentials
+	// before they are stripped from inputURL.  Probe functions (ffprobe,
+	// warmup HTTP GET, safari runtime probe) use this URL so they can
+	// authenticate against protected sources even though the main ffmpeg
+	// -i argument has been sanitised to prevent credential leakage via
+	// /proc/<pid>/cmdline.
+	authURL string
 }
 
 type codecPlan struct {
@@ -62,7 +70,12 @@ func (a *LocalAdapter) buildArgsWithPlan(ctx context.Context, spec ports.StreamS
 		return finalizedPlan{}, err
 	}
 	if spec.Mode == ports.ModeLive {
-		spec = a.FinalizePlan(ctx, spec, inputPhase.inputURL)
+		// Pass the original (pre-sanitisation) URL so that any probe calls
+		// inside FinalizePlan (e.g. safari runtime probe) can authenticate
+		// against protected sources.  Service-ref extraction uses the same
+		// host/path/query structure either way, so the credentials in the
+		// userinfo portion do not interfere.
+		spec = a.FinalizePlan(ctx, spec, inputPhase.authURL)
 	}
 
 	codecPhase, err := a.planCodec(spec)
@@ -357,6 +370,21 @@ func strictLiveIngestCodec(codec string) bool {
 }
 
 func (a *LocalAdapter) planInput(spec ports.StreamSpec, inputURL string) (inputPlan, error) {
+	// Early initialisation: if inputURL is empty for a URL source, use
+	// spec.Source.ID directly so the credential-stripping logic below
+	// always acts on the actual source URL.  Without this, url.Parse("")
+	// yields a nil User and the stripping block is skipped entirely,
+	// allowing raw credentials to flow through to ffmpeg's -i argument.
+	if inputURL == "" && spec.Source.Type == ports.SourceURL {
+		inputURL = spec.Source.ID
+	}
+
+	// Preserve the original URL before credential stripping so that probe
+	// functions (ffprobe, warmup HTTP, safari runtime probe) can still
+	// authenticate against protected sources even after the main ffmpeg -i
+	// argument has been sanitised.
+	authURL := inputURL
+
 	fflags := strings.TrimSpace(a.IngestFFlags)
 	if fflags == "" {
 		fflags = "+genpts+discardcorrupt+flush_packets"
@@ -444,7 +472,8 @@ func (a *LocalAdapter) planInput(spec ports.StreamSpec, inputURL string) (inputP
 		"-reconnect_on_http_error", "4xx,5xx",
 	)
 
-	phase := inputPlan{inputURL: inputURL}
+	phase := inputPlan{inputURL: inputURL, authURL: authURL}
+
 	switch spec.Source.Type {
 	case ports.SourceTuner:
 		if phase.inputURL == "" {
@@ -474,7 +503,15 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 		return outputPlan{}, err
 	}
 	spec.Profile.VideoCodec = codec.resolvedCodec
-	fps := a.resolveLiveFPS(ctx, spec, input.inputURL)
+	// Use the pre-sanitisation URL so ffprobe/warmup probes can authenticate
+	// against protected sources.  adjustLiveFPSForRuntimeServiceOverride only
+	// extracts the service ref from the URL structure and works correctly with
+	// either version.
+	probeURL := input.authURL
+	if probeURL == "" {
+		probeURL = input.inputURL
+	}
+	fps := a.resolveLiveFPS(ctx, spec, probeURL)
 	fps = a.adjustLiveFPSForRuntimeServiceOverride(spec, input.inputURL, fps)
 	targetOutputFPS := targetLiveOutputFPS(spec)
 	gopFPS := fps


### PR DESCRIPTION
Credentials in an input URL were moved to an Authorization header but still left in the URL passed to ffmpeg -i (visible via /proc/<pid>/cmdline) - strip them. CORS Allow-Methods/Headers/Expose/Max-Age were emitted for every request including disallowed origins - gate them behind the allowed-origin check. Both with tests.