### PR TITLE
test(webui): drop vestigial localStorage.clear() from codecDetection tests

### DIFF
--- a/frontend/webui/src/features/player/utils/codecDetection.test.ts
+++ b/frontend/webui/src/features/player/utils/codecDetection.test.ts
@@ -13,7 +13,10 @@ describe('codecDetection', () => {
   beforeEach(() => {
     resetCachedCodecs();
     vi.restoreAllMocks();
-    window.localStorage.clear();
+    // Note: codecDetection does not touch localStorage; the cache it owns is
+    // reset via resetCachedCodecs() above. (A vestigial window.localStorage
+    // .clear() here threw under Node 26, whose native experimental localStorage
+    // is undefined unless --localstorage-file is passed.)
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Problem

All 7 `codecDetection` tests fail **locally under Node 26** with:

```
TypeError: Cannot read properties of undefined (reading 'clear')
ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
```

Node 26 ships a native experimental `localStorage` global that resolves to `undefined` unless the process is started with `--localstorage-file`. The test's `beforeEach` called `window.localStorage.clear()`, which then threw. CI (older Node, real jsdom localStorage) is unaffected.

## Fix

`codecDetection.ts` does **not** use localStorage at all (verified), so the `window.localStorage.clear()` was a vestigial copy-paste — the cache it owns is already reset via `resetCachedCodecs()`. Removed the line (kept a comment explaining why).

This is intentionally **surgical**: no global test-setup shim. A plain-object localStorage shim was attempted and rejected because it is not a real `Storage` instance, which breaks `new StorageEvent({ storageArea: window.localStorage })` in unrelated cross-tab tests. The other localStorage-using suites (tokenStorage, Settings, HouseholdProfiles) genuinely use the API and are a separate Node-26-local concern; they pass on CI.

## Verification

`npx vitest run src/features/player/utils/codecDetection.test.ts` → **7 passed** locally on Node 26 (was 7 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)