### PR TITLE
fix(detector): verify interlaced VAAPI path at production bit depth (AV1 p010le)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter_benchmark.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_benchmark.go
@@ -29,12 +29,12 @@ func profileBenchmarksForBackend(backend string) []string {
 	}
 }
 
-// vaapiInterlacedProbeUploadFormat returns the hwupload pixel format the
-// interlaced path-correctness probe must encode at so it verifies the SAME bit
-// depth production drives the codec at (see encode_args.go: AV1 -> p010le 10-bit,
-// H.264/HEVC -> nv12 8-bit). Probing nv12 for AV1 "verifies" an 8-bit interlaced
-// path that is never served -- production always uploads AV1 as p010le.
-func vaapiInterlacedProbeUploadFormat(encoder string) string {
+// vaapiProductionUploadFormat returns the hwupload pixel format the VAAPI
+// pipeline must encode at so it verifies the SAME bit depth production drives
+// the codec at (see encode_args.go: AV1 -> p010le 10-bit, H.264/HEVC -> nv12
+// 8-bit). Probing nv12 for AV1 "verifies" an 8-bit path that is never served --
+// production always uploads AV1 as p010le.
+func vaapiProductionUploadFormat(encoder string) string {
 	if normalizeRequestedCodec(encoder) == "av1" {
 		return "p010le"
 	}
@@ -49,7 +49,7 @@ func vaapiEncodeOnlyInterlacedCorrectnessFilter(encoder string) string {
 	if normalizeRequestedCodec(encoder) == "av1" {
 		parts = append(parts, av1VAAPIGeometryPadFilter())
 	}
-	parts = append(parts, "format="+vaapiInterlacedProbeUploadFormat(encoder), "hwupload")
+	parts = append(parts, "format="+vaapiProductionUploadFormat(encoder), "hwupload")
 	return strings.Join(parts, ",")
 }
 

--- a/backend/internal/infra/media/ffmpeg/adapter_benchmark.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_benchmark.go
@@ -29,6 +29,18 @@ func profileBenchmarksForBackend(backend string) []string {
 	}
 }
 
+// vaapiInterlacedProbeUploadFormat returns the hwupload pixel format the
+// interlaced path-correctness probe must encode at so it verifies the SAME bit
+// depth production drives the codec at (see encode_args.go: AV1 -> p010le 10-bit,
+// H.264/HEVC -> nv12 8-bit). Probing nv12 for AV1 "verifies" an 8-bit interlaced
+// path that is never served -- production always uploads AV1 as p010le.
+func vaapiInterlacedProbeUploadFormat(encoder string) string {
+	if normalizeRequestedCodec(encoder) == "av1" {
+		return "p010le"
+	}
+	return "nv12"
+}
+
 func vaapiEncodeOnlyInterlacedCorrectnessFilter(encoder string) string {
 	parts := []string{
 		"setfield=tff",
@@ -37,7 +49,7 @@ func vaapiEncodeOnlyInterlacedCorrectnessFilter(encoder string) string {
 	if normalizeRequestedCodec(encoder) == "av1" {
 		parts = append(parts, av1VAAPIGeometryPadFilter())
 	}
-	parts = append(parts, "format=nv12", "hwupload")
+	parts = append(parts, "format="+vaapiInterlacedProbeUploadFormat(encoder), "hwupload")
 	return strings.Join(parts, ",")
 }
 

--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -923,7 +923,7 @@ func (d *Detector) testVAAPIInterlacedPathCorrectness(encoder string, full bool)
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	outPath := filepath.Join(tempDir, "probe.mkv")
-	filter := "format=nv12,setfield=tff,hwupload,deinterlace_vaapi"
+	filter := "format=" + vaapiInterlacedProbeUploadFormat(encoder) + ",setfield=tff,hwupload,deinterlace_vaapi"
 	if !full {
 		filter = vaapiEncodeOnlyInterlacedCorrectnessFilter(encoder)
 	}

--- a/backend/internal/infra/media/ffmpeg/detector.go
+++ b/backend/internal/infra/media/ffmpeg/detector.go
@@ -193,10 +193,7 @@ func (d *Detector) PreflightVAAPI() error {
 		// also probe 8-bit so the record shows whether a host does AV1 8-bit but
 		// not 10-bit (a p010 driver-promotion that fails elsewhere in the fleet).
 		isAV1 := normalizeRequestedCodec(enc) == "av1"
-		prodFormat := "nv12"
-		if isAV1 {
-			prodFormat = "p010le"
-		}
+		prodFormat := vaapiProductionUploadFormat(enc)
 		elapsed, verdict, reason := d.probeAndVerifyVaapiEncoder(enc, prodFormat)
 		verdicts[enc] = verdict
 		reasons[enc] = reason
@@ -923,7 +920,7 @@ func (d *Detector) testVAAPIInterlacedPathCorrectness(encoder string, full bool)
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	outPath := filepath.Join(tempDir, "probe.mkv")
-	filter := "format=" + vaapiInterlacedProbeUploadFormat(encoder) + ",setfield=tff,hwupload,deinterlace_vaapi"
+	filter := "format=" + vaapiProductionUploadFormat(encoder) + ",setfield=tff,hwupload,deinterlace_vaapi"
 	if !full {
 		filter = vaapiEncodeOnlyInterlacedCorrectnessFilter(encoder)
 	}

--- a/backend/internal/infra/media/ffmpeg/interlaced_probe_bitdepth_test.go
+++ b/backend/internal/infra/media/ffmpeg/interlaced_probe_bitdepth_test.go
@@ -1,0 +1,33 @@
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+)
+
+// The interlaced path-correctness probe must verify the bit depth production
+// actually serves: AV1 at p010le (10-bit), H.264/HEVC at nv12 (8-bit). Probing
+// nv12 for AV1 "verifies" an 8-bit path that is never served (production uploads
+// AV1 as p010le, see encode_args.go). Negative control: route AV1 back to nv12
+// and these go red.
+func TestVaapiInterlacedProbeUploadFormat_MatchesProductionBitDepth(t *testing.T) {
+	cases := map[string]string{
+		"av1": "p010le", "av1_vaapi": "p010le", "libsvtav1": "p010le",
+		"hevc": "nv12", "hevc_vaapi": "nv12", "h264": "nv12", "h264_vaapi": "nv12",
+	}
+	for enc, want := range cases {
+		if got := vaapiInterlacedProbeUploadFormat(enc); got != want {
+			t.Errorf("vaapiInterlacedProbeUploadFormat(%q) = %q, want %q", enc, got, want)
+		}
+	}
+}
+
+func TestInterlacedCorrectnessFilters_AV1UsesProductionP010(t *testing.T) {
+	eo := vaapiEncodeOnlyInterlacedCorrectnessFilter("av1_vaapi")
+	if !strings.Contains(eo, "format=p010le") || strings.Contains(eo, "format=nv12") {
+		t.Errorf("encode-only AV1 interlaced filter must upload p010le, got %q", eo)
+	}
+	if h := vaapiEncodeOnlyInterlacedCorrectnessFilter("hevc_vaapi"); !strings.Contains(h, "format=nv12") {
+		t.Errorf("encode-only HEVC interlaced filter must upload nv12, got %q", h)
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/interlaced_probe_bitdepth_test.go
+++ b/backend/internal/infra/media/ffmpeg/interlaced_probe_bitdepth_test.go
@@ -10,14 +10,14 @@ import (
 // nv12 for AV1 "verifies" an 8-bit path that is never served (production uploads
 // AV1 as p010le, see encode_args.go). Negative control: route AV1 back to nv12
 // and these go red.
-func TestVaapiInterlacedProbeUploadFormat_MatchesProductionBitDepth(t *testing.T) {
+func TestVaapiProductionUploadFormat_MatchesProductionBitDepth(t *testing.T) {
 	cases := map[string]string{
 		"av1": "p010le", "av1_vaapi": "p010le", "libsvtav1": "p010le",
 		"hevc": "nv12", "hevc_vaapi": "nv12", "h264": "nv12", "h264_vaapi": "nv12",
 	}
 	for enc, want := range cases {
-		if got := vaapiInterlacedProbeUploadFormat(enc); got != want {
-			t.Errorf("vaapiInterlacedProbeUploadFormat(%q) = %q, want %q", enc, got, want)
+		if got := vaapiProductionUploadFormat(enc); got != want {
+			t.Errorf("vaapiProductionUploadFormat(%q) = %q, want %q", enc, got, want)
 		}
 	}
 }


### PR DESCRIPTION
## Was

Die interlaced-Pfad-Korrektheits-Probe (Preflight) hardcodete **`format=nv12`** (8-bit) für jeden Codec — aber Produktion lädt **AV1 als `p010le`** (10-bit) hoch (`encode_args.go`: AV1 10-bit, H.264/HEVC 8-bit). Das Preflight markierte `vaapi_(encode_only|full)_interlaced_av1` also als `verified` auf Basis eines **8-bit**-Encodes, der nie ausgeliefert wird; der tatsächlich servierte **10-bit**-Pfad war nie preflight-verifiziert.

Das ist dieselbe Bit-Tiefen-Disziplin, die **B2 (#521)** aufs **Encoder-Verdict** angewandt hat — auf der **Pfad**-Probe fehlte sie.

## Fix

Ein Helper `vaapiInterlacedProbeUploadFormat(encoder)` → `p010le` für AV1, sonst `nv12` (spiegelt `encode_args.go`), genutzt von beiden Probe-Filtern (encode-only + full). Die Probe verifiziert jetzt die Bit-Tiefe, die Produktion wirklich serviert.

Das Encoder-Gate läuft die AV1-interlaced-Probe ohnehin nur, wenn `av1_vaapi` sein eigenes 10-bit-(p010)-Encoder-Verdict bestanden hat — der Fix bringt also den **Pfad**-Check mit dem **Encoder**-Check in Einklang.

## Verhaltensänderung (sichere Richtung)

Ein Host, der 8-bit-interlaced-AV1 kann, aber nicht 10-bit, **fällt jetzt korrekt** durch die Pfad-Probe und downgradet interlaced-AV1 auf h264 — statt einen 10-bit-Pfad zu servieren, den er nie verifiziert hat.

## Verifikation

- **Empirisch auf Staging** (AMD radeonsi, av1_vaapi): encode-only **und** full interlaced-AV1-Probe encoden + decoden bei `p010le` mit gesundem Luma (YAVG ~126 8-bit-normalisiert, ≥32).
- Tests: Helper + beide Filter routen AV1→p010le / sonst→nv12. **Negativ-Control** (AV1 zurück auf nv12) → rot.
- Pfad-Probe-Tests stubben via `pathProbeFn` → echte Filter unberührt; ganzes ffmpeg-Paket grün (13.9s).

## Kontext

Gefunden bei der Untersuchung des `XG2G_EXPERIMENTAL_ALLOW_UNVERIFIED_INTERLACED_VAAPI_CODECS`-Overrides: der Override ist auf Staging redundant (Preflight verifiziert den Pfad schon), aber das `verified` galt für die falsche Bit-Tiefe. Mit diesem Fix wird der Override ehrlich redundant. Baut auf #536 (signalstats 8-bit-Normalisierung) auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
