### PR TITLE
fix(ffmpeg): stop counting normal stops as GPU runtime failures (ultrareview PR 2)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter_process.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_process.go
@@ -206,6 +206,20 @@ func (a *LocalAdapter) ExecutedFFmpegPlan(handle ports.RunHandle) (ports.Execute
 	return plan, true
 }
 
+// shouldRecordHWRuntimeFailure reports whether a finished ffmpeg process should
+// count as a hardware-encoder runtime failure for the sticky GPU->CPU demotion
+// counter. Only a process that exited on its own (naturalExit) with a non-zero
+// status AND that emitted a recognized encoder failure line qualifies. A
+// deliberate stop (parentCtx cancel) or a watchdog stall termination kills the
+// process too — procErr is non-nil in those cases — but that is not evidence
+// the encoder failed, so it must not feed the demotion counter.
+func shouldRecordHWRuntimeFailure(naturalExit bool, procErr error, runtimeFailureLine string) bool {
+	if runtimeFailureLine == "" {
+		return false
+	}
+	return naturalExit && procErr != nil
+}
+
 func (a *LocalAdapter) monitorProcessWithStartTimeout(parentCtx context.Context, handle ports.RunHandle, cmd *exec.Cmd, stderr io.ReadCloser, sessionID string, hwBackend profiles.GPUBackend, pathID string, startTimeout time.Duration, startupSpan trace.Span, spawnedAt time.Time) {
 	defer func() {
 		a.mu.Lock()
@@ -327,10 +341,15 @@ func (a *LocalAdapter) monitorProcessWithStartTimeout(parentCtx context.Context,
 	var procErr error
 	var resultErr error
 	watchdogConsumed := false
+	// naturalExit is true only when ffmpeg terminated on its own — not killed by
+	// the watchdog or a user-initiated stop. Only a natural exit is evidence of
+	// an encoder failure for the sticky GPU->CPU demotion counter.
+	naturalExit := false
 
 	select {
 	case procErr = <-procErrCh:
 		resultErr = procErr
+		naturalExit = true
 	case wdErr := <-wdErrCh:
 		watchdogConsumed = true
 		if wdErr != nil {
@@ -344,6 +363,7 @@ func (a *LocalAdapter) monitorProcessWithStartTimeout(parentCtx context.Context,
 		}
 		procErr = <-procErrCh
 		resultErr = procErr
+		naturalExit = true
 	case <-parentCtx.Done():
 		a.terminateProcessGroup(cmd, sessionID)
 		procErr = <-procErrCh
@@ -364,7 +384,7 @@ func (a *LocalAdapter) monitorProcessWithStartTimeout(parentCtx context.Context,
 
 	<-scanDone
 
-	if runtimeFailureLine != "" && (procErr != nil || resultErr != nil) {
+	if shouldRecordHWRuntimeFailure(naturalExit, procErr, runtimeFailureLine) {
 		switch hwBackend {
 		case profiles.GPUBackendVAAPI:
 			a.recordVAAPIRuntimeFailure(sessionID, runtimeFailureLine)

--- a/backend/internal/infra/media/ffmpeg/adapter_process_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_process_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A normal user stop or watchdog termination kills ffmpeg (procErr != nil) and
+// may carry a latched transient vaapi/nvenc warning line, but that is NOT an
+// encoder failure and must not feed the sticky GPU->CPU demotion counter.
+func TestShouldRecordHWRuntimeFailure(t *testing.T) {
+	exitErr := errors.New("exit status 1")
+	const failLine = "vaapi: encode failed"
+
+	cases := []struct {
+		name        string
+		naturalExit bool
+		procErr     error
+		failureLine string
+		want        bool
+	}{
+		{"natural non-zero exit with failure line records", true, exitErr, failLine, true},
+		{"natural clean exit (code 0) does not record", true, nil, failLine, false},
+		{"no failure line never records", true, exitErr, "", false},
+		{"user-initiated stop does not record", false, exitErr, failLine, false},
+		{"watchdog stall termination does not record", false, exitErr, failLine, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldRecordHWRuntimeFailure(tc.naturalExit, tc.procErr, tc.failureLine))
+		})
+	}
+}


### PR DESCRIPTION
**PR 2 of the post-v3.7.0 ultrareview fix bundle** — the highest real-world blast radius of the set.

## #2 — normal stop / watchdog cancel demotes the host GPU→CPU (HIGH)
`monitorProcessWithStartTimeout` (adapter_process.go) ends with:
```go
if runtimeFailureLine != "" && (procErr != nil || resultErr != nil) { recordVAAPI/NVENCRuntimeFailure(...) }
```
`procErr` is non-nil in **all** termination paths, including the two deliberate ones:
- **user stop** — `case <-parentCtx.Done()` kills the process group, `resultErr = parentCtx.Err()`;
- **watchdog stall** — kills the process, `resultErr = wdErr`.

`isVAAPIRuntimeFailureLine` latches on any stderr line containing `vaapi` + a warning token, so a stream that emitted a *transient, non-fatal* warning and is then simply **stopped by the user** is recorded as a confirmed hardware failure. `recordVAAPIRuntimeFailure` bumps a monotonic counter reset **only** by a full startup preflight; at threshold 3 it clears all VAAPI caps and demotes the host to CPU **until restart**. A few normal stops → fleet-wide loss of hardware transcode.

## Fix
Track `naturalExit` (true only when ffmpeg terminated on its own — the `procErrCh` branch and the watchdog-returned-nil branch; false for user stop and watchdog stall) and extract the decision into a pure, unit-testable function:
```go
func shouldRecordHWRuntimeFailure(naturalExit bool, procErr error, runtimeFailureLine string) bool {
    if runtimeFailureLine == "" { return false }
    return naturalExit && procErr != nil
}
```
Only a self-terminated, non-zero exit with a recognized failure line now feeds the demotion counter. (Genuinely broken hardware is still caught by the startup preflight path, which is unchanged.) On a natural exit `resultErr == procErr`, so no real failure is lost.

## Verification
- New table test `TestShouldRecordHWRuntimeFailure` covers record / clean-exit / no-line / user-stop / watchdog cases.
- **Negative control:** stripping `naturalExit &&` reddens exactly the *user-stop* and *watchdog* cases.
- Full `internal/infra/media/ffmpeg` suite green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)