### PR TITLE
fix: config-interval startup panics + trivy config scan (ultrareview PR 1)

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -73,26 +73,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # Latest stable
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Build production image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        env:
-          SOURCE_DATE_EPOCH: "0"
-        with:
-          context: .
-          file: ./Dockerfile
-          push: false
-          load: true
-          tags: xg2g:${{ github.sha }}
-          provenance: false
-
       - name: Run Trivy config scanner
+        # `trivy config` is a filesystem/IaC misconfig scanner: it must scan the
+        # build context (Dockerfile etc.), NOT a built image ref. Passing
+        # image-ref here made it run `trivy config xg2g:<sha>`, which lstat-failed
+        # on the non-path ref and reddened this job on every release tag.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
-          image-ref: xg2g:${{ github.sha }}
           scan-type: "config"
+          scan-ref: "."
           format: "table"
           output: "trivy-config.txt"
           exit-code: "0"

--- a/backend/internal/config/validation.go
+++ b/backend/internal/config/validation.go
@@ -577,6 +577,17 @@ func validateEngineAndResilience(v *validate.Validator, cfg AppConfig) {
 		v.AddError("Limits.MaxTranscodes", "must be >= 0", cfg.Limits.MaxTranscodes)
 	}
 
+	// These intervals feed time.NewTicker, which panics on a non-positive
+	// duration. Reject bad values at config-load instead of crashing the worker
+	// at startup. Sessions.ExpiryCheckInterval treats 0 as "use default", so
+	// only a negative value is rejected there.
+	if cfg.Verification.Enabled && cfg.Verification.Interval <= 0 {
+		v.AddError("Verification.Interval", "must be > 0 when verification is enabled", cfg.Verification.Interval)
+	}
+	if cfg.Sessions.ExpiryCheckInterval < 0 {
+		v.AddError("Sessions.ExpiryCheckInterval", "must be >= 0 (0 = use default)", cfg.Sessions.ExpiryCheckInterval)
+	}
+
 	if cfg.Timeouts.TranscodeStart <= 0 {
 		v.AddError("Timeouts.TranscodeStart", "must be > 0", cfg.Timeouts.TranscodeStart)
 	}

