### PR TITLE
chore(config): register runtime-read env keys in validator allowlist

### DIFF
--- a/backend/internal/config/env_validation_test.go
+++ b/backend/internal/config/env_validation_test.go
@@ -74,6 +74,41 @@ func TestValidateEnvUsage_RuntimeKeyAllowed(t *testing.T) {
 	}
 }
 
+func TestKnownRuntimeEnvKeys_IncludesDirectReadEnvKeys(t *testing.T) {
+	// These keys are read directly via env helpers (envIntBounded/envFloatBounded/
+	// envBool/ParseBool) in the ffmpeg/pipeline packages, outside the config loader,
+	// so they never enter the loader's ConsumedEnvKeys set. They must be in the
+	// runtime allowlist or ValidateEnvUsage falsely flags them as
+	// "unknown XG2G env key (dead flag or typo)". Negative control: drop any one
+	// from runtimeEnvKeys and this goes red.
+	want := []string{
+		"XG2G_TRANSCODE_SHARPEN", "XG2G_TRANSCODE_DENOISE", "XG2G_TRANSCODE_DEBAND",
+		"XG2G_AV1_QVBR", "XG2G_AV1_QVBR_QUALITY",
+		"XG2G_AV1_NVENC_AUTO_RATIO_MAX", "XG2G_AV1_VAAPI_AUTO_RATIO_MAX",
+		"XG2G_HEVC_NVENC_AUTO_RATIO_MAX", "XG2G_HEVC_VAAPI_AUTO_RATIO_MAX",
+		"XG2G_ADAPTIVE_QUALITY_ENABLED",
+		"XG2G_ADAPTIVE_AV1_QUALITY_ENABLED", "XG2G_ADAPTIVE_AV1_MAXRATE_K", "XG2G_ADAPTIVE_AV1_BUFSIZE_K",
+		"XG2G_ADAPTIVE_HEVC_QUALITY_ENABLED", "XG2G_ADAPTIVE_HEVC_MAXRATE_K", "XG2G_ADAPTIVE_HEVC_BUFSIZE_K",
+		"XG2G_ADAPTIVE_H264_QUALITY_ENABLED", "XG2G_ADAPTIVE_H264_MAXRATE_K", "XG2G_ADAPTIVE_H264_BUFSIZE_K",
+		"XG2G_SAFARI_DIRTY_MAXRATE_K", "XG2G_SAFARI_DIRTY_BUFSIZE_K", "XG2G_SAFARI_DIRTY_AUDIO_BITRATE_K",
+		"XG2G_SAFARI_HEVC_VAAPI_QP", "XG2G_SAFARI_RUNTIME_PROBE_TIMEOUT_MS",
+		"XG2G_FPS_MIN", "XG2G_FPS_MAX", "XG2G_FPS_FALLBACK", "XG2G_FPS_PROBE_TIMEOUT_MS",
+		"XG2G_ENABLE_SYNTHETIC_PATH_CORRECTNESS_PREFLIGHT",
+		"XG2G_RUNTIME_PATH_CORRECTNESS_LOW_OBS", "XG2G_RUNTIME_PATH_CORRECTNESS_MIN_YAVG",
+		"XG2G_LIVE_NOBUFFER", "XG2G_INITIAL_REFRESH", "XG2G_RATE_LIMIT_ENABLED",
+	}
+
+	known := make(map[string]struct{})
+	for _, k := range KnownRuntimeEnvKeys() {
+		known[k] = struct{}{}
+	}
+	for _, k := range want {
+		if _, ok := known[k]; !ok {
+			t.Errorf("runtime-read env key %q missing from KnownRuntimeEnvKeys -> ValidateEnvUsage would falsely warn it as unknown", k)
+		}
+	}
+}
+
 func mapLookup(values map[string]string) envLookupFunc {
 	return func(key string) (string, bool) {
 		v, ok := values[key]

--- a/backend/internal/config/runtime_env.go
+++ b/backend/internal/config/runtime_env.go
@@ -86,9 +86,71 @@ var runtimeEnvKeys = []string{
 	"XG2G_SKIP_FPS_PROBE_ON_CACHE_HIT",
 	"XG2G_SKIP_FPS_PROBE_WARMUP",
 	"XG2G_BACKGROUND_SCAN_ENABLED",
+
+	// --- Keys read directly via env helpers OUTSIDE the config loader ---
+	// (encode_args.go, runtime_hardening.go, pipeline/profiles, fps probing, …).
+	// These bypass the loader's ConsumedEnvKeys tracking and the registry. The
+	// config validator (ValidateEnvUsage) runs at load time, BEFORE these runtime
+	// reads happen, so a static allowlist is the only mechanism that can stop them
+	// being flagged "unknown XG2G env key (dead flag or typo)". All are live and
+	// tested; see the referenced files for the read sites.
+
+	// Transcode post-filters (encode_args.go).
+	"XG2G_TRANSCODE_SHARPEN",
+	"XG2G_TRANSCODE_DENOISE",
+	"XG2G_TRANSCODE_DEBAND",
+
+	// AV1 QVBR rate control (encode_args.go).
+	"XG2G_AV1_QVBR",
+	"XG2G_AV1_QVBR_QUALITY",
+
+	// HW-encoder auto-ratio caps (encode_args.go / detector).
+	"XG2G_AV1_NVENC_AUTO_RATIO_MAX",
+	"XG2G_AV1_VAAPI_AUTO_RATIO_MAX",
+	"XG2G_HEVC_NVENC_AUTO_RATIO_MAX",
+	"XG2G_HEVC_VAAPI_AUTO_RATIO_MAX",
+
+	// Adaptive transcode-quality budget (runtime_hardening.go). The per-codec keys
+	// are assembled at runtime as "XG2G_ADAPTIVE_"+UPPER(codec)+"_…" for codec in
+	// {av1,hevc,h264}, so the full literal never appears in source — list all.
+	"XG2G_ADAPTIVE_QUALITY_ENABLED",
+	"XG2G_ADAPTIVE_AV1_QUALITY_ENABLED",
+	"XG2G_ADAPTIVE_AV1_MAXRATE_K",
+	"XG2G_ADAPTIVE_AV1_BUFSIZE_K",
+	"XG2G_ADAPTIVE_HEVC_QUALITY_ENABLED",
+	"XG2G_ADAPTIVE_HEVC_MAXRATE_K",
+	"XG2G_ADAPTIVE_HEVC_BUFSIZE_K",
+	"XG2G_ADAPTIVE_H264_QUALITY_ENABLED",
+	"XG2G_ADAPTIVE_H264_MAXRATE_K",
+	"XG2G_ADAPTIVE_H264_BUFSIZE_K",
+
+	// Safari "dirty"/HQ rate control + runtime probe (runtime_hardening / profiles).
+	"XG2G_SAFARI_DIRTY_MAXRATE_K",
+	"XG2G_SAFARI_DIRTY_BUFSIZE_K",
+	"XG2G_SAFARI_DIRTY_AUDIO_BITRATE_K",
+	"XG2G_SAFARI_HEVC_VAAPI_QP",
+	"XG2G_SAFARI_RUNTIME_PROBE_TIMEOUT_MS",
+
+	// FPS probing (pipeline/profiles).
+	"XG2G_FPS_MIN",
+	"XG2G_FPS_MAX",
+	"XG2G_FPS_FALLBACK",
+	"XG2G_FPS_PROBE_TIMEOUT_MS",
+
+	// Runtime path-correctness preflight.
+	"XG2G_ENABLE_SYNTHETIC_PATH_CORRECTNESS_PREFLIGHT",
+	"XG2G_RUNTIME_PATH_CORRECTNESS_LOW_OBS",
+	"XG2G_RUNTIME_PATH_CORRECTNESS_MIN_YAVG",
+
+	// Misc runtime toggles.
+	"XG2G_LIVE_NOBUFFER",
+	"XG2G_INITIAL_REFRESH",
+	"XG2G_RATE_LIMIT_ENABLED",
 }
 
-// KnownRuntimeEnvKeys returns all env keys read by ReadEnv.
+// KnownRuntimeEnvKeys returns every env key recognized at runtime: those read by
+// ReadEnv plus encode/runtime-hardening keys read directly via env helpers outside
+// the config loader. ValidateEnvUsage uses this set as its allowlist.
 func KnownRuntimeEnvKeys() []string {
 	out := make([]string, len(runtimeEnvKeys))
 	copy(out, runtimeEnvKeys)


### PR DESCRIPTION
## Was

`ValidateEnvUsage` warnte eine ganze **Klasse** echter, gelesener Env-Keys fälschlich als `unknown XG2G env key (dead flag or typo)`. Dieser PR registriert **34 Keys** in der Laufzeit-Allowlist `runtimeEnvKeys`, sodass der Validator sie als bekannt behandelt.

## Warum es passiert ist

Diese Keys werden über **loader-umgehende Helper** (`envIntBounded`/`envFloatBounded`/`envBool`/`ParseBool`) im ffmpeg/pipeline-Paket gelesen — sie landen daher nie im `ConsumedEnvKeys`-Set des Loaders und stehen in keiner Registry. Der Validator läuft beim **Config-Load**, *bevor* diese Runtime-Reads passieren → eine „bei-Lesen-als-consumed-markieren"-Mechanik kann prinzipiell nicht greifen. Die statische Allowlist `runtimeEnvKeys` ist der einzig funktionierende Ort (dort steht z.B. schon `XG2G_SAFARI_DIRTY_CRF`, ebenfalls fremd-paket-gelesen).

### Die dynamische Falle
Die per-Codec-Familie `XG2G_ADAPTIVE_<CODEC>_{QUALITY_ENABLED,MAXRATE_K,BUFSIZE_K}` (codec ∈ {av1,hevc,h264}) wird als `"XG2G_ADAPTIVE_"+strings.ToUpper(codec)+"_…"` **zur Laufzeit zusammengesetzt** — der volle Literal-String steht nie im Quellcode. Genau deshalb wirkten `XG2G_ADAPTIVE_AV1_MAXRATE_K`/`_BUFSIZE_K` bei einem Literal-Grep „tot", obwohl sie live sind (Test `…HonorsAV1BudgetEnv` belegt es end-to-end).

## Test / Negativ-Control

`TestKnownRuntimeEnvKeys_IncludesDirectReadEnvKeys` prüft alle 34 Keys gegen `KnownRuntimeEnvKeys()`.
- **Ohne** den Allowlist-Fix: rot (Keys fehlen).
- **Mit** Fix: grün.

## Risiko / Scope

- Kein Verhaltenscode — nur eine statische String-Liste + ein Test.
- Kein generierter Diff (`CONFIG_SURFACES.md` ist registry-abgeleitet); `verify-config` grün.
- Keiner dieser Keys war im laufenden Staging-Env gesetzt → **präventive Hygiene**, kein aktiver Bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
