### PR TITLE
feat(ffmpeg): verify AV1 at production bit-depth (p010/10-bit) (B2)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -88,6 +88,38 @@ func publishEncoderGauges(encoders []string, caps map[string]hardware.HardwareEn
 	}
 }
 
+// applyEncoderVerdicts overlays the three-state verdict + per-bit-depth results
+// onto the derived capability map. The admission field cap.Verified — the SINGLE
+// field every gate reads (autocodec via IsHardwareEncoderReady -> cap.Verified;
+// plan_codec via the verified set, which is set from the same production-format
+// verdict) and the ONLY field B3 may export as "admitted" — is DERIVED here from
+// the bit depth production drives this codec at (AV1: 10-bit p010; others: 8-bit
+// nv12). It is never set independently, so the exported fingerprint cannot
+// diverge from what admission applies. Verified8Bit/Verified10Bit are per-depth
+// detail (both fully decode-verified) and gate NOTHING by themselves.
+func applyEncoderVerdicts(caps map[string]hardware.VAAPIEncoderCapability, encoders []string, verdicts map[string]hardware.EncoderVerdict, reasons map[string]string, verified8, verified10 map[string]bool) {
+	for _, enc := range encoders {
+		verdict, ok := verdicts[enc]
+		if !ok {
+			continue
+		}
+		cap := caps[enc] // zero value for non-verified encoders
+		cap.Verdict = verdict
+		cap.Reason = reasons[enc]
+		cap.Verified8Bit = verified8[enc]
+		cap.Verified10Bit = verified10[enc]
+		if normalizeRequestedCodec(enc) == "av1" {
+			cap.Verified = cap.Verified10Bit
+		} else {
+			cap.Verified = cap.Verified8Bit
+		}
+		if !cap.Verified {
+			cap.AutoEligible = false
+		}
+		caps[enc] = cap
+	}
+}
+
 func (d *Detector) PreflightVAAPI() error {
 	publishEncoderGauges(vaapiEncodersToTest, nil)
 	if d.VaapiDevice == "" {
@@ -183,28 +215,10 @@ func (d *Detector) PreflightVAAPI() error {
 		envFloatBounded("XG2G_HEVC_VAAPI_AUTO_RATIO_MAX", capability.DefaultHEVCVAAPIAutoRatioMax, 1.0, 10.0),
 		envFloatBounded("XG2G_AV1_VAAPI_AUTO_RATIO_MAX", capability.DefaultAV1VAAPIAutoRatioMax, 1.0, 10.0),
 	)
-	// Overlay the three-state verdict onto every probed encoder so the record
-	// carries withheld/unverifiable too (B3 fleet visibility), while admission
-	// (cap.Verified) stays fail-closed for anything not VerdictVerified.
 	if d.vaapiEncoderCaps == nil {
 		d.vaapiEncoderCaps = make(map[string]hardware.VAAPIEncoderCapability, len(vaapiEncodersToTest))
 	}
-	for _, enc := range vaapiEncodersToTest {
-		verdict, ok := verdicts[enc]
-		if !ok {
-			continue
-		}
-		cap := d.vaapiEncoderCaps[enc] // zero value (Verified=false) for non-verified encoders
-		cap.Verdict = verdict
-		cap.Reason = reasons[enc]
-		cap.Verified = verdict == hardware.VerdictVerified
-		cap.Verified8Bit = verified8[enc]
-		cap.Verified10Bit = verified10[enc]
-		if !cap.Verified {
-			cap.AutoEligible = false
-		}
-		d.vaapiEncoderCaps[enc] = cap
-	}
+	applyEncoderVerdicts(d.vaapiEncoderCaps, vaapiEncodersToTest, verdicts, reasons, verified8, verified10)
 	for _, enc := range vaapiEncodersToTest {
 		cap, ok := d.vaapiEncoderCaps[enc]
 		if !ok || !cap.Verified {

--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -132,6 +132,8 @@ func (d *Detector) PreflightVAAPI() error {
 	verifiedElapsed := make(map[string]time.Duration, len(vaapiEncodersToTest))
 	verdicts := make(map[string]hardware.EncoderVerdict, len(vaapiEncodersToTest))
 	reasons := make(map[string]string, len(vaapiEncodersToTest))
+	verified8 := make(map[string]bool, len(vaapiEncodersToTest))
+	verified10 := make(map[string]bool, len(vaapiEncodersToTest))
 	for _, enc := range vaapiEncodersToTest {
 		if !strings.Contains(encoderList, enc) {
 			d.Logger.Info().Str("encoder", enc).Msg("vaapi preflight: encoder not in ffmpeg build, skipping")
@@ -139,15 +141,32 @@ func (d *Detector) PreflightVAAPI() error {
 			reasons[enc] = "encoder not in ffmpeg build"
 			continue
 		}
-		elapsed, verdict, reason := d.probeAndVerifyVaapiEncoder(enc)
+		// Judge each encoder at the bit depth production drives it at: AV1 at
+		// 10-bit (p010le, see encode_args), H.264/HEVC at 8-bit (nv12). For AV1
+		// also probe 8-bit so the record shows whether a host does AV1 8-bit but
+		// not 10-bit (a p010 driver-promotion that fails elsewhere in the fleet).
+		isAV1 := normalizeRequestedCodec(enc) == "av1"
+		prodFormat := "nv12"
+		if isAV1 {
+			prodFormat = "p010le"
+		}
+		elapsed, verdict, reason := d.probeAndVerifyVaapiEncoder(enc, prodFormat)
 		verdicts[enc] = verdict
 		reasons[enc] = reason
+		if isAV1 {
+			verified10[enc] = verdict == hardware.VerdictVerified
+			if _, v8, _ := d.probeAndVerifyVaapiEncoder(enc, "nv12"); v8 == hardware.VerdictVerified {
+				verified8[enc] = true
+			}
+		} else {
+			verified8[enc] = verdict == hardware.VerdictVerified
+		}
 		if verdict == hardware.VerdictVerified {
 			d.vaapiEncoders[enc] = true
 			verifiedElapsed[enc] = elapsed
-			d.Logger.Info().Str("encoder", enc).Dur("probe_elapsed", elapsed).Msg("vaapi preflight: encoder verified")
+			d.Logger.Info().Str("encoder", enc).Str("upload_format", prodFormat).Dur("probe_elapsed", elapsed).Bool("verified_8bit", verified8[enc]).Bool("verified_10bit", verified10[enc]).Msg("vaapi preflight: encoder verified")
 		} else {
-			d.Logger.Warn().Str("encoder", enc).Str("verdict", string(verdict)).Str("reason", reason).Msg("vaapi preflight: encoder not admitted")
+			d.Logger.Warn().Str("encoder", enc).Str("upload_format", prodFormat).Str("verdict", string(verdict)).Str("reason", reason).Msg("vaapi preflight: encoder not admitted")
 		}
 	}
 
@@ -179,6 +198,8 @@ func (d *Detector) PreflightVAAPI() error {
 		cap.Verdict = verdict
 		cap.Reason = reasons[enc]
 		cap.Verified = verdict == hardware.VerdictVerified
+		cap.Verified8Bit = verified8[enc]
+		cap.Verified10Bit = verified10[enc]
 		if !cap.Verified {
 			cap.AutoEligible = false
 		}
@@ -321,9 +342,10 @@ func (d *Detector) PreflightTranscodeProfiles() {
 }
 
 // probeAndVerifyVaapiEncoder encodes a short synthetic clip with the given VAAPI
-// encoder to a real file, then decode-verifies the output. It returns the encode
+// encoder at the given upload format (e.g. "nv12" for 8-bit, "p010le" for
+// 10-bit) to a real file, then decode-verifies the output. It returns the encode
 // elapsed time and a three-state verdict (verified/withheld/unverifiable).
-func (d *Detector) probeAndVerifyVaapiEncoder(encoder string) (time.Duration, hardware.EncoderVerdict, string) {
+func (d *Detector) probeAndVerifyVaapiEncoder(encoder, uploadFormat string) (time.Duration, hardware.EncoderVerdict, string) {
 	// Probe artifacts go under a guaranteed-writable working dir (HLSRoot, which
 	// the media pipeline already writes segments to) so a read-only/distroless
 	// rootfs with a non-writable /tmp does not turn a filesystem problem into a
@@ -352,7 +374,7 @@ func (d *Detector) probeAndVerifyVaapiEncoder(encoder string) (time.Duration, ha
 		"-vaapi_device", d.VaapiDevice,
 		"-f", "lavfi",
 		"-i", fmt.Sprintf("testsrc2=size=1280x720:rate=25:duration=%0.2f", dur),
-		"-vf", "format=nv12,hwupload",
+		"-vf", "format="+uploadFormat+",hwupload",
 		"-c:v", encoder,
 		"-frames:v", strconv.Itoa(decodeVerifyFrames),
 		outPath,
@@ -663,6 +685,12 @@ func (d *Detector) testNVENCH264Profile(profileID, encoder string) (time.Duratio
 // VaapiEncoderVerified returns true if the given encoder passed preflight.
 func (d *Detector) VaapiEncoderVerified(encoder string) bool {
 	return d.vaapiEncoders[encoder]
+}
+
+// VaapiEncoder10BitVerified reports whether the encoder's output was
+// decode-verified at 10-bit (p010le) — the depth production drives AV1 at.
+func (d *Detector) VaapiEncoder10BitVerified(encoder string) bool {
+	return d.vaapiEncoderCaps[encoder].Verified10Bit
 }
 
 // VaapiEncoderAutoEligible returns true if the encoder is verified and suitable

--- a/backend/internal/infra/media/ffmpeg/detector_bitdepth_test.go
+++ b/backend/internal/infra/media/ffmpeg/detector_bitdepth_test.go
@@ -38,3 +38,45 @@ func TestEncoderCapabilityBitDepthFields(t *testing.T) {
 		t.Fatalf("expected 8-bit-only capability, got 8bit=%v 10bit=%v", c.Verified8Bit, c.Verified10Bit)
 	}
 }
+
+// TestApplyEncoderVerdicts_AdmissionIsProductionBitDepth locks the single-source
+// invariant B3 depends on: cap.Verified (the field every gate reads and the only
+// field B3 may export as "admitted") IS the production-bit-depth verdict —
+// derived, never set independently. For AV1 that is Verified10Bit; Verified8Bit
+// is recorded but gates nothing. This is what guarantees export-source ==
+// gate-source.
+func TestApplyEncoderVerdicts_AdmissionIsProductionBitDepth(t *testing.T) {
+	mkAV1 := func(v8, v10 bool) hardware.VAAPIEncoderCapability {
+		caps := map[string]hardware.VAAPIEncoderCapability{"av1_vaapi": {AutoEligible: true}}
+		v := hardware.VerdictVerified
+		if !v10 {
+			v = hardware.VerdictWithheld
+		}
+		applyEncoderVerdicts(caps, []string{"av1_vaapi"},
+			map[string]hardware.EncoderVerdict{"av1_vaapi": v}, map[string]string{},
+			map[string]bool{"av1_vaapi": v8}, map[string]bool{"av1_vaapi": v10})
+		return caps["av1_vaapi"]
+	}
+
+	if c := mkAV1(true, true); !c.Verified || c.Verified != c.Verified10Bit {
+		t.Fatalf("av1 8+10 verified: Verified=%v must equal Verified10Bit=%v (export==gate)", c.Verified, c.Verified10Bit)
+	}
+	if c := mkAV1(true, false); c.Verified {
+		t.Fatal("av1 8-bit-only (10-bit withheld) must NOT be admitted — Verified8Bit gates nothing")
+	}
+	if c := mkAV1(true, false); !c.Verified8Bit {
+		t.Fatal("Verified8Bit must still record the 8-bit result for B3 observability")
+	}
+	if c := mkAV1(false, true); !c.Verified {
+		t.Fatal("av1 10-bit verified must be admitted even if the 8-bit probe was not verified")
+	}
+
+	// Non-AV1 admission == 8-bit verdict.
+	hevc := map[string]hardware.VAAPIEncoderCapability{"hevc_vaapi": {}}
+	applyEncoderVerdicts(hevc, []string{"hevc_vaapi"},
+		map[string]hardware.EncoderVerdict{"hevc_vaapi": hardware.VerdictVerified},
+		map[string]string{}, map[string]bool{"hevc_vaapi": true}, map[string]bool{})
+	if c := hevc["hevc_vaapi"]; !c.Verified || c.Verified != c.Verified8Bit {
+		t.Fatalf("hevc admission must equal Verified8Bit: Verified=%v 8bit=%v", c.Verified, c.Verified8Bit)
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/detector_bitdepth_test.go
+++ b/backend/internal/infra/media/ffmpeg/detector_bitdepth_test.go
@@ -1,0 +1,40 @@
+package ffmpeg
+
+import (
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
+)
+
+// TestVaapiEncoder10BitVerified covers the input to the plan-time bit-depth gate:
+// production drives AV1 at 10-bit (p010le), so plan_codec refuses the AV1 path
+// unless the encoder was decode-verified at 10-bit, not merely at 8-bit.
+func TestVaapiEncoder10BitVerified(t *testing.T) {
+	d := &Detector{
+		vaapiEncoderCaps: map[string]hardware.VAAPIEncoderCapability{
+			// AV1 verified at both depths (e.g. AMD radeonsi that promotes p010).
+			"av1_vaapi": {Verified: true, Verified8Bit: true, Verified10Bit: true},
+			// HEVC verified at 8-bit only (the common case).
+			"hevc_vaapi": {Verified: true, Verified8Bit: true, Verified10Bit: false},
+		},
+	}
+	if !d.VaapiEncoder10BitVerified("av1_vaapi") {
+		t.Error("av1_vaapi should be 10-bit verified")
+	}
+	if d.VaapiEncoder10BitVerified("hevc_vaapi") {
+		t.Error("hevc_vaapi should NOT be 10-bit verified (8-bit only)")
+	}
+	if d.VaapiEncoder10BitVerified("av1_nvenc") {
+		t.Error("absent encoder must not report 10-bit verified")
+	}
+}
+
+// TestEncoderCapabilityBitDepthFields guards that the record carries both depths
+// distinctly — what fleet visibility (B3) needs to tell "AV1 8-bit but not
+// 10-bit" apart from "no AV1 at all".
+func TestEncoderCapabilityBitDepthFields(t *testing.T) {
+	c := hardware.HardwareEncoderCapability{Verified: true, Verified8Bit: true, Verified10Bit: false}
+	if !c.Verified8Bit || c.Verified10Bit {
+		t.Fatalf("expected 8-bit-only capability, got 8bit=%v 10bit=%v", c.Verified8Bit, c.Verified10Bit)
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/plan_codec.go
+++ b/backend/internal/infra/media/ffmpeg/plan_codec.go
@@ -137,6 +137,12 @@ func (a *LocalAdapter) planCodec(spec ports.StreamSpec) (codecPlan, error) {
 			if !ok {
 				return codecPlan{}, fmt.Errorf("unsupported vaapi codec resolved by decision engine: %s", resolvedCodec)
 			}
+			// For AV1 this gate now means "verified at 10-bit (p010)": av1_vaapi
+			// only enters the verified set via the production-bit-depth (p010)
+			// decode-verify (see PreflightVAAPI), so a host that only does 8-bit AV1
+			// is not admitted here and never emits the p010 AV1 path. No separate
+			// 10-bit check is needed — it would diverge from this single source of
+			// truth (VaapiEncoder10BitVerified stays for fleet visibility / B3).
 			if !a.detector.VaapiEncoderVerified(reqEncoder) {
 				return codecPlan{}, fmt.Errorf("vaapi encoder %s not verified by preflight (device=%s, deviceErr=%v)", reqEncoder, a.VaapiDevice, a.detector.vaapiDeviceErr)
 			}

--- a/backend/internal/pipeline/hardware/encoder_caps_preserve_test.go
+++ b/backend/internal/pipeline/hardware/encoder_caps_preserve_test.go
@@ -1,0 +1,30 @@
+package hardware
+
+import "testing"
+
+// TestEightBitOnlyAV1PreservedButNotAdmitted locks the behavior of the
+// SetVAAPIEncoderCapabilities filter (keep records that are Verified OR
+// Verified8Bit OR Verified10Bit): an AV1 record verified only at 8-bit must be
+// PRESERVED in the registry so fleet visibility (B3) can report "AV1 8-bit but
+// not 10-bit", yet must NOT be admitted — admission gates on cap.Verified, which
+// is false for an 8-bit-only AV1 (production drives AV1 at 10-bit).
+func TestEightBitOnlyAV1PreservedButNotAdmitted(t *testing.T) {
+	SetVAAPIEncoderCapabilities(map[string]HardwareEncoderCapability{
+		"av1_vaapi":  {Verified: false, Verified8Bit: true, Verified10Bit: false},
+		"h264_vaapi": {Verified: true, Verified8Bit: true, AutoEligible: true},
+	})
+	SetVAAPIPreflightResult(true)
+	t.Cleanup(func() { SetVAAPIEncoderCapabilities(nil) })
+
+	// Preserved for B3 observability (direct registry read, package-internal).
+	if got, ok := vaapiEncCaps["av1_vaapi"]; !ok || !got.Verified8Bit || got.Verified10Bit {
+		t.Fatalf("8-bit-only av1 record must be preserved, got %+v ok=%v", got, ok)
+	}
+	// But NOT admitted — admission gates on cap.Verified.
+	if IsHardwareEncoderReady("av1") {
+		t.Fatal("8-bit-only av1 (Verified=false) must NOT be hardware-ready")
+	}
+	if !IsHardwareEncoderReady("h264") {
+		t.Fatal("h264 (Verified=true) should be hardware-ready")
+	}
+}

--- a/backend/internal/pipeline/hardware/gpu.go
+++ b/backend/internal/pipeline/hardware/gpu.go
@@ -177,7 +177,7 @@ func SetVAAPIEncoderCapabilities(capabilities map[string]HardwareEncoderCapabili
 	}
 	vaapiEncCaps = make(map[string]HardwareEncoderCapability, len(capabilities))
 	for k, v := range capabilities {
-		if v.Verified {
+		if v.Verified || v.Verified8Bit || v.Verified10Bit {
 			vaapiEncCaps[k] = v
 		}
 	}

--- a/backend/internal/pipeline/hardware/gpu.go
+++ b/backend/internal/pipeline/hardware/gpu.go
@@ -62,6 +62,15 @@ type HardwareEncoderCapability struct {
 	Reason       string
 	ProbeElapsed time.Duration
 	AutoEligible bool
+
+	// Per-bit-depth verification (B2). Production drives AV1 at 10-bit (p010le)
+	// while 8-bit (nv12) is the broad-compat depth; recording both lets plan-time
+	// gating reject "10-bit AV1 on 8-bit-only hardware" and lets fleet visibility
+	// (B3) distinguish a host that does AV1 8-bit but not 10-bit. For the overall
+	// Verified verdict an encoder is judged at the bit depth it is used at in
+	// production (AV1: 10-bit; H.264/HEVC: 8-bit).
+	Verified8Bit  bool
+	Verified10Bit bool
 }
 
 type VAAPIEncoderCapability = HardwareEncoderCapability


### PR DESCRIPTION
B2 of the AV1/VAAPI fleet-safety work (Q4 #517 → Q1 #518 → B1 #519/#520 → **B2** → B3). Enriches the B1 capability record with a bit-depth dimension.

## Problem
B1 made `verified` = *decodable*, but probed every encoder at **8-bit (nv12)** while production drives AV1 at **10-bit** (`encode_args` forces `p010le` for AV1). A host whose AV1 works at 8-bit but **not** 10-bit was admitted then failed mid-session — or "worked" only because a driver (AMD radeonsi) silently promotes p010, luck that doesn't hold fleet-wide.

## Change
Judge each encoder at the bit depth production uses it at:
- **AV1 decode-verified at 10-bit (p010le)** — that verdict is its admission `Verified` — **and** probed at 8-bit so the record also carries `Verified8Bit`.
- H.264/HEVC stay 8-bit (nv12).
- `HardwareEncoderCapability` gains `Verified8Bit`/`Verified10Bit` → B3 can tell *"AV1 8-bit but not 10-bit"* from *"no AV1 at all"*.

## Gate
Mechanism unchanged: `av1_vaapi` only enters the verified set via the 10-bit probe, so the **existing** `VaapiEncoderVerified` check in `plan_codec` already refuses the p010 AV1 path on 8-bit-only hardware. A separate 10-bit check would diverge from that single source of truth (it broke the existing av1 tests, which set `vaapiEncoders` — confirming the redundancy); `VaapiEncoder10BitVerified` is kept for B3/observability.

## Validation
Host (AMD radeonsi): `av1_vaapi upload_format=p010le verified_8bit=true verified_10bit=true → verified`; h264/hevc 8-bit-only as expected. Unit tests cover the gate input + record fields; full ffmpeg/hardware suites + scoped golangci-lint green; config surfaces unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)