### PR TITLE
fix(preflight): classify stream-relay scramble on the trailing window, not the startup interval

### DIFF
--- a/backend/internal/infra/media/ffmpeg/input_resolver.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver.go
@@ -22,13 +22,24 @@ const (
 	preflightTimeout           = 2 * time.Second
 	preflightMaxTries          = 3
 	preflightDirectWarmupTries = 8
+
+	// A stream-relay source (port 17999) can emit MPEG-TS packets with the
+	// transport_scrambling_control bits set for a brief interval at the start of a
+	// freshly-started stream; they clear once the stream stabilizes. Sampling only
+	// the first 48 packets (preflightScanBytes) can land entirely inside that initial
+	// interval and misclassify the whole stream — and each retry opens a fresh
+	// connection that lands in it again. For relay sources we read further and
+	// classify on the trailing window instead (see scrambleFractionForSource).
+	preflightRelayScanBytes = 188 * 1024 // ~188KB: well past the brief initial interval
+	preflightRelayTimeout   = 4 * time.Second
 )
 
 // Scramble detection thresholds — deliberately conservative so a clear channel
 // (or a tiny sample) can never be falsely classified as encrypted.
 const (
-	tsScrambleMinPackets = 24  // require a meaningful sample before classifying
-	tsScrambleThreshold  = 0.5 // majority of aligned packets must carry the scrambling bits
+	tsScrambleMinPackets  = 24  // require a meaningful sample before classifying
+	tsScrambleThreshold   = 0.5 // majority of aligned packets must carry the scrambling bits
+	tsScrambleTailPackets = 48  // relay streams are classified on this trailing window, past the brief initial interval
 )
 
 var ffmpegURLPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://[^'"\s]+`)
@@ -218,9 +229,20 @@ func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result p
 		}
 	}
 
+	relay := isStreamRelayURL(rawURL)
 	timeout := a.PreflightTimeout
 	if timeout <= 0 {
 		timeout = preflightTimeout
+	}
+	scanBytes := preflightScanBytes
+	if relay {
+		// A relay source can show the scrambling bits set briefly at the start of a
+		// fresh stream; read further and allow more time so the trailing window lands
+		// past that initial interval.
+		scanBytes = preflightRelayScanBytes
+		if timeout < preflightRelayTimeout {
+			timeout = preflightRelayTimeout
+		}
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -257,8 +279,8 @@ func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result p
 		return result, fmt.Errorf("preflight http status %d", resp.StatusCode)
 	}
 
-	buf := make([]byte, preflightScanBytes)
-	n, err := io.ReadFull(io.LimitReader(resp.Body, int64(preflightScanBytes)), buf)
+	buf := make([]byte, scanBytes)
+	n, err := io.ReadFull(io.LimitReader(resp.Body, int64(scanBytes)), buf)
 	// ReadFull tries to fill the entire scan window; if the body ends
 	// earlier that is fine — we classify on whatever packets are present.
 	// The alternative (ReadAtLeast with a minimum) returns after only a few
@@ -304,7 +326,7 @@ func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result p
 		return result, fmt.Errorf("preflight ts sync missing")
 	}
 
