### PR TITLE
ci(release): migrate to dockers_v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,33 +48,21 @@ changelog:
       - "^docs:"
       - "^test:"
 
-dockers:
-  - image_templates:
-      - "ghcr.io/manugh/xg2g:{{ .Tag }}-amd64"
+dockers_v2:
+  - id: xg2g
     dockerfile: infrastructure/docker/Dockerfile.release
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.source={{ .GitURL }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-  - image_templates:
-      - "ghcr.io/manugh/xg2g:{{ .Tag }}-arm64"
-    dockerfile: infrastructure/docker/Dockerfile.release
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.source={{ .GitURL }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-
-docker_manifests:
-  - name_template: "ghcr.io/manugh/xg2g:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/manugh/xg2g:{{ .Tag }}-amd64"
-      - "ghcr.io/manugh/xg2g:{{ .Tag }}-arm64"
-  - name_template: "ghcr.io/manugh/xg2g:latest"
-    image_templates:
-      - "ghcr.io/manugh/xg2g:{{ .Tag }}-amd64"
-      - "ghcr.io/manugh/xg2g:{{ .Tag }}-arm64"
+    images:
+      - "ghcr.io/manugh/xg2g"
+    tags:
+      - "{{ .Tag }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    sbom: false
+    labels:
+      org.opencontainers.image.source: "{{ .GitURL }}"
+      org.opencontainers.image.version: "{{ .Version }}"
 
 release:
   github:

--- a/infrastructure/docker/Dockerfile.release
+++ b/infrastructure/docker/Dockerfile.release
@@ -6,7 +6,8 @@
 ARG FFMPEG_BASE_IMAGE=ghcr.io/manugh/xg2g-ffmpeg:8.1
 FROM ${FFMPEG_BASE_IMAGE} AS runtime
 
-COPY --chown=xg2g:xg2g xg2g /usr/local/bin/xg2g
+ARG TARGETPLATFORM
+COPY --chown=xg2g:xg2g ${TARGETPLATFORM}/xg2g /usr/local/bin/xg2g
 
 USER 10001:10001
 WORKDIR /var/lib/xg2g


### PR DESCRIPTION
Migrates the release image config from the deprecated `dockers` + `docker_manifests` blocks to the unified `dockers_v2` block (single multi-platform entry, automatic manifest), removing the GoReleaser deprecation warning.

`Dockerfile.release` is adapted to the `dockers_v2` build-context contract: binaries are placed under `$TARGETPLATFORM`, so the binary is copied from `${TARGETPLATFORM}/xg2g`.

### Validation (on the build host, 10.10.55.14)
- `goreleaser check` passes; deprecation warning gone.
- Real `goreleaser release --snapshot` (docker enabled) builds both `linux/amd64` and `linux/arm64` images successfully.
- `COPY ${TARGETPLATFORM}/xg2g` confirmed to resolve — binary lands at `/usr/local/bin/xg2g` and executes (`xg2g version`).
- ffmpeg base is published multi-arch (amd64+arm64), so `platforms` is correct.

Notes: `sbom: false` preserves prior behaviour (no syft dependency). The actual private-base pull + manifest push run in CI (which authenticates to GHCR), unchanged by this PR.
