### PR TITLE
fix(recordings): count black-render code 242 as a decode warning (ultrareview PR 3)

### DIFF
--- a/backend/internal/control/http/v3/recordings/feedback_policy.go
+++ b/backend/internal/control/http/v3/recordings/feedback_policy.go
@@ -406,7 +406,7 @@ func buildPlaybackConfidenceWindowsFromObservations(observations []capreg.Playba
 			if confidenceIsBufferingWarningCode(observation.FeedbackCode) {
 				current.feature.BufferWarnings++
 			}
-			if confidenceIsDecodeWarningCode(observation.FeedbackCode) {
+			if capreg.IsDecodeWarningCode(observation.FeedbackCode) {
 				current.feature.DecodeWarnings++
 			}
 			if confidenceIsNetworkWarningCode(observation.FeedbackCode) {
@@ -496,20 +496,6 @@ func allocatePlaybackConfidenceCleanMS(buckets map[int64]*playbackConfidenceBuck
 func confidenceIsBufferingWarningCode(code int) bool {
 	switch code {
 	case 101, 102:
-		return true
-	default:
-		return false
-	}
-}
-
-func confidenceIsDecodeWarningCode(code int) bool {
-	// Keep in lock-step with capreg.isDecodeWarningCode. 103 is a generic decode
-	// warning; 242 is the HLS.js black-render code (playbackInfoCodeHLSJSRenderBlack)
-	// — a decode failure surfaced by the player. The windowed confidence engine
-	// must count it as a decode warning so repeated black-screening sets
-	// ConstraintNoProbeUp instead of letting the engine probe up.
-	switch code {
-	case 103, 242:
 		return true
 	default:
 		return false

--- a/backend/internal/control/http/v3/recordings/feedback_policy.go
+++ b/backend/internal/control/http/v3/recordings/feedback_policy.go
@@ -503,7 +503,17 @@ func confidenceIsBufferingWarningCode(code int) bool {
 }
 
 func confidenceIsDecodeWarningCode(code int) bool {
-	return code == 103
+	// Keep in lock-step with capreg.isDecodeWarningCode. 103 is a generic decode
+	// warning; 242 is the HLS.js black-render code (playbackInfoCodeHLSJSRenderBlack)
+	// — a decode failure surfaced by the player. The windowed confidence engine
+	// must count it as a decode warning so repeated black-screening sets
+	// ConstraintNoProbeUp instead of letting the engine probe up.
+	switch code {
+	case 103, 242:
+		return true
+	default:
+		return false
+	}
 }
 
 func confidenceIsNetworkWarningCode(code int) bool {

--- a/backend/internal/control/http/v3/recordings/feedback_policy_decode242_test.go
+++ b/backend/internal/control/http/v3/recordings/feedback_policy_decode242_test.go
@@ -14,14 +14,29 @@ import (
 )
 
 // Code 242 is the HLS.js black-render decode failure. The windowed confidence
-// engine must classify it as a decode warning (in lock-step with
-// capreg.isDecodeWarningCode), otherwise repeated black-screening never sets
+// engine must classify it as a decode warning (delegated to exported
+// capreg.IsDecodeWarningCode), otherwise repeated black-screening never sets
 // ConstraintNoProbeUp and the engine can keep probing up.
 func TestConfidenceIsDecodeWarningCode_CountsBlackRender242(t *testing.T) {
-	require.True(t, confidenceIsDecodeWarningCode(103), "103 generic decode warning")
-	require.True(t, confidenceIsDecodeWarningCode(242), "242 HLS.js black-render must count as decode")
-	require.False(t, confidenceIsDecodeWarningCode(104), "104 is a network warning, not decode")
-	require.False(t, confidenceIsDecodeWarningCode(0))
+	t.Run("capreg.IsDecodeWarningCode", func(t *testing.T) {
+		require.True(t, capreg.IsDecodeWarningCode(103), "103 generic decode warning")
+		require.True(t, capreg.IsDecodeWarningCode(242), "242 HLS.js black-render must count as decode")
+		require.False(t, capreg.IsDecodeWarningCode(104), "104 is a network warning, not decode")
+		require.False(t, capreg.IsDecodeWarningCode(0))
+	})
+
+	t.Run("via confidence engine", func(t *testing.T) {
+		now := time.Now().UTC()
+		obs := []capreg.PlaybackObservation{
+			{ObservedAt: now.Add(-1 * time.Second), Outcome: "warning", FeedbackCode: 103},
+		}
+		windows := buildPlaybackConfidenceWindowsFromObservations(obs, runtimepolicy.WindowFeatures{}, now)
+		total := 0
+		for _, w := range windows {
+			total += w.DecodeWarnings
+		}
+		require.Equal(t, 1, total, "103 decode warning must increment DecodeWarnings")
+	})
 }
 
 func TestBuildConfidenceWindows_BlackRender242DrivesDecodeWarnings(t *testing.T) {

--- a/backend/internal/control/http/v3/recordings/feedback_policy_decode242_test.go
+++ b/backend/internal/control/http/v3/recordings/feedback_policy_decode242_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package recordings
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/control/recordings/capreg"
+	"github.com/ManuGH/xg2g/internal/control/recordings/runtimepolicy"
+	"github.com/stretchr/testify/require"
+)
+
+// Code 242 is the HLS.js black-render decode failure. The windowed confidence
+// engine must classify it as a decode warning (in lock-step with
+// capreg.isDecodeWarningCode), otherwise repeated black-screening never sets
+// ConstraintNoProbeUp and the engine can keep probing up.
+func TestConfidenceIsDecodeWarningCode_CountsBlackRender242(t *testing.T) {
+	require.True(t, confidenceIsDecodeWarningCode(103), "103 generic decode warning")
+	require.True(t, confidenceIsDecodeWarningCode(242), "242 HLS.js black-render must count as decode")
+	require.False(t, confidenceIsDecodeWarningCode(104), "104 is a network warning, not decode")
+	require.False(t, confidenceIsDecodeWarningCode(0))
+}
+
+func TestBuildConfidenceWindows_BlackRender242DrivesDecodeWarnings(t *testing.T) {
+	now := time.Now().UTC()
+	obs := []capreg.PlaybackObservation{
+		{ObservedAt: now.Add(-1 * time.Second), Outcome: "warning", FeedbackCode: 242},
+	}
+
+	windows := buildPlaybackConfidenceWindowsFromObservations(obs, runtimepolicy.WindowFeatures{}, now)
+
+	total := 0
+	for _, w := range windows {
+		total += w.DecodeWarnings
+	}
+	require.Equal(t, 1, total, "a 242 black-render warning must increment DecodeWarnings")
+}

--- a/backend/internal/control/recordings/capreg/capreg_memory.go
+++ b/backend/internal/control/recordings/capreg/capreg_memory.go
@@ -224,7 +224,7 @@ func summarizeFeedbackObservations(observations []PlaybackObservation) FeedbackS
 				if isBufferingWarningCode(observation.FeedbackCode) {
 					summary.ConsecutiveBufferWarnings++
 				}
-				if isDecodeWarningCode(observation.FeedbackCode) {
+				if IsDecodeWarningCode(observation.FeedbackCode) {
 					summary.ConsecutiveDecodeWarnings++
 				}
 				if isNetworkWarningCode(observation.FeedbackCode) {
@@ -266,7 +266,7 @@ func isBufferingWarningCode(code int) bool {
 	}
 }
 
-func isDecodeWarningCode(code int) bool {
+func IsDecodeWarningCode(code int) bool {
 	switch code {
 	case 103, 242:
 		return true


### PR DESCRIPTION
**PR 3 of the post-v3.7.0 ultrareview fix bundle** — tied directly to the parked UHD/HEVC black-frame work.

## #1 — code 242 (HLS.js black-render) ignored by the windowed confidence engine (HIGH)
Two classifiers disagreed on the same feedback codes:
- `capreg.isDecodeWarningCode` (capreg_memory.go:269) counts **103 and 242** → drives `ConsecutiveDecodeWarnings` and the quality clamp.
- `confidenceIsDecodeWarningCode` (feedback_policy.go:506) matched **only 103**.

Code **242 = `playbackInfoCodeHLSJSRenderBlack`** (handlers_sessions.go:674), a `"warning"`-outcome decode failure. The production feedback path runs the windowed confidence engine (`buildPlaybackConfidenceWindowsFromObservations`, line 409: `if confidenceIsDecodeWarningCode(...) { feature.DecodeWarnings++ }`). So when observations exist, 242 black-render warnings added **zero** decode penalty to the confidence score and never set `ReasonDecodeWarningRecent` / `ConstraintNoProbeUp` — the engine could `probe_up`/`hold` while the client was repeatedly black-screening on decode.

## Fix
`confidenceIsDecodeWarningCode` now classifies **103 and 242**, in lock-step with `capreg.isDecodeWarningCode` (comment documents the lock-step requirement so the taxonomy can't silently drift again).

## Verification
- Unit test: `confidenceIsDecodeWarningCode(242) == true`, 103 true, 104/0 false.
- Integration test: a single `FeedbackCode: 242` `"warning"` observation through `buildPlaybackConfidenceWindowsFromObservations` yields `DecodeWarnings == 1`.
- **Negative control:** reverting to 103-only reddens **both** tests (242 → `DecodeWarnings` stays 0).
- Full `http/v3/recordings` package green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)