### PR TITLE
fix(ffmpeg): B1 follow-up — distroless-safe probe temp + named freeze limit

### DIFF
--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -24,7 +24,13 @@ import (
 
 // Decode-verify thresholds (B1). "verified" means the encoded output decoded to
 // a complete, non-black, non-flat frame sequence — not merely "the encoder
-// exited 0 while discarding its output".
+// exited 0 while discarding its output". The luma-range check is WITHIN-frame
+// (catches a flat/uniform field); it does NOT catch a content-rich freeze (a
+// dead stream repeating one good frame). That is a runtime pathology a fresh
+// preflight encode cannot exhibit anyway, and is deferred to the live runtime
+// watchdog (observeRuntimePathCorrectness) — an empirical YDIF temporal check
+// was rejected because it did not separate freeze from motion on synthetic
+// clips (frozen YDIF 3.25 > animated 2.80).
 const (
 	decodeVerifyFrames   = 10
 	decodeVerifyMinYAvg  = 32.0
@@ -318,11 +324,22 @@ func (d *Detector) PreflightTranscodeProfiles() {
 // encoder to a real file, then decode-verifies the output. It returns the encode
 // elapsed time and a three-state verdict (verified/withheld/unverifiable).
 func (d *Detector) probeAndVerifyVaapiEncoder(encoder string) (time.Duration, hardware.EncoderVerdict, string) {
-	tmpDir, err := os.MkdirTemp("", "xg2g-encode-verify-*")
-	if err != nil {
-		return 0, hardware.VerdictUnverifiable, "mktemp: " + err.Error()
+	// Probe artifacts go under a guaranteed-writable working dir (HLSRoot, which
+	// the media pipeline already writes segments to) so a read-only/distroless
+	// rootfs with a non-writable /tmp does not turn a filesystem problem into a
+	// false "unverifiable". A genuine setup failure is reported with a
+	// filesystem-specific reason that is never confused with "no software decoder".
+	tmpBase := d.HLSRoot
+	if tmpBase == "" {
+		tmpBase = os.TempDir()
+	} else if mkErr := os.MkdirAll(tmpBase, 0o750); mkErr != nil {
+		tmpBase = os.TempDir()
 	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpDir, err := os.MkdirTemp(tmpBase, "encode-verify-*")
+	if err != nil {
+		return 0, hardware.VerdictUnverifiable, "probe setup failed (cannot create temp dir): " + err.Error()
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }() // cleans up on every path incl. withheld/unverifiable/crash
 	outPath := filepath.Join(tmpDir, "probe.mkv")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)


### PR DESCRIPTION
Follow-up addressing the review of B1 #519 (which auto-merged before the review points landed).

**1. Distroless / false-`unverifiable` (review point 2).** The decode-verify probe writes its encode to a real file. It now uses **HLSRoot** (a guaranteed-writable media working dir) with an os-temp fallback, so a read-only rootfs with a non-writable `/tmp` doesn't turn a filesystem problem into a false `unverifiable`. A real temp-setup failure now carries a **filesystem-specific reason** ("probe setup failed (cannot create temp dir)"), never confused with "no software decoder". Cleanup stays `defer`-based on every path incl. crash; `0o750` (gosec).

**2. Named the freeze limitation (review point 1).** The third criterion (luma range) is **within-frame** → catches flat/uniform, **not** a content-rich freeze. An empirical YDIF temporal check was **rejected** — it didn't separate freeze from motion on synthetic clips (frozen 3.25 > animated 2.80). Freeze is a runtime pathology a fresh preflight encode can't exhibit; it stays with the live watchdog. Now explicit in code, not silent.

No verdict-logic change. Full ffmpeg suite + scoped golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)