### PR TITLE
ci(ghcr): dry-run retention workflow for xg2g package

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -1,0 +1,45 @@
+name: ghcr-retention
+
+# Prunes stale versions of the ghcr.io/manugh/xg2g container package.
+# Every push to main publishes a `sha-<commit>` dev image (+ untagged manifest
+# children), so the package accumulates thousands of versions over time.
+#
+# SAFETY: starts dry-run-only and manual. Add a PAT secret, dispatch with the
+# default (dry-run) to review what WOULD be deleted, then re-dispatch with
+# dry-run unchecked to actually delete. A weekly schedule is added only once the
+# dry-run output has been reviewed.
+#
+# Requires repo secret GHCR_CLEANUP_TOKEN: a classic PAT with `delete:packages`
+# (+ `read:packages`). GITHUB_TOKEN cannot use the tag-protection filters, so a
+# PAT is required to keep `latest` / `main` / release tags safe.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Preview only — list what would be deleted, delete nothing (uncheck to actually delete)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune stale xg2g image versions
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+        with:
+          account: user
+          token: ${{ secrets.GHCR_CLEANUP_TOKEN }}
+          image-names: "xg2g"
+          # Protect floating + release tags; everything else (sha-* dev tags) is a candidate.
+          image-tags: "!latest !main !v*"
+          # Also prune untagged manifest children (the bulk of the bloat).
+          tag-selection: both
+          # Only touch versions older than 4 weeks...
+          cut-off: 4w
+          # ...and always keep the 30 most recent tagged versions regardless of age.
+          keep-n-most-recent: 30
+          dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
Adds a **manual, dry-run-first** retention workflow to prune the bloated `ghcr.io/manugh/xg2g` package (thousands of versions from per-commit `sha-*` dev images + untagged children).

- Protects `latest`, `main`, and release tags (`v*`); prunes `sha-*` + untagged versions older than 4 weeks, always keeping the 30 newest.
- Ships **dry-run by default** + manual dispatch only — nothing deletes until reviewed. Weekly schedule added after first dry-run is checked.
- Needs repo secret `GHCR_CLEANUP_TOKEN` (classic PAT, `delete:packages` + `read:packages`) — `GITHUB_TOKEN` can't use the tag-protection filters.