### PR TITLE
fix(ffmpeg): learn output FPS from fMP4 segments via init.mp4

### DIFF
--- a/backend/internal/infra/media/ffmpeg/fps_detector.go
+++ b/backend/internal/infra/media/ffmpeg/fps_detector.go
@@ -136,7 +136,9 @@ func outputProbeInput(segmentPath string) (string, []string) {
 	if st, err := os.Stat(initPath); err != nil || st.Size() <= 0 {
 		return segmentPath, nil
 	}
-	return "concat:" + initPath + "|" + segmentPath, []string{"-protocol_whitelist", "concat,file"}
+	safeInit := "file:" + filepath.ToSlash(initPath)
+	safeSeg := "file:" + filepath.ToSlash(segmentPath)
+	return "concat:" + safeInit + "|" + safeSeg, []string{"-protocol_whitelist", "concat,file"}
 }
 
 func shouldRetryFPSProbe(err error) bool {

--- a/backend/internal/infra/media/ffmpeg/fps_detector.go
+++ b/backend/internal/infra/media/ffmpeg/fps_detector.go
@@ -97,13 +97,15 @@ func (a *LocalAdapter) probeOutputFPS(segmentPath string) (int, string, error) {
 		ffprobeBin = "ffprobe"
 	}
 
-	args := []string{
-		"-v", "error",
+	input, protoArgs := outputProbeInput(segmentPath)
+	args := []string{"-v", "error"}
+	args = append(args, protoArgs...)
+	args = append(args,
 		"-select_streams", "v:0",
 		"-show_entries", "stream=r_frame_rate,avg_frame_rate",
 		"-of", "default=noprint_wrappers=1",
-		segmentPath,
-	}
+		input,
+	)
 	// #nosec G204 -- ffprobe bin path is trusted
 	cmd := exec.CommandContext(probeCtx, ffprobeBin, args...)
 	var stderr bytes.Buffer
@@ -117,6 +119,24 @@ func (a *LocalAdapter) probeOutputFPS(segmentPath string) (int, string, error) {
 		return 0, "", fmt.Errorf("empty output")
 	}
 	return parseFPSProbeOutput(output)
+}
+
+// outputProbeInput builds the ffprobe input for a freshly written HLS output
+// segment. An fMP4 media segment (.m4s) carries only moof/mdat and is NOT
+// decodable on its own — it needs the init segment's moov, or ffprobe fails with
+// "no tfhd was found / Invalid data". So we prepend init.mp4 via the concat
+// protocol (the same approach used for the DVR scrub-preview keyframe). MPEG-TS
+// segments are self-contained and pass through unchanged. If the init segment
+// isn't there yet, fall back to the bare segment rather than failing outright.
+func outputProbeInput(segmentPath string) (string, []string) {
+	if !strings.EqualFold(filepath.Ext(segmentPath), ".m4s") {
+		return segmentPath, nil
+	}
+	initPath := filepath.Join(filepath.Dir(segmentPath), "init.mp4")
+	if st, err := os.Stat(initPath); err != nil || st.Size() <= 0 {
+		return segmentPath, nil
+	}
+	return "concat:" + initPath + "|" + segmentPath, []string{"-protocol_whitelist", "concat,file"}
 }
 
 func shouldRetryFPSProbe(err error) bool {

--- a/backend/internal/infra/media/ffmpeg/fps_detector_test.go
+++ b/backend/internal/infra/media/ffmpeg/fps_detector_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOutputProbeInput_FMP4PrependsInit(t *testing.T) {
+	dir := t.TempDir()
+	initPath := filepath.Join(dir, "init.mp4")
+	if err := os.WriteFile(initPath, []byte("moovdata"), 0o600); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+	seg := filepath.Join(dir, "seg_000000.m4s")
+	if err := os.WriteFile(seg, []byte("moofmdat"), 0o600); err != nil {
+		t.Fatalf("write seg: %v", err)
+	}
+
+	input, extra := outputProbeInput(seg)
+
+	want := "concat:" + initPath + "|" + seg
+	if input != want {
+		t.Fatalf("input = %q, want %q", input, want)
+	}
+	if len(extra) != 2 || extra[0] != "-protocol_whitelist" || extra[1] != "concat,file" {
+		t.Fatalf("extra args = %v, want [-protocol_whitelist concat,file]", extra)
+	}
+}
+
+// Negative control: a self-contained MPEG-TS segment must pass through
+// untouched — prepending init.mp4 (or whitelisting concat) for TS would be
+// wrong. If the fix ever over-reached to all segments this fails.
+func TestOutputProbeInput_TSPassesThrough(t *testing.T) {
+	seg := filepath.Join(t.TempDir(), "seg_000000.ts")
+	if err := os.WriteFile(seg, []byte("tsdata"), 0o600); err != nil {
+		t.Fatalf("write seg: %v", err)
+	}
+
+	input, extra := outputProbeInput(seg)
+
+	if input != seg {
+		t.Fatalf("input = %q, want bare segment %q", input, seg)
+	}
+	if extra != nil {
+		t.Fatalf("extra args = %v, want nil for TS", extra)
+	}
+}
+
+// Negative control: an fMP4 segment whose init.mp4 hasn't been written yet must
+// degrade to the bare segment, not emit a concat input pointing at a missing
+// file (which would fail differently). The probe simply returns its normal
+// not-decodable error and the caller retries on the next segment.
+func TestOutputProbeInput_FMP4WithoutInitFallsBack(t *testing.T) {
+	seg := filepath.Join(t.TempDir(), "seg_000000.m4s")
+	if err := os.WriteFile(seg, []byte("moofmdat"), 0o600); err != nil {
+		t.Fatalf("write seg: %v", err)
+	}
+
+	input, extra := outputProbeInput(seg)
+
+	if input != seg {
+		t.Fatalf("input = %q, want bare segment fallback %q", input, seg)
+	}
+	if extra != nil {
+		t.Fatalf("extra args = %v, want nil when init.mp4 absent", extra)
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/fps_detector_test.go
+++ b/backend/internal/infra/media/ffmpeg/fps_detector_test.go
@@ -23,7 +23,7 @@ func TestOutputProbeInput_FMP4PrependsInit(t *testing.T) {
 
 	input, extra := outputProbeInput(seg)
 
-	want := "concat:" + initPath + "|" + seg
+	want := "concat:file:" + filepath.ToSlash(initPath) + "|file:" + filepath.ToSlash(seg)
 	if input != want {
 		t.Fatalf("input = %q, want %q", input, want)
 	}


### PR DESCRIPTION
## Why

Spotted in **live staging logs** while a stream was running: every fMP4 session (Safari / HEVC / AV1 profiles) logs at debug level:

```
failed to learn fps from output segment … trun track id unknown, no tfhd was found … Invalid data found when processing input
```

`learnFPSFromOutput` ffprobes the first output segment to learn the real encoder FPS. But it reads a **bare `.m4s`**, which carries only `moof`/`mdat` and is undecodable without the init segment's `moov`. So the probe always fails on fMP4 → the output-FPS-learning optimization **silently no-ops** for every fMP4 session, falling back to input probing.

## What

`outputProbeInput()` prepends `init.mp4` via the **concat protocol** for `.m4s` (`concat:init.mp4|seg.m4s` + `-protocol_whitelist concat,file`) — the same approach already used for the DVR scrub-preview keyframe extraction. MPEG-TS segments are self-contained and pass through unchanged. If `init.mp4` hasn't been written yet, it degrades to the bare segment and retries on the next one.

## Tests

`outputProbeInput` is pure + unit-tested with **negative controls**:
- `.m4s` → `concat:init|seg` + protocol whitelist;
- `.ts` passes through untouched (the fix must not over-reach to TS);
- `.m4s` with no `init.mp4` falls back to the bare segment.

gofmt / build / vet / package tests clean.

## Impact

Low-risk, non-blocking correctness fix to an optimization helper (a background goroutine, not the main transcode path). Restores accurate output-FPS learning for fMP4 sessions and removes the recurring debug error. Verifiable on staging after deploy: the "failed to learn fps" line disappears and a "learned fps from encoder output" info line appears for fMP4 streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)