### PR TITLE
refactor: modernize interface{} → any across backend + lint gate (#6a)

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -19,3 +19,12 @@ linters:
 linters-settings:
   staticcheck:
     checks: ["all"]
+
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'

--- a/backend/cmd/daemon/report_cmd.go
+++ b/backend/cmd/daemon/report_cmd.go
@@ -60,8 +60,8 @@ var reportCmd = &cobra.Command{
 	},
 }
 
-func buildReportData(port int, token string) map[string]interface{} {
-	report := make(map[string]interface{})
+func buildReportData(port int, token string) map[string]any {
+	report := make(map[string]any)
 
 	// A. Status (API)
 	url := fmt.Sprintf("http://localhost:%d/api/v3/status", port)
@@ -79,7 +79,7 @@ func buildReportData(port int, token string) map[string]interface{} {
 	} else {
 		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode == http.StatusOK {
-			var status interface{}
+			var status any
 			if decodeErr := json.NewDecoder(resp.Body).Decode(&status); decodeErr != nil {
 				report["status_error"] = fmt.Sprintf("failed to decode status response: %v", decodeErr)
 			} else {
@@ -107,7 +107,7 @@ func buildReportData(port int, token string) map[string]interface{} {
 	}
 
 	// B. Fingerprint (Local)
-	report["fingerprint"] = map[string]interface{}{
+	report["fingerprint"] = map[string]any{
 		"os":            runtime.GOOS,
 		"arch":          runtime.GOARCH,
 		"cpus":          runtime.NumCPU(),

--- a/backend/cmd/xg2g-soak/prom.go
+++ b/backend/cmd/xg2g-soak/prom.go
@@ -189,11 +189,11 @@ func (p *PromClient) WaitStable(query string, target float64, stableFor, timeout
 type promQueryResult struct {
 	Status string `json:"status"`
 	Data   struct {
-		ResultType string        `json:"resultType"`
-		Value      []interface{} `json:"value"` // For scalar
+		ResultType string `json:"resultType"`
+		Value      []any  `json:"value"` // For scalar
 		Result     []struct {
 			Metric map[string]string `json:"metric"`
-			Value  []interface{}     `json:"value"`
+			Value  []any             `json:"value"`
 		} `json:"result"` // For vector
 	} `json:"data"`
 }

--- a/backend/internal/control/http/ui.go
+++ b/backend/internal/control/http/ui.go
@@ -61,4 +61,3 @@ func writeUIHTMLResponse(w http.ResponseWriter, status int, title, message strin
 		message,
 	)
 }
-

--- a/backend/internal/control/http/v3/handlers_common.go
+++ b/backend/internal/control/http/v3/handlers_common.go
@@ -77,7 +77,7 @@ func writeRegisteredProblem(w http.ResponseWriter, r *http.Request, status int, 
 
 // isNil is a robust nil check that handles the "typed nil interface" trap
 // for all nillable types (Ptr, Map, Slice, Func, Interface, Chan).
-func isNil(i interface{}) bool {
+func isNil(i any) bool {
 	if i == nil {
 		return true
 	}

--- a/backend/internal/control/http/v3/handlers_epg.go
+++ b/backend/internal/control/http/v3/handlers_epg.go
@@ -202,7 +202,7 @@ func (w *epgAdapter) GetPrograms(ctx context.Context) ([]epg.Programme, error) {
 	}
 
 	// Singleflight for Concurrency Protection
-	result, err, _ := s.epgSfg.Do("epg-load", func() (interface{}, error) {
+	result, err, _ := s.epgSfg.Do("epg-load", func() (any, error) {
 		//nolint:gosec // G703: path is strictly sanitized by dataFilePath
 		fileInfo, err := os.Stat(xmltvPath)
 		if err != nil {

--- a/backend/internal/control/http/v3/handlers_intents.go
+++ b/backend/internal/control/http/v3/handlers_intents.go
@@ -169,7 +169,7 @@ func (s *Server) handleV3Intents(w http.ResponseWriter, r *http.Request) {
 			} else if rawCapHash := normalize.Token(params["cap_hash"]); rawCapHash != "" {
 				expectedHash = rawCapHash
 			} else {
-				genericMap := make(map[string]interface{}, len(params))
+				genericMap := make(map[string]any, len(params))
 				for k, v := range params {
 					genericMap[k] = v
 				}

--- a/backend/internal/control/http/v3/library.go
+++ b/backend/internal/control/http/v3/library.go
@@ -40,7 +40,7 @@ func (s *Server) GetLibraryRoots(w http.ResponseWriter, r *http.Request) {
 // GetLibraryRootItems implements ServerInterface.
 // Per P0+ Gate #2: Returns 503 with Retry-After if scan running.
 // Phase 0 MVP: Direct param parsing + JSON encoding (type mapping refinement in Phase 1).
-func (s *Server) GetLibraryRootItems(w http.ResponseWriter, r *http.Request, rootId string, params interface{}) {
+func (s *Server) GetLibraryRootItems(w http.ResponseWriter, r *http.Request, rootId string, params any) {
 	s.mu.RLock()
 	librarySvc := s.libraryService
 	s.mu.RUnlock()
@@ -87,7 +87,7 @@ func (s *Server) GetLibraryRootItems(w http.ResponseWriter, r *http.Request, roo
 	}
 
 	// Build response (Phase 0 MVP: direct JSON encoding)
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"items":  items,
 		"total":  total,
 		"limit":  limit,

--- a/backend/internal/control/http/v3/receiver_context.go
+++ b/backend/internal/control/http/v3/receiver_context.go
@@ -35,7 +35,7 @@ func (s *Server) currentReceiverAbout(ctx context.Context) *openwebif.AboutInfo 
 		return cached
 	}
 
-	val, err, _ := s.receiverSfg.Do("receiver-about", func() (interface{}, error) {
+	val, err, _ := s.receiverSfg.Do("receiver-about", func() (any, error) {
 		s.mu.RLock()
 		cached := s.receiverAbout
 		cachedAt := s.receiverAboutAt
@@ -92,7 +92,7 @@ func (s *Server) currentReceiverLocations(ctx context.Context) []openwebif.Movie
 		return cached
 	}
 
-	val, err, _ := s.receiverSfg.Do("receiver-locations", func() (interface{}, error) {
+	val, err, _ := s.receiverSfg.Do("receiver-locations", func() (any, error) {
 		s.mu.RLock()
 		cached := s.receiverLocations
 		cachedAt := s.receiverLocationsAt

--- a/backend/internal/control/http/v3/receiver_current.go
+++ b/backend/internal/control/http/v3/receiver_current.go
@@ -70,7 +70,7 @@ func (s *Server) GetReceiverCurrent(w http.ResponseWriter, r *http.Request) {
 
 	// Get current service info with singleflight protection
 	// Get current service info with singleflight protection
-	val, err, _ := s.receiverSfg.Do("getcurrent", func() (interface{}, error) {
+	val, err, _ := s.receiverSfg.Do("getcurrent", func() (any, error) {
 		return client.GetCurrent(ctx)
 	})
 

--- a/backend/internal/control/http/v3/recordings_thumbnail.go
+++ b/backend/internal/control/http/v3/recordings_thumbnail.go
@@ -118,7 +118,7 @@ func ensureRecordingThumbnail(ctx context.Context, cfg config.AppConfig, sourceP
 		return nil
 	}
 
-	_, err, _ = recordingThumbnailBuildGroup.Do(thumbnailPath, func() (interface{}, error) {
+	_, err, _ = recordingThumbnailBuildGroup.Do(thumbnailPath, func() (any, error) {
 		if thumbnailInfo, statErr := os.Stat(thumbnailPath); statErr == nil && recordingThumbnailIsFresh(sourceInfo, thumbnailInfo) {
 			return nil, nil
 		}

--- a/backend/internal/control/middleware/recovery.go
+++ b/backend/internal/control/middleware/recovery.go
@@ -51,9 +51,9 @@ func Recoverer(next http.Handler) http.Handler {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
 				_ = json.NewEncoder(w).Encode(map[string]any{
-					"error":      "Internal server error",
+					"error":     "Internal server error",
 					"requestId": reqID,
-					"message":    "An unexpected error occurred. Please try again later.",
+					"message":   "An unexpected error occurred. Please try again later.",
 				})
 			}
 		}()

--- a/backend/internal/control/read/logs.go
+++ b/backend/internal/control/read/logs.go
@@ -11,7 +11,7 @@ type LogEntry struct {
 	Level   string
 	Message string
 	Time    time.Time
-	Fields  map[string]interface{}
+	Fields  map[string]any
 }
 
 // LogSource defines the minimal interface required to fetch log data.

--- a/backend/internal/control/recordings/manager.go
+++ b/backend/internal/control/recordings/manager.go
@@ -103,7 +103,7 @@ func (pm *probeManager) triggerProbe(key, serviceRef, sourceURL, localPath strin
 	}
 	// De-duplicate concurrent triggers across goroutines using the ResolveKey (usually hashed source)
 	executed := false
-	_, _, shared := pm.sf.Do(key, func() (interface{}, error) {
+	_, _, shared := pm.sf.Do(key, func() (any, error) {
 		executed = true
 		probeID := probeIDForKey(key)
 		startedAt := time.Now()

--- a/backend/internal/control/recordings/owi.go
+++ b/backend/internal/control/recordings/owi.go
@@ -29,7 +29,7 @@ type OWIMovie struct {
 	Length              string
 	Filename            string
 	Begin               int
-	Filesize            interface{} // Can be string or number, parsed by service/client
+	Filesize            any // Can be string or number, parsed by service/client
 }
 
 type OWITimer struct {

--- a/backend/internal/control/recordings/service.go
+++ b/backend/internal/control/recordings/service.go
@@ -633,7 +633,7 @@ func (s *service) classifyFilePresence(m OWIMovie) model.FilePresenceClass {
 	// For now, let's rely on the fact that List parsing populated `m.Filesize`.
 
 	// Quick parse helper (could be moved, but keeping local for now)
-	parseSize := func(val interface{}) int64 {
+	parseSize := func(val any) int64 {
 		s := fmt.Sprintf("%v", val)
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
 			return i

--- a/backend/internal/control/vod/prober.go
+++ b/backend/internal/control/vod/prober.go
@@ -83,7 +83,7 @@ func (m *Manager) probeWorker(ctx context.Context) {
 
 func (m *Manager) processProbe(ctx context.Context, req probeRequest) {
 	// Stampede prevention
-	_, err, _ := m.sfg.Do(req.ServiceRef, func() (interface{}, error) {
+	_, err, _ := m.sfg.Do(req.ServiceRef, func() (any, error) {
 		if runErr := m.runProbe(ctx, req); runErr != nil {
 			return nil, runErr
 		}

--- a/backend/internal/domain/session/lifecycle/events.go
+++ b/backend/internal/domain/session/lifecycle/events.go
@@ -24,7 +24,7 @@ const (
 
 // Event carries optional domain metadata for a transition.
 type Event struct {
-	Kind   EventKind
-	Reason model.ReasonCode
+	Kind       EventKind
+	Reason     model.ReasonCode
 	DetailCode model.ReasonDetailCode
 }

--- a/backend/internal/domain/session/lifecycle/illegal_transition_prod.go
+++ b/backend/internal/domain/session/lifecycle/illegal_transition_prod.go
@@ -14,10 +14,10 @@ import (
 
 func illegalTransition(rec *model.SessionRecord, from model.SessionState, ev EventKind, now time.Time) (Transition, error) {
 	tr := Transition{
-		From:   from,
-		To:     model.SessionFailed,
-		Event:  ev,
-		Reason: model.RInternalInvariantBreach,
+		From:        from,
+		To:          model.SessionFailed,
+		Event:       ev,
+		Reason:      model.RInternalInvariantBreach,
 		DetailCode:  model.DInternalInvariantBreach,
 		DetailDebug: fmt.Sprintf("illegal transition: %s + %v", from, ev),
 	}

--- a/backend/internal/domain/session/lifecycle/transitions_table.go
+++ b/backend/internal/domain/session/lifecycle/transitions_table.go
@@ -7,11 +7,11 @@ import "github.com/ManuGH/xg2g/internal/domain/session/model"
 
 // Transition is a single allowed edge in the lifecycle state machine.
 type Transition struct {
-	From       model.SessionState
-	To         model.SessionState
-	Event      EventKind
-	Reason     model.ReasonCode
-	DetailCode model.ReasonDetailCode
+	From        model.SessionState
+	To          model.SessionState
+	Event       EventKind
+	Reason      model.ReasonCode
+	DetailCode  model.ReasonDetailCode
 	DetailDebug string
 }
 

--- a/backend/internal/domain/session/manager/lease_expiry.go
+++ b/backend/internal/domain/session/manager/lease_expiry.go
@@ -17,7 +17,7 @@ import (
 )
 
 type stopEventBus interface {
-	Publish(ctx context.Context, topic string, event interface{}) error
+	Publish(ctx context.Context, topic string, event any) error
 }
 
 // LeaseExpiryWorker runs a background goroutine that expires sessions

--- a/backend/internal/domain/session/ports/bus.go
+++ b/backend/internal/domain/session/ports/bus.go
@@ -5,11 +5,11 @@ import "context"
 // Bus defines the interface for the event bus.
 // It mirrors the legacy bus.Bus interface to allow drop-in replacement.
 type Bus interface {
-	Publish(ctx context.Context, topic string, event interface{}) error
+	Publish(ctx context.Context, topic string, event any) error
 	Subscribe(ctx context.Context, topic string) (Subscription, error)
 }
 
 type Subscription interface {
-	C() <-chan interface{}
+	C() <-chan any
 	Close() error
 }

--- a/backend/internal/domain/session/store/sqlite_store.go
+++ b/backend/internal/domain/session/store/sqlite_store.go
@@ -282,7 +282,7 @@ func (s *SqliteStore) GetSession(ctx context.Context, id string) (*model.Session
 
 func (s *SqliteStore) QuerySessions(ctx context.Context, filter SessionFilter) ([]*model.SessionRecord, error) {
 	query := "SELECT * FROM sessions WHERE 1=1"
-	args := []interface{}{}
+	args := []any{}
 
 	if len(filter.States) > 0 {
 		query += " AND state IN ("
@@ -511,7 +511,7 @@ func (l *sqliteLease) Owner() string        { return l.owner }
 func (l *sqliteLease) ExpiresAt() time.Time { return l.expires }
 
 func scanSession(scanner interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }) (*model.SessionRecord, error) {
 	var rec model.SessionRecord
 	var profileJSON, contextJSON, playbackTraceJSON []byte

--- a/backend/internal/dvr/engine.go
+++ b/backend/internal/dvr/engine.go
@@ -55,7 +55,7 @@ func NewSeriesEngine(cfg config.AppConfig, rules *Manager, clientFactory func() 
 // ruleID: optional, if set only runs this specific rule
 func (e *SeriesEngine) RunOnce(ctx context.Context, trigger string, ruleID string) ([]SeriesRuleRunReport, error) {
 	// 1. Singleflight to prevent concurrent runs
-	res, err, _ := e.sfg.Do("run", func() (interface{}, error) {
+	res, err, _ := e.sfg.Do("run", func() (any, error) {
 		jobStart := time.Now()
 		e.logger.Info().Str("trigger", trigger).Str("rule_id", ruleID).Msg("starting series engine run")
 

--- a/backend/internal/health/health.go
+++ b/backend/internal/health/health.go
@@ -53,7 +53,7 @@ type HealthResponse struct {
 	Uptime    int64                  `json:"uptime,omitempty"` // Uptime in seconds since startup
 	Timestamp time.Time              `json:"timestamp"`
 	Checks    map[string]CheckResult `json:"checks,omitempty"`
-	Details   map[string]interface{} `json:"details,omitempty"`
+	Details   map[string]any         `json:"details,omitempty"`
 }
 
 // ReadinessResponse represents the readiness check response
@@ -63,7 +63,7 @@ type ReadinessResponse struct {
 	Timestamp time.Time              `json:"timestamp"`
 	Error     string                 `json:"error,omitempty"`
 	Checks    map[string]CheckResult `json:"checks,omitempty"`
-	Details   map[string]interface{} `json:"details,omitempty"`
+	Details   map[string]any         `json:"details,omitempty"`
 }
 
 // Checker defines the interface for health checks
@@ -190,7 +190,7 @@ func (m *Manager) Ready(ctx context.Context, verbose bool) ReadinessResponse {
 	m.mu.RUnlock()
 
 	// Use singleflight to prevent thundering herd on upstream.
-	val, err, _ := m.sfg.Do("readiness", func() (interface{}, error) {
+	val, err, _ := m.sfg.Do("readiness", func() (any, error) {
 		// Use DETACHED context for the shared probe.
 		// This prevents the first caller's context cancellation from aborting the shared run.
 		probeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/backend/internal/health/runtime_snapshot.go
+++ b/backend/internal/health/runtime_snapshot.go
@@ -375,10 +375,10 @@ func readComposeSpec(path string) (composeFileSpec, error) {
 	}
 	var raw struct {
 		Services map[string]struct {
-			Image       string      `yaml:"image"`
-			EnvFile     interface{} `yaml:"env_file"`
-			Environment interface{} `yaml:"environment"`
-			Volumes     interface{} `yaml:"volumes"`
+			Image       string `yaml:"image"`
+			EnvFile     any    `yaml:"env_file"`
+			Environment any    `yaml:"environment"`
+			Volumes     any    `yaml:"volumes"`
 		} `yaml:"services"`
 	}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
@@ -397,7 +397,7 @@ func readComposeSpec(path string) (composeFileSpec, error) {
 	return spec, nil
 }
 
-func normalizeComposeStringList(raw interface{}) []string {
+func normalizeComposeStringList(raw any) []string {
 	switch value := raw.(type) {
 	case nil:
 		return nil
@@ -407,7 +407,7 @@ func normalizeComposeStringList(raw interface{}) []string {
 			return nil
 		}
 		return []string{value}
-	case []interface{}:
+	case []any:
 		out := make([]string, 0, len(value))
 		for _, item := range value {
 			text := strings.TrimSpace(fmt.Sprint(item))
@@ -422,16 +422,16 @@ func normalizeComposeStringList(raw interface{}) []string {
 	}
 }
 
-func normalizeComposeEnvironment(raw interface{}) map[string]string {
+func normalizeComposeEnvironment(raw any) map[string]string {
 	out := map[string]string{}
 	switch value := raw.(type) {
 	case nil:
 		return out
-	case map[string]interface{}:
+	case map[string]any:
 		for key, rawValue := range value {
 			out[strings.TrimSpace(key)] = strings.TrimSpace(fmt.Sprint(rawValue))
 		}
-	case []interface{}:
+	case []any:
 		for _, item := range value {
 			entry := strings.TrimSpace(fmt.Sprint(item))
 			if entry == "" {
@@ -447,11 +447,11 @@ func normalizeComposeEnvironment(raw interface{}) map[string]string {
 	return out
 }
 
-func normalizeComposeVolumes(raw interface{}) []LifecycleRuntimeVolumeSnapshot {
+func normalizeComposeVolumes(raw any) []LifecycleRuntimeVolumeSnapshot {
 	switch value := raw.(type) {
 	case nil:
 		return nil
-	case []interface{}:
+	case []any:
 		out := make([]LifecycleRuntimeVolumeSnapshot, 0, len(value))
 		for _, item := range value {
 			entry := strings.TrimSpace(fmt.Sprint(item))

--- a/backend/internal/infra/bus/adapter.go
+++ b/backend/internal/infra/bus/adapter.go
@@ -16,7 +16,7 @@ func NewAdapter(b bus.Bus) *Adapter {
 	return &Adapter{inner: b}
 }
 
-func (a *Adapter) Publish(ctx context.Context, topic string, event interface{}) error {
+func (a *Adapter) Publish(ctx context.Context, topic string, event any) error {
 	return a.inner.Publish(ctx, topic, event)
 }
 
@@ -32,7 +32,7 @@ type subAdapter struct {
 	inner bus.Subscriber
 }
 
-func (s *subAdapter) C() <-chan interface{} {
+func (s *subAdapter) C() <-chan any {
 	return s.inner.C()
 }
 

--- a/backend/internal/log/logger.go
+++ b/backend/internal/log/logger.go
@@ -247,10 +247,10 @@ func WithTraceContext(ctx context.Context) zerolog.Logger {
 
 // LogBuffer implementation
 type LogEntry struct {
-	Timestamp time.Time              `json:"timestamp"`
-	Level     string                 `json:"level"`
-	Message   string                 `json:"message"`
-	Fields    map[string]interface{} `json:"fields,omitempty"`
+	Timestamp time.Time      `json:"timestamp"`
+	Level     string         `json:"level"`
+	Message   string         `json:"message"`
+	Fields    map[string]any `json:"fields,omitempty"`
 }
 
 const maxLogEntries = 100

--- a/backend/internal/normalize/normalize.go
+++ b/backend/internal/normalize/normalize.go
@@ -34,11 +34,11 @@ func ServiceRef(s string) string {
 	return s
 }
 
-// MapHash takes any map[string]interface{} (used often for capabilities or query params),
+// MapHash takes any map[string]any (used often for capabilities or query params),
 // deterministically marshals it using Go's built-in sorted json.Marshal algorithm,
 // and returns a SHA-256 hexadecimal string representation.
 // This is used for generating cryptographically stable `capHash` bindings in JWT tokens.
-func MapHash(m map[string]interface{}) (string, error) {
+func MapHash(m map[string]any) (string, error) {
 	if len(m) == 0 {
 		return "", nil // Empty map has no hash signature
 	}

--- a/backend/internal/openwebif/client.go
+++ b/backend/internal/openwebif/client.go
@@ -139,15 +139,15 @@ type AboutInfo struct {
 		Mem3 string `json:"mem3"` // Friendly summary, e.g. "548180 kB frei / 757484 kB insgesamt"
 
 		// Software versions
-		OEVer               string      `json:"oever"`               // OE-Alliance version
-		ImageVer            string      `json:"imagever"`            // OpenATV version
-		ImageDistro         string      `json:"imagedistro"`         // "openatv"
-		FriendlyImageDistro string      `json:"friendlyimagedistro"` // "OpenATV"
-		EnigmaVer           string      `json:"enigmaver"`           // Enigma2 date
-		KernelVer           string      `json:"kernelver"`           // Kernel version
-		DriverDate          string      `json:"driverdate"`          // Driver date
-		WebIFVer            string      `json:"webifver"`            // OWIF version
-		FPVersion           interface{} `json:"fp_version"`          // Front panel version (often null)
+		OEVer               string `json:"oever"`               // OE-Alliance version
+		ImageVer            string `json:"imagever"`            // OpenATV version
+		ImageDistro         string `json:"imagedistro"`         // "openatv"
+		FriendlyImageDistro string `json:"friendlyimagedistro"` // "OpenATV"
+		EnigmaVer           string `json:"enigmaver"`           // Enigma2 date
+		KernelVer           string `json:"kernelver"`           // Kernel version
+		DriverDate          string `json:"driverdate"`          // Driver date
+		WebIFVer            string `json:"webifver"`            // OWIF version
+		FPVersion           any    `json:"fp_version"`          // Front panel version (often null)
 
 		// Runtime
 		Uptime string `json:"uptime"` // e.g., "1d 07:40"
@@ -166,12 +166,12 @@ type AboutInfo struct {
 		// Storage and Network
 		HDD    []HDDInfo          `json:"hdd"`    // Storage devices
 		IFaces []NetworkInterface `json:"ifaces"` // Network interfaces
-		Shares []interface{}      `json:"shares"` // Network shares (often empty)
+		Shares []any              `json:"shares"` // Network shares (often empty)
 
 		// Additional fields
-		Streams interface{} `json:"streams"` // Active streams
+		Streams any `json:"streams"` // Active streams
 	} `json:"info"`
-	Service interface{} `json:"service"` // Current service info
+	Service any `json:"service"` // Current service info
 }
 
 // AboutTuner represents a tuner entry in /api/about.
@@ -195,19 +195,19 @@ type HDDInfo struct {
 
 // NetworkInterface represents a network interface.
 type NetworkInterface struct {
-	Name        string      `json:"name"`        // "eth0"
-	FriendlyNIC string      `json:"friendlynic"` // "Broadcom Gigabit Ethernet"
-	LinkSpeed   string      `json:"linkspeed"`   // "1 GBit/s"
-	MAC         string      `json:"mac"`         // "00:1d:ec:0f:e3:ed"
-	DHCP        bool        `json:"dhcp"`        // true if DHCP enabled
-	IP          string      `json:"ip"`          // IPv4 address
-	Mask        string      `json:"mask"`        // Netmask
-	Gateway     string      `json:"gw"`          // Gateway
-	IPv6        string      `json:"ipv6"`        // IPv6 address
-	IPMethod    string      `json:"ipmethod"`    // IP method
-	IPv4Method  string      `json:"ipv4method"`  // IPv4 method
-	V4Prefix    int         `json:"v4prefix"`    // IPv4 prefix
-	FirstPublic interface{} `json:"firstpublic"` // First public IP (often null)
+	Name        string `json:"name"`        // "eth0"
+	FriendlyNIC string `json:"friendlynic"` // "Broadcom Gigabit Ethernet"
+	LinkSpeed   string `json:"linkspeed"`   // "1 GBit/s"
+	MAC         string `json:"mac"`         // "00:1d:ec:0f:e3:ed"
+	DHCP        bool   `json:"dhcp"`        // true if DHCP enabled
+	IP          string `json:"ip"`          // IPv4 address
+	Mask        string `json:"mask"`        // Netmask
+	Gateway     string `json:"gw"`          // Gateway
+	IPv6        string `json:"ipv6"`        // IPv6 address
+	IPMethod    string `json:"ipmethod"`    // IP method
+	IPv4Method  string `json:"ipv4method"`  // IPv4 method
+	V4Prefix    int    `json:"v4prefix"`    // IPv4 prefix
+	FirstPublic any    `json:"firstpublic"` // First public IP (often null)
 }
 
 const (

--- a/backend/internal/openwebif/mock_server.go
+++ b/backend/internal/openwebif/mock_server.go
@@ -37,12 +37,12 @@ type MockServer struct {
 
 // BouquetsResponse matches OpenWebIF API structure.
 type BouquetsResponse struct {
-	Services [][]interface{} `json:"services"`
+	Services [][]any `json:"services"`
 }
 
 // ServicesResponse matches OpenWebIF API structure.
 type ServicesResponse struct {
-	Services []map[string]interface{} `json:"services"`
+	Services []map[string]any `json:"services"`
 }
 
 // NewMockServer creates a new OpenWebIF mock server.
@@ -204,7 +204,7 @@ func (m *MockServer) handleBouquets(w http.ResponseWriter, _ *http.Request) {
 		bouquets = append(bouquets, []string{ref, name})
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"bouquets": bouquets,
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -232,15 +232,15 @@ func (m *MockServer) handleAllServices(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Flat payload shape expected by /api/getallservices consumers.
-	servicesList := make([]map[string]interface{}, len(services))
+	servicesList := make([]map[string]any, len(services))
 	for i, svc := range services {
-		servicesList[i] = map[string]interface{}{
+		servicesList[i] = map[string]any{
 			"servicereference": svc[0],
 			"servicename":      svc[1],
 		}
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"services": servicesList,
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -279,9 +279,9 @@ func (m *MockServer) handleServices(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build response
-	servicesList := make([]map[string]interface{}, len(services))
+	servicesList := make([]map[string]any, len(services))
 	for i, svc := range services {
-		servicesList[i] = map[string]interface{}{
+		servicesList[i] = map[string]any{
 			"servicereference": svc[0],
 			"servicename":      svc[1],
 		}
@@ -326,7 +326,7 @@ func (m *MockServer) handleZap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"result":  true,
 		"message": "Channel switched successfully",
 	}
@@ -336,8 +336,8 @@ func (m *MockServer) handleZap(w http.ResponseWriter, r *http.Request) {
 
 // handleAbout handles /api/about
 func (m *MockServer) handleAbout(w http.ResponseWriter, _ *http.Request) {
-	resp := map[string]interface{}{
-		"info": map[string]interface{}{
+	resp := map[string]any{
+		"info": map[string]any{
 			"model":     "Mock Receiver",
 			"brand":     "MockBrand",
 			"boxtype":   "mockbox",
@@ -387,9 +387,9 @@ func (m *MockServer) handleGetCurrent(w http.ResponseWriter, _ *http.Request) {
 		pmtpid = 5000
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"result": true,
-		"info": map[string]interface{}{
+		"info": map[string]any{
 			"serviceref": m.currentServiceRef,
 			"name":       "Mock Channel",
 			"vpid":       strconv.Itoa(vpid),
@@ -411,7 +411,7 @@ func (m *MockServer) handleSignal(w http.ResponseWriter, _ *http.Request) {
 		standbyStr = "true"
 	}
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"result":    true,
 		"snr":       m.snrSignal,
 		"agc":       50,
@@ -433,7 +433,7 @@ func (m *MockServer) handleStatusInfo(w http.ResponseWriter, _ *http.Request) {
 	}
 	isRecordingStr := "false"
 
-	resp := map[string]interface{}{
+	resp := map[string]any{
 		"result":                 true,
 		"inStandby":              standbyStr,
 		"isRecording":            isRecordingStr,

--- a/backend/internal/pipeline/bus/bus.go
+++ b/backend/internal/pipeline/bus/bus.go
@@ -8,7 +8,7 @@ import "context"
 
 // Message is an opaque event payload. For MVP, we use a typed struct.
 // For NATS JetStream, this will map to subject + bytes.
-type Message = interface{}
+type Message = any
 
 // Handler applies an event/message within a context.
 type Handler func(ctx context.Context, msg Message) error

--- a/backend/internal/pipeline/exec/enigma2/client.go
+++ b/backend/internal/pipeline/exec/enigma2/client.go
@@ -203,7 +203,7 @@ func (c *Client) GetSignal(ctx context.Context) (*Signal, error) {
 	return &res, nil
 }
 
-func (c *Client) get(ctx context.Context, path string, params url.Values, v interface{}) error {
+func (c *Client) get(ctx context.Context, path string, params url.Values, v any) error {
 	u, err := url.Parse(c.BaseURL)
 	if err != nil {
 		return fmt.Errorf("invalid base URL: %w", err)

--- a/backend/internal/pipeline/exec/enigma2/readychecker.go
+++ b/backend/internal/pipeline/exec/enigma2/readychecker.go
@@ -51,7 +51,7 @@ func NormalizeServiceRef(ref string) string {
 // WaitReady blocks until the tuner is locked to the expected service or ctx errors.
 // It uses singleflight keyed by the provided contention key (e.g. host:slot).
 func (rc *ReadyChecker) WaitReady(ctx context.Context, key, expectedRef string) error {
-	_, err, _ := rc.sf.Do(key, func() (interface{}, error) {
+	_, err, _ := rc.sf.Do(key, func() (any, error) {
 		return nil, rc.waitReadyInner(ctx, expectedRef)
 	})
 	return err

--- a/backend/internal/validate/validate.go
+++ b/backend/internal/validate/validate.go
@@ -17,9 +17,9 @@ import (
 
 // Error represents a validation error
 type Error struct {
-	Field   string      // Field name that failed validation
-	Value   interface{} // The invalid value
-	Message string      // Human-readable error message
+	Field   string // Field name that failed validation
+	Value   any    // The invalid value
+	Message string // Human-readable error message
 }
 
 // Error implements the error interface
@@ -45,7 +45,7 @@ func New() *Validator {
 }
 
 // AddError adds a validation error
-func (v *Validator) AddError(field, message string, value interface{}) {
+func (v *Validator) AddError(field, message string, value any) {
 	v.errors = append(v.errors, Error{
 		Field:   field,
 		Value:   value,
@@ -234,7 +234,7 @@ func (v *Validator) NonNegative(field string, value int) {
 
 // Custom allows custom validation logic
 // The validator function should return an error if validation fails
-func (v *Validator) Custom(field string, value interface{}, validator func(interface{}) error) {
+func (v *Validator) Custom(field string, value any, validator func(any) error) {
 	if err := validator(value); err != nil {
 		v.AddError(field, err.Error(), value)
 	}

--- a/backend/test/load/openwebif_mock.go
+++ b/backend/test/load/openwebif_mock.go
@@ -204,7 +204,7 @@ func (m *MockServer) calculateLatency() time.Duration {
 
 func (m *MockServer) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"status":  "ok",
 		"version": "mock-1.0.0",
 	})
@@ -219,7 +219,7 @@ func (m *MockServer) handleBouquets(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"bouquets": bouquets,
 	})
 }
@@ -239,7 +239,7 @@ func (m *MockServer) handleGetServices(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"services": services,
 	})
 }
@@ -353,13 +353,13 @@ func (e *EPGMockServer) handleEPG(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate EPG events
-	events := make([]map[string]interface{}, 0, e.epgConfig.EventsPerChannel)
+	events := make([]map[string]any, 0, e.epgConfig.EventsPerChannel)
 	now := time.Now()
 
 	for i := 0; i < e.epgConfig.EventsPerChannel; i++ {
 		start := now.Add(time.Duration(i) * e.epgConfig.EventDuration)
 
-		event := map[string]interface{}{
+		event := map[string]any{
 			"id":              strconv.Itoa(1000 + i),
 			"begin_timestamp": start.Unix(),
 			"duration_sec":    int(e.epgConfig.EventDuration.Seconds()),
@@ -376,7 +376,7 @@ func (e *EPGMockServer) handleEPG(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"events": events,
 	})
 }


### PR DESCRIPTION
## #6a — `interface{}` → `any` (mechanical) + lint gate

Mechanical `gofmt -r 'interface{} -> any'` over **non-test, non-generated** backend source (**35 files**), plus a golangci-lint **gofmt-formatter rewrite-rule** so `interface{}` can't regress.

- **No behavior change** — `any` is a type alias for `interface{}`.
- Generated (`*_gen.go`) and `_test.go` left untouched (repo `tests: false` lint policy).
- `normalize.go` doc comment tidied to match (`map[string]any`).

### Verification (local, golangci-lint v2.12.2)
- `go build ./...` clean
- `golangci-lint run --new-from-rev=origin/main` → **0 new issues**
- gofmt-formatter gate confirmed to flag/forbid future `interface{}`

### Scope note
This is **#6a** of the refactor sequence (#6a→#2→#1). The Go-1.25 modernize pass (`slices`/`maps`/`errors.Join`) is intentionally **not** here — it's a separate commit (#6b) because `errors.Join` changes error strings and needs the golden tests re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
