### PR TITLE
fix(ffmpeg): demote on hardware encoder-open failures (Q1)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter_logparse.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse.go
@@ -238,12 +238,37 @@ func summarizeFFmpegFailureLine(line string) string {
 	return ""
 }
 
+// looksLikeEncoderOpenFailure matches ffmpeg lines reporting a hardware encoder
+// failing to open/initialize — e.g. feeding a 10-bit surface to an 8-bit-profile
+// VAAPI encoder. ffmpeg emits these without the "vaapi"/"nvenc" token on the
+// same line (the codec name sits in a separate component-prefix line), so the
+// backend-specific matchers miss them and no GPU->CPU demotion fires. The call
+// site already gates which backend's session this applies to, so a plain
+// substring match here is safe.
+func looksLikeEncoderOpenFailure(lower string) bool {
+	for _, kw := range []string{
+		"could not open encoder",
+		"cannot open encoder",
+		"failed to open encoder",
+		"error while opening encoder",
+		"no usable encoding profile",
+	} {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
 func isVAAPIRuntimeFailureLine(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
 	if lower == "" {
 		return false
 	}
 	if strings.Contains(lower, "vaapi") && looksLikeFFmpegWarning(lower) {
+		return true
+	}
+	if looksLikeEncoderOpenFailure(lower) {
 		return true
 	}
 	definitiveKeywords := []string{
@@ -273,6 +298,9 @@ func isNVENCRuntimeFailureLine(line string) bool {
 		return false
 	}
 	if strings.Contains(lower, "nvenc") && looksLikeFFmpegWarning(lower) {
+		return true
+	}
+	if looksLikeEncoderOpenFailure(lower) {
 		return true
 	}
 	definitiveKeywords := []string{

--- a/backend/internal/infra/media/ffmpeg/adapter_logparse_failure_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse_failure_test.go
@@ -1,0 +1,42 @@
+package ffmpeg
+
+import "testing"
+
+// TestEncoderOpenFailureClassified guards the Q1 fix: ffmpeg emits the codec
+// token (hevc_vaapi/av1_vaapi) on a separate component-prefix line from the
+// actual "could not open encoder" / "error while opening encoder" message, so
+// the backend matchers previously missed real hardware encoder-open failures
+// and never demoted GPU->CPU. The call site is already backend-gated, so these
+// substring matches only apply to the matching backend's failed sessions.
+func TestEncoderOpenFailureClassified(t *testing.T) {
+	failing := []string{
+		"could not open encoder before eof",
+		"[enc:hevc_vaapi] error while opening encoder - maybe incorrect parameters such as bit_rate, width or height",
+		"[av1_vaapi] no usable encoding profile found",
+		"cannot open encoder",
+		"failed to open encoder",
+	}
+	for _, line := range failing {
+		if !isVAAPIRuntimeFailureLine(line) {
+			t.Errorf("VAAPI classifier should flag encoder-open failure: %q", line)
+		}
+		if !isNVENCRuntimeFailureLine(line) {
+			t.Errorf("NVENC classifier should flag encoder-open failure: %q", line)
+		}
+	}
+
+	benign := []string{
+		"",
+		"frame=  100 fps= 50 q=28.0 size=512kB time=00:00:04.00 bitrate=1048.6kbits/s",
+		"opening 'index.m3u8' for writing",
+		"[libx264 @ 0x0] using cpu capabilities: mmx2 sse2",
+	}
+	for _, line := range benign {
+		if isVAAPIRuntimeFailureLine(line) {
+			t.Errorf("VAAPI classifier should NOT flag benign line: %q", line)
+		}
+		if isNVENCRuntimeFailureLine(line) {
+			t.Errorf("NVENC classifier should NOT flag benign line: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Second step of the AV1/VAAPI fleet-safety work (order: Q4 → **Q1** → B1+B2 → B3), pairing with the #517 demotion counter so demotion is both *triggered* and *visible*.

## Problem
When a HW encoder fails to **open** (e.g. a 10-bit surface into an 8-bit-profile VAAPI encoder — a real AMD radeonsi failure I reproduced: `Could not open encoder` / exit -22), ffmpeg prints the codec token on a *separate* component-prefix line from the error message. The matchers required `vaapi`/`nvenc` + warning on **one** line, so they missed it → the 3-strike GPU→CPU demotion **never fired** → the session died and the client stalled instead of falling back.

## Fix
Shared `looksLikeEncoderOpenFailure()` substring check (`could not open encoder`, `error while opening encoder`, `no usable encoding profile`, …) added to both backend matchers. The call site is already **backend-gated** (`switch hwBackend`) and only records on real process failure, so a software-encoder failure can't wrongly demote VAAPI.

## Verify
New `TestEncoderOpenFailureClassified` (real lines match, benign don't), full ffmpeg suite, scoped golangci-lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)