### PR TITLE
docs(deploy): make the reverse-proxy guide newcomer-first

### DIFF
--- a/deploy/REVERSE_PROXY.md
+++ b/deploy/REVERSE_PROXY.md
@@ -24,7 +24,7 @@ The shortest path to a working, secure deployment. Caddy gives you automatic
 HTTPS in a few lines and handles the redirect and forwarded headers for you.
 
 1. Point a DNS name at the host (e.g. `tv.example.com` → your server). No public
-   domain? See **"No public domain? (homelab)"** below.
+   domain? See **"No public domain? (homelab / internal only)"** below.
 2. Run xg2g normally — plain HTTP is fine, Caddy adds the TLS. (Don't set
    `XG2G_TLS_ENABLED`.)
 3. Drop in the reference `reverse-proxy/caddy/Caddyfile`, replacing

--- a/deploy/REVERSE_PROXY.md
+++ b/deploy/REVERSE_PROXY.md
@@ -18,6 +18,47 @@ to add them.
 
 ---
 
+## New here? Quick start (a domain + Caddy)
+
+The shortest path to a working, secure deployment. Caddy gives you automatic
+HTTPS in a few lines and handles the redirect and forwarded headers for you.
+
+1. Point a DNS name at the host (e.g. `tv.example.com` → your server). No public
+   domain? See **"No public domain? (homelab)"** below.
+2. Run xg2g normally — plain HTTP is fine, Caddy adds the TLS. (Don't set
+   `XG2G_TLS_ENABLED`.)
+3. Drop in the reference `reverse-proxy/caddy/Caddyfile`, replacing
+   `tv.example.com` and the upstream `host:port`.
+4. Set three env vars on xg2g so it trusts Caddy and accepts your URL:
+
+   ```sh
+   XG2G_CONNECTIVITY_PROFILE=reverse_proxy
+   XG2G_TRUSTED_PROXIES=<ip-or-cidr-Caddy-connects-from>   # same host → 127.0.0.1/32
+   XG2G_ALLOWED_ORIGINS=https://tv.example.com             # the exact URL you open
+   ```
+
+5. Start both and open `https://tv.example.com`. HTTPS, the HTTP→HTTPS redirect,
+   Secure cookies and the web player all work.
+
+A copy-paste Caddy + xg2g stack (with the Docker-network `TRUSTED_PROXIES`
+already resolved) is at `reverse-proxy/caddy/docker-compose.caddy.yml`.
+
+### Why the web player needs HTTPS
+
+This is the single thing newcomers trip over — **the streams won't start over
+plain HTTP on a LAN IP.** Three reasons, all by design:
+
+- Browsers restrict parts of the web platform to a **secure context** (HTTPS, or
+  `http://localhost` only) — a LAN IP over HTTP is *not* one.
+- xg2g serves authenticated media and a playback **session cookie**; these should
+  never cross the network in cleartext.
+- Public deployment profiles **enforce** TLS at startup (see the profile table).
+
+So pick an HTTPS path from the matrix below. `http://localhost` works for local
+dev; everything else needs a proxy (or xg2g's own TLS).
+
+---
+
 ## The setting that bites everyone: `XG2G_TRUSTED_PROXIES`
 
 When xg2g runs behind a proxy, the proxy's IP is what xg2g sees as the client.
@@ -89,6 +130,25 @@ Each file carries the required `XG2G_TRUSTED_PROXIES` and
 
 ---
 
+## No public domain? (homelab / internal only)
+
+You still get HTTPS without a public name — common for LAN + VPN (e.g.
+WireGuard) setups:
+
+- **Internal domain you control** (e.g. `tv.home.lan`): use a Caddy
+  DNS-challenge plugin for your DNS provider to get a real, trusted cert, and
+  resolve the name on your LAN via split-DNS (router / Pi-hole / OPNsense
+  Unbound). Reach it the same way over the VPN.
+- **No domain at all:** Caddy's internal CA (`tls internal`) issues a local cert
+  — install Caddy's root on your devices once and they trust it. Or enable
+  xg2g's own in-process TLS (`XG2G_TLS_ENABLED=true`), which self-signs for the
+  host's IPs (expect a one-time browser warning).
+
+Either way, set `XG2G_ALLOWED_ORIGINS` to the exact `https://…` URL you open,
+and `XG2G_TRUSTED_PROXIES` to the proxy when one is in front.
+
+---
+
 ## HTTP → HTTPS redirect: it belongs at the edge
 
 xg2g listens on a **single scheme** — either TLS *or* plain HTTP, never both —
@@ -116,3 +176,18 @@ upgrade subsequent requests on its own.
   so the browser origin and the playback origin must match — another reason to
   serve the UI and the API from the same HTTPS origin.
 - No WebSocket/SSE endpoints — no `Upgrade` handling needed.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Web UI loads, but **streams won't start** / the play button does nothing / `403` on play | You opened xg2g over plain HTTP on a LAN IP, or the page's origin isn't allow-listed | Open it via your **HTTPS** URL, and set `XG2G_ALLOWED_ORIGINS` to that exact origin |
+| **Container refuses to start** (`trustedProxies required` / `tls required`) | A public `XG2G_CONNECTIVITY_PROFILE` is set but its requirement is missing | Set `XG2G_TRUSTED_PROXIES` (reverse_proxy/tunnel) or `XG2G_TLS_ENABLED=true` (vps) — or use `lan` |
+| HTTPS works, but **you're logged out repeatedly / no HSTS / cookies aren't `Secure`** | xg2g doesn't trust your proxy, so it ignores `X-Forwarded-Proto` | Set `XG2G_TRUSTED_PROXIES` to the proxy's source IP/CIDR |
+| **Every visitor logs as the proxy's IP**; rate-limit throttles everyone together | Same — forwarded headers untrusted | Same — set `XG2G_TRUSTED_PROXIES` |
+| Behind a proxy but **mixed-content / requests fail** | UI on HTTP while API on HTTPS (or vice-versa) | Serve UI and API from the **same** HTTPS origin |
+
+Still stuck? Open the browser console (F12) on a failed play — a `403`, a CORS
+message, or a `Mixed Content` warning each map to a row above.

--- a/deploy/reverse-proxy/caddy/docker-compose.caddy.yml
+++ b/deploy/reverse-proxy/caddy/docker-compose.caddy.yml
@@ -1,0 +1,48 @@
+# Copy-paste Caddy + xg2g stack with automatic HTTPS.
+#
+#   docker compose -f docker-compose.caddy.yml up -d
+#   → open https://tv.example.com
+#
+# The network subnet is PINNED so XG2G_TRUSTED_PROXIES is deterministic (the #1
+# thing newcomers get wrong behind Docker). Only Caddy is exposed; xg2g is
+# reachable inside the network as "xg2g:8088".
+#
+# Before starting:
+#   1. Edit the mounted Caddyfile so the site is your domain and the upstream is
+#      `reverse_proxy xg2g:8088` (not 127.0.0.1).
+#   2. Replace tv.example.com below with your domain.
+
+services:
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks: [edge]
+
+  xg2g:
+    image: ghcr.io/manugh/xg2g:latest   # pin a release tag for production
+    restart: unless-stopped
+    environment:
+      - XG2G_LISTEN=:8088
+      - XG2G_CONNECTIVITY_PROFILE=reverse_proxy
+      # Caddy connects from the pinned subnet below — trust exactly that, nothing more.
+      - XG2G_TRUSTED_PROXIES=172.31.0.0/24
+      - XG2G_ALLOWED_ORIGINS=https://tv.example.com
+    # No published ports on purpose: reach xg2g only through Caddy.
+    networks: [edge]
+
+networks:
+  edge:
+    ipam:
+      config:
+        - subnet: 172.31.0.0/24   # keep XG2G_TRUSTED_PROXIES in sync if you change this
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Why

#550 documented every reverse-proxy / HTTPS scenario accurately, but as **reference** material. A new self-hoster landing on it hits the exact confusion this came out of — *"the web UI loads but streams won't start"* — without an obvious "do this" path or a place to look when it breaks. This adds the **onboarding layer** on top of the reference.

## What

- **"New here? Quick start (a domain + Caddy)"** at the top — the recommended happy path as 5 copy-paste steps, plus a short **"Why the web player needs HTTPS"** explainer (browser secure-context + authenticated media/cookies + public profiles enforce TLS). This is the single thing newcomers trip over, now stated up front.
- **"No public domain? (homelab / internal only)"** — internal domain + Caddy DNS-challenge + split-DNS, Caddy's internal CA, or xg2g's own self-signed TLS. Covers the common LAN + VPN/WireGuard reality where there's no public name.
- **"Troubleshooting"** symptom → cause → fix table, leading with *streams won't start / 403 on play* and an F12-console hint that maps each browser error to a row.
- **`reverse-proxy/caddy/docker-compose.caddy.yml`** — a copy-paste Caddy + xg2g stack with a **pinned network subnet** so `XG2G_TRUSTED_PROXIES` is deterministic, removing the #1 Docker footgun.

## Risk

Zero — docs + one example compose file. No code, no behavior change.

## Context

Final layer of the HTTP/HTTPS story: #548 (native hardening) → #549 (reconnect resilience) → #550 (scenario reference) → this (newcomer onboarding + troubleshooting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)