### PR TITLE
perf(ffmpeg): tighten reconnect backoff cap 5s->2s for faster cold-start pickup

### DIFF
--- a/backend/internal/infra/media/ffmpeg/plan_input.go
+++ b/backend/internal/infra/media/ffmpeg/plan_input.go
@@ -137,7 +137,12 @@ func (a *LocalAdapter) planInput(spec ports.StreamSpec, inputURL string) (inputP
 		"-reconnect", "1",
 		"-reconnect_at_eof", "1",
 		"-reconnect_streamed", "1",
-		"-reconnect_delay_max", "5",
+		// Cold-start FBC tuning race: xg2g must never zap an in-use receiver, so it
+		// relies on background tuner allocation and the first connection can race the
+		// enigma2/FBC lock and get a premature EOF. A tighter backoff cap lets ffmpeg
+		// re-pick the source within ~2s of the lock completing (and recover faster from
+		// mid-stream blips) instead of waiting up to 5s.
+		"-reconnect_delay_max", "2",
 		"-reconnect_on_network_error", "1",
 		"-reconnect_on_http_error", "4xx,5xx",
 	)


### PR DESCRIPTION
## What
Lowers the ffmpeg input `-reconnect_delay_max` from `5` to `2` seconds for live network inputs.

## Why
xg2g deliberately never zaps a receiver that's in active live use (the user's HDMI TV) — it relies on enigma2 **background tuner allocation**, so the first stream connection effectively triggers the FBC tune and can race the descrambler/ECM lock, returning a premature EOF (`Stream ends prematurely at 0 / Input/output error`). ffmpeg already reconnects through this, but the exponential backoff was capped at 5s, so the worst-case wait before it re-picks the now-ready source was ~5s.

A 2s cap lets ffmpeg re-pick the source within ~2s of the FBC lock completing, and also recovers faster from mid-stream network blips.

## Scope / risk
One-token tuning change in `planInput`. Low risk: tighter backoff = more frequent reconnect attempts in a degraded state (negligible cost), faster recovery. The deeper fix (keep the FBC demod warm across preflight->ffprobe->ffmpeg so the race never happens) is a follow-up that needs staging measurement.

Measured context on staging (session ed2dab96): cold ServusTV start hit `Stream ends prematurely at 0` then reconnected ~5s later to first segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