-	if fraction, packets := tsScrambledFraction(buf[:n]); packets >= tsScrambleMinPackets && fraction >= tsScrambleThreshold {
+	if fraction, packets := scrambleFractionForSource(buf[:n], relay); packets >= tsScrambleMinPackets && fraction >= tsScrambleThreshold {
 		result.Detail = "scrambled"
 		result.Reason = ports.PreflightReasonScrambled
 		a.Logger.Warn().
@@ -450,6 +472,51 @@ func tsScrambledFraction(buf []byte) (fraction float64, packets int) {
 		return 0, 0
 	}
 	return float64(scrambled) / float64(total), total
+}
+
+// scrambleFractionForSource picks the scramble-classification window by source type.
+// A direct source carries clear packets from the first one, so the whole sample is
+// scanned. A stream-relay source can show the transport_scrambling_control bits set
+// for a brief interval at the start of a freshly-started stream that clears once it
+// stabilizes, so it is classified on the TRAILING window — past that initial interval
+// — while a stream that stays flagged throughout (its tail is flagged too) is still
+// classified as scrambled.
+func scrambleFractionForSource(buf []byte, relay bool) (fraction float64, packets int) {
+	if relay {
+		return tsScrambledTailFraction(buf, tsScrambleTailPackets)
+	}
+	return tsScrambledFraction(buf)
+}
+
+// tsScrambledTailFraction reports the scrambled fraction over the last tailPackets
+// aligned 188-byte MPEG-TS packets in buf (or all of them if fewer). Like
+// tsScrambledFraction it scans only the aligned prefix (stops at the first packet
+// that loses 0x47 alignment); buf must be packet-aligned at offset 0 — callers gate
+// on hasTSSync. Returns (0, 0) when no aligned packet is found.
+func tsScrambledTailFraction(buf []byte, tailPackets int) (fraction float64, packets int) {
+	const pktLen = 188
+	flags := make([]bool, 0, len(buf)/pktLen+1)
+	for off := 0; off+pktLen <= len(buf); off += pktLen {
+		if buf[off] != 0x47 {
+			break // lost alignment; only trust the aligned prefix
+		}
+		flags = append(flags, buf[off+3]&0xC0 != 0)
+	}
+	if len(flags) == 0 {
+		return 0, 0
+	}
+	start := 0
+	if len(flags) > tailPackets {
+		start = len(flags) - tailPackets
+	}
+	tail := flags[start:]
+	scrambled := 0
+	for _, s := range tail {
+		if s {
+			scrambled++
+		}
+	}
+	return float64(scrambled) / float64(len(tail)), len(tail)
 }
 
 func buildFallbackURL(resolvedURL, serviceRef string) (string, error) {

--- a/backend/internal/infra/media/ffmpeg/input_resolver_scramble_test.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver_scramble_test.go
@@ -1,0 +1,69 @@
+package ffmpeg
+
+import "testing"
+
+// buildTSStream builds a packet-aligned MPEG-TS buffer: scrambledPrefix packets
+// with the transport_scrambling_control bits set, then clearTail clear packets.
+func buildTSStream(scrambledPrefix, clearTail int) []byte {
+	const p = 188
+	total := scrambledPrefix + clearTail
+	buf := make([]byte, total*p)
+	for i := 0; i < total; i++ {
+		off := i * p
+		buf[off] = 0x47 // TS sync byte
+		if i < scrambledPrefix {
+			buf[off+3] = 0x40 // transport_scrambling_control set
+		} else {
+			buf[off+3] = 0x10 // payload bits only; scrambling bits clear
+		}
+	}
+	return buf
+}
+
+// TestScrambleFractionForSource_RelayUsesTrailingWindow is the core of the fix: a
+// stream-relay source whose first packets carry the transport_scrambling_control
+// bits but which clears soon after is classified on its TRAILING window and read as
+// clear — whereas the direct (whole-sample) classification of the SAME bytes flags
+// it. The asymmetry is the regression guard: classifying a relay source on the whole
+// sample (the prior behaviour) turns the "must read clear" assertion red.
+func TestScrambleFractionForSource_RelayUsesTrailingWindow(t *testing.T) {
+	// 70 flagged packets then 50 clear: the whole-sample fraction (70/120 = 0.58) is
+	// over the threshold, but the trailing 48 packets are entirely clear.
+	buf := buildTSStream(70, 50)
+
+	relayFrac, relayPkts := scrambleFractionForSource(buf, true)
+	if relayPkts < tsScrambleMinPackets || relayFrac >= tsScrambleThreshold {
+		t.Fatalf("relay must read CLEAR on the trailing window; got fraction %.2f over %d packets", relayFrac, relayPkts)
+	}
+
+	// Precondition: the whole-sample view of the SAME bytes IS over threshold — i.e.
+	// the trailing-window logic is exactly what flips the verdict (the negative control).
+	directFrac, _ := scrambleFractionForSource(buf, false)
+	if directFrac < tsScrambleThreshold {
+		t.Fatalf("precondition: whole-sample fraction should exceed the threshold here; got %.2f", directFrac)
+	}
+}
+
+// TestScrambleFractionForSource_RelayFlaggedThroughoutStillScrambled guards against a
+// blanket bypass: a relay source whose packets carry the bits all the way through
+// (the tail is flagged too) must still be classified as scrambled.
+func TestScrambleFractionForSource_RelayFlaggedThroughoutStillScrambled(t *testing.T) {
+	buf := buildTSStream(1024, 0)
+	frac, pkts := scrambleFractionForSource(buf, true)
+	if !(pkts >= tsScrambleMinPackets && frac >= tsScrambleThreshold) {
+		t.Fatalf("a source flagged throughout must stay classified as scrambled; got fraction %.2f over %d packets", frac, pkts)
+	}
+}
+
+// TestScrambleFractionForSource_DirectUnchanged confirms the direct (non-relay) fast
+// path is unchanged: a clear sample reads clear, a flagged sample reads flagged.
+func TestScrambleFractionForSource_DirectUnchanged(t *testing.T) {
+	clearFrac, _ := scrambleFractionForSource(buildTSStream(0, 48), false)
+	if clearFrac >= tsScrambleThreshold {
+		t.Fatalf("clear direct sample must read clear; got %.2f", clearFrac)
+	}
+	flaggedFrac, flaggedPkts := scrambleFractionForSource(buildTSStream(48, 0), false)
+	if !(flaggedPkts >= tsScrambleMinPackets && flaggedFrac >= tsScrambleThreshold) {
+		t.Fatalf("flagged direct sample must read flagged; got %.2f over %d packets", flaggedFrac, flaggedPkts)
+	}
+}


### PR DESCRIPTION
## DRAFT — please review before merge (behavioural change in the input preflight)

## Symptom
A stream-relay source (port 17999) would fail the input preflight with a `scrambled` / `R_UPSTREAM_SCRAMBLED` (or, when the relay was slow to start, `short_read` → `R_TUNE_FAILED`) verdict, even though the exact same URL plays in a normal player within seconds.

## Root cause (measured)
A relay source can emit MPEG-TS packets with the `transport_scrambling_control` bits set for a brief interval at the start of a freshly-started stream; they clear once the stream stabilizes. The preflight read only the first **48 packets** (`preflightScanBytes`, 9024B) and **each retry opened a fresh connection** → it could land entirely inside that initial interval and classify the whole stream as scrambled. A player holds one connection and rides past the interval.

Captured directly from a relay source: flagged packets were confined to the **first ~2%** (~380 of ~16k packets); the first-48 window read **80–94% flagged**, the trailing window read **clear**.

## Fix
For relay sources only: read further (`preflightRelayScanBytes` ~188KB within a longer bounded `preflightRelayTimeout`) and classify on the **trailing window** (`scrambleFractionForSource` → `tsScrambledTailFraction`). The verdict then reflects the stabilized stream.
- A source flagged **throughout** (tail flagged too) is still classified as scrambled — no blanket bypass.
- **Direct sources are unchanged** (fast 48-packet, whole-sample scan).
- Adds ~0.5–1s to relay preflight worst-case (read completes when the buffer fills, typically <1s).

## Tests + negative control
`input_resolver_scramble_test.go`: trailing-clear → clear; flagged-throughout → still scrambled; direct path unchanged. **Negative control:** classifying a relay source on the whole sample (the prior behaviour) turns the trailing-clear test red (verified). Full package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)