### PR TITLE
feat(ffmpeg): decode-verify hardware encoders, three-state verdict (B1)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -18,7 +18,17 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+)
+
+// Decode-verify thresholds (B1). "verified" means the encoded output decoded to
+// a complete, non-black, non-flat frame sequence — not merely "the encoder
+// exited 0 while discarding its output".
+const (
+	decodeVerifyFrames   = 10
+	decodeVerifyMinYAvg  = 32.0
+	decodeVerifyMinRange = 16.0
 )
 
 type Detector struct {
@@ -43,6 +53,14 @@ type Detector struct {
 	nvencErr                 error
 	profileBenchmarksChecked bool
 	profileProbeFn           func(context.Context, profileProbeRequest) (time.Duration, error)
+
+	// B1 decode-verify seams + state.
+	decodeVerifyFn    func(context.Context, string, string, int) (hardware.EncoderVerdict, string)
+	decodeStatsFn     func(context.Context, string, string) (int, float64, float64, error)
+	softwareDecoderFn func(string) (string, bool)
+	minDecodeYAvg     float64 // overridable threshold; <=0 means decodeVerifyMinYAvg
+	decodersOnce      sync.Once
+	decodersAvail     map[string]bool
 }
 
 func newDetector(binPath string, logger zerolog.Logger, vaapiDevice, hlsRoot string) *Detector {
@@ -60,6 +78,7 @@ func publishEncoderGauges(encoders []string, caps map[string]hardware.HardwareEn
 		c, ok := caps[enc]
 		metricsgpu.SetEncoderVerified(enc, ok && c.Verified)
 		metricsgpu.SetEncoderAutoEligible(enc, ok && c.AutoEligible)
+		metricsgpu.SetEncoderUnverifiable(enc, ok && c.Verdict == hardware.VerdictUnverifiable)
 	}
 }
 
@@ -102,23 +121,27 @@ func (d *Detector) PreflightVAAPI() error {
 	}
 	encoderList := string(checkOut)
 
-	// 3. Test each encoder with a real 5-frame encode
+	// 3. Probe each encoder, then decode-verify its output (three-state verdict:
+	// verified / withheld / unverifiable). Only "verified" encoders are admitted.
 	verifiedElapsed := make(map[string]time.Duration, len(vaapiEncodersToTest))
+	verdicts := make(map[string]hardware.EncoderVerdict, len(vaapiEncodersToTest))
+	reasons := make(map[string]string, len(vaapiEncodersToTest))
 	for _, enc := range vaapiEncodersToTest {
 		if !strings.Contains(encoderList, enc) {
 			d.Logger.Info().Str("encoder", enc).Msg("vaapi preflight: encoder not in ffmpeg build, skipping")
+			verdicts[enc] = hardware.VerdictWithheld
+			reasons[enc] = "encoder not in ffmpeg build"
 			continue
 		}
-		elapsed, err := d.testVaapiEncoder(enc)
-		if err != nil {
-			d.Logger.Warn().Err(err).Str("encoder", enc).Msg("vaapi preflight: encoder test failed")
-		} else {
+		elapsed, verdict, reason := d.probeAndVerifyVaapiEncoder(enc)
+		verdicts[enc] = verdict
+		reasons[enc] = reason
+		if verdict == hardware.VerdictVerified {
 			d.vaapiEncoders[enc] = true
 			verifiedElapsed[enc] = elapsed
-			d.Logger.Info().
-				Str("encoder", enc).
-				Dur("probe_elapsed", elapsed).
-				Msg("vaapi preflight: encoder verified")
+			d.Logger.Info().Str("encoder", enc).Dur("probe_elapsed", elapsed).Msg("vaapi preflight: encoder verified")
+		} else {
+			d.Logger.Warn().Str("encoder", enc).Str("verdict", string(verdict)).Str("reason", reason).Msg("vaapi preflight: encoder not admitted")
 		}
 	}
 
@@ -135,6 +158,26 @@ func (d *Detector) PreflightVAAPI() error {
 		envFloatBounded("XG2G_HEVC_VAAPI_AUTO_RATIO_MAX", capability.DefaultHEVCVAAPIAutoRatioMax, 1.0, 10.0),
 		envFloatBounded("XG2G_AV1_VAAPI_AUTO_RATIO_MAX", capability.DefaultAV1VAAPIAutoRatioMax, 1.0, 10.0),
 	)
+	// Overlay the three-state verdict onto every probed encoder so the record
+	// carries withheld/unverifiable too (B3 fleet visibility), while admission
+	// (cap.Verified) stays fail-closed for anything not VerdictVerified.
+	if d.vaapiEncoderCaps == nil {
+		d.vaapiEncoderCaps = make(map[string]hardware.VAAPIEncoderCapability, len(vaapiEncodersToTest))
+	}
+	for _, enc := range vaapiEncodersToTest {
+		verdict, ok := verdicts[enc]
+		if !ok {
+			continue
+		}
+		cap := d.vaapiEncoderCaps[enc] // zero value (Verified=false) for non-verified encoders
+		cap.Verdict = verdict
+		cap.Reason = reasons[enc]
+		cap.Verified = verdict == hardware.VerdictVerified
+		if !cap.Verified {
+			cap.AutoEligible = false
+		}
+		d.vaapiEncoderCaps[enc] = cap
+	}
 	for _, enc := range vaapiEncodersToTest {
 		cap, ok := d.vaapiEncoderCaps[enc]
 		if !ok || !cap.Verified {
@@ -271,26 +314,186 @@ func (d *Detector) PreflightTranscodeProfiles() {
 	}
 }
 
-// testVaapiEncoder runs a real 5-frame encode test for a specific VAAPI encoder.
-func (d *Detector) testVaapiEncoder(encoder string) (time.Duration, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+// probeAndVerifyVaapiEncoder encodes a short synthetic clip with the given VAAPI
+// encoder to a real file, then decode-verifies the output. It returns the encode
+// elapsed time and a three-state verdict (verified/withheld/unverifiable).
+func (d *Detector) probeAndVerifyVaapiEncoder(encoder string) (time.Duration, hardware.EncoderVerdict, string) {
+	tmpDir, err := os.MkdirTemp("", "xg2g-encode-verify-*")
+	if err != nil {
+		return 0, hardware.VerdictUnverifiable, "mktemp: " + err.Error()
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+	outPath := filepath.Join(tmpDir, "probe.mkv")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	dur := float64(decodeVerifyFrames)/25.0 + 0.04
 	start := time.Now()
-	// #nosec G204 -- BinPath and VaapiDevice are trusted from config
+	// #nosec G204 -- BinPath/VaapiDevice are trusted config; outPath is a local temp.
 	cmd := exec.CommandContext(ctx, d.BinPath,
+		"-y",
 		"-vaapi_device", d.VaapiDevice,
 		"-f", "lavfi",
-		"-i", "testsrc=duration=0.2:size=1280x720:rate=25",
+		"-i", fmt.Sprintf("testsrc2=size=1280x720:rate=25:duration=%0.2f", dur),
 		"-vf", "format=nv12,hwupload",
 		"-c:v", encoder,
-		"-frames:v", "5",
+		"-frames:v", strconv.Itoa(decodeVerifyFrames),
+		outPath,
+	)
+	if out, encErr := cmd.CombinedOutput(); encErr != nil {
+		// Encoder failed to open/run: the hardware cannot produce this output.
+		return time.Since(start), hardware.VerdictWithheld, fmt.Sprintf("encode failed: %v (%s)", encErr, tailSummary(string(out), 2))
+	}
+	elapsed := time.Since(start)
+	verdict, reason := d.decodeVerifyEncode(ctx, outPath, normalizeRequestedCodec(encoder), decodeVerifyFrames)
+	return elapsed, verdict, reason
+}
+
+// decodeVerifyEncode decode-verifies an encoded file with a forced *software*
+// decoder, returning a three-state verdict. "verified" requires the output to
+// decode to the full frame count, be non-black (mean YAVG >= threshold) and
+// carry spatial content (max luma range >= decodeVerifyMinRange). If no software
+// decoder for the codec exists it returns "unverifiable" (fail-closed: never
+// trust "bytes were produced").
+func (d *Detector) decodeVerifyEncode(ctx context.Context, path, codec string, expectedFrames int) (hardware.EncoderVerdict, string) {
+	if d.decodeVerifyFn != nil {
+		return d.decodeVerifyFn(ctx, path, codec, expectedFrames)
+	}
+	swDec, ok := d.softwareDecoderFor(codec)
+	if !ok {
+		return hardware.VerdictUnverifiable, fmt.Sprintf("no software %s decoder available to verify output", codec)
+	}
+	frames, meanYAvg, maxRange, err := d.decodeStats(ctx, path, swDec)
+	if err != nil {
+		// Decoder is present but decoding failed -> the bitstream is bad.
+		return hardware.VerdictWithheld, fmt.Sprintf("software decode (%s) failed: %v", swDec, err)
+	}
+	minYAvg := d.minDecodeYAvg
+	if minYAvg <= 0 {
+		minYAvg = decodeVerifyMinYAvg
+	}
+	switch {
+	case frames < expectedFrames:
+		return hardware.VerdictWithheld, fmt.Sprintf("partial decode: %d/%d frames", frames, expectedFrames)
+	case meanYAvg < minYAvg:
+		return hardware.VerdictWithheld, fmt.Sprintf("output too dark: mean YAVG %.1f < %.1f", meanYAvg, minYAvg)
+	case maxRange < decodeVerifyMinRange:
+		return hardware.VerdictWithheld, fmt.Sprintf("flat output: max luma range %.1f < %.1f", maxRange, decodeVerifyMinRange)
+	}
+	return hardware.VerdictVerified, ""
+}
+
+// decodeStats software-decodes path with the given decoder and returns the
+// decoded frame count, mean luma (YAVG) and the maximum per-frame luma range
+// (YMAX-YMIN) via the signalstats filter.
+func (d *Detector) decodeStats(ctx context.Context, path, swDecoder string) (frames int, meanYAvg float64, maxRange float64, err error) {
+	if d.decodeStatsFn != nil {
+		return d.decodeStatsFn(ctx, path, swDecoder)
+	}
+	// #nosec G204 -- BinPath/swDecoder are trusted; path is a local temp file.
+	cmd := exec.CommandContext(ctx, d.BinPath,
+		"-v", "info",
+		"-c:v", swDecoder,
+		"-i", path,
+		"-vf", "signalstats,metadata=mode=print",
 		"-f", "null", "-",
 	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return 0, fmt.Errorf("encode test failed: %w (output: %s)", err, string(out))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		return 0, 0, 0, fmt.Errorf("%w (%s)", runErr, tailSummary(string(out), 2))
 	}
-	return time.Since(start), nil
+	var sum, curMin float64
+	haveMin := false
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.Contains(line, "lavfi.signalstats.YAVG="):
+			if v, ok := parseSignalStat(line, "lavfi.signalstats.YAVG="); ok {
+				frames++
+				sum += v
+			}
+		case strings.Contains(line, "lavfi.signalstats.YMIN="):
+			if v, ok := parseSignalStat(line, "lavfi.signalstats.YMIN="); ok {
+				curMin, haveMin = v, true
+			}
+		case strings.Contains(line, "lavfi.signalstats.YMAX="):
+			if v, ok := parseSignalStat(line, "lavfi.signalstats.YMAX="); ok && haveMin && v-curMin > maxRange {
+				maxRange = v - curMin
+			}
+		}
+	}
+	if frames == 0 {
+		return 0, 0, 0, errors.New("no decoded frames")
+	}
+	return frames, sum / float64(frames), maxRange, nil
+}
+
+func parseSignalStat(line, prefix string) (float64, bool) {
+	_, after, ok := strings.Cut(line, prefix)
+	if !ok {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(after), 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// softwareDecoderFor returns the preferred software decoder ffmpeg can use to
+// validate output for the given codec, and whether one is available at all.
+func (d *Detector) softwareDecoderFor(codec string) (string, bool) {
+	if d.softwareDecoderFn != nil {
+		return d.softwareDecoderFn(codec)
+	}
+	candidates := map[string][]string{
+		"av1":  {"libdav1d", "libaom-av1", "av1"},
+		"hevc": {"hevc"},
+		"h264": {"h264"},
+	}
+	avail := d.availableDecoders()
+	for _, dec := range candidates[normalizeRequestedCodec(codec)] {
+		if avail[dec] {
+			return dec, true
+		}
+	}
+	return "", false
+}
+
+// availableDecoders parses `ffmpeg -decoders` once and caches the decoder names.
+func (d *Detector) availableDecoders() map[string]bool {
+	d.decodersOnce.Do(func() {
+		set := map[string]bool{}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		// #nosec G204 -- BinPath is trusted from config.
+		out, err := exec.CommandContext(ctx, d.BinPath, "-hide_banner", "-decoders").Output()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				fields := strings.Fields(line)
+				// Lines look like " V....D libdav1d AV1 ...": flags then name.
+				if len(fields) >= 2 && strings.HasPrefix(fields[0], "V") {
+					set[fields[1]] = true
+				}
+			}
+		}
+		d.decodersAvail = set
+	})
+	return d.decodersAvail
+}
+
+// tailSummary returns the last n non-empty lines of s joined by "; ".
+func tailSummary(s string, n int) string {
+	var lines []string
+	for _, l := range strings.Split(s, "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			lines = append(lines, l)
+		}
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "; ")
 }
 
 func (d *Detector) testNVENCEncoder(encoder string) (time.Duration, error) {

--- a/backend/internal/infra/media/ffmpeg/detector_decode_verify_test.go
+++ b/backend/internal/infra/media/ffmpeg/detector_decode_verify_test.go
@@ -1,0 +1,72 @@
+package ffmpeg
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
+)
+
+// TestDecodeVerifyVerdicts is the controlled forced-flip acceptance for the
+// three-state verdict: both negative states (withheld, unverifiable) must fire
+// on demand, not just the state this host happens to produce.
+func TestDecodeVerifyVerdicts(t *testing.T) {
+	const want = 10
+	cases := []struct {
+		name      string
+		decoderOK bool
+		frames    int
+		yavg      float64
+		rng       float64
+		statsErr  error
+		verdict   hardware.EncoderVerdict
+		reasonHas string
+	}{
+		{"verified", true, 10, 100, 80, nil, hardware.VerdictVerified, ""},
+		// unverifiable: no software decoder to validate output — fail-closed, NOT withheld.
+		{"no_decoder_unverifiable", false, 0, 0, 0, nil, hardware.VerdictUnverifiable, "no software"},
+		// withheld: decoder present but decode failed (corrupt bitstream).
+		{"decode_error_withheld", true, 0, 0, 0, errors.New("error submitting packet to decoder"), hardware.VerdictWithheld, "decode"},
+		// withheld: partial decode (truncated/aborted output).
+		{"partial_withheld", true, 5, 100, 80, nil, hardware.VerdictWithheld, "partial"},
+		// withheld: black output.
+		{"dark_withheld", true, 10, 10, 80, nil, hardware.VerdictWithheld, "dark"},
+		// withheld: flat/grayfield output (passes a luma-mean-only check but not variance).
+		{"flat_withheld", true, 10, 100, 5, nil, hardware.VerdictWithheld, "flat"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &Detector{
+				softwareDecoderFn: func(string) (string, bool) { return "libdav1d", tc.decoderOK },
+				decodeStatsFn: func(context.Context, string, string) (int, float64, float64, error) {
+					return tc.frames, tc.yavg, tc.rng, tc.statsErr
+				},
+			}
+			verdict, reason := d.decodeVerifyEncode(context.Background(), "x.mkv", "av1", want)
+			if verdict != tc.verdict {
+				t.Fatalf("verdict = %q, want %q (reason: %s)", verdict, tc.verdict, reason)
+			}
+			if tc.reasonHas != "" && !strings.Contains(reason, tc.reasonHas) {
+				t.Errorf("reason %q should contain %q", reason, tc.reasonHas)
+			}
+		})
+	}
+}
+
+// TestDecodeVerifyYAvgThresholdFlip proves the "withheld" path fires on demand by
+// raising the YAVG threshold above any real value — the host-level forced flip.
+func TestDecodeVerifyYAvgThresholdFlip(t *testing.T) {
+	d := &Detector{
+		minDecodeYAvg:     200, // above any real 8-bit luma mean
+		softwareDecoderFn: func(string) (string, bool) { return "libdav1d", true },
+		decodeStatsFn: func(context.Context, string, string) (int, float64, float64, error) {
+			return 10, 120, 80, nil // verified at the default 32 threshold
+		},
+	}
+	verdict, reason := d.decodeVerifyEncode(context.Background(), "x.mkv", "av1", 10)
+	if verdict != hardware.VerdictWithheld {
+		t.Fatalf("verdict = %q, want withheld (reason: %s)", verdict, reason)
+	}
+}

--- a/backend/internal/metrics/gpu/metrics.go
+++ b/backend/internal/metrics/gpu/metrics.go
@@ -145,6 +145,20 @@ var (
 		[]string{"encoder"},
 	)
 
+	// EncoderUnverifiable reports whether an encoder's output could NOT be
+	// validated (1) — no software decoder available — as distinct from withheld
+	// (verified=0, unverifiable=0 = proven-bad output). Three states:
+	// verified=1 → verified; verified=0,unverifiable=0 → withheld; unverifiable=1.
+	EncoderUnverifiable = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "xg2g",
+			Subsystem: "gpu",
+			Name:      "encoder_unverifiable",
+			Help:      "Whether a hardware encoder's output could not be verified for lack of a software decoder (1) or not (0)",
+		},
+		[]string{"encoder"},
+	)
+
 	// RuntimeDemotionTotal counts hardware-encoder demotions triggered by repeated
 	// runtime encode failures, after which the backend falls back to CPU/software.
 	RuntimeDemotionTotal = promauto.NewCounterVec(
@@ -173,6 +187,12 @@ var (
 // SetEncoderVerified records whether a hardware encoder passed startup preflight.
 func SetEncoderVerified(encoder string, verified bool) {
 	EncoderVerified.WithLabelValues(encoder).Set(boolToGauge(verified))
+}
+
+// SetEncoderUnverifiable records whether a hardware encoder's output could not
+// be validated (no software decoder), as distinct from proven-bad (withheld).
+func SetEncoderUnverifiable(encoder string, unverifiable bool) {
+	EncoderUnverifiable.WithLabelValues(encoder).Set(boolToGauge(unverifiable))
 }
 
 // SetEncoderAutoEligible records whether a hardware encoder is auto-eligible.

--- a/backend/internal/pipeline/hardware/gpu.go
+++ b/backend/internal/pipeline/hardware/gpu.go
@@ -33,8 +33,33 @@ const (
 	PathStatusPreflightFailed = "preflight_failed"
 )
 
+// EncoderVerdict is the three-state result of capability probing. The crucial
+// distinction is withheld vs unverifiable: "the hardware cannot produce good
+// output" is a different fleet fact from "we could not check the output", and
+// fleet visibility (B3) depends on telling them apart.
+type EncoderVerdict string
+
+const (
+	// VerdictVerified: encoded output decoded to a complete, non-black, non-flat
+	// frame sequence. Safe to admit.
+	VerdictVerified EncoderVerdict = "verified"
+	// VerdictWithheld: the encoder ran but the output is bad (encode failed, or
+	// the decode-verify found partial/black/flat output, or decode failed while a
+	// software decoder WAS present). Do not admit.
+	VerdictWithheld EncoderVerdict = "withheld"
+	// VerdictUnverifiable: no software decoder was available to validate the
+	// output, so correctness could not be established. Fail-closed: do not admit,
+	// but record this as distinct from a proven-bad encoder.
+	VerdictUnverifiable EncoderVerdict = "unverifiable"
+)
+
 type HardwareEncoderCapability struct {
+	// Verified stays true iff Verdict == VerdictVerified, so existing admission
+	// (IsHardwareEncoderReady -> cap.Verified) keeps working unchanged and
+	// fail-closed for withheld/unverifiable.
 	Verified     bool
+	Verdict      EncoderVerdict
+	Reason       string
 	ProbeElapsed time.Duration
 	AutoEligible bool
 }


### PR DESCRIPTION
B1 of the AV1/VAAPI fleet-safety work (order: Q4 #517 → Q1 #518 → **B1** → B2 → B3). This is the load-bearing change: it makes `verified` mean *decodable*, and introduces the capability record that B2 enriches and B3 will export.

## Problem
Admission (`IsHardwareEncoderReady("av1")` → `cap.Verified`) was **decode-blind**: `cap.Verified` came from a 5-frame encode to `-f null -` exiting 0. A GPU/driver emitting valid headers but corrupt slices passed admission and shipped corrupt AV1 to every eligible client.

## Change
`verified` now means *the output actually decodes and is sane*:
- Encode a short synthetic clip to a real file, then **decode-verify** with a forced **software** decoder (`libdav1d` for av1; native for hevc/h264).
- All three criteria required: full decoded **frame count** (no partial), mean **YAVG ≥ 32** (not black), max per-frame **luma range ≥ 16** (not flat/grayfield).
- **Three-state verdict — `verified` / `withheld` / `unverifiable`.** No software decoder → `unverifiable` (fail-closed; *not* verified-on-bytes, *not* withheld). This is the distinction fleet visibility (B3) needs: *hardware can't do AV1* vs *we couldn't check it*.

Admission stays fail-closed: `Verified == (Verdict == verified)`, so withheld/unverifiable are never admitted. New gauge `xg2g_gpu_encoder_unverifiable{encoder}` exposes the 3rd state. The dead decode-blind `testVaapiEncoder` is removed.

## Acceptance — both negative states fire, not just this host's happy path
- `TestDecodeVerifyVerdicts` forces **verified / unverifiable / withheld** (partial, dark, flat, decode-error) deterministically (GPU-free).
- Real-host: raised-YAVG flip on **real av1_vaapi output** → decoded YAVG 126 → `withheld` at threshold 200. Happy path on the same AMD radeonsi host: av1_vaapi stays **verified** (no false withheld).

## Verify
Full ffmpeg (golden/argv) + hardware + metrics suites, scoped golangci-lint (0 issues), config surfaces unchanged.

**Note:** behavior change to admission (now decode-verified). On hosts where the 8-bit→p010 luck or a software decoder is absent, encoders will correctly flip to withheld/unverifiable — that delta is the point, observable via the Q4/B1 gauges. **B2 next** adds the bit-depth dimension (probe at production p010) to the same record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)