### PR TITLE
test(autocodec): prove excluded Apple clients get no AV1 (end-to-end)

### DIFF
--- a/backend/internal/control/http/v3/autocodec/client_av1_deny_e2e_test.go
+++ b/backend/internal/control/http/v3/autocodec/client_av1_deny_e2e_test.go
@@ -1,0 +1,68 @@
+package autocodec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/control/recordings/capabilities"
+	"github.com/ManuGH/xg2g/internal/domain/playbackprofile"
+	"github.com/ManuGH/xg2g/internal/pipeline/profiles"
+)
+
+// TestPickNativeHLSProfile_ExcludedClientGetsNoAV1 is the END-TO-END proof that an
+// Apple device without a hardware AV1 decoder (M2 Mac, iPhone 14) is not merely
+// denied by the policy gate but actually receives a NON-AV1 profile from the
+// decision-engine entry — even though it declared av1 first and emitted a runtime
+// av1 signal. Serving AV1 to such a device is a guaranteed black screen (Apple
+// ships no software AV1 decoder), so this is the highest-risk path for the
+// "Safari is reference" stance.
+func TestPickNativeHLSProfile_ExcludedClientGetsNoAV1(t *testing.T) {
+	smooth := true
+	base := func() *capabilities.PlaybackCapabilities {
+		return &capabilities.PlaybackCapabilities{
+			Containers:           []string{"mp4", "ts", "fmp4"},
+			VideoCodecs:          []string{"av1", "hevc", "h264"},
+			RuntimeProbeUsed:     true,
+			ClientCapsSource:     capabilities.ClientCapsSourceRuntimePlusFam,
+			ClientFamilyFallback: playbackprofile.ClientChromiumHLSJS,
+			VideoCodecSignals:    []capabilities.VideoCodecSignal{{Codec: "av1", Supported: true, Smooth: &smooth}},
+		}
+	}
+
+	excluded := []struct {
+		name   string
+		family string
+		dev    *capabilities.DeviceContext
+		dtype  string
+	}{
+		{"mac m2 (no hw av1 decode)", playbackprofile.ClientSafariNative,
+			&capabilities.DeviceContext{OSName: "macos", OSVersion: "14.4", Model: "MacBook Pro M2"}, ""},
+		{"iphone 14 a16 (no hw av1 decode)", playbackprofile.ClientIOSSafariNative,
+			&capabilities.DeviceContext{OSName: "ios", OSVersion: "18.1", Model: "iPhone 14 Pro A16"}, "iphone"},
+	}
+	for _, tc := range excluded {
+		t.Run(tc.name, func(t *testing.T) {
+			caps := base()
+			caps.DeviceContext = tc.dev
+			caps.DeviceType = tc.dtype
+
+			// Precondition: the policy gate denies AV1.
+			if ClientAV1PlaybackAllowed(*caps, tc.family) {
+				t.Fatalf("precondition: %s must be denied AV1 by the policy gate", tc.name)
+			}
+			// END-TO-END: the decision-engine entry returns a NON-AV1 profile.
+			got := PickNativeHLSProfileForClientAndHost("av1,hevc,h264", tc.family, caps, profiles.HWAccelAuto, playbackprofile.HostRuntimeSnapshot{})
+			t.Logf("%s -> profile %q", tc.name, got)
+			if got == profiles.ProfileAV1HW || strings.Contains(strings.ToLower(got), "av1") {
+				t.Fatalf("%s must NOT receive an AV1 profile (black-screen risk); got %q", tc.name, got)
+			}
+		})
+	}
+
+	// Contrast: an M3 Mac (hardware AV1 decode) is NOT stripped by the gate.
+	m3 := base()
+	m3.DeviceContext = &capabilities.DeviceContext{OSName: "macos", OSVersion: "14.4", Model: "MacBook Pro M3"}
+	if !ClientAV1PlaybackAllowed(*m3, playbackprofile.ClientSafariNative) {
+		t.Fatal("contrast: M3 Mac SHOULD be allowed AV1 by the policy gate")
+	}
+}


### PR DESCRIPTION
Raises the **client-side** AV1 decode guard to the same proof standard as the encoder side (B1/B2).

## Context
The guard `client_av1_policy.go` has existed since #393 (2026-04-28). It was tested at the **policy level** (`TestClientAV1PlaybackAllowed`: M2 Mac → `false`), but **not end-to-end** — nothing proved an excluded device actually receives a non-AV1 profile from the decision engine.

## This test
`PickNativeHLSProfileForClientAndHost` with an excluded Apple client (M2 Mac, iPhone 14/A16) that **declares av1 + emits a runtime av1 signal** returns a **non-AV1** profile (observed `safari_hevc`), not `av1_hw`. Serving AV1 to a device with no hardware AV1 decoder is a guaranteed black screen (Apple has no software AV1 decoder) — the highest-risk path for "Safari is reference". M3 Mac is the passing contrast.

Test-only; full autocodec suite + scoped golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)