### PR TITLE
feat(gpu): observe hardware-encoder capability + runtime demotion (Q4)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter_logparse.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	metricsgpu "github.com/ManuGH/xg2g/internal/metrics/gpu"
 	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
 	"github.com/rs/zerolog"
 	"os/exec"
@@ -298,6 +299,7 @@ func (a *LocalAdapter) recordVAAPIRuntimeFailure(sessionID, failureLine string) 
 		return
 	}
 	failures, demoted := hardware.RecordVAAPIRuntimeFailure()
+	metricsgpu.RecordRuntimeEncodeFailure("vaapi")
 	event := a.Logger.Warn().
 		Str("session_id", sessionID).
 		Int("vaapi_runtime_failures", failures)
@@ -305,6 +307,10 @@ func (a *LocalAdapter) recordVAAPIRuntimeFailure(sessionID, failureLine string) 
 		event = event.Str("ffmpeg_log", failureLine)
 	}
 	if demoted {
+		metricsgpu.RecordRuntimeDemotion("vaapi")
+		metricsgpu.SetEncoderVerified("h264_vaapi", false)
+		metricsgpu.SetEncoderVerified("hevc_vaapi", false)
+		metricsgpu.SetEncoderVerified("av1_vaapi", false)
 		event.Msg("vaapi runtime failure threshold reached; gpu demoted to cpu fallback")
 		return
 	}
@@ -316,6 +322,7 @@ func (a *LocalAdapter) recordNVENCRuntimeFailure(sessionID, failureLine string) 
 		return
 	}
 	failures, demoted := hardware.RecordNVENCRuntimeFailure()
+	metricsgpu.RecordRuntimeEncodeFailure("nvenc")
 	event := a.Logger.Warn().
 		Str("session_id", sessionID).
 		Int("nvenc_runtime_failures", failures)
@@ -323,6 +330,10 @@ func (a *LocalAdapter) recordNVENCRuntimeFailure(sessionID, failureLine string) 
 		event = event.Str("ffmpeg_log", failureLine)
 	}
 	if demoted {
+		metricsgpu.RecordRuntimeDemotion("nvenc")
+		metricsgpu.SetEncoderVerified("h264_nvenc", false)
+		metricsgpu.SetEncoderVerified("hevc_nvenc", false)
+		metricsgpu.SetEncoderVerified("av1_nvenc", false)
 		event.Msg("nvenc runtime failure threshold reached; gpu demoted to cpu fallback")
 		return
 	}

