### PR TITLE
fix(monitoring): re-point tuner-leak alert to live session gauge

### DIFF
--- a/monitoring/alerts-xg2g-phase5-3.yml
+++ b/monitoring/alerts-xg2g-phase5-3.yml
@@ -7,19 +7,22 @@
 # no live caller (capacity is enforced via tuner leases, host pressure via the live
 # CPU snapshot). Alerting on never-emitted series is a permanent false-positive that
 # trains operators to ignore the page, so those rules were removed rather than kept
-# as lies. What remains is the one invariant backed by metrics the daemon actually
-# emits: tuner leases held for an extended period without session activity.
+# as lies. What remains is backed by metrics the daemon actually emits: a tuner
+# lease held while the orchestrator reports zero active sessions, which pinpoints a
+# leak rather than a legitimately long-running session.
 groups:
   - name: xg2g_session_invariants
     interval: 30s
     rules:
       - alert: XG2G_TunerLeakSuspected
         expr: |
-          xg2g_tuners_in_use > 0
+          (xg2g_tuners_in_use > 0)
+          and
+          (xg2g_v3_sessions_active == 0)
         for: 5m
         labels:
           severity: critical
           gate: "nightly"
         annotations:
-          summary: "Tuner leak suspected (tuners in use for extended period)"
-          description: "xg2g_tuners_in_use > 0 for 5 minutes without releasing. Tuner leases not released or session teardown stuck."
+          summary: "Tuner leak suspected (tuners held with no active sessions)"
+          description: "xg2g_tuners_in_use > 0 while xg2g_v3_sessions_active == 0 for 5 minutes: a tuner lease was not released after its session ended. Both gauges are emitted by the live session orchestrator."


### PR DESCRIPTION
Re-points XG2G_TunerLeakSuspected to (xg2g_tuners_in_use > 0 AND xg2g_v3_sessions_active == 0). The session gauge was added in #455 (now merged); an earlier review correctly removed the correlation while the gauge did not yet exist in the codebase. This restores the precise leak condition — a tuner lease held with zero active sessions — instead of the cruder 'tuners > 0 for 5m', which also fires on legitimately long-running sessions. Label-free form retained.