### PR TITLE
fix(decision): align transcoder→transcode to the OpenAPI contract

### DIFF
--- a/backend/internal/control/playback/types.go
+++ b/backend/internal/control/playback/types.go
@@ -38,7 +38,7 @@ type PlaybackMode string
 const (
 	ModeDirectPlay   PlaybackMode = "direct_play"   // Client plays strict format directly
 	ModeDirectStream PlaybackMode = "direct_stream" // Remux container only (no re-encode)
-	ModeTranscode    PlaybackMode = "transcoder"    // Re-encode required
+	ModeTranscode    PlaybackMode = "transcode"     // Re-encode required
 	ModeError        PlaybackMode = "error"         // Hard failure (e.g. not found)
 	ModeDeny         PlaybackMode = "deny"          // Access forbidden or preparing
 )

--- a/backend/internal/control/recordings/types.go
+++ b/backend/internal/control/recordings/types.go
@@ -33,7 +33,7 @@ type PlaybackDecision string
 const (
 	DecisionDirectPlay   PlaybackDecision = "direct_play"
 	DecisionDirectStream PlaybackDecision = "direct_stream"
-	DecisionTranscode    PlaybackDecision = "transcoder"
+	DecisionTranscode    PlaybackDecision = "transcode"
 )
 
 type CachePolicy string


### PR DESCRIPTION
## fix(decision): align the two `"transcoder"` outliers to the contract `"transcode"`

### Audit correction first
The audit's "consolidate the 4 playback-decision engines" premise is **wrong**: they aren't redundant duplicates.
- `control/playback` = **live client playback** (`Decide(truth, caps, hint) → PlaybackPlan`)
- `control/recordings/decision` = **ADR-P8 recordings decision** (`Decide(ctx, input, schema) → (status, Decision, Problem)`)

Distinct domains — no engine merger is warranted (or done here).

### The real issue: a vocabulary split
Four `*Transcode*` enums across packages disagreed on the string value:
- `"transcode"` ← OpenAPI contract (`enum [direct_play, direct_stream, transcode, deny]`), generated servers (`PlaybackDecisionModeTranscode`), ADR-P8 `decision.ModeTranscode`, `clientplayback`
- `"transcoder"` ← `control/playback.ModeTranscode`, `control/recordings.DecisionTranscode` **(the outliers)**

The API mode flows out via a direct cast `PlaybackDecisionMode(dec.Mode)`. **No golden/contract pins `"transcoder"`, no consumer matches the literal, no reverse mapping** — the two outliers are simply contract-violating typos.

### Change
Align both outliers to `"transcode"`.

### Verification
- Full module build green; **decision / playback / recordings + v3 contract & golden tests all green** (the serialization path accepts `transcode`); `golangci-lint --new-from-rev` = 0; `verify-config` green
- Tests compare against constants (not literals), so internal logic is insulated; the change moves the API value **toward** the published contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)
