### PR TITLE
fix(layering): move benchmark-class helpers to ports so infra can import safely

### DIFF
--- a/backend/internal/domain/playbackprofile/benchmark.go
+++ b/backend/internal/domain/playbackprofile/benchmark.go
@@ -2,7 +2,6 @@ package playbackprofile
 
 import (
 	"github.com/ManuGH/xg2g/internal/domain/playbackprofile/ports"
-	"github.com/ManuGH/xg2g/internal/normalize"
 )
 
 const (
@@ -16,44 +15,12 @@ const (
 
 // BenchmarkClassForCodec returns the most specific measured benchmark class for a codec.
 // If no codec-specific benchmark exists, it falls back to the aggregate benchmark class.
-func BenchmarkClassForCodec(snapshot HostBenchmarkSnapshot, codec string) string {
-	codec = normalize.Token(codec)
-	fallback := normalize.Token(snapshot.Class)
-	if codec == "" {
-		return fallback
-	}
-
-	for _, benchmark := range snapshot.Codecs {
-		if normalize.Token(benchmark.Codec) != codec {
-			continue
-		}
-		if class := normalize.Token(benchmark.Class); class != "" {
-			return class
-		}
-		break
-	}
-
-	return fallback
+func BenchmarkClassForCodec(snapshot ports.HostBenchmarkSnapshot, codec string) string {
+	return ports.BenchmarkClassForCodec(snapshot, codec)
 }
 
 // BenchmarkClassForProfile returns the most specific benchmark class for a transcode profile.
 // If no profile-specific benchmark exists, it falls back to the aggregate benchmark class.
-func BenchmarkClassForProfile(snapshot HostBenchmarkSnapshot, profileID string) string {
-	profileID = normalize.Token(profileID)
-	fallback := normalize.Token(snapshot.Class)
-	if profileID == "" {
-		return fallback
-	}
-
-	for _, benchmark := range snapshot.Profiles {
-		if normalize.Token(benchmark.ProfileID) != profileID {
-			continue
-		}
-		if class := normalize.Token(benchmark.Class); class != "" {
-			return class
-		}
-		break
-	}
-
-	return fallback
+func BenchmarkClassForProfile(snapshot ports.HostBenchmarkSnapshot, profileID string) string {
+	return ports.BenchmarkClassForProfile(snapshot, profileID)
 }

--- a/backend/internal/domain/playbackprofile/ports/benchmark.go
+++ b/backend/internal/domain/playbackprofile/ports/benchmark.go
@@ -4,6 +4,8 @@
 
 package ports
 
+import "github.com/ManuGH/xg2g/internal/normalize"
+
 const (
 	BenchmarkProfileAudioAACStereo   = "audio_aac_stereo"
 	BenchmarkProfileVideoH2641080P   = "video_h264_1080p"
@@ -12,3 +14,47 @@ const (
 	BenchmarkProfileVideoH2642160P   = "video_h264_2160p"
 	BenchmarkProfileVideoH2642160P50 = "video_h264_2160p50"
 )
+
+// BenchmarkClassForCodec returns the most specific measured benchmark class for a codec.
+// If no codec-specific benchmark exists, it falls back to the aggregate benchmark class.
+func BenchmarkClassForCodec(snapshot HostBenchmarkSnapshot, codec string) string {
+	codec = normalize.Token(codec)
+	fallback := normalize.Token(snapshot.Class)
+	if codec == "" {
+		return fallback
+	}
+
+	for _, benchmark := range snapshot.Codecs {
+		if normalize.Token(benchmark.Codec) != codec {
+			continue
+		}
+		if class := normalize.Token(benchmark.Class); class != "" {
+			return class
+		}
+		break
+	}
+
+	return fallback
+}
+
+// BenchmarkClassForProfile returns the most specific benchmark class for a transcode profile.
+// If no profile-specific benchmark exists, it falls back to the aggregate benchmark class.
+func BenchmarkClassForProfile(snapshot HostBenchmarkSnapshot, profileID string) string {
+	profileID = normalize.Token(profileID)
+	fallback := normalize.Token(snapshot.Class)
+	if profileID == "" {
+		return fallback
+	}
+
+	for _, benchmark := range snapshot.Profiles {
+		if normalize.Token(benchmark.ProfileID) != profileID {
+			continue
+		}
+		if class := normalize.Token(benchmark.Class); class != "" {
+			return class
+		}
+		break
+	}
+
+	return fallback
+}

--- a/backend/internal/infra/media/ffmpeg/runtime_hardening.go
+++ b/backend/internal/infra/media/ffmpeg/runtime_hardening.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ManuGH/xg2g/internal/config"
-	"github.com/ManuGH/xg2g/internal/domain/playbackprofile"
 	playbackports "github.com/ManuGH/xg2g/internal/domain/playbackprofile/ports"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/ManuGH/xg2g/internal/pipeline/hardware"
@@ -211,7 +210,7 @@ func (a *LocalAdapter) hostBenchmarkClass(profileID string) string {
 	if a.hostBenchmarkClassFn != nil {
 		return a.hostBenchmarkClassFn(profileID)
 	}
-	return playbackprofile.BenchmarkClassForProfile(hardware.SnapshotHostBenchmark(), profileID)
+	return playbackports.BenchmarkClassForProfile(hardware.SnapshotHostBenchmark(), profileID)
 }
 
 func (a *LocalAdapter) evaluateAdaptiveTranscodeQualityHardening(_ context.Context, spec ports.StreamSpec, inputURL string) runtimeHardeningDecision {


### PR DESCRIPTION
## Problem

CI Nightly `TestLayeringRules` fails with:

```
--- FAIL: TestLayeringRules (0.04s)
    imports_test.go:91: Layering violations detected:
          ❌ internal/infra/media/ffmpeg/runtime_hardening.go imports github.com/ManuGH/xg2g/internal/domain/playbackprofile
             Reason: Infra layer must not import domain logic (except domain/*/ports and domain/vod types)
```

The infra layer in `runtime_hardening.go` was importing `domain/playbackprofile` solely to call `BenchmarkClassForProfile`.

## Fix

Move `BenchmarkClassForCodec` + `BenchmarkClassForProfile` into the existing `playbackprofile/ports` package, which already owns `HostBenchmarkSnapshot` and the profile-ID constants. The domain package re-exports them as thin wrappers, so all existing control-layer callers remain unchanged.

The infra caller now imports `playbackprofile/ports` (already on the layering allowlist) instead of `playbackprofile`.

Closes #563.