### PR TITLE
feat(scan): periodically refresh capability cache to drain cold channels

### DIFF
--- a/backend/internal/app/bootstrap/bootstrap.go
+++ b/backend/internal/app/bootstrap/bootstrap.go
@@ -697,6 +697,7 @@ func (c *Container) runInitialRefresh(ctx context.Context) {
 		if backgroundScanEnabled() {
 			c.Logger.Info().Msg("triggering media truth background scan")
 			c.scanManager.RunBackground()
+			c.scanManager.StartPeriodicRefresh(backgroundScanInterval())
 		} else {
 			c.Logger.Warn().Msg("Background media truth scan is disabled (XG2G_BACKGROUND_SCAN_ENABLED=false)")
 		}
@@ -705,6 +706,19 @@ func (c *Container) runInitialRefresh(ctx context.Context) {
 
 func backgroundScanEnabled() bool {
 	return config.ParseBool("XG2G_BACKGROUND_SCAN_ENABLED", true)
+}
+
+// defaultBackgroundScanInterval is the cadence at which the capability cache is
+// re-checked so still-cold channels (never probed, or past next_retry_at) are
+// drained. Once every channel is warm, RunBackground self-gates to a no-op, so
+// this is cheap in steady state.
+const defaultBackgroundScanInterval = time.Hour
+
+// backgroundScanInterval controls the periodic capability-refresh cadence.
+// XG2G_BACKGROUND_SCAN_INTERVAL=0 (or negative) disables periodic refresh,
+// leaving only the one-shot startup scan.
+func backgroundScanInterval() time.Duration {
+	return config.ParseDuration("XG2G_BACKGROUND_SCAN_INTERVAL", defaultBackgroundScanInterval)
 }
 
 func resolveConfigPath(explicit string) (path string, explicitMode bool, err error) {

--- a/backend/internal/config/runtime_env.go
+++ b/backend/internal/config/runtime_env.go
@@ -86,6 +86,7 @@ var runtimeEnvKeys = []string{
 	"XG2G_SKIP_FPS_PROBE_ON_CACHE_HIT",
 	"XG2G_SKIP_FPS_PROBE_WARMUP",
 	"XG2G_BACKGROUND_SCAN_ENABLED",
+	"XG2G_BACKGROUND_SCAN_INTERVAL",
 
 	// --- Keys read directly via env helpers OUTSIDE the config loader ---
 	// (encode_args.go, runtime_hardening.go, pipeline/profiles, fps probing, …).

--- a/backend/internal/pipeline/scan/periodic_refresh.go
+++ b/backend/internal/pipeline/scan/periodic_refresh.go
@@ -1,0 +1,56 @@
+package scan
+
+import (
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/log"
+)
+
+// StartPeriodicRefresh launches a background loop that re-triggers a capability
+// scan every interval, draining channels whose media-truth capability is still
+// cold — never probed (scan_state NULL) or past next_retry_at. RunBackground is
+// self-gating: hasPendingProbeCandidates makes it a no-op when the cache is already
+// warm, and the isScanning guard makes it a no-op when a scan is already in flight.
+// So this loop adds receiver load only when there is genuine cold work to drain, and
+// goes quiet once every channel is warm.
+//
+// Why this exists: the one-shot startup scan (bootstrap.runInitialRefresh) can be
+// starved indefinitely on a receiver that is in continuous use — waitForPlaybackIdle
+// pauses the scan while a stream is active and ProbeDelay rate-limits each probe, so a
+// large cold backlog never fully drains in a single pass. Without periodic re-triggering
+// those channels stay cold forever and every first playback pays the full synchronous
+// cold-tune probe in the playback-decision path.
+//
+// interval <= 0 disables periodic refresh (startup scan only). The loop is bound to the
+// lifecycle context attached via AttachLifecycle; Stop() cancels it and waits via bgWG.
+func (m *Manager) StartPeriodicRefresh(interval time.Duration) {
+	if m == nil || interval <= 0 {
+		return
+	}
+
+	ctx, err := m.backgroundContext()
+	if err != nil {
+		log.L().Warn().Err(err).Msg("scan: periodic capability refresh not started (lifecycle context not attached)")
+		return
+	}
+
+	m.bgWG.Add(1)
+	go func() {
+		defer m.bgWG.Done()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		log.L().Info().Dur("interval", interval).Msg("scan: periodic capability refresh enabled")
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// Self-gating: no-op when the cache is warm or a scan is already running.
+				m.RunBackground()
+			}
+		}
+	}()
+}

--- a/backend/internal/pipeline/scan/periodic_refresh.go
+++ b/backend/internal/pipeline/scan/periodic_refresh.go
@@ -28,13 +28,21 @@ func (m *Manager) StartPeriodicRefresh(interval time.Duration) {
 		return
 	}
 
-	ctx, err := m.backgroundContext()
-	if err != nil {
-		log.L().Warn().Err(err).Msg("scan: periodic capability refresh not started (lifecycle context not attached)")
+	m.lifecycleMu.Lock()
+	if m.runtimeCtx == nil {
+		m.lifecycleMu.Unlock()
+		log.L().Warn().Msg("scan: periodic capability refresh not started (lifecycle context not attached)")
 		return
 	}
-
+	if m.runtimeCtx.Err() != nil {
+		m.lifecycleMu.Unlock()
+		log.L().Warn().Msg("scan: periodic capability refresh not started (lifecycle already cancelled)")
+		return
+	}
+	ctx := m.runtimeCtx
 	m.bgWG.Add(1)
+	m.lifecycleMu.Unlock()
+
 	go func() {
 		defer m.bgWG.Done()
 

--- a/backend/internal/pipeline/scan/periodic_refresh_test.go
+++ b/backend/internal/pipeline/scan/periodic_refresh_test.go
@@ -1,0 +1,82 @@
+package scan
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newRefreshTestManager builds a Manager whose scan work is replaced by the given
+// closure (the scanFn seam), with the lifecycle context attached so backgroundContext
+// is available. Setting scanFn also bypasses RunBackground's warm-cache short-circuit,
+// so every trigger reaches the closure deterministically.
+func newRefreshTestManager(scan func(context.Context) error) *Manager {
+	m := NewManager(nil, "", nil)
+	m.scanFn = scan
+	m.ProbeDelay = 0
+	m.AttachLifecycle(context.Background())
+	return m
+}
+
+// TestStartPeriodicRefresh_FiresRepeatedly is the load-bearing assertion: with a
+// positive interval the loop must re-trigger the scan again and again. Neuter
+// StartPeriodicRefresh (e.g. flip the interval guard) and this goes red at 0 calls.
+func TestStartPeriodicRefresh_FiresRepeatedly(t *testing.T) {
+	var calls int32
+	m := newRefreshTestManager(func(ctx context.Context) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	})
+	defer m.Stop()
+
+	m.StartPeriodicRefresh(15 * time.Millisecond)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&calls) >= 3 {
+			return // periodic refresh re-triggered the scan as required
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("periodic refresh fired %d times, want >= 3", atomic.LoadInt32(&calls))
+}
+
+// TestStartPeriodicRefresh_DisabledWhenIntervalZero guards the off switch: a
+// non-positive interval must not start any loop.
+func TestStartPeriodicRefresh_DisabledWhenIntervalZero(t *testing.T) {
+	var calls int32
+	m := newRefreshTestManager(func(ctx context.Context) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	})
+	defer m.Stop()
+
+	m.StartPeriodicRefresh(0)
+
+	time.Sleep(150 * time.Millisecond)
+	if n := atomic.LoadInt32(&calls); n != 0 {
+		t.Fatalf("interval<=0 must not start a refresh loop, but scan fired %d times", n)
+	}
+}
+
+// TestStartPeriodicRefresh_StopsOnLifecycleCancel proves the loop is bound to the
+// lifecycle: after Stop() it must stop re-triggering.
+func TestStartPeriodicRefresh_StopsOnLifecycleCancel(t *testing.T) {
+	var calls int32
+	m := newRefreshTestManager(func(ctx context.Context) error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	})
+
+	m.StartPeriodicRefresh(15 * time.Millisecond)
+	time.Sleep(90 * time.Millisecond)
+
+	m.Stop() // cancels runtimeCtx and waits on bgWG
+	stopped := atomic.LoadInt32(&calls)
+
+	time.Sleep(150 * time.Millisecond)
+	if grew := atomic.LoadInt32(&calls) - stopped; grew != 0 {
+		t.Fatalf("scan kept firing %d more times after Stop()", grew)
+	}
+}


### PR DESCRIPTION
## Problem

The capability / media-truth cache is populated by a **one-shot** startup scan (`bootstrap.runInitialRefresh` → `RunBackground()`). On a receiver in continuous use that scan is starved:
- `waitForPlaybackIdle` pauses scanning whenever a stream is active, and
- `ProbeDelay` (5s) rate-limits each probe, while each cold probe itself costs ~8s.

So a large cold backlog never drains in a single pass. Channels left cold (`scan_state` NULL or past `next_retry_at`) then pay the **full synchronous cold-tune probe in the playback-decision path** on first playback.

**Measured on staging (v3.8.0, this branch's baseline):** `POST /api/v3/live/stream-info` took **7.7s cold vs 0.009s warm** for the same FTA channel, and **153 of 287** channels were still `scan_state=NULL` after hours of uptime (49 more retry-locked). The cold decision-probe is the single largest startup-latency contributor (~16s cold → ~9s warm, trigger→first-segment).

## Fix

`Manager.StartPeriodicRefresh(interval)` — a lifecycle-bound loop that re-triggers `RunBackground()` every `XG2G_BACKGROUND_SCAN_INTERVAL` (default **1h**, `0`/negative = disabled → startup-only).

`RunBackground` is already **self-gating**:
- `hasPendingProbeCandidates` → no-op when the cache is warm,
- `isScanning` CAS → no-op when a scan is already running.

So the loop only adds receiver load when there is genuine cold work to drain, reuses the existing idle-pause + rate-limit + `next_retry_at` skipping (no duplicate scan engine), and goes quiet once every channel is warm. Bound to `AttachLifecycle`; `Stop()` cancels it via `bgWG`.

## Tests
- `TestStartPeriodicRefresh_FiresRepeatedly` (load-bearing; **negative-control proven** — neutering the interval guard makes it red at 0 calls)
- `TestStartPeriodicRefresh_DisabledWhenIntervalZero`
- `TestStartPeriodicRefresh_StopsOnLifecycleCancel`
- All pass under `-race`; full `scan` package green; `go vet` + docs-drift clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
