### PR TITLE
fix(preflight): widen relay scramble scan past descrambler-lock latency

### DIFF
--- a/backend/internal/infra/media/ffmpeg/input_resolver.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver.go
@@ -291,7 +291,15 @@ func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result p
 	// If we got at least the minimum sample, classify what we have even
 	// when the full scan window wasn't filled (e.g. timeout on a slow or
 	// bursty live source).
-	if n >= preflightMinBytes && err != nil {
+	// For relay streams we must have read far enough to clear the
+	// descrambler lock window (~2000 packets), otherwise the trailing
+	// 48-packet sample still lands inside the lock and a healthy stream
+	// is falsely flagged R_UPSTREAM_SCRAMBLED.
+	minRequiredBytes := preflightMinBytes
+	if relay {
+		minRequiredBytes = 188 * 2500 // ~2000 pkt lock + 48 pkt trailing window + margin
+	}
+	if n >= minRequiredBytes && err != nil {
 		err = nil
 	}
 	// If we got fewer bytes than the minimum required for sync/scramble

--- a/backend/internal/infra/media/ffmpeg/input_resolver.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver.go
@@ -30,7 +30,7 @@ const (
 	// interval and misclassify the whole stream — and each retry opens a fresh
 	// connection that lands in it again. For relay sources we read further and
 	// classify on the trailing window instead (see scrambleFractionForSource).
-	preflightRelayScanBytes = 188 * 1024 // ~188KB: well past the brief initial interval
+	preflightRelayScanBytes = 188 * 4096 // ~752KB: past observed descrambler/ECM-lock (~367KB / ~2000 pkt on a real icam channel) + margin. 188*1024 landed INSIDE the lock -> false R_UPSTREAM_SCRAMBLED while VLC (waits longer) played fine. A genuinely scrambled channel stays scrambled throughout, so the trailing window still flags it.
 	preflightRelayTimeout   = 4 * time.Second
 )
 

--- a/backend/internal/infra/media/ffmpeg/input_resolver_scramble_window_test.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver_scramble_window_test.go
@@ -1,0 +1,45 @@
+package ffmpeg
+
+import "testing"
+
+// tsBuf builds n aligned 188-byte MPEG-TS packets; scrambled sets both
+// transport_scrambling_control bits (byte[3] & 0xC0).
+func tsBuf(n int, scrambled bool) []byte {
+	b := make([]byte, n*188)
+	for i := 0; i < n; i++ {
+		b[i*188] = 0x47
+		if scrambled {
+			b[i*188+3] = 0xC0
+		}
+	}
+	return b
+}
+
+// A relay (port 17999) icam channel is scrambled until the descrambler/ECM locks,
+// then clears. The relay scan window must reach PAST that lock so the trailing
+// sample sits in the cleared stream, else a healthy channel is false-flagged
+// R_UPSTREAM_SCRAMBLED (real bug: VLC played it fine while xg2g refused).
+// Measured lock ~2000 packets (~367KB) on a real channel.
+func TestRelayScrambleClassification_ToleratesDescramblerLockLatency(t *testing.T) {
+	const lockPackets = 2000
+	buf := append(tsBuf(lockPackets, true), tsBuf(3000, false)...) // ~940KB: lock then clear
+
+	// The configured relay window must clear a ~2000-packet lock with margin.
+	// Negative control: revert preflightRelayScanBytes to 188*1024 and this fails.
+	if preflightRelayScanBytes < 188*(lockPackets+512) {
+		t.Fatalf("preflightRelayScanBytes=%d too small to clear a ~%d-packet descrambler lock", preflightRelayScanBytes, lockPackets)
+	}
+
+	// Classified over the actual configured window -> cleared stream -> NOT scrambled.
+	n := min(len(buf), preflightRelayScanBytes)
+	frac, pkts := scrambleFractionForSource(buf[:n], true)
+	if pkts < tsScrambleMinPackets || frac >= tsScrambleThreshold {
+		t.Fatalf("relay window must classify the post-lock stream as clear, got frac=%.3f pkts=%d", frac, pkts)
+	}
+
+	// Sanity: a genuinely scrambled channel (scrambled throughout) still flags.
+	allScr := tsBuf(4096, true)
+	if frac2, _ := scrambleFractionForSource(allScr, true); frac2 < tsScrambleThreshold {
+		t.Fatalf("a fully-scrambled relay stream must still flag, got frac=%.3f", frac2)
+	}
+}


### PR DESCRIPTION
## Symptom

`⚠ Sitzung fehlgeschlagen: R_UPSTREAM_SCRAMBLED` auf einem icam-Sender über den 17999-Relay — **obwohl VLC denselben Stream in Sekunden öffnet** (`http://10.10.55.64:17999/1:0:19:11:6:85:C00000:0:0:0:`). Zweiter Sender mit diesem Muster (nach #527).

## Ursache (deterministisch gemessen)

Der Stream **startet scrambled und wird dann klar** — Descrambler/ECM-Lock-Latenz:

```
pkt    0– 1000: 93.5% scrambled
pkt 1000– 2000: 77.8% scrambled
pkt 2000+:        0.0%  (klar für die restlichen ~67.000 Pakete)
```

Der Lock liegt bei **~2000 Paketen (~367KB)**. `preflightRelayScanBytes = 188*1024` (~192KB) liest **komplett innerhalb** des Lock-Fensters → der Trailing-48-Klassifizierer sieht ~90% scrambled → `R_UPSTREAM_SCRAMBLED`. VLC wartet länger und bekommt den klaren Stream. Der #527-Kommentar („~188KB: well past the brief initial interval") war für diesen Sender schlicht falsch.

## Fix

`preflightRelayScanBytes` → `188*4096` (~752KB), past den beobachteten Lock + Margin. True-Scramble bleibt erkannt (durchgehend scrambled → Tail bleibt ~100%).

## Verifikation

Gegen den **echten Capture-Stream**: Trailing-48-Fraction = **89.6% bei 188*1024** (geflaggt) vs **0.0% bei 188*3072/4096** (klar). Neuer Test baut einen lock-then-clear-Buffer; **Negativ-Control** (const zurück auf 188*1024) → rot. Ganzes ffmpeg-Paket grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
