### PR TITLE
build(ffmpeg): bump 8.1 -> 8.1.1

### DIFF
--- a/backend/scripts/build-ffmpeg.sh
+++ b/backend/scripts/build-ffmpeg.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # FFmpeg Auto-Build Script for xg2g
-# Builds pinned FFmpeg 8.1 with HLS/VAAPI/NVENC/x264/AAC support
+# Builds pinned FFmpeg 8.1.1 with HLS/VAAPI/NVENC/x264/AAC support
 set -euo pipefail
 
-FFMPEG_VERSION="8.1"
+FFMPEG_VERSION="8.1.1"
 FFMPEG_URL="https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
 NVCODEC_HEADERS_VERSION="n13.0.19.0"
 NVCODEC_HEADERS_REPO="https://git.videolan.org/git/ffmpeg/nv-codec-headers.git"
@@ -24,7 +24,7 @@ fi
 
 # Verify checksum (sha256)
 echo "Verifying checksum..."
-EXPECTED_SHA256="b072aed6871998cce9b36e7774033105ca29e33632be5b6347f3206898e0756a"
+EXPECTED_SHA256="b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"
 VERIFY_LINE="${EXPECTED_SHA256}  ffmpeg-${FFMPEG_VERSION}.tar.xz"
 verify_checksum() {
     if command -v sha256sum >/dev/null 2>&1; then

--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -174,10 +174,10 @@ make docker-ffmpeg-base
 make docker-dev-fast
 ```
 
-`make docker-ffmpeg-base` builds `xg2g-ffmpeg:8.1` once from [Dockerfile.ffmpeg-base](../../Dockerfile.ffmpeg-base). `make docker-dev-fast` then rebuilds the app container with `XG2G_FFMPEG_BASE_IMAGE=xg2g-ffmpeg:8.1`, so the main [Dockerfile](../../Dockerfile) can reuse the cached FFmpeg runtime layer instead of rebuilding FFmpeg.
+`make docker-ffmpeg-base` builds `xg2g-ffmpeg:8.1.1` once from [Dockerfile.ffmpeg-base](../../Dockerfile.ffmpeg-base). `make docker-dev-fast` then rebuilds the app container with `XG2G_FFMPEG_BASE_IMAGE=xg2g-ffmpeg:8.1.1`, so the main [Dockerfile](../../Dockerfile) can reuse the cached FFmpeg runtime layer instead of rebuilding FFmpeg.
 
 The tagged release pipeline follows the same pattern via
-`ghcr.io/manugh/xg2g-ffmpeg:8.1`, so release cuts do not recompile FFmpeg
+`ghcr.io/manugh/xg2g-ffmpeg:8.1.1`, so release cuts do not recompile FFmpeg
 from source on every tag.
 
 If FFmpeg version or build flags change in `backend/scripts/build-ffmpeg.sh`, rebuild the base image first:

--- a/docs/ops/FFMPEG_BUILD.md
+++ b/docs/ops/FFMPEG_BUILD.md
@@ -12,7 +12,7 @@ xg2g uses a **pinned, reproducible FFmpeg build** (8.1) bundled into the contain
 - Scoped (no global LD_LIBRARY_PATH leak)
 - Explicit (contract via ENV in Dockerfile)
 - Auditable (verification commands below)
-- Published separately as `ghcr.io/manugh/xg2g-ffmpeg:8.1`
+- Published separately as `ghcr.io/manugh/xg2g-ffmpeg:8.1.1`
 - Reused by tagged release images so tag cuts do not rebuild FFmpeg from source
 
 ## Architecture
@@ -190,7 +190,7 @@ export LD_LIBRARY_PATH=/opt/ffmpeg/lib
 
 `Dockerfile.ffmpeg-base` is the canonical FFmpeg container build. The
 `.github/workflows/ffmpeg-base.yml` workflow publishes
-`ghcr.io/manugh/xg2g-ffmpeg:8.1` from `main` whenever FFmpeg build inputs
+`ghcr.io/manugh/xg2g-ffmpeg:8.1.1` from `main` whenever FFmpeg build inputs
 change. Tagged releases then inherit that base image instead of recompiling
 FFmpeg inside the release workflow.
 

--- a/infrastructure/docker/Dockerfile.release
+++ b/infrastructure/docker/Dockerfile.release
@@ -3,7 +3,7 @@
 # It expects the 'xg2g' binary to be in the build context and reuses the
 # prebuilt FFmpeg runtime base published from Dockerfile.ffmpeg-base.
 
-ARG FFMPEG_BASE_IMAGE=ghcr.io/manugh/xg2g-ffmpeg:8.1
+ARG FFMPEG_BASE_IMAGE=ghcr.io/manugh/xg2g-ffmpeg:8.1.1
 FROM ${FFMPEG_BASE_IMAGE} AS runtime
 
 ARG TARGETPLATFORM

--- a/mk/variables.mk
+++ b/mk/variables.mk
@@ -43,7 +43,7 @@ DOCKER_IMAGE := xg2g
 DOCKER_REGISTRY ?=
 PLATFORMS := linux/amd64
 # Keep in sync with backend/scripts/build-ffmpeg.sh.
-FFMPEG_VERSION := 8.1
+FFMPEG_VERSION := 8.1.1
 FFMPEG_BASE_IMAGE ?= $(DOCKER_IMAGE)-ffmpeg
 FFMPEG_BASE_TAG := $(FFMPEG_BASE_IMAGE):$(FFMPEG_VERSION)
 


### PR DESCRIPTION
Patch bump of the pinned FFmpeg (8.1 → 8.1.1; bugfix/security, no API change per ffmpeg policy). sha256 verified by downloading the ffmpeg.org tarball and hashing locally (`b6863adde…`). Touches FFMPEG_VERSION, the checksum, the Dockerfile.release base tag, and `:8.1` doc examples. On merge, the (now native multi-arch) ffmpeg-base workflow publishes `xg2g-ffmpeg:8.1.1` for amd64+arm64.