### PR TITLE
refactor(backend): modernize stdlib usage (Go 1.25, behavior-preserving)

### DIFF
--- a/backend/cmd/configgen/main.go
+++ b/backend/cmd/configgen/main.go
@@ -659,7 +659,7 @@ func schemaItemsForEntry(entry config.ConfigEntry) map[string]any {
 }
 
 func resolveFieldType(path string) (reflect.Type, bool) {
-	cfgType := reflect.TypeOf(config.AppConfig{})
+	cfgType := reflect.TypeFor[config.AppConfig]()
 	parts := strings.Split(path, ".")
 	curr := cfgType
 	for _, part := range parts {

--- a/backend/cmd/xg2g-soak/scenario_gpu.go
+++ b/backend/cmd/xg2g-soak/scenario_gpu.go
@@ -128,7 +128,7 @@ func runGPUSaturationScenario(cfg Config, prom *PromClient, client *SessionClien
 
 	rejectCount := 0
 	gpuBusyRejectCount := 0
-	for i := 0; i < burstCount; i++ {
+	for i := range burstCount {
 		serviceRef := fmt.Sprintf("soak-gpu-burst-%d", i)
 		// Use Pulse - this should get gpu_busy rejection
 		res := client.StartSession(serviceRef, "pulse")

--- a/backend/internal/admission/monitor.go
+++ b/backend/internal/admission/monitor.go
@@ -262,7 +262,7 @@ func (m *ResourceMonitor) TotalActiveSessions() int64 {
 func (m *ResourceMonitor) hasPreemptibleSession(p Priority) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	for i := PriorityPulse; i < p; i++ {
+	for i := range p {
 		if len(m.sessionIDs[i]) > 0 {
 			return true
 		}
@@ -275,7 +275,7 @@ func (m *ResourceMonitor) SelectPreemptionTarget(p Priority) (string, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	// Pulse < Live < Recording
-	for i := PriorityPulse; i < p; i++ {
+	for i := range p {
 		ids := m.sessionIDs[i]
 		if len(ids) > 0 {
 			// Preempt the oldest one in this class for now

--- a/backend/internal/admission/monitor.go
+++ b/backend/internal/admission/monitor.go
@@ -262,7 +262,7 @@ func (m *ResourceMonitor) TotalActiveSessions() int64 {
 func (m *ResourceMonitor) hasPreemptibleSession(p Priority) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	for i := range p {
+	for i := PriorityPulse; i < p; i++ {
 		if len(m.sessionIDs[i]) > 0 {
 			return true
 		}
@@ -275,7 +275,7 @@ func (m *ResourceMonitor) SelectPreemptionTarget(p Priority) (string, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	// Pulse < Live < Recording
-	for i := range p {
+	for i := PriorityPulse; i < p; i++ {
 		ids := m.sessionIDs[i]
 		if len(ids) > 0 {
 			// Preempt the oldest one in this class for now

--- a/backend/internal/config/clone.go
+++ b/backend/internal/config/clone.go
@@ -3,6 +3,8 @@
 
 package config
 
+import "maps"
+
 // Clone returns an alias-free deep copy of AppConfig.
 // Only reference types (maps/slices) are cloned; nested structs are copied by value.
 func Clone(in AppConfig) AppConfig {
@@ -67,9 +69,7 @@ func cloneStringMap(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/backend/internal/config/deprecations.go
+++ b/backend/internal/config/deprecations.go
@@ -35,7 +35,7 @@ func LoadDeprecations() ([]Deprecation, error) {
 		return nil, err
 	}
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		path := filepath.Join(curr, "docs", "deprecations.json")
 		if _, err := os.Stat(path); err == nil {
 			// #nosec G304 - path is constructed locally with hardcoded filename relative to CWD

--- a/backend/internal/config/guardrail.go
+++ b/backend/internal/config/guardrail.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -148,12 +149,7 @@ func isLegacyEnvHandledByGuardrail(key string) bool {
 	if key == "XG2G_FFMPEG_PATH" {
 		return true
 	}
-	for _, legacyKey := range legacyCompatEnvKeys {
-		if key == legacyKey {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(legacyCompatEnvKeys, key)
 }
 
 func legacyCompatEnvDiagnostic(key, value string) (legacyEnvDiagnostic, bool) {

--- a/backend/internal/config/logmask.go
+++ b/backend/internal/config/logmask.go
@@ -66,7 +66,7 @@ func MaskSecrets(data any) any {
 	case reflect.Slice, reflect.Array:
 		length := val.Len()
 		result := make([]any, length)
-		for i := 0; i < length; i++ {
+		for i := range length {
 			result[i] = MaskSecrets(val.Index(i).Interface())
 		}
 		return result

--- a/backend/internal/config/merge_file.go
+++ b/backend/internal/config/merge_file.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -141,9 +142,7 @@ func (l *Loader) mergeFileRecordingRoots(dst *AppConfig, src *FileConfig) {
 		if dst.RecordingRoots == nil {
 			dst.RecordingRoots = make(map[string]string)
 		}
-		for k, v := range src.Recording {
-			dst.RecordingRoots[k] = v
-		}
+		maps.Copy(dst.RecordingRoots, src.Recording)
 	}
 }
 

--- a/backend/internal/config/registry.go
+++ b/backend/internal/config/registry.go
@@ -328,7 +328,7 @@ func buildRegistry() (*Registry, error) {
 
 // ValidateFieldCoverage uses reflection to ensure every field in AppConfig is registered.
 func (r *Registry) ValidateFieldCoverage(cfg AppConfig) error {
-	t := reflect.TypeOf(cfg)
+	t := reflect.TypeFor[AppConfig]()
 	return r.validateStruct("", t)
 }
 

--- a/backend/internal/config/server.go
+++ b/backend/internal/config/server.go
@@ -136,10 +136,7 @@ func ParseServerConfigForApp(cfg AppConfig) ServerConfig {
 		maxHeaderBytes = base.MaxHeaderBytes
 	}
 
-	shutdownTimeout := ParseDuration("XG2G_SERVER_SHUTDOWN_TIMEOUT", base.ShutdownTimeout)
-	if shutdownTimeout < 3*time.Second {
-		shutdownTimeout = 3 * time.Second
-	}
+	shutdownTimeout := max(ParseDuration("XG2G_SERVER_SHUTDOWN_TIMEOUT", base.ShutdownTimeout), 3*time.Second)
 
 	return ServerConfig{
 		ListenAddr:      listen,

--- a/backend/internal/config/validation.go
+++ b/backend/internal/config/validation.go
@@ -606,12 +606,12 @@ func parsePlaybackDecisionPreviousKey(raw string) (keyID string, secret string) 
 	if value == "" {
 		return "", ""
 	}
-	idx := strings.Index(value, ":")
-	if idx < 0 {
+	before, after, ok := strings.Cut(value, ":")
+	if !ok {
 		return "", strings.TrimSpace(value)
 	}
-	keyID = strings.TrimSpace(value[:idx])
-	secret = strings.TrimSpace(value[idx+1:])
+	keyID = strings.TrimSpace(before)
+	secret = strings.TrimSpace(after)
 	return keyID, secret
 }
 

--- a/backend/internal/control/authz/exposure.go
+++ b/backend/internal/control/authz/exposure.go
@@ -6,6 +6,7 @@ package authz
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 )
@@ -195,9 +196,7 @@ func MissingExposurePolicies() []string {
 
 func ExposurePolicies() map[string]ExposurePolicy {
 	out := make(map[string]ExposurePolicy, len(operationExposurePolicies))
-	for operationID, policy := range operationExposurePolicies {
-		out[operationID] = policy
-	}
+	maps.Copy(out, operationExposurePolicies)
 	return out
 }
 

--- a/backend/internal/control/http/fileserver.go
+++ b/backend/internal/control/http/fileserver.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/ManuGH/xg2g/internal/log"
@@ -109,12 +110,7 @@ func validateSecureFileRequest(w http.ResponseWriter, r *http.Request, logger ze
 }
 
 func isSensitiveExtension(ext string) bool {
-	for _, denied := range sensitiveFileExtensions {
-		if ext == denied {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(sensitiveFileExtensions, ext)
 }
 
 func resolveSecureFilePath(dataDir, requestPath string) (string, error) {
@@ -235,7 +231,7 @@ func isPathTraversal(p string) bool {
 	// Work on a copy
 	decoded := p
 	// Attempt multiple decode passes to catch double/triple encodings
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		prev := decoded
 		if d, err := url.PathUnescape(decoded); err == nil {
 			decoded = d

--- a/backend/internal/control/http/v3/admission_state.go
+++ b/backend/internal/control/http/v3/admission_state.go
@@ -63,10 +63,7 @@ func (s *storeAdmissionState) Snapshot(ctx context.Context) (admission.RuntimeSt
 		}
 	}
 
-	availTuners := int(s.tunerCount.Load()) - activeCount
-	if availTuners < 0 {
-		availTuners = 0
-	}
+	availTuners := max(int(s.tunerCount.Load())-activeCount, 0)
 
 	return admission.RuntimeState{
 		TunerSlots:       availTuners,

--- a/backend/internal/control/http/v3/exposure_security.go
+++ b/backend/internal/control/http/v3/exposure_security.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -87,10 +88,7 @@ func (s *Server) ExposureSecurityMiddleware(next http.Handler) http.Handler {
 			allowed, retryAfter := s.allowExposureRequest(r, operationID, policy)
 			if !allowed {
 				s.logExposureRateLimit(r, operationID, policy)
-				retryAfterSeconds := int(math.Ceil(retryAfter.Seconds()))
-				if retryAfterSeconds < 1 {
-					retryAfterSeconds = 1
-				}
+				retryAfterSeconds := max(int(math.Ceil(retryAfter.Seconds())), 1)
 				w.Header().Set("Retry-After", strconv.Itoa(retryAfterSeconds))
 				w.Header().Set("X-RateLimit-Class", string(policy.RateLimitClass))
 				writeRegisteredProblem(w, r, http.StatusTooManyRequests, "security/rate_limited", "Rate Limit Exceeded", problemcode.CodeRateLimitExceeded, "Too many requests for this endpoint exposure class.", map[string]any{
@@ -188,8 +186,8 @@ func (s *Server) exposureClientKey(r *http.Request, cfg config.AppConfig) string
 func forwardedForIPs(raw string) []net.IP {
 	parts := strings.Split(raw, ",")
 	out := make([]net.IP, 0, len(parts))
-	for i := len(parts) - 1; i >= 0; i-- {
-		candidate := net.ParseIP(strings.TrimSpace(parts[i]))
+	for _, v := range slices.Backward(parts) {
+		candidate := net.ParseIP(strings.TrimSpace(v))
 		if candidate == nil {
 			continue
 		}

--- a/backend/internal/control/http/v3/handlers_common.go
+++ b/backend/internal/control/http/v3/handlers_common.go
@@ -107,10 +107,9 @@ func parsePaginationParams(r *http.Request) (offset int, limit int) {
 	// Parse limit
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
 		if val, err := strconv.Atoi(limitStr); err == nil && val > 0 {
-			limit = val
-			if limit > 1000 {
-				limit = 1000 // Cap at 1000
-			}
+			limit = min(val,
+				// Cap at 1000
+				1000)
 		}
 	}
 

--- a/backend/internal/control/http/v3/handlers_config.go
+++ b/backend/internal/control/http/v3/handlers_config.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -295,12 +296,7 @@ func principalHasScope(principal *auth.Principal, scope string) bool {
 	if principal == nil || scope == "" {
 		return false
 	}
-	for _, candidate := range principal.Scopes {
-		if candidate == scope {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(principal.Scopes, scope)
 }
 
 func buildMonetizationStatus(cfg config.MonetizationConfig, principal *auth.Principal) *MonetizationStatus {

--- a/backend/internal/control/http/v3/handlers_services.go
+++ b/backend/internal/control/http/v3/handlers_services.go
@@ -104,7 +104,6 @@ func (s *Server) GetServicesBouquets(w http.ResponseWriter, r *http.Request) {
 	resp := make([]Bouquet, 0, len(bouquets))
 	for _, b := range bouquets {
 		// Scoping
-		b := b
 		resp = append(resp, Bouquet{
 			Name:     &b.Name,
 			Services: &b.Count,

--- a/backend/internal/control/http/v3/handlers_services.go
+++ b/backend/internal/control/http/v3/handlers_services.go
@@ -102,11 +102,11 @@ func (s *Server) GetServicesBouquets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := make([]Bouquet, 0, len(bouquets))
-	for _, b := range bouquets {
+	for i := range bouquets {
 		// Scoping
 		resp = append(resp, Bouquet{
-			Name:     &b.Name,
-			Services: &b.Count,
+			Name:     &bouquets[i].Name,
+			Services: &bouquets[i].Count,
 		})
 	}
 

--- a/backend/internal/control/http/v3/handlers_timers.go
+++ b/backend/internal/control/http/v3/handlers_timers.go
@@ -210,7 +210,7 @@ func (s *Server) AddTimer(w http.ResponseWriter, r *http.Request) {
 	var createdTimer *openwebif.Timer
 
 verifyAddLoop:
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		checkTimers, err := client.GetTimers(r.Context())
 		if err == nil {
 			targetNormalized := strings.TrimSuffix(realSRef, ":")
@@ -401,7 +401,7 @@ func (s *Server) UpdateTimer(w http.ResponseWriter, r *http.Request, timerId str
 	verified := false
 	var updatedTimer *openwebif.Timer
 verifyUpdateLoop:
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		checkTimers, err := client.GetTimers(ctx)
 		if err == nil {
 			targetNormalized := strings.TrimSuffix(newSRef, ":")

--- a/backend/internal/control/http/v3/http.go
+++ b/backend/internal/control/http/v3/http.go
@@ -134,7 +134,6 @@ func (s *Server) GetLogs(w http.ResponseWriter, r *http.Request, params GetLogsP
 	var resp []LogEntry
 	for _, e := range entries {
 		// Scoping for pointer safety in loop
-		e := e
 		resp = append(resp, LogEntry{
 			Level:   &e.Level,
 			Message: &e.Message,

--- a/backend/internal/control/http/v3/http.go
+++ b/backend/internal/control/http/v3/http.go
@@ -132,13 +132,13 @@ func (s *Server) GetLogs(w http.ResponseWriter, r *http.Request, params GetLogsP
 	}
 
 	var resp []LogEntry
-	for _, e := range entries {
+	for i := range entries {
 		// Scoping for pointer safety in loop
 		resp = append(resp, LogEntry{
-			Level:   &e.Level,
-			Message: &e.Message,
-			Time:    &e.Time,
-			Fields:  &e.Fields,
+			Level:   &entries[i].Level,
+			Message: &entries[i].Message,
+			Time:    &entries[i].Time,
+			Fields:  &entries[i].Fields,
 		})
 	}
 

--- a/backend/internal/control/http/v3/intent_client_request.go
+++ b/backend/internal/control/http/v3/intent_client_request.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"encoding/json"
+	"maps"
 
 	"github.com/ManuGH/xg2g/internal/control/recordings/capabilities"
 	"github.com/ManuGH/xg2g/internal/domain/session/model"
@@ -35,9 +36,7 @@ func normalizeIntentClientCaps(caps *PlaybackCapabilities) *capabilities.Playbac
 func normalizeIntentParams(params *map[string]string, clientCaps *capabilities.PlaybackCapabilities, capHash string) map[string]string {
 	out := make(map[string]string)
 	if params != nil {
-		for key, value := range *params {
-			out[key] = value
-		}
+		maps.Copy(out, *params)
 	}
 	if clientCaps != nil {
 		if clientFamily := normalize.Token(clientCaps.ClientFamilyFallback); clientFamily != "" {

--- a/backend/internal/control/http/v3/intents/service.go
+++ b/backend/internal/control/http/v3/intents/service.go
@@ -580,7 +580,7 @@ func (s *Service) persistStartSession(ctx context.Context, intent Intent, store 
 	}
 
 	persisted := false
-	for attempt := 0; attempt < startReplayRecoveryAttempts; attempt++ {
+	for attempt := range startReplayRecoveryAttempts {
 		existingID, exists, err := store.PutSessionWithIdempotency(ctx, session, idempotencyKey, admissionLeaseTTL)
 		if err != nil {
 			intent.Logger.Error().Err(err).Msg("failed to persist intent")

--- a/backend/internal/control/http/v3/live_playback_attestation_key.go
+++ b/backend/internal/control/http/v3/live_playback_attestation_key.go
@@ -159,12 +159,12 @@ func parseLiveDecisionKeyEntry(raw string) (kid string, secret []byte) {
 	if entry == "" {
 		return "", nil
 	}
-	idx := strings.Index(entry, ":")
-	if idx < 0 {
+	before, after, ok := strings.Cut(entry, ":")
+	if !ok {
 		return "", []byte(entry)
 	}
-	kid = normalizeLiveDecisionKeyID(entry[:idx])
-	secretValue := strings.TrimSpace(entry[idx+1:])
+	kid = normalizeLiveDecisionKeyID(before)
+	secretValue := strings.TrimSpace(after)
 	if secretValue == "" {
 		return "", nil
 	}

--- a/backend/internal/control/http/v3/rbac.go
+++ b/backend/internal/control/http/v3/rbac.go
@@ -7,6 +7,7 @@ package v3
 import (
 	"context"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -85,12 +86,7 @@ func (s scopeSet) allows(required []Scope) bool {
 	if len(required) == 0 {
 		return true
 	}
-	for _, scope := range required {
-		if s.has(scope) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(required, s.has)
 }
 
 func (s scopeSet) has(scope Scope) bool {

--- a/backend/internal/control/http/v3/recordings/feedback_policy.go
+++ b/backend/internal/control/http/v3/recordings/feedback_policy.go
@@ -2,6 +2,7 @@ package recordings
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -456,7 +457,7 @@ func buildPlaybackConfidenceWindowsFromObservations(observations []capreg.Playba
 	for key := range buckets {
 		starts = append(starts, key)
 	}
-	sort.Slice(starts, func(i, j int) bool { return starts[i] < starts[j] })
+	slices.Sort(starts)
 
 	windows := make([]runtimepolicy.WindowFeatures, 0, len(starts))
 	for _, key := range starts {

--- a/backend/internal/control/http/v3/recordings_hls.go
+++ b/backend/internal/control/http/v3/recordings_hls.go
@@ -345,10 +345,7 @@ func (s *Server) writeArtifactError(w http.ResponseWriter, r *http.Request, reco
 		metrics.IncPlaybackError(playbackSchemaRecordingLabel, stage, "RECORDING_PREPARING")
 		retrySec := 5
 		if err.RetryAfter > 0 {
-			retrySec = int(err.RetryAfter.Seconds())
-			if retrySec < 1 {
-				retrySec = 1
-			}
+			retrySec = max(int(err.RetryAfter.Seconds()), 1)
 		}
 		s.writePreparingResponse(w, r, recordingId, "PREPARING", retrySec)
 	case artifacts.CodeNotFound:

--- a/backend/internal/control/http/v3/sessions/list_sessions_debug.go
+++ b/backend/internal/control/http/v3/sessions/list_sessions_debug.go
@@ -22,14 +22,8 @@ func (s *Service) ListSessionsDebug(ctx context.Context, req ListSessionsDebugRe
 	}
 
 	total := len(allSessions)
-	start := req.Offset
-	if start > total {
-		start = total
-	}
-	end := start + req.Limit
-	if end > total {
-		end = total
-	}
+	start := min(req.Offset, total)
+	end := min(start+req.Limit, total)
 	sessions := allSessions[start:end]
 
 	return ListSessionsDebugResult{

--- a/backend/internal/control/http/v3/system_info.go
+++ b/backend/internal/control/http/v3/system_info.go
@@ -450,10 +450,7 @@ func calculateMemory(totalStr, availableStr string) ResourceInfo {
 	total := parseMemKB(totalStr)
 	available := parseMemKB(availableStr)
 
-	used := total - available
-	if used < 0 {
-		used = 0
-	}
+	used := max(total-available, 0)
 
 	return ResourceInfo{
 		MemoryTotal:     totalStr,

--- a/backend/internal/control/middleware/lan_guard.go
+++ b/backend/internal/control/middleware/lan_guard.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/ManuGH/xg2g/internal/log"
@@ -155,8 +156,8 @@ func (g *LANGuard) resolveClientIP(r *http.Request) net.IP {
 	// Parse XFF list
 	parts := strings.Split(xff, ",")
 	// Traverse Right-to-Left
-	for i := len(parts) - 1; i >= 0; i-- {
-		ipPart := strings.TrimSpace(parts[i])
+	for _, v := range slices.Backward(parts) {
+		ipPart := strings.TrimSpace(v)
 		ip := net.ParseIP(ipPart)
 		if ip == nil {
 			continue

--- a/backend/internal/control/recordings/capreg/store.go
+++ b/backend/internal/control/recordings/capreg/store.go
@@ -354,8 +354,7 @@ func (s *MemoryStore) LookupDecisionObservation(_ context.Context, requestID str
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for _, v := range slices.Backward(s.observations) {
-		observation := v
+	for _, observation := range slices.Backward(s.observations) {
 		if observation.RequestID != requestID || observation.ObservationKind != "decision" {
 			continue
 		}

--- a/backend/internal/control/recordings/capreg/store.go
+++ b/backend/internal/control/recordings/capreg/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -353,8 +354,8 @@ func (s *MemoryStore) LookupDecisionObservation(_ context.Context, requestID str
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for idx := len(s.observations) - 1; idx >= 0; idx-- {
-		observation := s.observations[idx]
+	for _, v := range slices.Backward(s.observations) {
+		observation := v
 		if observation.RequestID != requestID || observation.ObservationKind != "decision" {
 			continue
 		}

--- a/backend/internal/control/recordings/duration_truth.go
+++ b/backend/internal/control/recordings/duration_truth.go
@@ -2,6 +2,7 @@ package recordings
 
 import (
 	"math"
+	"slices"
 	"sort"
 )
 
@@ -221,10 +222,8 @@ func ResolveDurationTruth(in DurationTruthResolveInput) DurationTruth {
 		if !reason.Valid() {
 			return
 		}
-		for _, existing := range out.Reasons {
-			if existing == reason {
-				return
-			}
+		if slices.Contains(out.Reasons, reason) {
+			return
 		}
 		out.Reasons = append(out.Reasons, reason)
 	}

--- a/backend/internal/control/recordings/helpers.go
+++ b/backend/internal/control/recordings/helpers.go
@@ -3,6 +3,7 @@ package recordings
 import (
 	"errors"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -102,11 +103,8 @@ func ParseRecordingDurationSeconds(length string) (int64, error) {
 	if len(fields) == 2 {
 		found := false
 		suffix := strings.ToLower(fields[1])
-		for _, s := range suffixes {
-			if suffix == s {
-				found = true
-				break
-			}
+		if slices.Contains(suffixes, suffix) {
+			found = true
 		}
 		if !found {
 			return 0, ErrDurationInvalid

--- a/backend/internal/control/recordings/runtimepolicy/confidence.go
+++ b/backend/internal/control/recordings/runtimepolicy/confidence.go
@@ -1,6 +1,7 @@
 package runtimepolicy
 
 import (
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -558,10 +559,5 @@ func maxTime(a, b time.Time) time.Time {
 }
 
 func hasString(values []string, needle string) bool {
-	for _, value := range values {
-		if value == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, needle)
 }

--- a/backend/internal/control/recordings/runtimepolicy/replay.go
+++ b/backend/internal/control/recordings/runtimepolicy/replay.go
@@ -147,11 +147,8 @@ func RunReplay(replay RuntimePolicyReplay) ReplayResult {
 
 func CompareReplayExpectations(replay RuntimePolicyReplay, result ReplayResult) []ReplayMismatch {
 	var mismatches []ReplayMismatch
-	limit := len(replay.Ticks)
-	if len(result.Ticks) < limit {
-		limit = len(result.Ticks)
-	}
-	for i := 0; i < limit; i++ {
+	limit := min(len(result.Ticks), len(replay.Ticks))
+	for i := range limit {
 		expected := replay.Ticks[i].Expected
 		actual := result.Ticks[i]
 		if expected.Action != actual.Decision.Action {

--- a/backend/internal/control/recordings/truth.go
+++ b/backend/internal/control/recordings/truth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/ManuGH/xg2g/internal/config"
@@ -136,10 +137,8 @@ func (t *truthProvider) GetMediaTruth(ctx context.Context, serviceRef string) (p
 		return mt, ErrNotFound{RecordingID: serviceRef}
 	case TruthStatusUpstreamUnavailable:
 		// Check for specific failure signals
-		for _, r := range outcome.Reasons {
-			if r == ReasonProbeFailed {
-				return mt, ErrUpstream{Op: "probe", Cause: fmt.Errorf("probe failed permanently: %w", playback.ErrUpstream)}
-			}
+		if slices.Contains(outcome.Reasons, ReasonProbeFailed) {
+			return mt, ErrUpstream{Op: "probe", Cause: fmt.Errorf("probe failed permanently: %w", playback.ErrUpstream)}
 		}
 		// Generic Upstream
 		return mt, ErrUpstream{Op: "upstream", Cause: playback.ErrUpstream}

--- a/backend/internal/control/vod/prober.go
+++ b/backend/internal/control/vod/prober.go
@@ -60,7 +60,7 @@ func (m *Manager) StartProberPool(ctx context.Context) {
 	m.started = true
 	m.mu.Unlock()
 
-	for i := 0; i < MaxConcurrentProbes; i++ {
+	for range MaxConcurrentProbes {
 		m.workerWg.Add(1)
 		go m.probeWorker(workerCtx)
 	}
@@ -148,10 +148,7 @@ func (m *Manager) runProbe(ctx context.Context, req probeRequest) error {
 			// Throttle re-probes for missing files (e.g. NAS unavailable)
 			// Backoff: 1 minute
 			lastProbe := time.Unix(0, current.UpdatedAt)
-			since := time.Since(lastProbe)
-			if since < 0 {
-				since = 0
-			}
+			since := max(time.Since(lastProbe), 0)
 			if since < 1*time.Minute {
 				m.mu.Unlock()
 				log.Debug().Str("id", id).Msg("skipping probe for MISSING artifact (throttled)")

--- a/backend/internal/control/vod/recording_cache_evictor.go
+++ b/backend/internal/control/vod/recording_cache_evictor.go
@@ -140,7 +140,7 @@ func evictRecordingCache(
 
 	if len(remaining) > maxEntries {
 		overflow := len(remaining) - maxEntries
-		for i := 0; i < overflow; i++ {
+		for i := range overflow {
 			toDelete[remaining[i].path] = struct{}{}
 			reasons[remaining[i].path] = CacheEvictReasonMaxEntries
 		}
@@ -162,10 +162,7 @@ func evictRecordingCache(
 		}
 	}
 
-	res.Entries = len(dirs) - res.EvictedTTL - res.EvictedMaxEntries
-	if res.Entries < 0 {
-		res.Entries = 0
-	}
+	res.Entries = max(len(dirs)-res.EvictedTTL-res.EvictedMaxEntries, 0)
 	return res, nil
 }
 

--- a/backend/internal/daemon/manager.go
+++ b/backend/internal/daemon/manager.go
@@ -308,8 +308,7 @@ func (m *manager) Shutdown(ctx context.Context) error {
 
 	// Execute shutdown hooks in reverse order (LIFO)
 	m.logger.Debug().Int("hooks", len(m.shutdownHooks)).Msg("Executing shutdown hooks")
-	for _, v := range slices.Backward(m.shutdownHooks) {
-		hook := v
+	for _, hook := range slices.Backward(m.shutdownHooks) {
 		m.logger.Debug().Str("hook", hook.name).Msg("Executing shutdown hook")
 
 		hookStart := time.Now()

--- a/backend/internal/daemon/manager.go
+++ b/backend/internal/daemon/manager.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -307,8 +308,8 @@ func (m *manager) Shutdown(ctx context.Context) error {
 
 	// Execute shutdown hooks in reverse order (LIFO)
 	m.logger.Debug().Int("hooks", len(m.shutdownHooks)).Msg("Executing shutdown hooks")
-	for i := len(m.shutdownHooks) - 1; i >= 0; i-- {
-		hook := m.shutdownHooks[i]
+	for _, v := range slices.Backward(m.shutdownHooks) {
+		hook := v
 		m.logger.Debug().Str("hook", hook.name).Msg("Executing shutdown hook")
 
 		hookStart := time.Now()

--- a/backend/internal/domain/connectivity/contract.go
+++ b/backend/internal/domain/connectivity/contract.go
@@ -474,12 +474,7 @@ func severityRank(value FindingSeverity) int {
 }
 
 func hasScope(scopes []FindingScope, want FindingScope) bool {
-	for _, scope := range scopes {
-		if scope == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(scopes, want)
 }
 
 func originListAllowsAll(origins []string) bool {

--- a/backend/internal/domain/session/manager/orchestrator_helpers.go
+++ b/backend/internal/domain/session/manager/orchestrator_helpers.go
@@ -608,10 +608,7 @@ func (o *Orchestrator) waitForProcessExit(ctx context.Context, handle ports.RunH
 			}
 
 			// Exponential backoff
-			interval = interval * 2
-			if interval > maxInterval {
-				interval = maxInterval
-			}
+			interval = min(interval*2, maxInterval)
 			ticker.Reset(interval)
 		}
 	}
@@ -753,16 +750,16 @@ func playlistInitSegment(content []byte) string {
 		if !strings.HasPrefix(line, "#EXT-X-MAP:") {
 			continue
 		}
-		uriIdx := strings.Index(line, `URI="`)
-		if uriIdx < 0 {
+		_, after, ok := strings.Cut(line, `URI="`)
+		if !ok {
 			continue
 		}
-		rest := line[uriIdx+len(`URI="`):]
-		endIdx := strings.IndexByte(rest, '"')
-		if endIdx < 0 {
+		rest := after
+		before0, _, ok0 := strings.Cut(rest, "\"")
+		if !ok0 {
 			continue
 		}
-		uri := strings.TrimSpace(rest[:endIdx])
+		uri := strings.TrimSpace(before0)
 		if uri == "" || strings.Contains(uri, "..") || filepath.IsAbs(uri) {
 			return ""
 		}

--- a/backend/internal/domain/session/manager/testkit/admission.go
+++ b/backend/internal/domain/session/manager/testkit/admission.go
@@ -8,7 +8,7 @@ import "github.com/ManuGH/xg2g/internal/admission"
 
 func NewAdmissibleAdmission() *admission.ResourceMonitor {
 	m := admission.NewResourceMonitor(1000, 1000, 10)
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		m.ObserveCPULoad(0.1)
 	}
 	return m

--- a/backend/internal/domain/session/ports/preflight.go
+++ b/backend/internal/domain/session/ports/preflight.go
@@ -137,8 +137,8 @@ func ClassifyPreflightReason(detail string, httpStatus int) PreflightReason {
 		return PreflightReasonInternal
 	}
 
-	if strings.HasPrefix(raw, "http_status_") {
-		code, err := strconv.Atoi(strings.TrimPrefix(raw, "http_status_"))
+	if after, ok := strings.CutPrefix(raw, "http_status_"); ok {
+		code, err := strconv.Atoi(after)
 		if err == nil {
 			if reason := classifyPreflightHTTPStatus(code); reason != "" {
 				return reason

--- a/backend/internal/domain/session/store/memory_store.go
+++ b/backend/internal/domain/session/store/memory_store.go
@@ -7,6 +7,7 @@ package store
 import (
 	"context"
 	"errors"
+	"maps"
 	"sort"
 	"sync"
 	"time"
@@ -340,9 +341,7 @@ func cloneSessionRecord(rec *model.SessionRecord) *model.SessionRecord {
 	cp := *rec
 	if rec.ContextData != nil {
 		cp.ContextData = make(map[string]string, len(rec.ContextData))
-		for k, v := range rec.ContextData {
-			cp.ContextData[k] = v
-		}
+		maps.Copy(cp.ContextData, rec.ContextData)
 	}
 	cp.PlaybackTrace = rec.PlaybackTrace.Clone()
 	return &cp

--- a/backend/internal/dvr/engine.go
+++ b/backend/internal/dvr/engine.go
@@ -7,6 +7,7 @@ package dvr
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -235,11 +236,8 @@ func (e *SeriesEngine) processRule(ctx context.Context, client OWIClient, rule S
 		if len(rule.Days) > 0 {
 			dayMatch := false
 			weekday := int(localStart.Weekday()) // 0=Sunday
-			for _, d := range rule.Days {
-				if d == weekday {
-					dayMatch = true
-					break
-				}
+			if slices.Contains(rule.Days, weekday) {
+				dayMatch = true
 			}
 			if !dayMatch {
 				continue

--- a/backend/internal/dvr/match.go
+++ b/backend/internal/dvr/match.go
@@ -6,6 +6,7 @@ package dvr
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -46,13 +47,7 @@ func (r *SeriesRule) Matches(epgTitle string, epgChannelRef string, epgStart tim
 	// 3. Day Match
 	if len(r.Days) > 0 {
 		day := int(epgStart.Weekday()) // 0=Sunday
-		found := false
-		for _, d := range r.Days {
-			if d == day {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(r.Days, day)
 		if !found {
 			return MatchResult{Matched: false, Reasons: []string{"day mismatch"}}
 		}

--- a/backend/internal/epg/fuzzy.go
+++ b/backend/internal/epg/fuzzy.go
@@ -55,13 +55,7 @@ func levenshtein(a, b string) int {
 			del := dp[idx(i-1, j)] + 1
 			ins := dp[idx(i, j-1)] + 1
 			sub := dp[idx(i-1, j-1)] + cost
-			m := del
-			if ins < m {
-				m = ins
-			}
-			if sub < m {
-				m = sub
-			}
+			m := min(sub, min(ins, del))
 			dp[idx(i, j)] = m
 		}
 	}

--- a/backend/internal/health/connectivity_contract.go
+++ b/backend/internal/health/connectivity_contract.go
@@ -6,6 +6,7 @@ package health
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/ManuGH/xg2g/internal/config"
@@ -106,10 +107,5 @@ func summarizeConnectivityFindings(report connectivitydomain.ContractReport, sco
 }
 
 func hasConnectivityScope(scopes []connectivitydomain.FindingScope, want connectivitydomain.FindingScope) bool {
-	for _, scope := range scopes {
-		if scope == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(scopes, want)
 }

--- a/backend/internal/health/health.go
+++ b/backend/internal/health/health.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"strings"
@@ -725,8 +726,6 @@ func cloneChecks(in map[string]CheckResult) map[string]CheckResult {
 		return nil
 	}
 	out := make(map[string]CheckResult, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }

--- a/backend/internal/health/runtime_snapshot.go
+++ b/backend/internal/health/runtime_snapshot.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -196,9 +197,7 @@ func CollectLifecycleRuntimeSnapshot(ctx context.Context, cfg config.AppConfig, 
 			snapshot.Compose.Image = strings.TrimSpace(svc.Image)
 			snapshot.Compose.EnvFiles = append([]string(nil), svc.EnvFile...)
 			snapshot.Compose.Environment = map[string]string{}
-			for k, v := range svc.Environment {
-				snapshot.Compose.Environment[k] = v
-			}
+			maps.Copy(snapshot.Compose.Environment, svc.Environment)
 			snapshot.Compose.Volumes = append([]LifecycleRuntimeVolumeSnapshot(nil), svc.Volumes...)
 		}
 	}

--- a/backend/internal/hls/extractor.go
+++ b/backend/internal/hls/extractor.go
@@ -53,8 +53,8 @@ func ExtractSegmentTruth(playlist string) (*SegmentTruth, error) {
 			continue
 		}
 
-		if strings.HasPrefix(line, "#EXT-X-PROGRAM-DATE-TIME:") {
-			pdtStr := strings.TrimPrefix(line, "#EXT-X-PROGRAM-DATE-TIME:")
+		if after, ok := strings.CutPrefix(line, "#EXT-X-PROGRAM-DATE-TIME:"); ok {
+			pdtStr := after
 			t, err := time.Parse(time.RFC3339Nano, pdtStr)
 			if err != nil {
 				// Retry without Nano if needed
@@ -76,9 +76,9 @@ func ExtractSegmentTruth(playlist string) (*SegmentTruth, error) {
 			continue
 		}
 
-		if strings.HasPrefix(line, "#EXTINF:") {
+		if after, ok := strings.CutPrefix(line, "#EXTINF:"); ok {
 			// Format: #EXTINF:10.000,
-			durPart := strings.TrimPrefix(line, "#EXTINF:")
+			durPart := after
 			if idx := strings.Index(durPart, ","); idx != -1 {
 				durPart = durPart[:idx]
 			}

--- a/backend/internal/household/model.go
+++ b/backend/internal/household/model.go
@@ -2,6 +2,7 @@ package household
 
 import (
 	"errors"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -125,19 +126,15 @@ func IsServiceAllowedNormalized(profile Profile, serviceRef, bouquet string) boo
 
 	normalizedServiceRef := normalizeServiceRef(serviceRef)
 	if normalizedServiceRef != "" {
-		for _, allowed := range profile.AllowedServiceRefs {
-			if allowed == normalizedServiceRef {
-				return true
-			}
+		if slices.Contains(profile.AllowedServiceRefs, normalizedServiceRef) {
+			return true
 		}
 	}
 
 	normalizedBouquet := normalizeIdentifier(bouquet)
 	if normalizedBouquet != "" {
-		for _, allowed := range profile.AllowedBouquets {
-			if allowed == normalizedBouquet {
-				return true
-			}
+		if slices.Contains(profile.AllowedBouquets, normalizedBouquet) {
+			return true
 		}
 	}
 
@@ -293,10 +290,7 @@ func normalizeMaxFSK(value *int) *int {
 	if value == nil {
 		return nil
 	}
-	normalized := *value
-	if normalized < 0 {
-		normalized = 0
-	}
+	normalized := max(*value, 0)
 	return &normalized
 }
 

--- a/backend/internal/infra/ffmpeg/builder.go
+++ b/backend/internal/infra/ffmpeg/builder.go
@@ -30,8 +30,8 @@ func mapProfileToArgs(spec vod.Spec) ([]string, error) {
 
 	// Handle file:// URI scheme for local files
 	inputPath := spec.Input
-	if strings.HasPrefix(inputPath, "file://") {
-		raw := strings.TrimPrefix(inputPath, "file://")
+	if after, ok := strings.CutPrefix(inputPath, "file://"); ok {
+		raw := after
 		if decoded, err := url.PathUnescape(raw); err == nil {
 			inputPath = decoded
 		}

--- a/backend/internal/infra/media/ffmpeg/adapter.go
+++ b/backend/internal/infra/media/ffmpeg/adapter.go
@@ -841,7 +841,7 @@ func (a *LocalAdapter) startTimeoutForProfile(sourceType ports.SourceType, profi
 }
 
 func argsHardwareBackend(args []string) profiles.GPUBackend {
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		if args[i] == "-vaapi_device" {
 			return profiles.GPUBackendVAAPI
 		}
@@ -902,11 +902,11 @@ func scanFFmpegLogTokens(data []byte, atEOF bool) (advance int, token []byte, er
 }
 
 func parseFFmpegFrameCount(line string) (int, bool) {
-	idx := strings.Index(line, "frame=")
-	if idx < 0 {
+	_, after, ok := strings.Cut(line, "frame=")
+	if !ok {
 		return 0, false
 	}
-	rest := strings.TrimLeft(line[idx+len("frame="):], " ")
+	rest := strings.TrimLeft(after, " ")
 	if rest == "" {
 		return 0, false
 	}

--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -638,11 +638,11 @@ func (d *Detector) measureSignalStatsYAvg(ctx context.Context, mediaPath string)
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
 		const prefix = "lavfi.signalstats.YAVG="
-		idx := strings.Index(line, prefix)
-		if idx < 0 {
+		_, after, ok := strings.Cut(line, prefix)
+		if !ok {
 			continue
 		}
-		value := strings.TrimSpace(line[idx+len(prefix):])
+		value := strings.TrimSpace(after)
 		yavg, parseErr := strconv.ParseFloat(value, 64)
 		if parseErr != nil {
 			return 0, fmt.Errorf("parse signalstats yavg %q: %w", value, parseErr)

--- a/backend/internal/infra/media/ffmpeg/encode_args.go
+++ b/backend/internal/infra/media/ffmpeg/encode_args.go
@@ -217,10 +217,7 @@ func appendVaapiRateControlArgs(args []string, prof ports.ProfileSpec, outputCod
 		// Use a 25% target headroom (-b:v = 75% of -maxrate) to keep the ring stable.
 		bV := prof.VideoMaxRateK
 		if isAV1 {
-			bV = (prof.VideoMaxRateK * 3) / 4
-			if bV < 1 {
-				bV = 1
-			}
+			bV = max((prof.VideoMaxRateK*3)/4, 1)
 		}
 		// AV1 QVBR: quality-targeted encode that still honours -maxrate as a hard
 		// ceiling. Verified on this AMD stack (Mesa 25.0.7 / VCN4): QVBR holds the

--- a/backend/internal/infra/media/ffmpeg/executed_plan.go
+++ b/backend/internal/infra/media/ffmpeg/executed_plan.go
@@ -19,7 +19,7 @@ func executedFFmpegPlanFromArgs(args []string) ports.ExecutedFFmpegPlan {
 	var segmentType, segmentFile, hwaccel, vcodec, acodec string
 	hasVaapiDevice := false
 
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		switch args[i] {
 		case "-hls_segment_type":
 			if i+1 < len(args) {

--- a/backend/internal/infra/media/ffmpeg/fps_detector.go
+++ b/backend/internal/infra/media/ffmpeg/fps_detector.go
@@ -289,13 +289,7 @@ func (a *LocalAdapter) detectFPS(ctx context.Context, inputURL string) (int, str
 		if !shouldRetryFPSProbe(err) {
 			return 0, "", err
 		}
-		retryTimeout := timeout * 2
-		if retryTimeout < 2500*time.Millisecond {
-			retryTimeout = 2500 * time.Millisecond
-		}
-		if retryTimeout > 8*time.Second {
-			retryTimeout = 8 * time.Second
-		}
+		retryTimeout := min(max(timeout*2, 2500*time.Millisecond), 8*time.Second)
 		retryOutput, retryErr := a.runFPSProbe(ctx, inputURL, retryTimeout, true)
 		if retryErr != nil {
 			return 0, "", fmt.Errorf("ffprobe failed after retry (primary=%v, retry=%w)", err, retryErr)

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -68,19 +68,13 @@ func (a *LocalAdapter) planLiveSegmentLayout(spec ports.StreamSpec) (liveSegment
 	}
 	if shouldUseShortFMP4StartupSegments(spec) && layout.segmentDurationSec > safariDirtyHLSTimeSec {
 		layout.segmentDurationSec = safariDirtyHLSTimeSec
-		layout.initSegmentDurationSec = safariDirtyHLSInitTimeSec
-		if layout.initSegmentDurationSec > layout.segmentDurationSec {
-			layout.initSegmentDurationSec = layout.segmentDurationSec
-		}
+		layout.initSegmentDurationSec = min(safariDirtyHLSInitTimeSec, layout.segmentDurationSec)
 	}
 	if layout.segmentDurationSec <= 0 {
 		return liveSegmentLayout{}, fmt.Errorf("invalid hls segment seconds: %d", layout.segmentDurationSec)
 	}
 	if a.DVRWindow > 0 {
-		layout.listSize = int(math.Ceil(a.DVRWindow.Seconds() / float64(layout.segmentDurationSec)))
-		if layout.listSize < 3 {
-			layout.listSize = 3
-		}
+		layout.listSize = max(int(math.Ceil(a.DVRWindow.Seconds()/float64(layout.segmentDurationSec))), 3)
 	}
 	return layout, nil
 }

--- a/backend/internal/jobs/picons.go
+++ b/backend/internal/jobs/picons.go
@@ -62,8 +62,8 @@ func extractPiconRefs(items []playlist.Item) map[string]bool {
 		if idx := strings.Index(filename, "?"); idx != -1 {
 			filename = filename[:idx]
 		}
-		if idx := strings.Index(filename, ".png"); idx != -1 {
-			refUnderscore := filename[:idx]
+		if before, _, ok := strings.Cut(filename, ".png"); ok {
+			refUnderscore := before
 			// Convert Underscore -> Colon for Upstream URL generation
 			refColon := strings.ReplaceAll(refUnderscore, "_", ":")
 			refs[refColon] = true

--- a/backend/internal/log/logger.go
+++ b/backend/internal/log/logger.go
@@ -318,7 +318,7 @@ func (w *structuredBufferWriter) Write(p []byte) (n int, err error) {
 
 	// Process lines outside of the framing lock to reduce contention
 	start := 0
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		if lines[i] == '\n' {
 			w.processLine(lines[start:i])
 			start = i + 1

--- a/backend/internal/media/codec/codec.go
+++ b/backend/internal/media/codec/codec.go
@@ -1,5 +1,7 @@
 package codec
 
+import "slices"
+
 import "fmt"
 
 // ID identifies a normalized media codec token.
@@ -138,12 +140,7 @@ func (r CompatibilityResult) Compatible() bool {
 }
 
 func (r CompatibilityResult) Has(reason CompatibilityReason) bool {
-	for _, existing := range r.Reasons {
-		if existing == reason {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.Reasons, reason)
 }
 
 func (r *CompatibilityResult) Add(reason CompatibilityReason) {

--- a/backend/internal/media/playback/matrix.go
+++ b/backend/internal/media/playback/matrix.go
@@ -1,6 +1,8 @@
 package playback
 
 import (
+	"slices"
+
 	"github.com/ManuGH/xg2g/internal/media/codec"
 	"github.com/ManuGH/xg2g/internal/media/container"
 )
@@ -59,12 +61,7 @@ func (r CompatibilityResult) Compatible() bool {
 }
 
 func (r CompatibilityResult) Has(reason CompatibilityReason) bool {
-	for _, existing := range r.Reasons {
-		if existing == reason {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.Reasons, reason)
 }
 
 func (r *CompatibilityResult) Add(reason CompatibilityReason) {
@@ -120,10 +117,5 @@ func EvaluatePackagingCompatibility(matrix ClientPlaybackMatrix, request StreamR
 }
 
 func containsCodec(codecs []codec.ID, target codec.ID) bool {
-	for _, existing := range codecs {
-		if existing == target {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(codecs, target)
 }

--- a/backend/internal/openwebif/client.go
+++ b/backend/internal/openwebif/client.go
@@ -1480,10 +1480,7 @@ func (c *Client) backoffDuration(attempt int) time.Duration {
 		return 0
 	}
 	factor := 1 << (attempt - 1)
-	d := time.Duration(factor) * c.backoff
-	if d > c.maxBackoff {
-		d = c.maxBackoff
-	}
+	d := min(time.Duration(factor)*c.backoff, c.maxBackoff)
 	return d
 }
 
@@ -1539,10 +1536,7 @@ func wrapError(operation string, err error, status int, body []byte) error {
 
 	// Append body snippet if available (useful for Enigma2 stack traces)
 	if len(body) > 0 {
-		limit := 500
-		if len(body) < limit {
-			limit = len(body)
-		}
+		limit := min(len(body), 500)
 		snippet = string(body[:limit])
 		snippet = strings.ReplaceAll(snippet, "\n", " ")
 		snippet = strings.ReplaceAll(snippet, "\r", "")
@@ -1553,10 +1547,7 @@ func wrapError(operation string, err error, status int, body []byte) error {
 			if idx := strings.Index(strings.ToLower(snippet), pattern); idx != -1 {
 				// Redact 16 chars or until space after the pattern
 				start := idx + len(pattern)
-				end := start + 16
-				if end > len(snippet) {
-					end = len(snippet)
-				}
+				end := min(start+16, len(snippet))
 				if spaceIdx := strings.Index(snippet[start:end], " "); spaceIdx != -1 {
 					end = start + spaceIdx
 				}
@@ -1869,8 +1860,8 @@ func extractHost(base string) string {
 			return u.Host
 		}
 	}
-	if idx := strings.Index(base, "/"); idx >= 0 {
-		return base[:idx]
+	if before, _, ok := strings.Cut(base, "/"); ok {
+		return before
 	}
 	return base
 }

--- a/backend/internal/pipeline/api/hls_policy.go
+++ b/backend/internal/pipeline/api/hls_policy.go
@@ -115,8 +115,8 @@ func parseHLSPlaylistMetrics(content []byte) hlsPlaylistMetrics {
 	scanner := bufio.NewScanner(bytes.NewReader(content))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "#EXT-X-TARGETDURATION:") {
-			raw := strings.TrimSpace(strings.TrimPrefix(line, "#EXT-X-TARGETDURATION:"))
+		if after, ok := strings.CutPrefix(line, "#EXT-X-TARGETDURATION:"); ok {
+			raw := strings.TrimSpace(after)
 			target, err := strconv.Atoi(raw)
 			if err == nil && target > 0 {
 				metrics.TargetDurationSec = target

--- a/backend/internal/pipeline/api/session_health.go
+++ b/backend/internal/pipeline/api/session_health.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -255,10 +256,8 @@ func appendUniqueReason(reasons []string, code string) []string {
 	if code == "" {
 		return reasons
 	}
-	for _, existing := range reasons {
-		if existing == code {
-			return reasons
-		}
+	if slices.Contains(reasons, code) {
+		return reasons
 	}
 	return append(reasons, code)
 }

--- a/backend/internal/pipeline/exec/enigma2/client.go
+++ b/backend/internal/pipeline/exec/enigma2/client.go
@@ -367,10 +367,7 @@ func shouldRetry(resp *http.Response, err error) bool {
 }
 
 func (c *Client) backoffFor(attempt int) time.Duration {
-	wait := c.backoff * time.Duration(1<<attempt)
-	if wait > c.maxBackoff {
-		wait = c.maxBackoff
-	}
+	wait := min(c.backoff*time.Duration(1<<attempt), c.maxBackoff)
 	jitter := time.Duration(c.randInt63n(int64(wait/5 + 1)))
 	return wait + jitter
 }

--- a/backend/internal/pipeline/hardware/host_pressure.go
+++ b/backend/internal/pipeline/hardware/host_pressure.go
@@ -1,6 +1,7 @@
 package hardware
 
 import (
+	"slices"
 	"sync"
 
 	"github.com/ManuGH/xg2g/internal/domain/playbackprofile"
@@ -146,10 +147,8 @@ func classifyHostPressure(snapshot playbackprofile.HostRuntimeSnapshot) (playbac
 }
 
 func appendHostPressureSignal(signals []playbackprofile.HostPressureSignal, signal playbackprofile.HostPressureSignal) []playbackprofile.HostPressureSignal {
-	for _, existing := range signals {
-		if existing == signal {
-			return signals
-		}
+	if slices.Contains(signals, signal) {
+		return signals
 	}
 	return append(signals, signal)
 }

--- a/backend/internal/pipeline/scan/manager.go
+++ b/backend/internal/pipeline/scan/manager.go
@@ -677,10 +677,7 @@ func (m *Manager) scanInternal(ctx context.Context, force bool) error {
 		failCount := atomic.LoadInt32(&m.consecutiveFailureCount)
 		if failCount > 0 {
 			multiplier := 1 << (failCount - 1)
-			backoff := time.Duration(multiplier) * time.Second
-			if backoff > 30*time.Second {
-				backoff = 30 * time.Second
-			}
+			backoff := min(time.Duration(multiplier)*time.Second, 30*time.Second)
 			if backoff > delay {
 				delay = backoff
 			}

--- a/backend/internal/platform/fs/confinement.go
+++ b/backend/internal/platform/fs/confinement.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -109,8 +110,8 @@ func resolveWithExistingPrefix(path string) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("failed to resolve path: %w", err)
 			}
-			for i := len(missingParts) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, missingParts[i])
+			for _, v := range slices.Backward(missingParts) {
+				resolved = filepath.Join(resolved, v)
 			}
 			return resolved, nil
 		}

--- a/backend/internal/platform/httpx/client.go
+++ b/backend/internal/platform/httpx/client.go
@@ -22,15 +22,9 @@ func NewClient(timeout time.Duration) *http.Client {
 		timeout = defaultClientTimeout
 	}
 
-	dialTimeout := timeout
-	if dialTimeout > defaultDialTimeout {
-		dialTimeout = defaultDialTimeout
-	}
+	dialTimeout := min(timeout, defaultDialTimeout)
 
-	responseHeaderTimeout := timeout
-	if responseHeaderTimeout > defaultResponseHeaderTimeout {
-		responseHeaderTimeout = defaultResponseHeaderTimeout
-	}
+	responseHeaderTimeout := min(timeout, defaultResponseHeaderTimeout)
 
 	return &http.Client{
 		Timeout: timeout,

--- a/backend/internal/platform/net/outbound.go
+++ b/backend/internal/platform/net/outbound.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -173,12 +174,7 @@ func schemeAllowed(allowed []string, scheme string) bool {
 }
 
 func portAllowed(allowed []int, port int) bool {
-	for _, p := range allowed {
-		if p == port {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, port)
 }
 
 func urlPort(u *url.URL, scheme string) (int, error) {

--- a/backend/internal/recordings/pathmap.go
+++ b/backend/internal/recordings/pathmap.go
@@ -101,8 +101,8 @@ func (pm *PathMapper) ResolveLocalExisting(receiverPath string) (string, bool) {
 		var rel string
 		if clean == root {
 			rel = ""
-		} else if strings.HasPrefix(clean, root+"/") {
-			rel = strings.TrimPrefix(clean, root+"/")
+		} else if after, ok := strings.CutPrefix(clean, root+"/"); ok {
+			rel = after
 		} else {
 			continue
 		}
@@ -190,9 +190,9 @@ func (pm *PathMapper) ResolveLocalUnsafe(receiverPath string) (string, bool) {
 		// Check for exact match
 		if clean == root {
 			rel = ""
-		} else if strings.HasPrefix(clean, root+"/") {
+		} else if after, ok := strings.CutPrefix(clean, root+"/"); ok {
 			// Prefix match - extract relative path
-			rel = strings.TrimPrefix(clean, root+"/")
+			rel = after
 		} else {
 			// No match
 			continue

--- a/backend/internal/validate/validate.go
+++ b/backend/internal/validate/validate.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -118,13 +119,7 @@ func (v *Validator) URL(field, value string, allowedSchemes []string) {
 
 	// Check allowed schemes
 	if len(allowedSchemes) > 0 {
-		schemeValid := false
-		for _, scheme := range allowedSchemes {
-			if u.Scheme == scheme {
-				schemeValid = true
-				break
-			}
-		}
+		schemeValid := slices.Contains(allowedSchemes, u.Scheme)
 		if !schemeValid {
 			v.AddError(field,
 				fmt.Sprintf("unsupported URL scheme %q (allowed: %v)", u.Scheme, allowedSchemes),
@@ -208,10 +203,8 @@ func (v *Validator) NotEmpty(field, value string) {
 
 // OneOf validates that a value is one of the allowed values
 func (v *Validator) OneOf(field, value string, allowed []string) {
-	for _, a := range allowed {
-		if value == a {
-			return
-		}
+	if slices.Contains(allowed, value) {
+		return
 	}
 	v.AddError(field,
 		fmt.Sprintf("value must be one of %v, got %q", allowed, value),


### PR DESCRIPTION
## Summary

Behavior-preserving Go 1.25 stdlib modernization of the xg2g backend (#6b), applied via golangci-lint v2's `modernize` analyzer with autofix. **34 fixes across 73 files.** The full test suite stays green and no golden/contract/argv tests required changes.

## Modernizations applied

| Modernization | Notes |
|---|---|
| `slices.Contains` / `slices.ContainsFunc` | manual found-in-loop patterns (22 occurrences) |
| `slices.Sort` | `sort.Slice` on a comparable slice |
| `slices.Backward` | reverse index loops (5) |
| `maps.Copy` | `m[k]=v` copy loops (7) |
| `min` / `max` builtins | if-based clamps (~26) |
| `reflect.TypeFor[T]` | `reflect.TypeOf(T{})` (2) |
| `strings.Cut` / `strings.CutPrefix` | `strings.Index` / `HasPrefix`+`TrimPrefix` (15) |
| range-over-int | `for i := 0; i < N; i++` (21) |
| drop redundant loop-var copies | `x := x` no longer needed (Go 1.22+) (4) |

## Deliberately skipped (behavior / restructuring risk)

- **`atomictypes`** — converting `int64`→`atomic.Int64` touches every usage; too invasive.
- **`omitzero`** — `omitempty`→`omitzero` changes JSON serialization semantics (a behavior change).
- **`stringsbuilder`** — `s += s` loop → `strings.Builder` is a real refactor, not a 1:1 rewrite.
- **`stringsseq`** (`SplitSeq`) and **`waitgroupgo`** (`WaitGroup.Go`) — restructure control flow; held back to keep the diff strictly equivalence-only.

## errors.Join — SKIPPED

`errors.Join` was **not applied**. The `modernize` analyzer surfaced no `errors.Join` candidates, and introducing it manually is speculative: it changes error-string formatting and could break golden/error-matching tests. Per the safety-first directive, it was skipped rather than risk a behavior change. No golden files were edited.

## Out of scope / untouched

- Generated files (`*_gen.go`) and `vendor/` were not modified.
- Test files were excluded (project `.golangci.yml` runs with `tests: false`).

## Verification (all green)

- `go build -buildvcs=false ./...` — clean
- `go vet -buildvcs=false ./...` — clean
- `go test -buildvcs=false ./internal/infra/media/ffmpeg/... ./internal/control/...` — pass (argv + contract goldens)
- Full `go test -buildvcs=false ./...` — **100 packages pass, 0 failures**
- `golangci-lint run --new-from-rev=origin/main ./...` — **0 new issues**
- `make generate-config && make verify-config` — **"Config surfaces are up-to-date"** (no config-surface drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)