### PR TITLE
chore(security): annotate 9 verified-safe gosec findings (#nosec, no behavior change)

### DIFF
--- a/backend/internal/app/bootstrap/bootstrap.go
+++ b/backend/internal/app/bootstrap/bootstrap.go
@@ -421,7 +421,7 @@ func logConfigFingerprint(logger zerolog.Logger, cfg config.AppConfig) {
 	canonicalCfg := config.Clone(cfg)
 	canonicalCfg.Monetization = canonicalCfg.Monetization.Normalized()
 
-	configBytes, marshalErr := json.Marshal(canonicalCfg)
+	configBytes, marshalErr := json.Marshal(canonicalCfg) // #nosec G117 -- marshaled only to compute a sha256 fingerprint; bytes (incl. APIToken) are hashed, never logged or persisted
 	if marshalErr != nil {
 		return
 	}

--- a/backend/internal/control/http/v3/auth.go
+++ b/backend/internal/control/http/v3/auth.go
@@ -210,7 +210,7 @@ func (s *Server) issueCookieSession(w http.ResponseWriter, r *http.Request, toke
 	if maxAge <= 0 {
 		maxAge = sessionCookieMaxAgeSeconds
 	}
-	setServerCookie(w, &http.Cookie{
+	setServerCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly+SameSite=Lax set; Secure=effectiveHTTPS is request-derived, opaque to gosec
 		Name:     sessionCookieName,
 		Value:    sessionID,
 		Path:     "/api/v3/",

--- a/backend/internal/control/http/v3/handlers_deviceauth.go
+++ b/backend/internal/control/http/v3/handlers_deviceauth.go
@@ -137,7 +137,7 @@ func (s *Server) CompleteWebBootstrap(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 
-	http.Redirect(w, r, result.TargetPath, http.StatusSeeOther)
+	http.Redirect(w, r, result.TargetPath, http.StatusSeeOther) // #nosec G710 -- TargetPath normalized to a same-origin absolute path (normalizeWebBootstrapTargetPath rejects scheme/host/userinfo/'//')
 }
 
 func writeDeviceSessionServiceError(w http.ResponseWriter, r *http.Request, err error) {

--- a/backend/internal/control/http/v3/household_unlock.go
+++ b/backend/internal/control/http/v3/household_unlock.go
@@ -56,7 +56,7 @@ func (s *Server) PostHouseholdUnlock(w http.ResponseWriter, r *http.Request, par
 		return
 	}
 
-	setServerCookie(w, &http.Cookie{
+	setServerCookie(w, &http.Cookie{ // #nosec G124 -- HttpOnly+SameSite=Lax set; Secure=s.requestIsHTTPS(r) is request-derived, opaque to gosec
 		Name:     householdUnlockCookieName,
 		Value:    sessionID,
 		Path:     "/api/v3/",
@@ -129,7 +129,7 @@ func setServerCookie(w http.ResponseWriter, cookie *http.Cookie) {
 }
 
 func clearServerCookie(w http.ResponseWriter, name, path string, secure bool) {
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, &http.Cookie{ // #nosec G124 -- cookie cleared with HttpOnly+SameSite=Lax+Secure set, MaxAge=-1
 		Name:     strings.TrimSpace(name),
 		Value:    "",
 		Path:     path,

--- a/backend/internal/control/http/v3/recordings_admin.go
+++ b/backend/internal/control/http/v3/recordings_admin.go
@@ -388,7 +388,7 @@ func updateRecordingMetaTitle(localPath, title string) error {
 	}
 
 	tmpPath := metaPath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(updated), mode); err != nil {
+	if err := os.WriteFile(tmpPath, []byte(updated), mode); err != nil { // #nosec G703 -- tmpPath derives from resolver-confined localPath (same path justified for G304 above)
 		return fmt.Errorf("write recording meta: %w", err)
 	}
 	if err := os.Rename(tmpPath, metaPath); err != nil {

--- a/backend/internal/control/http/v3/recordings_admin.go
+++ b/backend/internal/control/http/v3/recordings_admin.go
@@ -388,7 +388,7 @@ func updateRecordingMetaTitle(localPath, title string) error {
 	}
 
 	tmpPath := metaPath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(updated), mode); err != nil { // #nosec G703 -- tmpPath derives from resolver-confined localPath (same path justified for G304 above)
+	if err := os.WriteFile(tmpPath, []byte(updated), mode); err != nil { // #nosec G304 -- tmpPath derives from resolver-confined localPath (same path justified for G304 above)
 		return fmt.Errorf("write recording meta: %w", err)
 	}
 	if err := os.Rename(tmpPath, metaPath); err != nil {

--- a/backend/internal/control/http/v3/storage_monitor.go
+++ b/backend/internal/control/http/v3/storage_monitor.go
@@ -231,7 +231,7 @@ func (m *StorageMonitor) probe(ctx context.Context, path string) ProbeResult {
 		Access:       StorageItemAccessNone,
 	}
 
-	cmd := exec.CommandContext(probeCtx, "/bin/sh", "-c", storageProbeScript, "xg2g-storage-probe", path)
+	cmd := exec.CommandContext(probeCtx, "/bin/sh", "-c", storageProbeScript, "xg2g-storage-probe", path) // #nosec G204 -- constant storageProbeScript; path passed as positional arg, not interpolated into the script
 	out, err := cmd.Output()
 	if err != nil {
 		if probeCtx.Err() == context.DeadlineExceeded {

--- a/backend/internal/infra/media/ffmpeg/adapter.go
+++ b/backend/internal/infra/media/ffmpeg/adapter.go
@@ -1415,7 +1415,7 @@ func (a *LocalAdapter) Start(ctx context.Context, spec ports.StreamSpec) (ports.
 	delete(a.processDetails, handle)
 	a.mu.Unlock()
 
-	go a.monitorProcessWithStartTimeout(ctx, handle, cmd, stderr, spec.SessionID, argsHardwareBackend(args), plan.pathID, a.startTimeoutForProfile(spec.Source.Type, plan.effectiveProfile), startupSpan, spawnedAt)
+	go a.monitorProcessWithStartTimeout(ctx, handle, cmd, stderr, spec.SessionID, argsHardwareBackend(args), plan.pathID, a.startTimeoutForProfile(spec.Source.Type, plan.effectiveProfile), startupSpan, spawnedAt) // #nosec G118 -- goroutine receives the request-scoped ctx (first arg), not context.Background/TODO
 	if sourceKey != "" {
 		go a.learnFPSFromOutput(sourceKey, spec.SessionID)
 	}

--- a/backend/internal/verification/checks/checks.go
+++ b/backend/internal/verification/checks/checks.go
@@ -111,7 +111,7 @@ func NewRealRunner() *RealRunner {
 }
 
 func (r *RealRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204 -- internal verification runner; name/args are trusted internal values, never request input
 	return cmd.Output()
 }
 


### PR DESCRIPTION
## Annotate 9 verified-safe gosec findings

A full-module `golangci-lint run` (gosec) surfaced 9 pre-existing findings (CI is scoped, so they don't block it). **Each was verified individually** — all are false positives or trusted/intentional. Annotated with justified `#nosec`, matching the repo's existing pattern (e.g. `recordings_thumbnail.go` G204, `recordings_admin.go` G304).

| Finding | Site | Why safe |
|---|---|---|
| G710 open redirect | `handlers_deviceauth.go:140` | `normalizeWebBootstrapTargetPath` rejects scheme/host/userinfo/`//` → same-origin absolute path only |
| G117 secret marshal | `bootstrap.go:424` | marshaled only to compute a sha256 fingerprint; bytes never logged/persisted |
| G124 cookies ×3 | `auth.go`, `household_unlock.go` | HttpOnly+SameSite set; `Secure` is request-derived (opaque to gosec) |
| G703 path traversal | `recordings_admin.go:391` | write path resolver-confined (same path already justified for G304) |
| G204 subprocess ×2 | `storage_monitor.go`, `checks.go` | trusted binaries; args not request-derived |
| G118 goroutine ctx | `adapter.go:1418` | goroutine receives the request-scoped `ctx`, not Background |

**No code/behavior change — annotations only.** `go build` clean; gosec now reports 0 issues module-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
