### PR TITLE
ci(verify): add codegen-freshness gate for the generated TS API client

### DIFF
--- a/backend/scripts/verify-client-ts-fresh.sh
+++ b/backend/scripts/verify-client-ts-fresh.sh
@@ -18,7 +18,7 @@ trap 'rm -f "$before_diff" "$after_diff" "$before_untracked" "$after_untracked"'
 git diff -- "$TARGET_PATH" > "$before_diff"
 git ls-files --others --exclude-standard -- "$TARGET_PATH" | LC_ALL=C sort > "$before_untracked"
 
-make generate-client
+"${MAKE:-make}" generate-client
 
 git diff -- "$TARGET_PATH" > "$after_diff"
 git ls-files --others --exclude-standard -- "$TARGET_PATH" | LC_ALL=C sort > "$after_untracked"

--- a/backend/scripts/verify-client-ts-fresh.sh
+++ b/backend/scripts/verify-client-ts-fresh.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# The generated @hey-api/openapi-ts TypeScript client must stay in lock-step with
+# the OpenAPI contract (backend/api/openapi.yaml). Regenerate and fail on drift —
+# mirrors verify-embedded-webui-dist for the embedded WebUI bundle.
+TARGET_PATH="frontend/webui/src/client-ts"
+
+before_diff="$(mktemp)"
+after_diff="$(mktemp)"
+before_untracked="$(mktemp)"
+after_untracked="$(mktemp)"
+trap 'rm -f "$before_diff" "$after_diff" "$before_untracked" "$after_untracked"' EXIT
+
+git diff -- "$TARGET_PATH" > "$before_diff"
+git ls-files --others --exclude-standard -- "$TARGET_PATH" | LC_ALL=C sort > "$before_untracked"
+
+make generate-client
+
+git diff -- "$TARGET_PATH" > "$after_diff"
+git ls-files --others --exclude-standard -- "$TARGET_PATH" | LC_ALL=C sort > "$after_untracked"
+
+if ! cmp -s "$before_diff" "$after_diff" || ! cmp -s "$before_untracked" "$after_untracked"; then
+  echo "❌ Generated TS API client drift detected."
+  echo "   frontend/webui/src/client-ts is out of sync with backend/api/openapi.yaml."
+  echo "   Run: make generate-client   (then commit the regenerated client)"
+  echo ""
+  echo "Status for tracked scope:"
+  git status --short -- "$TARGET_PATH"
+  exit 1
+fi
+
+echo "✅ Generated TS API client drift lock passed"

--- a/mk/backend.mk
+++ b/mk/backend.mk
@@ -15,7 +15,7 @@ ui-build: ## Build WebUI assets
 
 generate-client: ## Regenerate the TypeScript API client from the OpenAPI spec
 	@echo "Regenerating TS API client from backend/api/openapi.yaml..."
-	@cd $(FRONTEND_DIR)/webui && npm ci && npm run generate-client
+	@cd $(FRONTEND_DIR)/webui && { [ -d node_modules ] || npm ci; } && npm run generate-client
 	@echo "✅ TS API client regenerated"
 
 build: ## Build xg2g binary (Go-only, offline-safe)

--- a/mk/backend.mk
+++ b/mk/backend.mk
@@ -2,7 +2,7 @@
 # Backend Targets
 # ===================================================================================================
 
-.PHONY: backend-build backend-run generate-config verify-config generate verify-generate gen-openapi-hard ui-build build build-with-ui build-offline backend-dev backend-dev-ui webui-dev dev-ui dev android-local-smoke android-tv-smoke install doctor check-tools dev-tools
+.PHONY: backend-build backend-run generate-config verify-config generate verify-generate gen-openapi-hard ui-build generate-client build build-with-ui build-offline backend-dev backend-dev-ui webui-dev dev-ui dev android-local-smoke android-tv-smoke install doctor check-tools dev-tools
 
 ui-build: ## Build WebUI assets
 	@echo "Building WebUI assets..."
@@ -12,6 +12,11 @@ ui-build: ## Build WebUI assets
 	@mkdir -p "$(WEBUI_DIST_DIR)"
 	@cp -R $(FRONTEND_DIR)/webui/dist/. "$(WEBUI_DIST_DIR)"/
 	@echo "✅ WebUI build complete"
+
+generate-client: ## Regenerate the TypeScript API client from the OpenAPI spec
+	@echo "Regenerating TS API client from backend/api/openapi.yaml..."
+	@cd $(FRONTEND_DIR)/webui && npm ci && npm run generate-client
+	@echo "✅ TS API client regenerated"
 
 build: ## Build xg2g binary (Go-only, offline-safe)
 	@echo "▶ build (Go-only, offline-safe)"

--- a/mk/verify.mk
+++ b/mk/verify.mk
@@ -2,7 +2,7 @@
 # Governance and Verification Gates
 # ===================================================================================================
 
