### PR TITLE
feat: playback truth rebuild — AV1 10-bit p010, adaptive bitrate ceiling, mobile player & resume

### DIFF
--- a/frontend/webui/src/features/player/usePlaybackOrchestrator.ts
+++ b/frontend/webui/src/features/player/usePlaybackOrchestrator.ts
@@ -510,6 +510,7 @@ export function usePlaybackOrchestrator(
   useEffect(() => { authHeadersRef.current = authHeaders; });
   useEffect(() => { mergeSessionPlaybackTraceRef.current = mergeSessionPlaybackTrace; });
 
+
   // Native playback (managed Safari/iOS native HLS) runs through the native
   // bridge and never drives the MSE controller's snapshot loop, so the executed
   // session trace (GET /sessions) previously never reached the stats panel —
@@ -523,6 +524,7 @@ export function usePlaybackOrchestrator(
     // edge); the broader nativePlaybackState.session.sessionId can outlive an
     // ended session until full teardown.
     if (!nativeSessionId) {
+
       return;
     }
     let cancelled = false;

--- a/frontend/webui/src/features/player/usePlaybackOrchestrator.ts
+++ b/frontend/webui/src/features/player/usePlaybackOrchestrator.ts
@@ -524,7 +524,6 @@ export function usePlaybackOrchestrator(
     // edge); the broader nativePlaybackState.session.sessionId can outlive an
     // ended session until full teardown.
     if (!nativeSessionId) {
-
       return;
     }
     let cancelled = false;


### PR DESCRIPTION
## Was ist das

Wiederhergestellter Branch `feat/playback-truth-rebuild`: war lokal gelöscht, die 28 Commits hingen dangling (nicht in `main`, nicht auf origin). Jetzt re-verankert und gepusht.

## Umfang — 28 Commits (main..feat)
- bafdbadd fix(profiles): stop advertising features the encoder never delivers
- 0b8c955a feat(live): scale the adaptive quality bitrate ceiling by source resolution
- 0bcbe6b8 feat(live): encode AV1 in 10-bit (p010) for smoother gradients
- 434803c6 perf+polish(webui): memoize AppContext value; wrap EPG toolbar actions
- 886edf70 fix(webui): a11y refinements — readable metadata, visible focus, clearer borders
- 66aacd82 fix(webui): apply the compact mobile player layout on phones
- 5722d86c feat(webui): resume browser playback on foreground (mobile + desktop)
- 29d14494 feat(webui): retry lazy chunk imports, reload on persistent failure
- 6606fbae fix(security): allow self-hosted fonts in the CSP
- df3c9864 fix(webui): recover from stale service worker and basename-less URLs
- d5b714db refactor(webui): bundle i18n locales statically
- 1ec5f737 fix(webui): mount the app even if the i18n locale import stalls
- 15cbbc38 fix(webui): drive desktop rail visibility from nav-mode, not 768px
- 0aaefe85 fix(webui): guard clipboard copy on insecure origins
- 045d1dbb fix(webui): stop iOS Safari painting the whole UI black
- 943a20e4 fix(webui): boot survives blocked/throwing localStorage
- 314f35f6 fix(webui): scope native trace poll to nativeSessionId only
- 1ae5e639 refactor(webui): delete dead duplicate telemetry/stats-rows modules
- 405b8b9e fix(live): effective profile records the resolved hwAccel (one source)
- 6330e451 fix(live): extractPlaybackTrace descends into .trace before the heuristic
- 05063201 fix(live): descend into .trace when merging the native session snapshot
- 4f223b39 fix(live): feed the executed session trace to the native stats panel
- 6b07e234 fix(live): repeat SPS/PPS on every keyframe for all live copy
- 078f671a fix(live): player panel reports execution truth, not the startup prediction
- 064f64cc feat(live): capture execution-truth ffmpeg plan from the real argv
- dced1b16 fix(live): preview keeps video on copy when only audio needs transcoding
- c7250d94 fix(live): session stats report the executed profile, never the prediction
- c0e27f71 fix(live): copy progressive playable sources instead of re-encoding to AV1

## Merge-Status / Review-Hinweis

Divergent zu `main` (+32 Commits seit Abzweig, inkl. Releases **v3.5.0 / v3.5.1**, FFmpeg 8.1→8.1.1, OTel-Telemetry). Kein Fast-Forward. Konflikte vor Merge aufzulösen:

- `backend/internal/infra/media/ffmpeg/adapter.go`
- `backend/internal/infra/media/ffmpeg/plan_builder.go`
- `frontend/webui/src/features/player/usePlaybackOrchestrator.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
