### PR TITLE
chore(ffmpeg): sharpen two live-transcode defaults + tuning doc

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter.go
+++ b/backend/internal/infra/media/ffmpeg/adapter.go
@@ -147,12 +147,14 @@ func NewLocalAdapter(binPath string, ffprobeBin string, hlsRoot string, e2 *enig
 		liveProbeSize = "1M" // 1MB for low-latency live ingest
 	}
 	// Stream-relay transcode inputs need a deeper probe than the general live
-	// default; 10s is conservative but visible at startup. Overridable so a
-	// fleet can dial it down once verified (e.g. 3s cut ffmpeg→first-frame from
-	// ~12s to ~4s on a 4K relay with no detection errors).
+	// default to resolve dimensions/audio. 5s is the sharpened default: it
+	// roughly halves the relay-transcode startup wait vs the old 10s while
+	// keeping margin for slower/burstier relays. (3s was verified clean on a 4K
+	// relay.) Raise XG2G_STREAMRELAY_ANALYZE_DURATION if a relay needs deeper
+	// probing; lower it (e.g. 3000000) for the fastest start.
 	streamRelayAnalyzeDuration := strings.TrimSpace(config.ParseString("XG2G_STREAMRELAY_ANALYZE_DURATION", ""))
 	if streamRelayAnalyzeDuration == "" {
-		streamRelayAnalyzeDuration = "10000000" // 10s
+		streamRelayAnalyzeDuration = "5000000" // 5s
 	}
 	streamRelayProbeSize := strings.TrimSpace(config.ParseString("XG2G_STREAMRELAY_PROBE_SIZE", ""))
 	if streamRelayProbeSize == "" {

--- a/backend/internal/infra/media/ffmpeg/adapter_args_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_args_test.go
@@ -1563,7 +1563,7 @@ func TestBuildArgs_StreamRelayTranscodeUsesRobustLiveProbe(t *testing.T) {
 
 	analyze, ok := valueAfter(args, "-analyzeduration")
 	require.True(t, ok)
-	assert.Equal(t, "10000000", analyze)
+	assert.Equal(t, "5000000", analyze)
 
 	probe, ok := valueAfter(args, "-probesize")
 	require.True(t, ok)

--- a/backend/internal/infra/media/ffmpeg/av1_qvbr_test.go
+++ b/backend/internal/infra/media/ffmpeg/av1_qvbr_test.go
@@ -30,7 +30,7 @@ func TestAppendVaapiRateControlArgs_AV1QVBR(t *testing.T) {
 
 		gq, ok := valueAfter(args, "-global_quality")
 		assert.True(t, ok)
-		assert.Equal(t, "110", gq, "default quality target")
+		assert.Equal(t, "90", gq, "default quality target")
 
 		assert.Contains(t, args, "-async_depth")
 	})

--- a/backend/internal/infra/media/ffmpeg/encode_args.go
+++ b/backend/internal/infra/media/ffmpeg/encode_args.go
@@ -238,7 +238,11 @@ func appendVaapiRateControlArgs(args []string, prof ports.ProfileSpec, outputCod
 			args = append(args, "-bufsize", fmt.Sprintf("%dk", prof.VideoBufSizeK))
 		}
 		if av1QVBR {
-			args = append(args, "-global_quality", strconv.Itoa(envIntBounded("XG2G_AV1_QVBR_QUALITY", 110, 1, 255)))
+			// Default 90 (sharpened from 110): a higher AV1 quality target that
+			// the VideoMaxRateK ceiling still bounds, so it spends the available
+			// bitrate on visibly cleaner motion. Lower XG2G_AV1_QVBR_QUALITY for
+			// even higher quality (more bitrate); raise it to save bandwidth.
+			args = append(args, "-global_quality", strconv.Itoa(envIntBounded("XG2G_AV1_QVBR_QUALITY", 90, 1, 255)))
 		}
 		if isAV1 {
 			args = append(args, "-async_depth", "1")

--- a/deploy/PERFORMANCE_TUNING.md
+++ b/deploy/PERFORMANCE_TUNING.md
@@ -1,0 +1,56 @@
+# Performance & Quality Tuning
+
+xg2g's live-transcode defaults are chosen to be **safe for any deployment** shipped
+via GitHub (unknown relays, hosts, bandwidth). A few env vars let you trade startup
+latency / bitrate / robustness for your specific setup.
+
+## Sharpened defaults (no config needed)
+
+These ship on by default now — they are a bit more aggressive than the old
+ultra-conservative values, but still safe for typical broadcast sources:
+
+| What | Old | Now | Effect |
+|---|---|---|---|
+| Stream-relay transcode probe | 10s | **5s** | ~halves channel start time; detection stays correct on normal broadcast TS |
+| AV1 quality target (QVBR) | 110 | **90** | spends more of the available bitrate on cleaner motion (still bounded by the maxrate ceiling) |
+| 50p motion (interlaced) | — | **auto** | enabled when the host benchmark can sustain it; weak hosts stay 25p (no overload) |
+
+The 50p host-gate and the configurable startup probe are **code** (apply
+automatically once you update the image). The values below are **deployment env
+tuning** — set them per install.
+
+## Optional tuning
+
+| Env | Default | Lower → | Raise → |
+|---|---|---|---|
+| `XG2G_STREAMRELAY_ANALYZE_DURATION` | `5000000` (5s) | faster start (e.g. `3000000` for fast relays) | safer detection for slow/bursty relays |
+| `XG2G_AV1_QVBR_QUALITY` | `90` (scale 1–255) | higher quality, more bitrate (e.g. `25`) | lower bitrate |
+| `XG2G_SAFARI_HQ50_MAXRATE_K` | `12000–14000` (resolution-scaled) | — | higher quality ceiling for demanding channels (needs the bandwidth) |
+| `XG2G_SAFARI_HQ50_BUFSIZE_K` | `2× maxrate` | — | smoother / more consistent bit allocation (e.g. `3× maxrate`) |
+
+## Recommended profiles
+
+**Home LAN / WireGuard, bandwidth not a constraint — maximum quality**
+(verified: AV1 1080p50 10-bit, ~12 Mbit/s avg, smooth):
+```
+XG2G_STREAMRELAY_ANALYZE_DURATION=3000000
+XG2G_AV1_QVBR_QUALITY=25
+XG2G_SAFARI_HQ50_BUFSIZE_K=44000
+```
+
+**Bandwidth-constrained / remote over a slow link — keep it lean:**
+```
+# leave the defaults; optionally raise QVBR to spend fewer bits
+XG2G_AV1_QVBR_QUALITY=110
+```
+
+## Honest trade-offs
+
+- **Lower QVBR / higher maxrate = more bitrate** — free on a LAN, but can rebuffer
+  over a slow remote link. The maxrate ceiling bounds the peak either way.
+- **Shorter analyze duration = faster start, less margin** — `3000000` was verified
+  clean on a 4K relay, but a slow/bursty relay may need the `5000000` default (or
+  more) to resolve dimensions/audio reliably.
+- **There is no ABR ladder yet**: a single rendition is served, so a congested
+  network rebuffers instead of downshifting. Keep the bitrate within the link's
+  sustained throughput.


### PR DESCRIPTION
## What
Modest, evidence-backed sharpening of two shipped defaults (still safe for any GitHub deployment), plus a short tuning doc.

- **Stream-relay transcode probe `10s -> 5s`** — ~halves relay-transcode startup; 3s was verified clean on a 4K relay, 5s keeps margin for slower relays.
- **AV1 QVBR quality `110 -> 90`** — higher quality target, still bounded by the maxrate ceiling → cleaner motion at the available bitrate.
- **Bufsize default left at 2× maxrate** (the 3× value was an unproven hypothesis) → documented as optional tuning instead.

## Doc
`deploy/PERFORMANCE_TUNING.md`: the sharpened defaults, the optional env knobs (`XG2G_STREAMRELAY_ANALYZE_DURATION`, `XG2G_AV1_QVBR_QUALITY`, `XG2G_SAFARI_HQ50_MAXRATE_K/BUFSIZE_K`) with honest trade-offs, and two recommended profiles (free-bandwidth LAN max-quality vs bandwidth-constrained).

Tests updated for the new defaults; full ffmpeg+config suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)