### PR TITLE
fix(scan): give capability probe live-style reconnect tolerance

### DIFF
--- a/backend/internal/infra/ffmpeg/probe.go
+++ b/backend/internal/infra/ffmpeg/probe.go
@@ -68,26 +68,7 @@ func probeWithBinAndOptions(ctx context.Context, binaryPath string, path string,
 		path = u.String()
 	}
 
-	args := []string{
-		"-v", "error",
-		"-user_agent", "VLC/3.0.21 LibVLC/3.0.21",
-		"-headers", headers,
-	}
-	if whitelist, ok := InputProtocolWhitelist(path); ok {
-		args = append(args, "-protocol_whitelist", whitelist)
-	}
-	if opts.AnalyzeDuration > 0 {
-		args = append(args, "-analyzeduration", strconv.FormatInt(opts.AnalyzeDuration.Microseconds(), 10))
-	}
-	if opts.ProbeSizeBytes > 0 {
-		args = append(args, "-probesize", strconv.FormatInt(opts.ProbeSizeBytes, 10))
-	}
-	args = append(args,
-		"-print_format", "json",
-		"-show_format",
-		"-show_streams",
-		path,
-	)
+	args := buildProbeArgs(path, headers, opts)
 
 	ffprobeBin := strings.TrimSpace(binaryPath)
 	if ffprobeBin == "" {
@@ -306,4 +287,57 @@ type probeData struct {
 		BitRate    string `json:"bit_rate,omitempty"`
 		FormatName string `json:"format_name"`
 	} `json:"format"`
+}
+
+// buildProbeArgs assembles the ffprobe argument list for a probe of path.
+//
+// For HTTP(S) inputs it mirrors the live-playback reconnect tolerance (see
+// media/ffmpeg/plan_input.go). A capability probe of a live channel races the
+// receiver's cold tune + descramble (FBC lock / ECM); during that window the
+// stream relay returns a premature EOF / "Input/output error" at byte 0. Without
+// reconnect, ffprobe gives up and the channel is flagged failed/cold for 24h —
+// exactly the pay-TV channels that most need pre-warming. With the reconnect
+// options ffprobe re-opens through that cold window (bounded by the caller's
+// context timeout and -reconnect_delay_max) and probes once real data flows, the
+// same way live ffmpeg already succeeds on these channels. Non-HTTP inputs (local
+// files) get no reconnect flags, since they are HTTP-protocol options.
+func buildProbeArgs(path, headers string, opts ProbeOptions) []string {
+	args := []string{
+		"-v", "error",
+		"-user_agent", "VLC/3.0.21 LibVLC/3.0.21",
+		"-headers", headers,
+	}
+	if whitelist, ok := InputProtocolWhitelist(path); ok {
+		args = append(args, "-protocol_whitelist", whitelist)
+	}
+	if isHTTPProbeInput(path) {
+		args = append(args,
+			"-reconnect", "1",
+			"-reconnect_at_eof", "1",
+			"-reconnect_streamed", "1",
+			"-reconnect_delay_max", "2",
+			"-reconnect_on_network_error", "1",
+			"-reconnect_on_http_error", "4xx,5xx",
+		)
+	}
+	if opts.AnalyzeDuration > 0 {
+		args = append(args, "-analyzeduration", strconv.FormatInt(opts.AnalyzeDuration.Microseconds(), 10))
+	}
+	if opts.ProbeSizeBytes > 0 {
+		args = append(args, "-probesize", strconv.FormatInt(opts.ProbeSizeBytes, 10))
+	}
+	args = append(args,
+		"-print_format", "json",
+		"-show_format",
+		"-show_streams",
+		path,
+	)
+	return args
+}
+
+// isHTTPProbeInput reports whether path is an http(s) URL, for which the reconnect
+// options are meaningful (they are HTTP-protocol options in libavformat).
+func isHTTPProbeInput(path string) bool {
+	p := strings.ToLower(strings.TrimSpace(path))
+	return strings.HasPrefix(p, "http://") || strings.HasPrefix(p, "https://")
 }

