### PR TITLE
feat(ffmpeg): preserve 50p motion for interlaced live when host benchmarks strong

### DIFF
--- a/backend/internal/infra/media/ffmpeg/plan_5050p_test.go
+++ b/backend/internal/infra/media/ffmpeg/plan_5050p_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/rs/zerolog"
+)
+
+func liveTranscodeSpec(mode ports.RuntimeMode) ports.StreamSpec {
+	s := ports.StreamSpec{Mode: ports.ModeLive, Format: ports.FormatHLS}
+	s.Profile.TranscodeVideo = true
+	s.Profile.Deinterlace = true
+	s.Profile.EffectiveRuntimeMode = mode
+	return s
+}
+
+// When promoted to HQ50, the output framerate must NOT be clamped (return 0 =
+// no -r): the send_field bob deinterlace emits native 50fps and force_key_frames
+// keeps segments aligned. Clamping would collapse motion back toward 25.
+func TestTargetLiveOutputFPS_HQ50NoClamp(t *testing.T) {
+	if got := targetLiveOutputFPS(liveTranscodeSpec(ports.RuntimeModeHQ50)); got != 0 {
+		t.Fatalf("HQ50 output fps clamp = %d, want 0 (no clamp)", got)
+	}
+}
+
+// Negative control: HQ25 stays at 25 fps. If this regresses, every interlaced
+// transcode silently changes framerate.
+func TestTargetLiveOutputFPS_HQ25Pins25(t *testing.T) {
+	if got := targetLiveOutputFPS(liveTranscodeSpec(ports.RuntimeModeHQ25)); got != 25 {
+		t.Fatalf("HQ25 output fps = %d, want 25", got)
+	}
+}
+
+// HQ50 deinterlaces with send_field (one frame per field → 50p, smooth motion).
+func TestDeinterlaceFilter_HQ50UsesSendField(t *testing.T) {
+	a := &LocalAdapter{Logger: zerolog.Nop()}
+	f := a.deinterlaceFilterForProfile(liveTranscodeSpec(ports.RuntimeModeHQ50))
+	if !strings.Contains(f, "send_field") {
+		t.Fatalf("HQ50 deinterlace = %q, want send_field (50p)", f)
+	}
+}
+
+// Negative control: HQ25 deinterlaces with send_frame (25p), collapsing fields.
+func TestDeinterlaceFilter_HQ25UsesSendFrame(t *testing.T) {
+	a := &LocalAdapter{Logger: zerolog.Nop()}
+	f := a.deinterlaceFilterForProfile(liveTranscodeSpec(ports.RuntimeModeHQ25))
+	if !strings.Contains(f, "send_frame") {
+		t.Fatalf("HQ25 deinterlace = %q, want send_frame (25p)", f)
+	}
+}
+
+// The 50p promotion only applies to interlaced transcodes — progressive and
+// copy/passthrough never promote (these return before the host benchmark is even
+// consulted, so they are deterministic without benchmark state). Guards against
+// over-reaching to non-interlaced or copy streams.
+func TestShouldPromote50p_RequiresInterlacedTranscode(t *testing.T) {
+	a := &LocalAdapter{Logger: zerolog.Nop()}
+
+	progressive := liveTranscodeSpec(ports.RuntimeModeHQ25)
+	progressive.Profile.Deinterlace = false
+	if a.shouldPromoteInterlacedTo50p(progressive) {
+		t.Fatal("progressive source must never promote to 50p")
+	}
+
+	copyStream := liveTranscodeSpec(ports.RuntimeModeHQ25)
+	copyStream.Profile.TranscodeVideo = false
+	if a.shouldPromoteInterlacedTo50p(copyStream) {
+		t.Fatal("copy/passthrough must never promote to 50p")
+	}
+
+	vod := liveTranscodeSpec(ports.RuntimeModeHQ25)
+	vod.Mode = ports.ModeRecording
+	if a.shouldPromoteInterlacedTo50p(vod) {
+		t.Fatal("non-live must never promote to 50p")
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/plan_input.go
+++ b/backend/internal/infra/media/ffmpeg/plan_input.go
@@ -387,6 +387,9 @@ func targetLiveOutputFPS(spec ports.StreamSpec) int {
 	if !spec.Profile.TranscodeVideo {
 		return 0
 	}
+	// HQ50 must NOT clamp the framerate: the send_field bob deinterlace already
+	// emits native 50fps and -force_key_frames keeps segment boundaries aligned
+	// (time-based). Only HQ25 pins -r 25.
 	if effectiveLiveRuntimeMode(spec.Profile) != ports.RuntimeModeHQ25 {
 		return 0
 	}

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -3,7 +3,10 @@ package ffmpeg
 import (
 	"context"
 	"fmt"
+	"github.com/ManuGH/xg2g/internal/domain/playbackprofile"
+	playbackports "github.com/ManuGH/xg2g/internal/domain/playbackprofile/ports"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
 	"github.com/ManuGH/xg2g/internal/pipeline/profiles"
 	"math"
 	"os"
@@ -18,6 +21,13 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 		return outputPlan{}, err
 	}
 	spec.Profile.VideoCodec = codec.resolvedCodec
+	if a.shouldPromoteInterlacedTo50p(spec) {
+		// Host benchmarked strong enough to sustain the doubled encode load, so
+		// keep the full motion of the interlaced source instead of collapsing 50
+		// fields to 25p. The existing send_field deinterlace + targetLiveOutputFPS
+		// (HQ50) then emit true 50p. EffectiveRuntimeMode wins over PolicyModeHint.
+		spec.Profile.EffectiveRuntimeMode = ports.RuntimeModeHQ50
+	}
 	// Use the pre-sanitisation URL so ffprobe/warmup probes can authenticate
 	// against protected sources.  adjustLiveFPSForRuntimeServiceOverride only
 	// extracts the service ref from the URL structure and works correctly with
@@ -59,6 +69,27 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 	out.effectiveProfile.HWAccel = resolvedExecutedHWAccel(codec)
 
 	return out, nil
+}
+
+// shouldPromoteInterlacedTo50p reports whether an interlaced live transcode
+// should preserve full 50-field motion (50p) instead of the safe-default 25p.
+// We only promote when the host's startup benchmark for the 1080i50 profile came
+// back "strong" (encoder fast enough to sustain the doubled framerate). Moderate
+// or weak hosts stay at 25p so a 50p transcode can never overload them. The
+// interlaced flag comes from the scan (Deinterlace=true), so this is capability-
+// gated, not guesswork.
+func (a *LocalAdapter) shouldPromoteInterlacedTo50p(spec ports.StreamSpec) bool {
+	if spec.Mode != ports.ModeLive || spec.Format != ports.FormatHLS {
+		return false
+	}
+	if !spec.Profile.TranscodeVideo || !spec.Profile.Deinterlace {
+		return false
+	}
+	class := playbackprofile.BenchmarkClassForProfile(
+		hardware.SnapshotHostBenchmark(),
+		playbackports.BenchmarkProfileVideoH2641080I50,
+	)
+	return class == "strong"
 }
 
 func (a *LocalAdapter) planLiveSegmentLayout(spec ports.StreamSpec) (liveSegmentLayout, error) {

--- a/backend/internal/pipeline/hardware/benchmark_summary.go
+++ b/backend/internal/pipeline/hardware/benchmark_summary.go
@@ -13,6 +13,13 @@ const (
 	hostBenchmarkClassStrong   = "strong"
 )
 
+// SnapshotHostBenchmark exposes the current host encode-benchmark snapshot to
+// callers outside this package (e.g. the ffmpeg adapter deciding whether the
+// host can sustain a 50fps deinterlace).
+func SnapshotHostBenchmark() playbackprofile.HostBenchmarkSnapshot {
+	return snapshotHostBenchmark()
+}
+
 func snapshotHostBenchmark() playbackprofile.HostBenchmarkSnapshot {
 	codecs := []string{"h264", "hevc", "av1"}
 	results := make([]playbackprofile.HostCodecBenchmark, 0, len(codecs))


### PR DESCRIPTION
## What
Interlaced broadcast (1080i25 = 50 fields/s) was deinterlaced to **25p** (HQ25 → send_frame), discarding half the motion → judder on sports/motion. The host already benchmarks 1080i50 encode capability at startup, and the 50p machinery (HQ50 → send_field + unclamped framerate) already exists for AV1 — the capability was measured then ignored for the general path.

Now an interlaced live transcode is promoted to **HQ50 (50p)** when the startup host benchmark for `video_h264_1080i50` is `strong`. Moderate/weak hosts stay at the safe 25p. Interlaced flag comes from the scan (`Deinterlace=true`) → capability-gated, not guesswork.

## Verified on staging
Favorite channel (1080i25 H.264 → AV1 transcode), host benchmarked `strong`:
- source: `top first, 25 fps, 50 tbr`
- output: **`r_frame_rate=50/1`** (true 50p)
- `effective_runtime_mode: hq50`, plays clean.

## Safety
Reuses existing parts (send_field deinterlace + HQ50 no-clamp from the AV1 path + `SnapshotHostBenchmark`). Progressive/copy untouched; weak hosts stay 25p. Tests cover HQ50/HQ25 mechanics + gate preconditions with negative controls; full ffmpeg+hardware suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)