### PR TITLE
docs(readme): clarify PolyForm NC is source-available, not open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Docker health checks, and CI-backed release automation are built in.
 
 ## License
 
-[PolyForm Noncommercial 1.0.0](LICENSE)
+[PolyForm Noncommercial 1.0.0](LICENSE) — **source-available, not OSI open-source.** The code is public, but use is restricted:
 
 - Free for personal, homelab, and educational use.
 - Commercial use requires permission.

--- a/backend/templates/README.md.tmpl
+++ b/backend/templates/README.md.tmpl
@@ -153,7 +153,7 @@ Docker health checks, and CI-backed release automation are built in.
 
 ## License
 
-[PolyForm Noncommercial 1.0.0](LICENSE)
+[PolyForm Noncommercial 1.0.0](LICENSE) — **source-available, not OSI open-source.** The code is public, but use is restricted:
 
 - Free for personal, homelab, and educational use.
 - Commercial use requires permission.


### PR DESCRIPTION
One small, on-point touch to the README License section.

**Why:** the license badge correctly says PolyForm NC, but the License section was a bare link — so people (and AI summaries that scrape the repo) keep calling xg2g "quelloffen / open source". It's **source-available, non-commercial** — NOT an OSI open-source license.

**Change:** the License line now reads *"source-available, not OSI open-source. The code is public, but use is restricted"* — followed by the existing personal/commercial bullets. Edited the source template (`backend/templates/README.md.tmpl`); `README.md` regenerated via `render-docs`. No other content changed.

(Everything else in the README is already accurate — codecs list AV1/HEVC/etc., the hardware story is honest, device caveats are stated. This was the one genuine gap.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)