### PR TITLE
fix(ffmpeg): enable libdav1d so AV1 decode-verify works in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libx264-dev \
     libx265-dev \
     libva-dev \
+    libdav1d-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Build FFmpeg
@@ -50,6 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libva2 \
     libx264-164 \
     libx265-215 \
+    libdav1d7 \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
         apt-get install -y --no-install-recommends intel-media-va-driver; \
       fi \

--- a/Dockerfile.ffmpeg-base
+++ b/Dockerfile.ffmpeg-base
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libx264-dev \
     libx265-dev \
+    libdav1d-dev \
     libva-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -41,6 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libva2 \
     libx264-164 \
     libx265-215 \
+    libdav1d7 \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
         apt-get install -y --no-install-recommends intel-media-va-driver; \
       fi \

--- a/backend/scripts/build-ffmpeg.sh
+++ b/backend/scripts/build-ffmpeg.sh
@@ -68,6 +68,7 @@ echo "Configuring FFmpeg..."
   --enable-gpl \
   --enable-libx264 \
   --enable-libx265 \
+  --enable-libdav1d \
   --enable-vaapi \
   --enable-nvenc \
   --enable-protocol=hls \


### PR DESCRIPTION
## Problem found by deploying the AV1 work to staging (LXC 110)
The shipped container ffmpeg was built **without a software AV1 decoder** (only the native, incomplete `av1` decoder, which fails on the 10-bit p010 output that AV1HW produces). So the B1/B2 decode-verify could never validate `av1_vaapi` output → it **withheld AV1 on every deployment**, even though the AMD VAAPI encoder produces good, decodable AV1 (proven on the *same* GPU on a host with libdav1d: av1_vaapi p010 → YAVG 126).

## Fix
- FFmpeg build: `libdav1d-dev` + `--enable-libdav1d`
- Runtime base: `libdav1d7`

## Verified on staging (LXC 110, same AMD Phoenix GPU)
With this image: `av1_vaapi upload_format=p010le verified_8bit=true verified_10bit=true → verified`; `verified_encoders 2 → 3`. Container healthy, API 200.

(Companion: a B1 robustness tweak — treat *only the native av1 decoder available* as `unverifiable` rather than `withheld` — will follow so a genuinely libdav1d-less host reports honestly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)