--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -9,6 +9,7 @@ import (
 	playbackports "github.com/ManuGH/xg2g/internal/domain/playbackprofile/ports"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/ManuGH/xg2g/internal/infra/media/ffmpeg/capability"
+	metricsgpu "github.com/ManuGH/xg2g/internal/metrics/gpu"
 	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
 	"github.com/ManuGH/xg2g/internal/pipeline/profiles"
 	"github.com/rs/zerolog"
@@ -51,7 +52,19 @@ func newDetector(binPath string, logger zerolog.Logger, vaapiDevice, hlsRoot str
 // PreflightVAAPI validates that the configured VAAPI device is functional.
 // Tests each available encoder (h264_vaapi, hevc_vaapi) independently.
 // Results are cached per-encoder: buildArgs checks the specific encoder.
+// publishEncoderGauges mirrors the per-encoder verified/auto-eligible verdicts
+// into Prometheus gauges so fleet hardware-encode capability is observable.
+// A nil caps map sets every listed encoder to 0 (not verified / not eligible).
+func publishEncoderGauges(encoders []string, caps map[string]hardware.HardwareEncoderCapability) {
+	for _, enc := range encoders {
+		c, ok := caps[enc]
+		metricsgpu.SetEncoderVerified(enc, ok && c.Verified)
+		metricsgpu.SetEncoderAutoEligible(enc, ok && c.AutoEligible)
+	}
+}
+
 func (d *Detector) PreflightVAAPI() error {
+	publishEncoderGauges(vaapiEncodersToTest, nil)
 	if d.VaapiDevice == "" {
 		return nil
 	}
@@ -136,6 +149,7 @@ func (d *Detector) PreflightVAAPI() error {
 
 	// Publish per-encoder results for higher layers (HTTP/profile selection).
 	hardware.SetVAAPIEncoderCapabilities(d.vaapiEncoderCaps)
+	publishEncoderGauges(vaapiEncodersToTest, d.vaapiEncoderCaps)
 
 	hardware.SetVAAPIPreflightResult(true)
 	d.Logger.Info().
@@ -147,6 +161,7 @@ func (d *Detector) PreflightVAAPI() error {
 
 // PreflightNVENC validates that the visible NVIDIA runtime can execute real NVENC encodes.
 func (d *Detector) PreflightNVENC() error {
+	publishEncoderGauges(nvencEncodersToTest, nil)
 	if !hardware.HasNVENC() {
 		return nil
 	}
@@ -219,6 +234,7 @@ func (d *Detector) PreflightNVENC() error {
 	}
 
 	hardware.SetNVENCEncoderCapabilities(d.nvencEncoderCaps)
+	publishEncoderGauges(nvencEncodersToTest, d.nvencEncoderCaps)
 	hardware.SetNVENCPreflightResult(true)
 	d.Logger.Info().
 		Int("verified_encoders", len(d.nvencEncoders)).

--- a/backend/internal/metrics/gpu/metrics.go
+++ b/backend/internal/metrics/gpu/metrics.go
@@ -113,3 +113,86 @@ func RecordTranscodeError(codec, reason string) {
 func RecordStreamDetectionError(port, errorType string) {
 	StreamDetectionErrors.WithLabelValues(port, errorType).Inc()
 }
+
+// --- Hardware encoder capability + runtime-demotion telemetry ---
+//
+// These make the otherwise process-local hardware-encode verdicts observable so
+// fleet AV1/HEVC safety is queryable, and so a baseline exists before stricter
+// admission checks change which encoders count as verified.
+
+var (
+	// EncoderVerified reports whether a hardware encoder passed startup preflight
+	// (1) or not (0), per encoder (e.g. "av1_vaapi", "hevc_vaapi", "h264_vaapi").
+	EncoderVerified = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "xg2g",
+			Subsystem: "gpu",
+			Name:      "encoder_verified",
+			Help:      "Whether a hardware encoder passed startup preflight (1) or not (0)",
+		},
+		[]string{"encoder"},
+	)
+
+	// EncoderAutoEligible reports whether a verified hardware encoder is eligible
+	// for automatic codec negotiation (1) or not (0), per encoder.
+	EncoderAutoEligible = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "xg2g",
+			Subsystem: "gpu",
+			Name:      "encoder_auto_eligible",
+			Help:      "Whether a verified hardware encoder is auto-eligible for negotiation (1) or not (0)",
+		},
+		[]string{"encoder"},
+	)
+
+	// RuntimeDemotionTotal counts hardware-encoder demotions triggered by repeated
+	// runtime encode failures, after which the backend falls back to CPU/software.
+	RuntimeDemotionTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "xg2g",
+			Subsystem: "gpu",
+			Name:      "runtime_demotion_total",
+			Help:      "Hardware encoder demotions caused by repeated runtime encode failures",
+		},
+		[]string{"backend"}, // "vaapi" | "nvenc"
+	)
+
+	// RuntimeEncodeFailureTotal counts individual runtime hardware-encode failures
+	// observed in ffmpeg output (the pre-demotion signal).
+	RuntimeEncodeFailureTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "xg2g",
+			Subsystem: "gpu",
+			Name:      "runtime_encode_failure_total",
+			Help:      "Individual runtime hardware-encode failures observed in ffmpeg output",
+		},
+		[]string{"backend"},
+	)
+)
+
+// SetEncoderVerified records whether a hardware encoder passed startup preflight.
+func SetEncoderVerified(encoder string, verified bool) {
+	EncoderVerified.WithLabelValues(encoder).Set(boolToGauge(verified))
+}
+
+// SetEncoderAutoEligible records whether a hardware encoder is auto-eligible.
+func SetEncoderAutoEligible(encoder string, eligible bool) {
+	EncoderAutoEligible.WithLabelValues(encoder).Set(boolToGauge(eligible))
+}
+
+// RecordRuntimeDemotion records a hardware-encoder backend demotion (vaapi|nvenc).
+func RecordRuntimeDemotion(backend string) {
+	RuntimeDemotionTotal.WithLabelValues(backend).Inc()
+}
+
+// RecordRuntimeEncodeFailure records a single runtime hardware-encode failure.
+func RecordRuntimeEncodeFailure(backend string) {
+	RuntimeEncodeFailureTotal.WithLabelValues(backend).Inc()
+}
+
+func boolToGauge(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/backend/internal/metrics/gpu/metrics_test.go
+++ b/backend/internal/metrics/gpu/metrics_test.go
@@ -211,3 +211,38 @@ func BenchmarkRecordStreamDetectionError(b *testing.B) {
 		RecordStreamDetectionError("8001", "timeout")
 	}
 }