--- a/backend/internal/infra/ffmpeg/probe.go
+++ b/backend/internal/infra/ffmpeg/probe.go
@@ -308,10 +308,8 @@ func buildProbeArgs(path, headers string, opts ProbeOptions) []string {
 		"-headers", headers,
 	}
 	if whitelist, ok := InputProtocolWhitelist(path); ok {
-		args = append(args, "-protocol_whitelist", whitelist)
-	}
-	if isHTTPProbeInput(path) {
 		args = append(args,
+			"-protocol_whitelist", whitelist,
 			"-reconnect", "1",
 			"-reconnect_at_eof", "1",
 			"-reconnect_streamed", "1",
@@ -333,11 +331,4 @@ func buildProbeArgs(path, headers string, opts ProbeOptions) []string {
 		path,
 	)
 	return args
-}
-
-// isHTTPProbeInput reports whether path is an http(s) URL, for which the reconnect
-// options are meaningful (they are HTTP-protocol options in libavformat).
-func isHTTPProbeInput(path string) bool {
-	p := strings.ToLower(strings.TrimSpace(path))
-	return strings.HasPrefix(p, "http://") || strings.HasPrefix(p, "https://")
 }

--- a/backend/internal/infra/ffmpeg/probe_args_test.go
+++ b/backend/internal/infra/ffmpeg/probe_args_test.go
@@ -1,0 +1,73 @@
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func probeArgsContain(args []string, flag, val string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBuildProbeArgs_HTTPGetsReconnectTolerance is the load-bearing assertion:
+// an HTTP capability probe must carry the live-style reconnect flags so it can
+// survive the cold-tune / descramble premature-EOF. Remove the reconnect block
+// and this goes red.
+func TestBuildProbeArgs_HTTPGetsReconnectTolerance(t *testing.T) {
+	args := buildProbeArgs("http://10.0.0.1:17999/1:0:19:8E:B:85:C00000:0:0:0:", "Connection: close\r\n", ProbeOptions{})
+
+	for _, pair := range [][2]string{
+		{"-reconnect", "1"},
+		{"-reconnect_at_eof", "1"},
+		{"-reconnect_streamed", "1"},
+		{"-reconnect_on_network_error", "1"},
+	} {
+		if !probeArgsContain(args, pair[0], pair[1]) {
+			t.Fatalf("http probe args missing %s %s; got: %v", pair[0], pair[1], args)
+		}
+	}
+
+	// Reconnect options must precede the input URL (they are input options).
+	reIdx, urlIdx := -1, -1
+	for i, a := range args {
+		if a == "-reconnect_at_eof" {
+			reIdx = i
+		}
+		if strings.HasPrefix(a, "http://") {
+			urlIdx = i
+		}
+	}
+	if reIdx < 0 || urlIdx < 0 || reIdx > urlIdx {
+		t.Fatalf("reconnect flags must come before the input URL: reIdx=%d urlIdx=%d args=%v", reIdx, urlIdx, args)
+	}
+}
+
+// TestBuildProbeArgs_NonHTTPHasNoReconnect: local-file probes must not get the
+// HTTP reconnect options.
+func TestBuildProbeArgs_NonHTTPHasNoReconnect(t *testing.T) {
+	args := buildProbeArgs("/var/lib/xg2g/testdata/sample.ts", "", ProbeOptions{})
+	if probeArgsContain(args, "-reconnect", "1") || probeArgsContain(args, "-reconnect_at_eof", "1") {
+		t.Fatalf("non-http probe must not get reconnect flags; got: %v", args)
+	}
+}
+
+// TestBuildProbeArgs_PreservesProbeBudgetAndInput: the extraction must not drop
+// the analyze/probe budget or the trailing input path.
+func TestBuildProbeArgs_PreservesProbeBudgetAndInput(t *testing.T) {
+	args := buildProbeArgs("http://x/y", "h", ProbeOptions{AnalyzeDuration: 3 * time.Second, ProbeSizeBytes: 5 << 20})
+	if !probeArgsContain(args, "-analyzeduration", "3000000") {
+		t.Fatalf("analyzeduration not preserved: %v", args)
+	}
+	if !probeArgsContain(args, "-probesize", "5242880") {
+		t.Fatalf("probesize not preserved: %v", args)
+	}
+	if args[len(args)-1] != "http://x/y" {
+		t.Fatalf("input path must be the last arg, got: %v", args)
+	}
+}


### PR DESCRIPTION
## Problem

A capability / media-truth probe (`scan` → `ffprobe`) of a **live channel** races the receiver's cold tune + descramble (FBC lock / ECM). During that window the OSCam stream relay returns a premature EOF:

`ffprobe failed: ... Stream ends prematurely at 0 ... Input/output error (1:0:19:…:85:…)`

ffprobe had **no reconnect options** and even sent `Connection: close`, so it gave up → the channel was flagged `failed`/cold with a **24h retry lockout**. So the background scan (and the periodic refresh from #606) could never pre-warm exactly the **pay-TV channels with the worst cold-start**. Observed on staging: ~half the bouquet sits on the `:85:` (Sky) network and these systematically failed the probe — while **live playback succeeds** on the same channels, because live ffmpeg already reconnects through the cold window.

## Fix

Mirror the live-playback reconnect tolerance (`media/ffmpeg/plan_input.go`) on the ffprobe invocation, for HTTP(S) inputs only: `-reconnect 1 -reconnect_at_eof 1 -reconnect_streamed 1 -reconnect_on_network_error 1 -reconnect_on_http_error 4xx,5xx -reconnect_delay_max 2`.

ffprobe re-opens through the premature-EOF cold window and probes once real data flows — bounded by the caller's `context` timeout (8s/20s) and `-reconnect_delay_max`, so a genuinely dead channel still fails fast (and keeps the 24h lockout). Non-HTTP (local file) probes are unchanged. Arg construction extracted to a pure `buildProbeArgs` to make it testable.

## Tests
- `TestBuildProbeArgs_HTTPGetsReconnectTolerance` (load-bearing; **negative-control proven** — neuter the HTTP gate → red, "missing -reconnect 1")
- `TestBuildProbeArgs_NonHTTPHasNoReconnect`
- `TestBuildProbeArgs_PreservesProbeBudgetAndInput`
- Full `internal/infra/ffmpeg` package green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
