### PR TITLE
fix(ci): bump v3 fan-out baseline 101→103 for Go 1.25 stdlib modernization

### DIFF
--- a/backend/scripts/check-fanout.sh
+++ b/backend/scripts/check-fanout.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Guardrail for the v3 package decomposition: block fan-out regressions.
-# Baseline 101 reflects the current intentional v3 composition:
+# Baseline 103 reflects the current intentional v3 composition:
 # - original 79-import hardening baseline (strict JWT verification + hwaccel enforcement)
 # - internal/admission for receiver/session admission state tracking
 # - internal/control/middleware + net for trusted-proxy HTTPS enforcement on session exchange
@@ -13,12 +13,14 @@ set -euo pipefail
 #   capreg, vod/preflight, channels, control/playback, control/read, platform/net,
 #   normalize, m3u, pipeline api/bus, recordings/artifacts, and stdlib additions
 #   (crypto/rand, syscall, runtime/debug)
+# - Go 1.25 stdlib modernization: maps (maps.Copy in intent_client_request),
+#   slices (slices.Backward, slices.Contains, slices.ContainsFunc, slices.Sort)
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}/backend"
 
-MAX_V3_FANOUT="${MAX_V3_FANOUT:-101}"
+MAX_V3_FANOUT="${MAX_V3_FANOUT:-103}"
 ACTUAL_IMPORTS_RAW="$(go list -f '{{join .Imports "\n"}}' ./internal/control/http/v3 | sort)"
 mapfile -t ACTUAL_IMPORTS <<< "${ACTUAL_IMPORTS_RAW}"
 ACTUAL_V3_FANOUT="${#ACTUAL_IMPORTS[@]}"


### PR DESCRIPTION
## Root Cause

The `verify-v3-fanout` nightly gate failed because `internal/control/http/v3` now has 103 imports, exceeding the baseline of 101.

Two new stdlib imports were introduced by commit `ebd7f351` (`refactor(backend): modernize stdlib usage`):

| Import | Usage |
|---|---|
| `maps` | `maps.Copy` in `intent_client_request.go` |
| `slices` | `slices.Backward`, `slices.Contains`, `slices.ContainsFunc`, `slices.Sort` across `exposure_security.go`, `handlers_config.go`, `rbac.go`, and `recordings/feedback_policy.go` |

Both are legitimate Go 1.25 stdlib modernizations and are used in production code.

## Fix

- Bump `MAX_V3_FANOUT` default from 101 → 103 in `backend/scripts/check-fanout.sh`
- Document the `maps`/ `slices` additions in the baseline comment

Fixes #531.