--- a/backend/internal/config/validation_intervals_test.go
+++ b/backend/internal/config/validation_intervals_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These guard the two interval fields that flow into time.NewTicker
+// (Verification worker, lease-expiry worker), which panics on a non-positive
+// duration. Validation must reject the bad value instead of crashing at startup.
+
+func TestValidate_VerificationIntervalMustBePositiveWhenEnabled(t *testing.T) {
+	for _, d := range []time.Duration{0, -1 * time.Minute} {
+		cfg := baseV3Config(t)
+		cfg.Verification.Enabled = true
+		cfg.Verification.Interval = d
+
+		err := Validate(cfg)
+		require.Error(t, err, "interval %s must be rejected", d)
+		require.Contains(t, err.Error(), "Verification.Interval")
+	}
+}
+
+func TestValidate_VerificationIntervalIgnoredWhenDisabled(t *testing.T) {
+	// Disabled verification never starts the worker, so a zero interval is fine.
+	cfg := baseV3Config(t)
+	cfg.Verification.Enabled = false
+	cfg.Verification.Interval = 0
+
+	require.NoError(t, Validate(cfg))
+}
+
+func TestValidate_VerificationIntervalPositiveOK(t *testing.T) {
+	cfg := baseV3Config(t)
+	cfg.Verification.Enabled = true
+	cfg.Verification.Interval = 60 * time.Second
+
+	require.NoError(t, Validate(cfg))
+}
+
+func TestValidate_SessionExpiryIntervalRejectsNegative(t *testing.T) {
+	cfg := baseV3Config(t)
+	cfg.Sessions.ExpiryCheckInterval = -1 * time.Second
+
+	err := Validate(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Sessions.ExpiryCheckInterval")
+}
+
+func TestValidate_SessionExpiryIntervalZeroAllowed(t *testing.T) {
+	// 0 is the documented "use default" sentinel honored by the lease worker.
+	cfg := baseV3Config(t)
+	cfg.Sessions.ExpiryCheckInterval = 0
+
+	require.NoError(t, Validate(cfg))
+}

--- a/backend/internal/domain/session/manager/lease_expiry.go
+++ b/backend/internal/domain/session/manager/lease_expiry.go
@@ -31,8 +31,13 @@ type LeaseExpiryWorker struct {
 // Run starts the lease expiry check loop
 // ADR-009: CTO Patch 2/3 compliant (efficient query, multi-state expiry)
 func (w *LeaseExpiryWorker) Run(ctx context.Context) error {
-	// CTO Patch 1: Use config-driven interval (not hardcoded)
-	interval := w.Config.Sessions.ExpiryCheckInterval
+	// CTO Patch 1: Use config-driven interval (not hardcoded).
+	// Guard against nil Config to avoid a startup panic if the worker is
+	// constructed without a config (e.g. in tests or from alternate paths).
+	var interval time.Duration
+	if w.Config != nil {
+		interval = w.Config.Sessions.ExpiryCheckInterval
+	}
 	if interval <= 0 {
 		// 0 means "use default"; a negative value would panic time.NewTicker.
 		interval = 10 * time.Second

--- a/backend/internal/domain/session/manager/lease_expiry.go
+++ b/backend/internal/domain/session/manager/lease_expiry.go
@@ -33,7 +33,8 @@ type LeaseExpiryWorker struct {
 func (w *LeaseExpiryWorker) Run(ctx context.Context) error {
 	// CTO Patch 1: Use config-driven interval (not hardcoded)
 	interval := w.Config.Sessions.ExpiryCheckInterval
-	if interval == 0 {
+	if interval <= 0 {
+		// 0 means "use default"; a negative value would panic time.NewTicker.
 		interval = 10 * time.Second
 	}
 

--- a/backend/internal/domain/session/manager/lease_expiry_test.go
+++ b/backend/internal/domain/session/manager/lease_expiry_test.go
@@ -118,3 +118,36 @@ func TestLeaseExpiryWorker_TerminalizesNewSessionsWithoutPublish(t *testing.T) {
 	assert.Equal(t, "LEASE_EXPIRED", gotExpired.StopReason)
 	assert.Empty(t, bus.topics)
 }
+
+func TestLeaseExpiryWorker_NilConfigDoesNotPanic(t *testing.T) {
+	// The review thread identified a potential nil-pointer dereference when
+	// w.Config is nil. Verify that Run() recovers with the default interval
+	// instead of panicking, and that expireStaleSessions also works without
+	// a Config.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	st := store.NewMemoryStore()
+	bus := &recordedStopEventBus{}
+
+	worker := &LeaseExpiryWorker{
+		Store:  st,
+		Bus:    bus,
+		Config: nil,
+	}
+
+	// expireStaleSessions must not panic with nil Config.
+	require.NotPanics(t, func() {
+		worker.expireStaleSessions(ctx)
+	})
+
+	// Run must not panic with nil Config; it should default to 10s.
+	// Use an already-canceled context so Run returns immediately.
+	cancelledCtx, cancel2 := context.WithCancel(context.Background())
+	cancel2() // cancel immediately
+
+	require.NotPanics(t, func() {
+		err := worker.Run(cancelledCtx)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/backend/internal/verification/worker.go
+++ b/backend/internal/verification/worker.go
@@ -45,6 +45,11 @@ var (
 
 // NewWorker creates a new verification worker.
 func NewWorker(store Store, cadence time.Duration, checkers ...Checker) *Worker {
+	// Defense-in-depth: time.NewTicker panics on a non-positive cadence.
+	// Config validation rejects this, but keep the worker safe in isolation.
+	if cadence <= 0 {
+		cadence = 60 * time.Second
+	}
 	w := &Worker{
 		store:      store,
 		cadence:    cadence,


### PR DESCRIPTION
**PR 1 of the post-v3.7.0 ultrareview fix bundle** — the mechanical, low-risk quick wins. Each finding was adversarially verified (≥2/3 lenses) in the review and re-ground-truthed against the code here.

## #3 — `XG2G_VERIFY_INTERVAL` ≤ 0 panics the verification worker at startup (HIGH)
`merge_env.go:320` parses the env via `envDuration` (accepts `0s`/negative); `Validate()` never checked it; `verification/worker.go` does `time.NewTicker(cadence)` which **panics on a non-positive duration**. Verification defaults on (`XG2G_VERIFY_ENABLED=true`), so a misconfigured `0s` crashes the process on boot.
**Fix:** `Validate()` rejects `Verification.Interval <= 0` when enabled; `NewWorker` clamps to 60s defensively.

## #4 — negative `XG2G_SESSION_EXPIRY_CHECK_INTERVAL` panics the lease-expiry worker (HIGH)
Same `time.NewTicker` panic. The runtime guard in `lease_expiry.go` only caught `== 0`, not `< 0`, so a negative value reached the ticker.
**Fix:** `Validate()` rejects negative; the worker guard widened to `<= 0` (0 stays the documented *use default 10s* sentinel, so valid configs are unaffected).

## #8 — `Scan Image Configuration` fails on every release tag (HIGH, chronic)
The job ran `trivy config` (a **filesystem/IaC** misconfig scanner) against `image-ref: xg2g:<sha>`. The pinned trivy-action passes the image ref as the scan path, `lstat` fails on the non-path, and the job has been red on **every** `v*` tag v3.4.5..v3.7.0. The real vuln scans (production container, SBOM, secrets) were unaffected — this was never a CVE.
**Fix:** scan the build context (`scan-type: config`, `scan-ref: "."`); the image build + buildx steps existed only to feed the bad image-ref and are removed. (No other job `needs:` this one.)

## Verification
- New `validation_intervals_test.go` covers reject (0/negative) + accept (positive, disabled, 0-sentinel) cases.
- **Negative control:** with `validation.go` stashed, both reject tests go red (`error expected but got nil`); restored → green.
- `go test` green for `config`, `verification`, `session/manager`; `gofmt`/`go vet` clean; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)