### PR TITLE
fix(auth): empty-token wipe + media legacy-cookie bypass (ultrareview MEDIUM bundle 1)

### DIFF
--- a/backend/internal/config/env.go
+++ b/backend/internal/config/env.go
@@ -34,9 +34,9 @@ func parseStringWithLookup(logger zerolog.Logger, lookup envLookupFunc, key, def
 		case value == "":
 			// An explicitly-empty env var falls back to the default for EVERY
 			// key, sensitive or not. This case must be first: otherwise a
-			// set-but-empty sensitive key (e.g. XG2G_API_TOKEN=) matched the
-			// sensitive case below and returned "", silently wiping a
-			// file-configured token (auth then fails closed -> lockout).
+			// set-but-empty sensitive key (an API-token/password var set to "")
+			// matched the sensitive case below and returned "", silently wiping
+			// a file-configured token (auth then fails closed -> lockout).
 			logger.Debug().
 				Str("key", key).
 				Str("default", defaultValue).

--- a/backend/internal/config/env.go
+++ b/backend/internal/config/env.go
@@ -31,20 +31,25 @@ func parseStringWithLookup(logger zerolog.Logger, lookup envLookupFunc, key, def
 	if value, exists := lookup(key); exists {
 		lowerKey := strings.ToLower(key)
 		switch {
-		case strings.Contains(lowerKey, "token") || strings.Contains(lowerKey, "password"):
-			// For sensitive vars, just log that it was set
-			logger.Debug().
-				Str("key", key).
-				Str("source", "environment").
-				Bool("sensitive", true).
-				Msg("using environment variable")
 		case value == "":
+			// An explicitly-empty env var falls back to the default for EVERY
+			// key, sensitive or not. This case must be first: otherwise a
+			// set-but-empty sensitive key (e.g. XG2G_API_TOKEN=) matched the
+			// sensitive case below and returned "", silently wiping a
+			// file-configured token (auth then fails closed -> lockout).
 			logger.Debug().
 				Str("key", key).
 				Str("default", defaultValue).
 				Str("source", "default").
 				Msg("using default value (environment variable is empty)")
 			return defaultValue
+		case strings.Contains(lowerKey, "token") || strings.Contains(lowerKey, "password"):
+			// For sensitive vars, just log that it was set (never the value)
+			logger.Debug().
+				Str("key", key).
+				Str("source", "environment").
+				Bool("sensitive", true).
+				Msg("using environment variable")
 		default:
 			logger.Debug().
 				Str("key", key).

--- a/backend/internal/config/env_test.go
+++ b/backend/internal/config/env_test.go
@@ -52,6 +52,24 @@ func TestParseString(t *testing.T) {
 			envSet:       true,
 			want:         "secret123",
 		},
+		{
+			// Regression: a set-but-empty sensitive var must fall back to the
+			// default, NOT return "" and silently wipe a file-configured value.
+			name:         "sensitive token empty falls back to default",
+			key:          "TEST_API_TOKEN",
+			defaultValue: "file-token",
+			envValue:     "",
+			envSet:       true,
+			want:         "file-token",
+		},
+		{
+			name:         "sensitive password empty falls back to default",
+			key:          "TEST_PASSWORD_EMPTY",
+			defaultValue: "file-secret",
+			envValue:     "",
+			envSet:       true,
+			want:         "file-secret",
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/control/auth/token.go
+++ b/backend/internal/control/auth/token.go
@@ -15,6 +15,16 @@ import (
 const (
 	sessionCookieName = "xg2g_session"
 	legacyCookieName  = "X-API-Token"
+
+	// Source descriptions returned by ExtractTokenDetailedWithOptions. The v3
+	// auth middleware enforces the media-endpoint session-cookie invariant by
+	// comparing against SessionCookieSource EXACTLY — never by substring, since
+	// the legacy LegacyCookieSource ("X-API-Token cookie") also contains the
+	// word "cookie" and would otherwise satisfy the check.
+	BearerSource        = "Authorization header (Bearer)"
+	SessionCookieSource = "xg2g_session cookie"
+	LegacyHeaderSource  = "X-API-Token header"
+	LegacyCookieSource  = "X-API-Token cookie"
 )
 
 // TokenExtractOptions controls accepted token sources during request parsing.
@@ -51,18 +61,18 @@ func ExtractTokenDetailedWithOptions(r *http.Request, opts TokenExtractOptions) 
 
 	// 1. Authorization Header
 	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
-		return strings.TrimSpace(auth[7:]), "Authorization header (Bearer)"
+		return strings.TrimSpace(auth[7:]), BearerSource
 	}
 
 	// 2. Cookie
 	if sessionID := ExtractSessionToken(r); sessionID != "" {
 		if opts.ResolveSessionToken != nil {
 			if token, ok := opts.ResolveSessionToken(sessionID); ok && token != "" {
-				return token, "xg2g_session cookie"
+				return token, SessionCookieSource
 			}
 			return "", ""
 		}
-		return sessionID, "xg2g_session cookie"
+		return sessionID, SessionCookieSource
 	}
 
 	if !opts.AllowLegacySources {
@@ -71,12 +81,12 @@ func ExtractTokenDetailedWithOptions(r *http.Request, opts TokenExtractOptions) 
 
 	// 3. Legacy Header
 	if t := r.Header.Get("X-API-Token"); t != "" {
-		return t, "X-API-Token header"
+		return t, LegacyHeaderSource
 	}
 
 	// 4. Check for legacy Cookie (X-API-Token) as last resort
 	if c, err := r.Cookie(legacyCookieName); err == nil && c.Value != "" {
-		return c.Value, "X-API-Token cookie"
+		return c.Value, LegacyCookieSource
 	}
 
 	return "", ""

--- a/backend/internal/control/http/v3/auth.go
+++ b/backend/internal/control/http/v3/auth.go
@@ -78,8 +78,10 @@ func (s *Server) authMiddlewareImpl(next http.Handler) http.Handler {
 			return
 		}
 
-		// Security Invariant (P3-Auth): Media endpoints (HLS/Direct Stream) normally REQUIRE session cookies.
-		if isMediaRequest(r) && !strings.Contains(authSource, "cookie") {
+		// Security Invariant (P3-Auth): Media endpoints (HLS/Direct Stream) REQUIRE
+		// the real session cookie. Match the canonical source EXACTLY — a substring
+		// "cookie" check let the legacy "X-API-Token cookie" source satisfy this.
+		if isMediaRequest(r) && authSource != auth.SessionCookieSource {
 			logger.Warn().
 				Str("event", "auth.media_no_cookie").
 				Msg("media request attempted without session cookie (bearer not allowed for media)")

--- a/backend/internal/control/http/v3/auth_test.go
+++ b/backend/internal/control/http/v3/auth_test.go
@@ -160,6 +160,42 @@ func TestAuthMiddleware_MediaRequiresSessionCookie(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_MediaRejectsLegacyTokenCookie(t *testing.T) {
+	// With legacy sources enabled, a request authenticated via the legacy
+	// X-API-Token COOKIE must NOT satisfy the media session-cookie invariant.
+	// Its source ("X-API-Token cookie") contains the word "cookie" but is not
+	// the real session cookie — a substring check let it bypass the media gate.
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	s := &Server{
+		cfg: config.AppConfig{
+			APIToken:                     "secret-token",
+			APITokenScopes:               []string{string(ScopeV3Read)},
+			APIDisableLegacyTokenSources: false, // legacy token sources ON
+		},
+	}
+	handler := s.authMiddleware(next)
+
+	// media endpoint + valid token via the legacy X-API-Token COOKIE -> rejected
+	reqMedia := httptest.NewRequest(http.MethodGet, "/api/v3/recordings/abc/stream.mp4", nil)
+	reqMedia.AddCookie(&http.Cookie{Name: "X-API-Token", Value: "secret-token"})
+	wMedia := httptest.NewRecorder()
+	handler.ServeHTTP(wMedia, reqMedia)
+	assert.Equal(t, http.StatusUnauthorized, wMedia.Code,
+		"legacy X-API-Token cookie must not satisfy the media session-cookie requirement")
+
+	// sanity: the SAME legacy cookie authenticates a NON-media request (legacy
+	// enabled, valid token) — proving the 401 above is the media gate, not a bad token
+	reqAPI := httptest.NewRequest(http.MethodGet, "/", nil)
+	reqAPI.AddCookie(&http.Cookie{Name: "X-API-Token", Value: "secret-token"})
+	wAPI := httptest.NewRecorder()
+	handler.ServeHTTP(wAPI, reqAPI)
+	assert.Equal(t, http.StatusOK, wAPI.Code,
+		"legacy cookie should authenticate a non-media request when legacy sources are enabled")
+}
+
 func TestAuthMiddleware_InvalidToken(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("next handler should not be called")


### PR DESCRIPTION
**Auth bundle (bundle 1 of the ultrareview MEDIUMs).** Both findings were re-ground-truthed at the real code before fixing — and the ground-truth corrected one of the severities.

## #1 — empty sensitive env var wipes a file-configured token (config footgun, NOT a bypass)
`config/env.go parseStringWithLookup` evaluated the **sensitive-key** case (`token`/`password`) *before* the **empty-value** case. So a **set-but-empty** sensitive var — e.g. `XG2G_API_TOKEN=` from an unset compose variable expanding to empty — fell into the sensitive case and returned `""`, silently replacing a file/default-configured token. Non-sensitive empty vars correctly fall back to the default; only sensitive ones had this asymmetry.

**Severity corrected by ground-truthing:** the review framed this as "disabling token auth" (implying open access). The real impact is the **opposite** — `auth.go` is **fail-closed** (`hasTokens == false → 401`), so an empty token is a **lockout / wiped-config footgun**, not an auth hole. Still a real bug worth fixing.

**Fix:** evaluate `value == ""` **first**, so every key — sensitive or not — falls back to the default on empty.

## #2 — media session-cookie invariant bypassable via the legacy X-API-Token cookie (real, when legacy enabled)
The P3-Auth media gate (`auth.go`) required a session cookie via `strings.Contains(authSource, "cookie")`. But the legacy source description is `"X-API-Token cookie"` — which also contains `"cookie"`. So a request authenticated purely via the **legacy `X-API-Token` COOKIE** satisfied the session-only requirement for HLS/stream endpoints, defeating the intent.

**Default-safe:** `XG2G_API_DISABLE_LEGACY_TOKEN_SOURCES` defaults `true` (legacy off), so the default deployment is unaffected; this bites operators who keep legacy sources on during migration.

**Fix:** the four source descriptions are now **exported constants** in the `auth` package (single source of truth), and the media gate compares `authSource != auth.SessionCookieSource` **exactly** — the legacy `"X-API-Token cookie"` no longer matches.

## Verification
- #1: new `TestParseString` cases (empty `token`/`password` → default). **Negative control:** reverting the reorder makes them return `""` → red.
- #2: new `TestAuthMiddleware_MediaRejectsLegacyTokenCookie` — legacy cookie on a media path → 401, same cookie on a non-media path → 200 (proves it's the media gate, not a bad token). **Negative control:** reverting to the substring check makes the media request 200 (the bypass) → red.
- `config` + `control/auth` + `control/http/v3` suites green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)