### PR TITLE
perf(preflight): clear-lead fast path skips 752KB descrambler-lock read for FTA relay sources

### DIFF
--- a/backend/internal/infra/media/ffmpeg/input_resolver.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver.go
@@ -305,7 +305,11 @@ func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result p
 		if leadErr == io.EOF || leadErr == io.ErrUnexpectedEOF {
 			leadErr = nil
 		}
-		if leadErr == nil && nLead >= preflightMinBytes && hasTSSync(buf[:nLead]) {
+		if leadErr != nil {
+			result.Bytes = nLead
+			return result, leadErr
+		}
+		if nLead >= preflightMinBytes && hasTSSync(buf[:nLead]) {
 			if frac, pkts := tsScrambledFraction(buf[:nLead]); pkts >= tsScrambleMinPackets && frac < tsScrambleThreshold {
 				latency := time.Since(start)
 				a.Logger.Info().

--- a/backend/internal/infra/media/ffmpeg/input_resolver.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver.go
@@ -199,6 +199,11 @@ func (a *LocalAdapter) selectStreamURLWithPreflight(ctx context.Context, session
 	return "", ports.NewPreflightError(result)
 }
 
+// preflightRelayLeadProbeBytes is the leading sample read for the relay clear-lead
+// fast path: enough packets (>> tsScrambleMinPackets) to tell an FTA/clear head from
+// a scrambled one, yet tiny vs the full descrambler-lock scan window.
+const preflightRelayLeadProbeBytes = 188 * 128 // ~24KB / 128 packets
+
 func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result ports.PreflightResult, err error) {
 	start := time.Now()
 	defer func() {
@@ -280,7 +285,44 @@ func (a *LocalAdapter) preflightTS(ctx context.Context, rawURL string) (result p
 	}
 
 	buf := make([]byte, scanBytes)
-	n, err := io.ReadFull(io.LimitReader(resp.Body, int64(scanBytes)), buf)
+	bodyReader := io.LimitReader(resp.Body, int64(scanBytes))
+
+	// Clear-lead fast path (stream-relay only): a channel that needs descrambling
+	// carries the transport_scrambling_control bits from its first packet until the
+	// ECM locks, so if the LEADING window is already clear the source is FTA/passthrough
+	// and we accept it without draining the full ~752KB descrambler-lock window, which
+	// cuts ~4s off startup for clear channels. A scrambled head (descrambling in
+	// progress or genuinely scrambled) fails this check and falls through to the
+	// unchanged trailing-window classification below.
+	n := 0
+	if relay {
+		lead := preflightRelayLeadProbeBytes
+		if lead > scanBytes {
+			lead = scanBytes
+		}
+		nLead, leadErr := io.ReadFull(bodyReader, buf[:lead])
+		n = nLead
+		if leadErr == io.EOF || leadErr == io.ErrUnexpectedEOF {
+			leadErr = nil
+		}
+		if leadErr == nil && nLead >= preflightMinBytes && hasTSSync(buf[:nLead]) {
+			if frac, pkts := tsScrambledFraction(buf[:nLead]); pkts >= tsScrambleMinPackets && frac < tsScrambleThreshold {
+				latency := time.Since(start)
+				a.Logger.Info().
+					Str("url", sanitizeURLForLog(rawURL)).
+					Int("bytes", nLead).
+					Dur("latency", latency).
+					Int("resolved_port", result.ResolvedPort).
+					Str("preflight_fast_path", "clear_lead").
+					Msg("preflight clear-lead fast path (FTA/passthrough relay source)")
+				result = ports.NewSuccessfulPreflightResult(nLead, latency.Milliseconds(), result.ResolvedPort)
+				return result, nil
+			}
+		}
+	}
+
+	m, err := io.ReadFull(bodyReader, buf[n:])
+	n += m
 	// ReadFull tries to fill the entire scan window; if the body ends
 	// earlier that is fine — we classify on whatever packets are present.
 	// The alternative (ReadAtLeast with a minimum) returns after only a few

--- a/backend/internal/infra/media/ffmpeg/input_resolver_clearlead_test.go
+++ b/backend/internal/infra/media/ffmpeg/input_resolver_clearlead_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/rs/zerolog"
+)
+
+// relayServerServing binds a server to 127.0.0.1:17999 so preflightTS classifies
+// it as a stream-relay source (isStreamRelayURL gates on port 17999), serving body.
+func relayServerServing(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	_ = srv.Listener.Close()
+	ln, err := net.Listen("tcp", "127.0.0.1:17999")
+	if err != nil {
+		t.Skipf("port 17999 unavailable for relay preflight test: %v", err)
+	}
+	srv.Listener = ln
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newRelayPreflightAdapter() *LocalAdapter {
+	return NewLocalAdapter("", "", "", nil, zerolog.New(io.Discard), "", "", 0, 0, true, 2*time.Second, 6, 0, 0, "")
+}
+
+// A clear (FTA/passthrough) relay source is clean from its first packet, so the
+// clear-lead fast path must accept it after reading only the leading probe -- not
+// the full ~752KB descrambler-lock window. This is the ~4s startup win.
+func TestPreflightTS_RelayClearLead_FastPath(t *testing.T) {
+	srv := relayServerServing(t, tsBuf(4096, false)) // 752KB, all clear
+	res, err := newRelayPreflightAdapter().preflightTS(context.Background(), srv.URL)
+	if err != nil || !res.OK {
+		t.Fatalf("clear relay source must preflight OK, got ok=%v err=%v reason=%s", res.OK, err, res.Reason)
+	}
+	if res.Bytes > preflightRelayLeadProbeBytes {
+		t.Fatalf("clear-lead fast path must stop at the lead probe (<=%d), read %d", preflightRelayLeadProbeBytes, res.Bytes)
+	}
+	if res.Bytes >= preflightRelayScanBytes {
+		t.Fatalf("fast path must NOT drain the full window (%d), read %d", preflightRelayScanBytes, res.Bytes)
+	}
+}
+
+// NEGATIVE CONTROL 1: a descrambling channel is scrambled at the head until the ECM
+// locks, then clears. It must NOT trip the clear-lead fast path; it must drain the
+// full window and be classified OK on the cleared trailing sample (the original bug
+// this window guards against).
+func TestPreflightTS_RelayScrambledLeadThenClear_ReadsFullWindow(t *testing.T) {
+	body := append(tsBuf(2000, true), tsBuf(3000, false)...) // lock then clear, ~940KB
+	srv := relayServerServing(t, body)
+	res, err := newRelayPreflightAdapter().preflightTS(context.Background(), srv.URL)
+	if err != nil || !res.OK {
+		t.Fatalf("descrambling source (scrambled head, clear tail) must preflight OK, got ok=%v err=%v reason=%s", res.OK, err, res.Reason)
+	}
+	if res.Bytes < 188*2000 {
+		t.Fatalf("scrambled head must defeat the fast path and drain past the lock (>=%d), read %d", 188*2000, res.Bytes)
+	}
+}
+
+// NEGATIVE CONTROL 2: a genuinely scrambled channel (scrambled throughout) must still
+// be flagged -- the fast path must never pass it.
+func TestPreflightTS_RelayFullyScrambled_StillFlagged(t *testing.T) {
+	srv := relayServerServing(t, tsBuf(4096, true)) // scrambled throughout
+	res, err := newRelayPreflightAdapter().preflightTS(context.Background(), srv.URL)
+	if err == nil || res.OK {
+		t.Fatalf("fully scrambled source must be rejected, got ok=%v err=%v", res.OK, err)
+	}
+	if res.Reason != ports.PreflightReasonScrambled {
+		t.Fatalf("expected scrambled reason, got %q (detail=%s)", res.Reason, res.Detail)
+	}
+}


### PR DESCRIPTION
## What
Adds a **clear-lead fast path** to the stream-relay TS preflight (`preflightTS`). When the leading sample of a `:17999` relay source is already unscrambled, the preflight accepts it immediately instead of reading the full ~752KB descrambler-lock window.

## Why
Measured on staging (real iPhone session + synthetic intent trigger): time-to-first-segment for ServusTV (FTA, delivered via OSCam streamrelay passthrough) was ~10–12s, and ~4s of that is the xg2g relay preflight (`input_preflight_finished latency_ms≈4200`). Yet the raw relay delivers its first byte in <1ms — the 4s is entirely the conservative 752KB read that exists to clear the descrambler/ECM-lock window before sampling for scrambling.

A channel that actually needs descrambling is scrambled **from its first packet** until the ECM locks. So a clear leading window proves the source is FTA/passthrough — there is no lock to wait for, and the full read is pure latency.

## Safety / negative controls
- **Descrambling channel** (scrambled head → clears): fails the clear-lead check → drains the full window → classified on the cleared trailing sample exactly as before.
- **Genuinely scrambled** (scrambled throughout): fails the clear-lead check → full window → still flagged `R_UPSTREAM_SCRAMBLED`.
- The fast-path test has a proven negative control: neutering the early-return makes it read the full 770KB and the assertion goes red.

## Scope
Pure logic in `preflightTS`; no ENV/config-surface change. Stream-relay (:17999) only — the direct (:8001) path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
