### PR TITLE
fix(nvenc): fail-closed av1_nvenc — unverifiable, not false-verified

### DIFF
--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -305,6 +305,11 @@ func (d *Detector) PreflightNVENC() error {
 		envFloatBounded("XG2G_HEVC_NVENC_AUTO_RATIO_MAX", capability.DefaultHEVCNVENCAutoRatioMax, 1.0, 10.0),
 		envFloatBounded("XG2G_AV1_NVENC_AUTO_RATIO_MAX", capability.DefaultAV1NVENCAutoRatioMax, 1.0, 10.0),
 	)
+	// Fail-closed: NVENC has no decode-verify (testNVENCEncoder trusts exit 0 on a
+	// discarded "-f null -" output), so av1_nvenc must not be admitted on an
+	// encoder-ran signal alone — that would be a black-screen risk. See
+	// clampUnverifiedNVENCAV1.
+	clampUnverifiedNVENCAV1(d.nvencEncoderCaps, d.nvencEncoders)
 	for _, enc := range nvencEncodersToTest {
 		cap, ok := d.nvencEncoderCaps[enc]
 		if !ok || !cap.Verified {
@@ -324,6 +329,41 @@ func (d *Detector) PreflightNVENC() error {
 		Int("verified_encoders", len(d.nvencEncoders)).
 		Msg("nvenc preflight: passed")
 	return nil
+}
+
+// clampUnverifiedNVENCAV1 enforces the fail-closed latch for NVENC AV1.
+//
+// NVENC has NO decode-verify: testNVENCEncoder discards output to "-f null -" and
+// treats exit 0 as success, so DeriveHardwareEncoderCapabilities marks av1_nvenc
+// Verified=true on "the encoder ran", NOT "the output is decodable". That is the
+// exact gap B1 closed for VAAPI via decodeVerifyEncode, still wide open on NVENC —
+// and unlike the VAAPI false-WITHHELD (too cautious, safe), an unvalidated av1_nvenc
+// is false-VERIFIED: it can serve corrupt or black AV1 to a client that has no
+// software AV1 fallback. Until NVENC grows its own decode-verify, av1_nvenc is
+// reported UNVERIFIABLE and is NOT admitted — the honest three-state verdict,
+// mirroring the VAAPI verify-oracle fix. h264_nvenc/hevc_nvenc stay verified
+// (universally decodable, far lower consequence), so an NVIDIA host keeps hardware
+// HEVC/H264 and only loses unvalidated AV1.
+//
+// It closes BOTH admission paths: the per-encoder cap (Verified=false ->
+// SetNVENCEncoderCapabilities drops it -> IsNVENCEncoderReady/IsHardwareEncoderReady
+// fail) and the detector bool map (delete -> NVENCEncoderVerified, the plan_codec
+// gate, fails). The cap is retained with Verdict=unverifiable so the
+// xg2g_gpu_encoder_unverifiable gauge surfaces the asymmetry instead of it reading
+// as a plain "not present".
+func clampUnverifiedNVENCAV1(caps map[string]hardware.NVENCEncoderCapability, verified map[string]bool) {
+	const enc = "av1_nvenc"
+	cap, ok := caps[enc]
+	if !ok {
+		return
+	}
+	delete(verified, enc)
+	caps[enc] = hardware.NVENCEncoderCapability{
+		Verdict:      hardware.VerdictUnverifiable,
+		Reason:       "nvenc has no decode-verify; av1 output cannot be validated (black-screen risk) — admitted only once NVENC output validation exists",
+		ProbeElapsed: cap.ProbeElapsed,
+		// Verified / AutoEligible deliberately left false: fail-closed.
+	}
 }
 
 // PreflightTranscodeProfiles measures a small set of synthetic startup probes

--- a/backend/internal/infra/media/ffmpeg/detector_nvenc_av1_latch_test.go
+++ b/backend/internal/infra/media/ffmpeg/detector_nvenc_av1_latch_test.go
@@ -22,55 +22,54 @@ import (
 // the post-latch assertions go red; over-reach to h264_nvenc and the surgical-scope
 // assertions go red. No NVIDIA hardware required.
 func TestNVENCAV1FailClosed_NotAdmittedWithoutDecodeVerify(t *testing.T) {
-	// Post-derive state on an NVIDIA host: exit-0 "verified" everything.
-	derived := map[string]hardware.NVENCEncoderCapability{
-		"h264_nvenc": {Verified: true, AutoEligible: true, ProbeElapsed: 10 * time.Millisecond},
-		"av1_nvenc":  {Verified: true, AutoEligible: true, ProbeElapsed: 20 * time.Millisecond},
+	// av1_nvenc admission is gated by THREE distinct stores; a latch that closes two
+	// of three leaves a silent hole. This test drives all three real gates:
+	//   1. global nvencEncCaps    -> hardware.IsNVENCEncoderReady (+ IsHardwareEncoderReady,
+	//      the autocodec/intent/B3 funnel) — set from d.nvencEncoderCaps via Set, filtered on Verified.
+	//   2. detector d.nvencEncoders -> d.NVENCEncoderVerified (the plan_codec gate).
+	//   3. detector d.nvencEncoderCaps -> d.NVENCEncoderAutoEligible.
+	// Post-derive state on an NVIDIA host: exit-0 "verified" everything in all three.
+	d := &Detector{
+		nvencEncoders: map[string]bool{"h264_nvenc": true, "av1_nvenc": true},
+		nvencEncoderCaps: map[string]hardware.NVENCEncoderCapability{
+			"h264_nvenc": {Verified: true, AutoEligible: true, ProbeElapsed: 10 * time.Millisecond},
+			"av1_nvenc":  {Verified: true, AutoEligible: true, ProbeElapsed: 20 * time.Millisecond},
+		},
 	}
-	nvencEncoders := map[string]bool{"h264_nvenc": true, "av1_nvenc": true}
-
 	t.Cleanup(func() { hardware.SetNVENCEncoderCapabilities(nil) })
 
-	// BUG DEMONSTRATION: pre-latch, av1_nvenc is admitted at the real global gate.
-	hardware.SetNVENCEncoderCapabilities(derived)
+	// BUG DEMONSTRATION: pre-latch, ALL THREE readers admit av1_nvenc.
+	hardware.SetNVENCEncoderCapabilities(d.nvencEncoderCaps)
 	hardware.SetNVENCPreflightResult(true)
-	if !hardware.IsNVENCEncoderReady("av1_nvenc") {
-		t.Fatal("precondition: pre-latch, exit-0 av1_nvenc IS admitted — the false-verified gap this latch closes")
+	if !d.NVENCEncoderVerified("av1_nvenc") || !d.NVENCEncoderAutoEligible("av1_nvenc") || !hardware.IsNVENCEncoderReady("av1_nvenc") {
+		t.Fatal("precondition: pre-latch, exit-0 av1_nvenc is admitted by all three readers — the false-verified gap this latch closes")
 	}
 
-	// APPLY THE LATCH.
-	clampUnverifiedNVENCAV1(derived, nvencEncoders)
+	// APPLY THE LATCH, then mirror to the global store exactly as PreflightNVENC does.
+	clampUnverifiedNVENCAV1(d.nvencEncoderCaps, d.nvencEncoders)
+	hardware.SetNVENCEncoderCapabilities(d.nvencEncoderCaps)
 
-	// Detector-side bool map (plan_codec gate via NVENCEncoderVerified): dropped.
-	if nvencEncoders["av1_nvenc"] {
-		t.Error("av1_nvenc must be removed from the detector nvencEncoders map (plan_codec admission path)")
+	// ALL THREE readers must now refuse av1_nvenc — completeness, no silent third path.
+	if d.NVENCEncoderVerified("av1_nvenc") {
+		t.Error("store 2 (nvencEncoders / plan_codec gate): av1_nvenc still admitted")
 	}
-	// Cap: unverifiable, not verified, not auto-eligible; ProbeElapsed kept for the gauge.
-	got := derived["av1_nvenc"]
-	if got.Verdict != hardware.VerdictUnverifiable {
-		t.Errorf("av1_nvenc verdict = %q, want unverifiable", got.Verdict)
+	if d.NVENCEncoderAutoEligible("av1_nvenc") {
+		t.Error("store 3 (nvencEncoderCaps / NVENCEncoderAutoEligible): av1_nvenc still auto-eligible")
 	}
-	if got.Verified || got.AutoEligible {
-		t.Errorf("av1_nvenc must be fail-closed: Verified=%v AutoEligible=%v, want both false", got.Verified, got.AutoEligible)
-	}
-	if got.ProbeElapsed != 20*time.Millisecond {
-		t.Errorf("av1_nvenc ProbeElapsed should be preserved for observability, got %v", got.ProbeElapsed)
-	}
-	// Surgical: h264_nvenc untouched on both paths (latch is av1-only; NVIDIA host keeps HW H264/HEVC).
-	if h := derived["h264_nvenc"]; !h.Verified || !h.AutoEligible {
-		t.Error("h264_nvenc must stay verified+auto-eligible (latch is av1-only)")
-	}
-	if !nvencEncoders["h264_nvenc"] {
-		t.Error("h264_nvenc must stay in the detector nvencEncoders map (latch is av1-only)")
-	}
-
-	// REAL global admission gate after the latch: av1 closed, h264 open.
-	hardware.SetNVENCEncoderCapabilities(derived)
 	if hardware.IsNVENCEncoderReady("av1_nvenc") {
-		t.Error("post-latch: av1_nvenc must NOT be admitted at the global NVENC gate")
+		t.Error("store 1 (global nvencEncCaps / IsNVENCEncoderReady+IsHardwareEncoderReady): av1_nvenc still admitted")
 	}
-	if !hardware.IsNVENCEncoderReady("h264_nvenc") {
-		t.Error("post-latch: h264_nvenc must remain admitted")
+	// Explicit three-state label retained for the gauge; ProbeElapsed preserved.
+	if got := d.nvencEncoderCaps["av1_nvenc"]; got.Verdict != hardware.VerdictUnverifiable || got.Verified || got.AutoEligible {
+		t.Errorf("av1_nvenc cap = %+v, want {Verdict:unverifiable, Verified:false, AutoEligible:false}", got)
+	}
+	if got := d.nvencEncoderCaps["av1_nvenc"].ProbeElapsed; got != 20*time.Millisecond {
+		t.Errorf("av1_nvenc ProbeElapsed must be preserved for observability, got %v", got)
+	}
+
+	// SURGICAL: h264_nvenc untouched on every one of the three readers (latch is av1-only).
+	if !d.NVENCEncoderVerified("h264_nvenc") || !d.NVENCEncoderAutoEligible("h264_nvenc") || !hardware.IsNVENCEncoderReady("h264_nvenc") {
+		t.Error("h264_nvenc must remain admitted on all three readers — an NVIDIA host keeps HW H264/HEVC")
 	}
 }
 

--- a/backend/internal/infra/media/ffmpeg/detector_nvenc_av1_latch_test.go
+++ b/backend/internal/infra/media/ffmpeg/detector_nvenc_av1_latch_test.go
@@ -1,0 +1,91 @@
+package ffmpeg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
+)
+
+// TestNVENCAV1FailClosed_NotAdmittedWithoutDecodeVerify proves the NVENC AV1
+// fail-closed latch closes a FALSE-VERIFIED gap (the mirror image of the VAAPI
+// false-withheld this branch's sibling PR fixes): NVENC has no decode-verify —
+// testNVENCEncoder discards output to "-f null -" and trusts exit 0 — so
+// DeriveHardwareEncoderCapabilities marks av1_nvenc Verified=true on "the encoder
+// ran", not "the output decodes". Admitting that can serve corrupt/black AV1 to a
+// client with no software AV1 fallback. The latch demotes av1_nvenc to unverifiable
+// / not-admitted while leaving h264_nvenc untouched.
+//
+// The test first DEMONSTRATES the bug — pre-latch, the REAL global admission gate
+// (IsNVENCEncoderReady) admits av1_nvenc — then applies the latch and asserts both
+// admission paths close. It is its own negative control: make the latch a no-op and
+// the post-latch assertions go red; over-reach to h264_nvenc and the surgical-scope
+// assertions go red. No NVIDIA hardware required.
+func TestNVENCAV1FailClosed_NotAdmittedWithoutDecodeVerify(t *testing.T) {
+	// Post-derive state on an NVIDIA host: exit-0 "verified" everything.
+	derived := map[string]hardware.NVENCEncoderCapability{
+		"h264_nvenc": {Verified: true, AutoEligible: true, ProbeElapsed: 10 * time.Millisecond},
+		"av1_nvenc":  {Verified: true, AutoEligible: true, ProbeElapsed: 20 * time.Millisecond},
+	}
+	nvencEncoders := map[string]bool{"h264_nvenc": true, "av1_nvenc": true}
+
+	t.Cleanup(func() { hardware.SetNVENCEncoderCapabilities(nil) })
+
+	// BUG DEMONSTRATION: pre-latch, av1_nvenc is admitted at the real global gate.
+	hardware.SetNVENCEncoderCapabilities(derived)
+	hardware.SetNVENCPreflightResult(true)
+	if !hardware.IsNVENCEncoderReady("av1_nvenc") {
+		t.Fatal("precondition: pre-latch, exit-0 av1_nvenc IS admitted — the false-verified gap this latch closes")
+	}
+
+	// APPLY THE LATCH.
+	clampUnverifiedNVENCAV1(derived, nvencEncoders)
+
+	// Detector-side bool map (plan_codec gate via NVENCEncoderVerified): dropped.
+	if nvencEncoders["av1_nvenc"] {
+		t.Error("av1_nvenc must be removed from the detector nvencEncoders map (plan_codec admission path)")
+	}
+	// Cap: unverifiable, not verified, not auto-eligible; ProbeElapsed kept for the gauge.
+	got := derived["av1_nvenc"]
+	if got.Verdict != hardware.VerdictUnverifiable {
+		t.Errorf("av1_nvenc verdict = %q, want unverifiable", got.Verdict)
+	}
+	if got.Verified || got.AutoEligible {
+		t.Errorf("av1_nvenc must be fail-closed: Verified=%v AutoEligible=%v, want both false", got.Verified, got.AutoEligible)
+	}
+	if got.ProbeElapsed != 20*time.Millisecond {
+		t.Errorf("av1_nvenc ProbeElapsed should be preserved for observability, got %v", got.ProbeElapsed)
+	}
+	// Surgical: h264_nvenc untouched on both paths (latch is av1-only; NVIDIA host keeps HW H264/HEVC).
+	if h := derived["h264_nvenc"]; !h.Verified || !h.AutoEligible {
+		t.Error("h264_nvenc must stay verified+auto-eligible (latch is av1-only)")
+	}
+	if !nvencEncoders["h264_nvenc"] {
+		t.Error("h264_nvenc must stay in the detector nvencEncoders map (latch is av1-only)")
+	}
+
+	// REAL global admission gate after the latch: av1 closed, h264 open.
+	hardware.SetNVENCEncoderCapabilities(derived)
+	if hardware.IsNVENCEncoderReady("av1_nvenc") {
+		t.Error("post-latch: av1_nvenc must NOT be admitted at the global NVENC gate")
+	}
+	if !hardware.IsNVENCEncoderReady("h264_nvenc") {
+		t.Error("post-latch: h264_nvenc must remain admitted")
+	}
+}
+
+// TestClampUnverifiedNVENCAV1_NoopWhenAbsent guards the latch on hosts/builds with
+// no av1_nvenc at all: it must be a no-op, not a panic or a spurious entry.
+func TestClampUnverifiedNVENCAV1_NoopWhenAbsent(t *testing.T) {
+	caps := map[string]hardware.NVENCEncoderCapability{
+		"h264_nvenc": {Verified: true, AutoEligible: true},
+	}
+	nvencEncoders := map[string]bool{"h264_nvenc": true}
+	clampUnverifiedNVENCAV1(caps, nvencEncoders)
+	if _, present := caps["av1_nvenc"]; present {
+		t.Error("clamp must not invent an av1_nvenc entry when none was probed")
+	}
+	if !caps["h264_nvenc"].Verified || !nvencEncoders["h264_nvenc"] {
+		t.Error("clamp must leave h264_nvenc untouched when av1_nvenc is absent")
+	}
+}


### PR DESCRIPTION
## DRAFT — verification-critical, review before merge (do not auto-merge)

## The gap (a false-VERIFIED — the mirror image of the VAAPI fix, and worse)
The VAAPI work removed false-*withheld* (too cautious = safe: HEVC fallback). **NVENC has the opposite, more dangerous gap: false-*verified*.** It has NO output validation at all — `testNVENCEncoder` encodes 5 frames to `-f null -` (output discarded) and trusts exit 0, so `DeriveHardwareEncoderCapabilities` sets `Verified=true` on *"the encoder ran"*, never sets a `Verdict`, and the admission gates (`IsHardwareEncoderReady`/`IsNVENCEncoderReady` → `cap.Verified`; `NVENCEncoderVerified` → `nvencEncoders`) admit it. That is the exact `-f null -` state B1 removed for VAAPI, still wide open on NVENC.

For AV1 it is a **black-screen risk**: corrupt or black AV1 served to a client with no software AV1 fallback. A latent false-verified gap activates **silently** the moment any NVIDIA host joins a (today AMD) fleet — no alarm says "this half is unvalidated." That is why it ranks above B3 (visibility, deferrable): B3 is risk-free, this is a sharp trap that should be defused *before* it goes live.

## What this does — and deliberately does NOT
- **Does NOT** build NVENC decode-verify: there is no NVIDIA target to verify against, so doing it now would repeat the dev-host blind flight VAAPI had before the LXC 110 deploy.
- **Makes the asymmetry loud and fail-closed:** until NVENC has its own decode-verify, `av1_nvenc` is reported `unverifiable` and **not admitted**, closing **both** admission paths (per-encoder cap + `nvencEncoders` bool map). `h264_nvenc`/`hevc_nvenc` stay verified (universally decodable, far lower consequence) — an NVIDIA host keeps hardware H264/HEVC and only loses **unvalidated** AV1: HEVC (safe) instead of broken AV1 (black screen).

## Test discipline
The test drives the **real global admission gate**: it first DEMONSTRATES the bug (pre-latch, `IsNVENCEncoderReady` admits `av1_nvenc`), then applies the latch and asserts both paths close while `h264_nvenc` is untouched (surgical, av1-only). **Negative control:** neutering the latch to a no-op turns the test red at exactly those assertions (verified during development).

## Honest scope/limitation (not overstated)
`PreflightNVENC` is device-gated (`HasNVENC` stats `/dev/nvidia*`) and exec-based with no seam, so — like **every** preflight integration in this package (none are end-to-end tested) — the **one-line call-site** is read-verified, not end-to-end tested. The **latch function itself** is test-proven with a negative control. Full NVENC decode-verify (so `av1_nvenc` can be *verified*, not just fail-closed) is the tracked follow-up, gated on having an NVIDIA host to verify against.

Companion to the VAAPI verify-oracle fix (sibling PR). Independent change; no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)