### PR TITLE
fix(detector): normalize signalstats luma to 8-bit before YAVG thresholds

### DIFF
--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -37,6 +37,21 @@ const (
 	decodeVerifyMinRange = 16.0
 )
 
+// signalStatsLumaVF is the ffmpeg -vf used for EVERY luma (YAVG) measurement
+// (decode-verify, the synthetic path-correctness probe, and the runtime
+// watchdog). The leading format=yuv420p forces an 8-bit decode BEFORE signalstats
+// so YAVG is always reported on the 0-255 scale that every threshold here assumes
+// (decodeVerifyMinYAvg, the synthetic-probe 32, and the runtime watchdog's
+// XG2G_RUNTIME_PATH_CORRECTNESS_MIN_YAVG default 8). Without it a 10-bit p010 AV1
+// decode makes signalstats report on the 0-1023 scale -- empirically (staging
+// av1_vaapi p010) raw signalstats YAVG 497.5 for a bright pattern that is 124.4 at
+// 8-bit, ~4x inflated. That made (a) the runtime black-detector ~4x too lenient on
+// the exact 10-bit interlaced-AV1 path and (b) the measurement ffmpeg-build
+// dependent (one build reported ~126, another ~497 for similar content). yuv420p
+// makes it scale- and build-stable. The encoded stream is untouched; this is the
+// measurement decode only.
+const signalStatsLumaVF = "format=yuv420p,signalstats,metadata=mode=print"
+
 type Detector struct {
 	BinPath     string
 	Logger      zerolog.Logger
@@ -488,7 +503,7 @@ func (d *Detector) decodeStats(ctx context.Context, path, swDecoder string) (fra
 		"-v", "info",
 		"-c:v", swDecoder,
 		"-i", path,
-		"-vf", "signalstats,metadata=mode=print",
+		"-vf", signalStatsLumaVF,
 		"-f", "null", "-",
 	)
 	out, runErr := cmd.CombinedOutput()
@@ -959,7 +974,7 @@ func (d *Detector) measureSignalStatsYAvg(ctx context.Context, mediaPath string)
 		"-v", "info",
 		"-hwaccel", "none",
 		"-i", mediaPath,
-		"-vf", "signalstats,metadata=mode=print",
+		"-vf", signalStatsLumaVF,
 		"-frames:v", "1",
 		"-f", "null", "-",
 	}

--- a/backend/internal/infra/media/ffmpeg/detector_signalstats_scale_test.go
+++ b/backend/internal/infra/media/ffmpeg/detector_signalstats_scale_test.go
@@ -1,0 +1,23 @@
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSignalStatsLumaVF_Is8BitNormalized locks the luma-measurement filter to
+// 8-bit normalization. Without the leading format=yuv420p, signalstats reports
+// YAVG on the decoded bit depth (0-1023 for 10-bit p010 AV1), which makes the
+// runtime black-detector ~4x too lenient on the interlaced-AV1 path and the
+// measurement ffmpeg-build dependent. Empirically on staging av1_vaapi p010:
+// raw signalstats YAVG 497.5 vs format=yuv420p,signalstats YAVG 124.4 (exactly
+// /4, the 1023/255 ratio). Negative control: drop the "format=yuv420p," prefix
+// and this test goes red.
+func TestSignalStatsLumaVF_Is8BitNormalized(t *testing.T) {
+	if !strings.HasPrefix(signalStatsLumaVF, "format=yuv420p,") {
+		t.Fatalf("luma measurement filter must downconvert to 8-bit before signalstats so the 0-255 thresholds stay meaningful on 10-bit AV1; got %q", signalStatsLumaVF)
+	}
+	if !strings.Contains(signalStatsLumaVF, "signalstats") {
+		t.Fatalf("luma measurement filter must run signalstats; got %q", signalStatsLumaVF)
+	}
+}


### PR DESCRIPTION
## Was

Jede Luma-Messung (YAVG) im Detector — **decode-verify**, die **synthetische Pfad-Korrektheits-Probe** und der **Runtime-Schwarzbild-Watchdog** — lief `signalstats` auf der nativen Bittiefe. Für **10-bit p010 AV1** meldet das YAVG auf 0–1023-Skala, aber alle drei Thresholds sind 8-bit (0–255): `decodeVerifyMinYAvg=32`, die 32 der synthetischen Probe, und `XG2G_RUNTIME_PATH_CORRECTNESS_MIN_YAVG` (default 8).

## Warum es zählt

Auf dem **10-bit interlaced-AV1-Pfad** feuerte der Runtime-Schwarz-Detektor erst unter ~0,78 % statt der gewollten ~3,1 % Luma — **~4× zu lasch**, ein dunkel-aber-nicht-rein-schwarzes kaputtes Frame konnte durchrutschen. Zusätzlich war die Messung **ffmpeg-build-abhängig** (YAVG ~126 auf einem Build, ~497 auf einem anderen für ähnlichen Inhalt).

Gefunden bei der Staging-Untersuchung des Override-Pfads: der Runtime-Watchdog meldete für interlaced-av1-Sessions YAVG **497**/500 — unmöglich auf 8-bit.

## Fix

Eine geteilte Filter-Konstante `signalStatsLumaVF`, die `format=yuv420p` voranstellt → 8-bit-Decode **vor** signalstats → YAVG immer 0–255, alle Thresholds korrekt kalibriert und build-stabil. Nur die Mess-Dekodierung; der enkodierte Stream bleibt unangetastet.

## Negativ-Control (am kontrollierenden Layer)

Echte Staging-ffmpeg, echtes av1_vaapi p010:

| Filter | YAVG |
|---|---|
| `signalstats` (alt) | **497.539** |
| `format=yuv420p,signalstats` (neu) | **124.384** (exakt /4) |

- Guard-Test `TestSignalStatsLumaVF_Is8BitNormalized`: **rot** ohne den `format=yuv420p,`-Prefix, grün mit.
- Ganzes ffmpeg-Paket grün (decode-verify/Pfad/Watchdog) — **kein Verdict-Change**: diese Proben nutzen helles `testsrc2`, das die 32 auf beiden Skalen besteht.

## Scope-Hinweis

`decodeStats` (Kern-Verdict) wird mit-normalisiert, ist aber durch das helle Testsignal nicht fehl-verdiktend gewesen — die Konsistenz beseitigt die Build-Abhängigkeit. Verhalten ändert sich real nur dort, wo es soll: der Runtime-Watchdog erreicht auf 10-bit AV1 seine **beabsichtigte** Empfindlichkeit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