-.PHONY: verify verify-generated-artifacts verify-generated-artifacts-contract verify-openapi-hard-mode verify-embedded-webui-dist verify-config verify-doc-links verify-capabilities contract-matrix verify-purity contract-freeze-check verify-no-sleep verify-no-panic verify-no-ignored-errors verify-determinism verify-codegen-transport verify-router-parity verify-oapi-codegen-version verify-no-hardcoded-baseurl verify-no-adhoc-terminal-mapping verify-no-adhoc-session-mapping verify-doc-image-tags verify-docs-compiled verify-digest-lock verify-release-policy verify-release-output-contract verify-runtime verify-hot-reload-governance verify-compose-resolver verify-systemd-runtime-contract verify-installation-contract verify-public-deployment verify-capacity-autocodec-demotion verify-codec-path-matrix gate-a gate-webui gate-repo-hygiene gate-v3-contract verify-v3-fanout verify-dead-packages
+.PHONY: verify verify-generated-artifacts verify-generated-artifacts-contract verify-openapi-hard-mode verify-embedded-webui-dist verify-client-ts-fresh verify-config verify-doc-links verify-capabilities contract-matrix verify-purity contract-freeze-check verify-no-sleep verify-no-panic verify-no-ignored-errors verify-determinism verify-codegen-transport verify-router-parity verify-oapi-codegen-version verify-no-hardcoded-baseurl verify-no-adhoc-terminal-mapping verify-no-adhoc-session-mapping verify-doc-image-tags verify-docs-compiled verify-digest-lock verify-release-policy verify-release-output-contract verify-runtime verify-hot-reload-governance verify-compose-resolver verify-systemd-runtime-contract verify-installation-contract verify-public-deployment verify-capacity-autocodec-demotion verify-codec-path-matrix gate-a gate-webui gate-repo-hygiene gate-v3-contract verify-v3-fanout verify-dead-packages
 
 verify: verify-generated-artifacts verify-doc-links verify-capabilities contract-matrix verify-purity contract-freeze-check verify-no-sleep verify-no-panic verify-no-ignored-errors verify-determinism verify-codegen-transport verify-router-parity verify-oapi-codegen-version verify-no-hardcoded-baseurl verify-no-adhoc-terminal-mapping verify-no-adhoc-session-mapping verify-no-hls-startup-policy-client-usage verify-doc-image-tags verify-digest-lock verify-release-policy verify-release-output-contract verify-runtime verify-hot-reload-governance verify-compose-resolver verify-systemd-runtime-contract verify-installation-contract ## Run all governance verification gates
 
@@ -40,7 +40,10 @@ verify-openapi-hard-mode: ## Verify OpenAPI hard-mode generated artifacts are up
 verify-embedded-webui-dist: ## Verify embedded WebUI dist is up-to-date
 	@./$(BACKEND_DIR)/scripts/verify-embedded-webui-dist.sh
 
-verify-generated-artifacts: verify-config verify-docs-compiled verify-generate verify-openapi-hard-mode verify-embedded-webui-dist verify-generated-artifacts-contract ## Verify all committed generated artifacts and governance rules
+verify-client-ts-fresh: ## Verify generated TS API client is up-to-date with openapi.yaml
+	@./$(BACKEND_DIR)/scripts/verify-client-ts-fresh.sh
+
+verify-generated-artifacts: verify-config verify-docs-compiled verify-generate verify-openapi-hard-mode verify-embedded-webui-dist verify-client-ts-fresh verify-generated-artifacts-contract ## Verify all committed generated artifacts and governance rules
 	@echo "✅ Generated artifact governance passed"
 
 verify-release-output-contract: ## Verify the normative release/package output contract

--- a/mk/verify.mk
+++ b/mk/verify.mk
@@ -41,7 +41,7 @@ verify-embedded-webui-dist: ## Verify embedded WebUI dist is up-to-date
 	@./$(BACKEND_DIR)/scripts/verify-embedded-webui-dist.sh
 
 verify-client-ts-fresh: ## Verify generated TS API client is up-to-date with openapi.yaml
-	@./$(BACKEND_DIR)/scripts/verify-client-ts-fresh.sh
+	@MAKE="$(MAKE)" ./$(BACKEND_DIR)/scripts/verify-client-ts-fresh.sh
 
 verify-generated-artifacts: verify-config verify-docs-compiled verify-generate verify-openapi-hard-mode verify-embedded-webui-dist verify-client-ts-fresh verify-generated-artifacts-contract ## Verify all committed generated artifacts and governance rules
 	@echo "✅ Generated artifact governance passed"


### PR DESCRIPTION
## Was

Der generierte TS-Client (`frontend/webui/src/client-ts`, @hey-api/openapi-ts) entsteht aus `backend/api/openapi.yaml` — aber **nichts in der CI regeneriert + difft ihn**. Eine Spec-Änderung kann den Client also still veralten lassen. Das war der **oberste systemische Befund** des Frontend↔Backend-Integrations-Audits. Das bestehende `verify-generated-artifacts-contract` prüft nur Generierungs-**Marker**, nicht Freshness.

## Fix

`verify-client-ts-fresh` (Script spiegelt `verify-embedded-webui-dist`): regeneriert via `make generate-client` und schlägt bei jedem git-diff/untracked unter `client-ts` fehl. Eingehängt in `verify-generated-artifacts`. Neues Target `make generate-client`.

## Verifikation

- **Baseline** (sauberer origin/main): Regenerieren → **0 Diff** → der committete Client ist frisch UND openapi-ts ist deterministisch → Gate grün.
- **Negativ-Control**: eine Client-Datei verändern → Gate erkennt Drift → `❌` + `make Error 1`.

Analog zum `verify-embedded-webui-dist`-Gate, das den Reason-i18n-PR (#539) gerade rot gemacht hat, bis der eingebettete dist mitgeneriert war — dieselbe Klasse, jetzt auch für den API-Client geschlossen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
