### PR TITLE
test(recordings): de-flake TestTruthProvider_ProbeFailure_PersistsState

### DIFF
--- a/backend/internal/control/recordings/truth_test.go
+++ b/backend/internal/control/recordings/truth_test.go
@@ -187,6 +187,13 @@ func TestTruthProvider_ProbeFailure_PersistsState(t *testing.T) {
 	// Resolve must observe Preparing before the probe is allowed to fail it.
 	probeCalled := make(chan struct{}, 10)
 	releaseProbe := make(chan struct{})
+	var closeOnce sync.Once
+	closeReleaseProbe := func() {
+		closeOnce.Do(func() {
+			close(releaseProbe)
+		})
+	}
+	defer closeReleaseProbe()
 	probeResultErr := errors.New("probe failed permanently")
 
 	// Seed with existing metadata (ResolvedPath) to check non-destructive update
@@ -200,7 +207,11 @@ func TestTruthProvider_ProbeFailure_PersistsState(t *testing.T) {
 		},
 		ProbeHook: func(ctx context.Context, path string) (*vod.StreamInfo, error) {
 			probeCalled <- struct{}{} // Signal probe attempt
-			<-releaseProbe            // Block until the test has observed Preparing
+			select {
+			case <-releaseProbe: // Block until the test has observed Preparing
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 			return nil, probeResultErr
 		},
 	}
@@ -230,7 +241,7 @@ func TestTruthProvider_ProbeFailure_PersistsState(t *testing.T) {
 
 	// Only now let the probe fail: FAILED is persisted strictly after Preparing
 	// was observed above, so the assertion can never race the persist.
-	close(releaseProbe)
+	closeReleaseProbe()
 
 	// Wait for the async probe to error out and persist FAILED state.
 	assert.Eventually(t, func() bool {

--- a/backend/internal/control/recordings/truth_test.go
+++ b/backend/internal/control/recordings/truth_test.go
@@ -180,8 +180,13 @@ func TestTruthProvider_ImpossibleProbe_BlockedPreparing(t *testing.T) {
 func TestTruthProvider_ProbeFailure_PersistsState(t *testing.T) {
 	cfg := &config.AppConfig{}
 
-	// Use a channel to synchronize probe execution
+	// probeCalled signals that the async probe has started; releaseProbe gates
+	// when it is allowed to finish and persist FAILED. Parking the probe until
+	// the test has observed Preparing removes the race between the async
+	// MarkFailed and the second truth read inside resolvePreparing: the first
+	// Resolve must observe Preparing before the probe is allowed to fail it.
 	probeCalled := make(chan struct{}, 10)
+	releaseProbe := make(chan struct{})
 	probeResultErr := errors.New("probe failed permanently")
 
 	// Seed with existing metadata (ResolvedPath) to check non-destructive update
@@ -195,6 +200,7 @@ func TestTruthProvider_ProbeFailure_PersistsState(t *testing.T) {
 		},
 		ProbeHook: func(ctx context.Context, path string) (*vod.StreamInfo, error) {
 			probeCalled <- struct{}{} // Signal probe attempt
+			<-releaseProbe            // Block until the test has observed Preparing
 			return nil, probeResultErr
 		},
 	}
@@ -208,13 +214,25 @@ func TestTruthProvider_ProbeFailure_PersistsState(t *testing.T) {
 	res, err := NewResolver(cfg, mgr, opts)
 	require.NoError(t, err)
 
-	// 1. First Call: Should return Preparing and trigger probe
+	// 1. First Call: Should return Preparing and trigger probe.
+	// The probe is parked in ProbeHook (it has not persisted FAILED yet), so
+	// this observation of Preparing is deterministic, not timing-dependent.
 	got, err := res.Resolve(context.Background(), "ref", IntentStream, ProfileGeneric)
 	assert.Error(t, err)
 	assert.Equal(t, string(playback.MediaStatusPreparing), got.TruthStatus)
 
-	// Wait for async probe to error out and persist FAILED state.
-	// We rely on Eventually because we don't have a callback hook in this simple mock.
+	// The first Resolve must have triggered exactly one probe.
+	select {
+	case <-probeCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Resolve did not trigger the async probe")
+	}
+
+	// Only now let the probe fail: FAILED is persisted strictly after Preparing
+	// was observed above, so the assertion can never race the persist.
+	close(releaseProbe)
+
+	// Wait for the async probe to error out and persist FAILED state.
 	assert.Eventually(t, func() bool {
 		m, ok := mgr.GetMetadata("ref")
 		return ok && m.State == vod.ArtifactStateFailed


### PR DESCRIPTION
## What

De-flake `TestTruthProvider_ProbeFailure_PersistsState`.

## Why

The test raced its own async probe. The first `Resolve` triggers a background probe (via the decision engine's `GetMediaTruth` callback), and `resolvePreparing` then does a *second* truth read to build the result. The mock's `ProbeHook` returned its error immediately, so `triggerProbe` could call `MarkFailed` before that second read happened — flipping `TruthStatus` from `Preparing` to `UpstreamUnavailable` and failing the `== Preparing` assertion.

It passed locally and on PR runs but flaked under the **Coverage** workflow, where the instrumentation perturbs goroutine scheduling enough to occasionally let the probe win the race. Not a real regression — both orderings are valid at runtime — but it cost a red check on an already-merged commit and erodes trust in CI.

## Change

Gate the probe instead of relying on timing. `ProbeHook` signals that it started, then parks on a release channel until the test has observed `Preparing`. Only then is the probe released to fail, so `MarkFailed` is strictly ordered *after* the assertion. The race collapses to a single valid ordering. No production code touched.

## Verification

- `-run TestTruthProvider_ProbeFailure_PersistsState -race -count=200` — green
- same test `-coverpkg=./... -count=50` (mirrors the Coverage workflow that exposed it) — green
- full `internal/control/recordings` package under `-race` — green
