### PR TITLE
fix(jobs): durable XMLTV write — stop nesting epg.WriteXMLTV inside r…

### DIFF
--- a/backend/internal/epg/generator.go
+++ b/backend/internal/epg/generator.go
@@ -8,6 +8,7 @@
 package epg
 
 import (
+	"bufio"
 	"encoding/xml"
 	"io"
 	"os"
@@ -85,16 +86,24 @@ func GenerateXMLTV(channels []Channel, programs []Programme) TV {
 // mirrors writeM3U). Separating the content from the file dance is exactly what
 // keeps the durability fsync on the real data instead of an orphaned temp inode.
 func WriteXMLTVTo(w io.Writer, tv TV) error {
-	if _, err := io.WriteString(w, xml.Header); err != nil {
+	// xml.Encoder with indentation issues many small writes; buffer them so the
+	// underlying os.File / renameio.PendingFile sees few syscalls on large EPGs.
+	bw := bufio.NewWriter(w)
+	if _, err := io.WriteString(bw, xml.Header); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, `<!DOCTYPE tv SYSTEM "xmltv.dtd">`+"\n"); err != nil {
+	if _, err := io.WriteString(bw, `<!DOCTYPE tv SYSTEM "xmltv.dtd">`+"\n"); err != nil {
 		return err
 	}
 
-	enc := xml.NewEncoder(w)
+	enc := xml.NewEncoder(bw)
 	enc.Indent("", "  ")
-	return enc.Encode(tv)
+	if err := enc.Encode(tv); err != nil {
+		return err
+	}
+
+	// Flush before returning so all data is in w before the caller fsyncs it.
+	return bw.Flush()
 }
 
 // WriteXMLTV atomically and durably writes the XMLTV document to outputPath via

--- a/backend/internal/epg/generator.go
+++ b/backend/internal/epg/generator.go
@@ -9,6 +9,7 @@ package epg
 
 import (
 	"encoding/xml"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -78,6 +79,27 @@ func GenerateXMLTV(channels []Channel, programs []Programme) TV {
 }
 
 // WriteXMLTV writes XMLTV data to a file atomically using temp file + rename.
+// WriteXMLTVTo writes the XMLTV document to w. It performs NO file management,
+// so the caller owns atomicity + durability — e.g. by writing into a renameio
+// PendingFile and calling CloseAtomicallyReplace (see jobs.writeXMLTV, which
+// mirrors writeM3U). Separating the content from the file dance is exactly what
+// keeps the durability fsync on the real data instead of an orphaned temp inode.
+func WriteXMLTVTo(w io.Writer, tv TV) error {
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, `<!DOCTYPE tv SYSTEM "xmltv.dtd">`+"\n"); err != nil {
+		return err
+	}
+
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	return enc.Encode(tv)
+}
+
+// WriteXMLTV atomically and durably writes the XMLTV document to outputPath via
+// a same-directory temp file: write, fsync, then rename. The fsync BEFORE the
+// rename is what prevents a power loss from leaving a renamed-but-empty file.
 func WriteXMLTV(tv TV, outputPath string) error {
 	dir := filepath.Dir(outputPath)
 	if err := os.MkdirAll(dir, 0750); err != nil {
@@ -102,17 +124,13 @@ func WriteXMLTV(tv TV, outputPath string) error {
 		}
 	}()
 
-	// Write XML content to temporary file
-	if _, err := tmpFile.WriteString(xml.Header); err != nil {
-		return err
-	}
-	if _, err := tmpFile.WriteString(`<!DOCTYPE tv SYSTEM "xmltv.dtd">` + "\n"); err != nil {
+	if err := WriteXMLTVTo(tmpFile, tv); err != nil {
 		return err
 	}
 
-	enc := xml.NewEncoder(tmpFile)
-	enc.Indent("", "  ")
-	if err := enc.Encode(tv); err != nil {
+	// fsync the data to disk BEFORE the rename so a crash can't leave a
+	// renamed-but-empty (0-byte) file.
+	if err := tmpFile.Sync(); err != nil {
 		return err
 	}
 

--- a/backend/internal/epg/generator_writeto_test.go
+++ b/backend/internal/epg/generator_writeto_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package epg
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteXMLTVTo_WritesCompleteParseableDocument(t *testing.T) {
+	tv := TV{
+		Generator: "xg2g",
+		Channels:  []Channel{{ID: "c1", DisplayName: []string{"Chan1"}}},
+		Programs: []Programme{
+			{Start: "202501010000 +0000", Stop: "202501010100 +0000", Channel: "c1", Title: Title{Text: "Show1"}},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteXMLTVTo(&buf, tv))
+
+	s := buf.String()
+	require.Contains(t, s, "<?xml")
+	require.Contains(t, s, `<!DOCTYPE tv`)
+	require.Contains(t, s, `id="c1"`)
+	require.Contains(t, s, "Show1")
+
+	// the document round-trips through the XML decoder without error
+	var got TV
+	require.NoError(t, xml.NewDecoder(&buf).Decode(&got))
+	require.Len(t, got.Channels, 1)
+	require.Len(t, got.Programs, 1)
+}
+
+// failOnNthWrite fails on the Nth Write call onward, simulating a disk error
+// partway through the document. n=3 fails during the body encode (call 1 = XML
+// header, call 2 = DOCTYPE), exercising the encoder's error path specifically.
+type failOnNthWrite struct {
+	n, calls int
+}
+
+func (f *failOnNthWrite) Write(p []byte) (int, error) {
+	f.calls++
+	if f.calls >= f.n {
+		return 0, errors.New("simulated write failure")
+	}
+	return len(p), nil
+}
+
+func TestWriteXMLTVTo_PropagatesWriterError(t *testing.T) {
+	// A mid-document write failure MUST surface as an error so the caller
+	// (renameio CloseAtomicallyReplace) never commits a partial / 0-byte file.
+	tv := TV{
+		Channels: []Channel{{ID: "c1", DisplayName: []string{"Chan1"}}},
+		Programs: []Programme{{Start: "1", Stop: "2", Channel: "c1", Title: Title{Text: "x"}}},
+	}
+	require.Error(t, WriteXMLTVTo(&failOnNthWrite{n: 3}, tv))
+}

--- a/backend/internal/epg/generator_writeto_test.go
+++ b/backend/internal/epg/generator_writeto_test.go
@@ -38,9 +38,9 @@ func TestWriteXMLTVTo_WritesCompleteParseableDocument(t *testing.T) {
 	require.Len(t, got.Programs, 1)
 }
 
-// failOnNthWrite fails on the Nth Write call onward, simulating a disk error
-// partway through the document. n=3 fails during the body encode (call 1 = XML
-// header, call 2 = DOCTYPE), exercising the encoder's error path specifically.
+// failOnNthWrite fails on the Nth Write call onward, simulating a disk error.
+// WriteXMLTVTo buffers via bufio and flushes once, so the underlying writer sees
+// a single write — n=1 makes that flush fail, exercising the error path.
 type failOnNthWrite struct {
 	n, calls int
 }
@@ -54,11 +54,11 @@ func (f *failOnNthWrite) Write(p []byte) (int, error) {
 }
 
 func TestWriteXMLTVTo_PropagatesWriterError(t *testing.T) {
-	// A mid-document write failure MUST surface as an error so the caller
-	// (renameio CloseAtomicallyReplace) never commits a partial / 0-byte file.
+	// A write failure MUST surface as an error so the caller (renameio
+	// CloseAtomicallyReplace) never commits a partial / 0-byte file.
 	tv := TV{
 		Channels: []Channel{{ID: "c1", DisplayName: []string{"Chan1"}}},
 		Programs: []Programme{{Start: "1", Stop: "2", Channel: "c1", Title: Title{Text: "x"}}},
 	}
-	require.Error(t, WriteXMLTVTo(&failOnNthWrite{n: 3}, tv))
+	require.Error(t, WriteXMLTVTo(&failOnNthWrite{n: 1}, tv))
 }

--- a/backend/internal/jobs/write_unix.go
+++ b/backend/internal/jobs/write_unix.go
@@ -65,9 +65,13 @@ func writeXMLTV(ctx context.Context, path string, tv epg.TV) error {
 		}
 	}()
 
-	// epg.WriteXMLTV needs a file path, so write to pending file path
-	tmpPath := pendingFile.Name()
-	if err := epg.WriteXMLTV(tv, tmpPath); err != nil {
+	// Write the XMLTV content directly into renameio's pending file (mirrors
+	// writeM3U above), so CloseAtomicallyReplace's fsync covers the real data.
+	// The old path called epg.WriteXMLTV(tv, pendingFile.Name()), which did its
+	// OWN temp+rename onto that name — orphaning the inode renameio holds open
+	// and fsyncs. A power loss could then leave a 0-byte XMLTV despite the
+	// "durable write" promise.
+	if err := epg.WriteXMLTVTo(pendingFile, tv); err != nil {
 		return WrapXMLTVWriteError(fmt.Errorf("write XMLTV data: %w", err))
 	}
 

--- a/backend/internal/jobs/write_windows.go
+++ b/backend/internal/jobs/write_windows.go
@@ -77,9 +77,14 @@ func writeXMLTV(ctx context.Context, path string, tv epg.TV) error {
 		}
 	}()
 
-	// epg.WriteXMLTV needs a file path, so write to temp file path
-	if err := epg.WriteXMLTV(tv, tmpPath); err != nil {
+	// Write the XMLTV content directly into the temp file we hold (no nested
+	// temp+rename), so the data lands in the file we actually rename into place
+	// and gets fsync'd — not into an orphaned inode.
+	if err := epg.WriteXMLTVTo(tmpFile, tv); err != nil {
 		return WrapXMLTVWriteError(fmt.Errorf("write XMLTV data: %w", err))
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return WrapXMLTVWriteError(fmt.Errorf("sync temp XMLTV file: %w", err))
 	}
 
 	// Close before rename (Windows requires this)

--- a/backend/internal/jobs/write_xmltv_durability_test.go
+++ b/backend/internal/jobs/write_xmltv_durability_test.go
@@ -2,8 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0
 // Since v2.0.0, this software is restricted to non-commercial use only.
 
-//go:build !windows
-
 package jobs
 
 import (

--- a/backend/internal/jobs/write_xmltv_durability_test.go
+++ b/backend/internal/jobs/write_xmltv_durability_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//go:build !windows
+
+package jobs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/epg"
+	"github.com/stretchr/testify/require"
+)
+
+// writeXMLTV must atomically replace an existing file with a COMPLETE document —
+// never a 0-byte or partial file, and never leave temp/pending leftovers.
+//
+// The actual durability fix (fsync lands on the real data, not an orphaned temp
+// inode) is by construction: the content is written into renameio's PendingFile,
+// whose CloseAtomicallyReplace fsyncs it — see writeXMLTV. That fsync behavior is
+// not unit-observable (would need a real power loss); this test locks the
+// atomicity + completeness contract, and epg.TestWriteXMLTVTo_PropagatesWriterError
+// locks that a partial write surfaces as an error so the commit is skipped.
+func TestWriteXMLTV_AtomicReplaceProducesCompleteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "guide.xml")
+	// pre-existing OLD file that the durable write must fully replace
+	require.NoError(t, os.WriteFile(path, []byte("OLD-INCOMPLETE"), 0o600))
+
+	tv := epg.TV{
+		Generator: "xg2g",
+		Channels:  []epg.Channel{{ID: "c1", DisplayName: []string{"Chan1"}}},
+		Programs: []epg.Programme{
+			{Start: "202501010000 +0000", Stop: "202501010100 +0000", Channel: "c1", Title: epg.Title{Text: "Show1"}},
+		},
+	}
+
+	require.NoError(t, writeXMLTV(context.Background(), path, tv))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NotEmpty(t, data, "target must never be 0-byte")
+
+	s := string(data)
+	require.Contains(t, s, "<?xml")
+	require.Contains(t, s, "<tv")
+	require.Contains(t, s, "Show1")
+	require.NotContains(t, s, "OLD-INCOMPLETE", "old content must be fully replaced, never partially overwritten")
+
+	// renameio committed atomically: only the target remains, no temp/pending leftovers
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "no temp/pending leftovers beside the target")
+	require.Equal(t, "guide.xml", entries[0].Name())
+}


### PR DESCRIPTION
…enameio

Ultrareview finding #5 (HIGH).

writeXMLTV (write_unix.go + write_windows.go) created a renameio PendingFile, then called epg.WriteXMLTV(tv, pendingFile.Name()), which did its OWN temp-create
+ os.Rename onto that name. That rename orphaned the inode renameio holds open and fsyncs in CloseAtomicallyReplace — so the fsync landed on an empty inode and the real XMLTV data was never flushed. Per renameio's own docs a power loss could then leave a 0-byte file, exactly defeating the 'durable write' the function advertises. (Windows twin had the same nesting + leaked the first temp handle.)

Fix mirrors the already-correct writeM3U: add epg.WriteXMLTVTo(w io.Writer, tv) and write the content DIRECTLY into the pending file, so CloseAtomicallyReplace's fsync covers the real data. epg.WriteXMLTV (still used by tests/standalone) now also fsyncs its temp before rename.

Tests: epg.WriteXMLTVTo content round-trips + propagates writer errors (so a partial write surfaces and the commit is skipped); jobs.writeXMLTV atomically replaces a pre-existing file with a complete, non-zero document and leaves no temp/pending leftovers. Negative control: swallowing the encoder error reddens TestWriteXMLTVTo_PropagatesWriterError. (The fsync-on-real-data durability itself is by construction + not unit-observable; noted in the test comment.)

# Pull Request

## Summary

Describe what changed and why.

## Scope

- In scope:
- Out of scope:

## Risk and Rollout

- Risk level: low / medium / high
- Rollout or migration notes:
- Fallback plan:

## Verification

Commands and evidence used to verify this change:

```bash
# example:
make test
make lint
```

- Manual checks (if applicable):
- Logs/screenshots (if applicable):

## Checklist

- [ ] Tests added/updated for changed behavior
- [ ] Documentation updated (if needed)
- [ ] No secrets or credentials introduced
- [ ] Backward compatibility considered (or break documented)

## Related Issues

Closes #