+
+func TestEncoderCapabilityGauges(t *testing.T) {
+	EncoderVerified.Reset()
+	EncoderAutoEligible.Reset()
+
+	SetEncoderVerified("av1_vaapi", true)
+	SetEncoderVerified("hevc_vaapi", false)
+	SetEncoderAutoEligible("av1_vaapi", true)
+
+	if got := testutil.ToFloat64(EncoderVerified.WithLabelValues("av1_vaapi")); got != 1 {
+		t.Errorf("av1_vaapi verified: want 1, got %v", got)
+	}
+	if got := testutil.ToFloat64(EncoderVerified.WithLabelValues("hevc_vaapi")); got != 0 {
+		t.Errorf("hevc_vaapi verified: want 0, got %v", got)
+	}
+	if got := testutil.ToFloat64(EncoderAutoEligible.WithLabelValues("av1_vaapi")); got != 1 {
+		t.Errorf("av1_vaapi auto-eligible: want 1, got %v", got)
+	}
+}
+
+func TestRuntimeDemotionTelemetry(t *testing.T) {
+	RuntimeDemotionTotal.Reset()
+	RuntimeEncodeFailureTotal.Reset()
+
+	RecordRuntimeEncodeFailure("vaapi")
+	RecordRuntimeEncodeFailure("vaapi")
+	RecordRuntimeDemotion("vaapi")
+
+	if got := testutil.ToFloat64(RuntimeEncodeFailureTotal.WithLabelValues("vaapi")); got != 2 {
+		t.Errorf("vaapi runtime failures: want 2, got %v", got)
+	}
+	if got := testutil.ToFloat64(RuntimeDemotionTotal.WithLabelValues("vaapi")); got != 1 {
+		t.Errorf("vaapi demotions: want 1, got %v", got)
+	}
+}


### PR DESCRIPTION
First step of the AV1/VAAPI fleet-safety work (the agreed order: **Q4 instrument → Q1 → B1+B2 → B3**). Instrument **before** changing verdict behavior, so the baseline is visible when stricter admission later flips some encoders from verified→withheld.

## New metrics (`internal/metrics/gpu`)
| metric | type | when |
|--------|------|------|
| `xg2g_gpu_encoder_verified{encoder}` | gauge 1/0 | set at VAAPI/NVENC preflight |
| `xg2g_gpu_encoder_auto_eligible{encoder}` | gauge 1/0 | set at preflight |
| `xg2g_gpu_runtime_demotion_total{backend}` | counter | GPU→CPU demotion (3-strike) |
| `xg2g_gpu_runtime_encode_failure_total{backend}` | counter | each runtime failure line |

## Why
- Today every capability verdict and the silent GPU→CPU demotion live in process globals / a single Warn log — fleet AV1 readiness is unknowable. These gauges make *"how many hosts have av1_vaapi verified + auto-eligible?"* one PromQL query.
- Demotion gauges drop to 0 when a backend demotes, so a node that fell back to CPU is visible.

## Behavior
Pure observability — **no** change to encode selection, admission, or fallback. `go build`, `go vet`, package tests (incl. new `TestEncoderCapabilityGauges`/`TestRuntimeDemotionTelemetry`), scoped golangci-lint all green; config surfaces unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)