### PR TITLE
fix(live): widen truth freshness window 2h->7d to kill cold-start re-probe

### DIFF
--- a/backend/internal/control/http/v3/recordings/live_truth.go
+++ b/backend/internal/control/http/v3/recordings/live_truth.go
@@ -26,13 +26,22 @@ const (
 	liveTruthOriginUnverified = "live_unverified"
 )
 
-// liveTruthFreshnessWindow is the maximum age of a scan-probed capability
-// entry before live playback truth considers it stale. Overridable at
-// startup via SetLiveTruthFreshnessWindow.
+// defaultLiveTruthFreshnessWindow is the maximum age of a scan-probed capability
+// entry before live playback truth considers it stale and re-verifies it. Media
+// truth (container/codecs/resolution/fps) is stable per channel for weeks, so the
+// previous 2h window forced a slow synchronous re-probe on essentially every cold
+// start; on stream-relay / pay-TV channels that probe can take ~20s+ (it races the
+// cold tune through several failing fallbacks) and then falls back to this very
+// truth anyway, producing a stuttery, autoplay-killing start. 7 days re-verifies
+// stale truth at a sane cadence while keeping warm cold starts fast.
+const defaultLiveTruthFreshnessWindow = 7 * 24 * time.Hour
+
+// liveTruthFreshnessWindow is the live-truth staleness threshold
+// (see defaultLiveTruthFreshnessWindow). Overridable via SetLiveTruthFreshnessWindow.
 var liveTruthFreshnessWindow atomic.Int64
 
 func init() {
-	liveTruthFreshnessWindow.Store(int64(2 * time.Hour))
+	liveTruthFreshnessWindow.Store(int64(defaultLiveTruthFreshnessWindow))
 }
 
 // SetLiveTruthFreshnessWindow allows operators to override the stale scan

--- a/backend/internal/control/http/v3/recordings/playback_info_test.go
+++ b/backend/internal/control/http/v3/recordings/playback_info_test.go
@@ -2624,6 +2624,9 @@ func TestService_ResolvePlaybackInfo_LiveTargetedProbeFailureStillFailsClosed(t 
 }
 
 func TestService_ResolvePlaybackInfo_LiveStaleScanTruthUsesTargetedProbe(t *testing.T) {
+	prevWindow := liveTruthFreshnessWindow.Load()
+	SetLiveTruthFreshnessWindow(time.Hour)
+	t.Cleanup(func() { liveTruthFreshnessWindow.Store(prevWindow) })
 	recSvc := &stubRecordingsService{
 		getMediaTruthFn: func(context.Context, string) (playback.MediaTruth, error) {
 			t.Fatal("GetMediaTruth must not be called for live playback")
@@ -2685,6 +2688,9 @@ func TestService_ResolvePlaybackInfo_LiveStaleScanTruthUsesTargetedProbe(t *test
 }
 
 func TestService_ResolvePlaybackInfo_LiveStaleScanTruthFailsClosedWithoutFreshProbe(t *testing.T) {
+	prevWindow := liveTruthFreshnessWindow.Load()
+	SetLiveTruthFreshnessWindow(time.Hour)
+	t.Cleanup(func() { liveTruthFreshnessWindow.Store(prevWindow) })
 	recSvc := &stubRecordingsService{
 		getMediaTruthFn: func(context.Context, string) (playback.MediaTruth, error) {
 			t.Fatal("GetMediaTruth must not be called for live playback")
@@ -3288,4 +3294,66 @@ func TestService_ResolvePlaybackInfo_Problem(t *testing.T) {
 	require.NotNil(t, err.Problem)
 	assert.Equal(t, 400, err.Problem.Status)
 	assert.Equal(t, string(decision.ProblemCapabilitiesInvalid), err.Problem.Code)
+}
+
+// TestService_ResolvePlaybackInfo_LiveAgedTruthWithinWindowServedWithoutProbe is the
+// load-bearing assertion for the widened freshness window: a capability a few hours old
+// (well within the default 7d window) must be served straight from cache WITHOUT a
+// blocking synchronous probe. Narrow the window back toward 2h and this goes red.
+func TestService_ResolvePlaybackInfo_LiveAgedTruthWithinWindowServedWithoutProbe(t *testing.T) {
+	recSvc := &stubRecordingsService{
+		getMediaTruthFn: func(context.Context, string) (playback.MediaTruth, error) {
+			t.Fatal("GetMediaTruth must not be called for live playback")
+			return playback.MediaTruth{}, nil
+		},
+	}
+
+	agedCapability := scan.Capability{
+		ServiceRef:  "1:0:1:2B66:3F3:1:C00000:0:0:0:",
+		State:       scan.CapabilityStateOK,
+		Container:   "ts",
+		VideoCodec:  "h264",
+		AudioCodec:  "aac",
+		Codec:       "h264",
+		Resolution:  "1920x1080",
+		Width:       1920,
+		Height:      1080,
+		FPS:         25,
+		LastScan:    time.Now().UTC().Add(-3 * time.Hour),
+		LastSuccess: time.Now().UTC().Add(-3 * time.Hour),
+	}
+
+	truthSource := &stubTruthSource{
+		getCapabilityFn: func(serviceRef string) (scan.Capability, bool) {
+			return agedCapability, true
+		},
+		probeCapabilityFn: func(ctx context.Context, serviceRef string) (scan.Capability, bool, error) {
+			t.Fatal("ProbeCapability must not be called for truth within the freshness window")
+			return scan.Capability{}, false, nil
+		},
+	}
+
+	svc := NewService(stubDeps{
+		svc:         recSvc,
+		truthSource: truthSource,
+		cfg: config.AppConfig{
+			FFmpeg: config.FFmpegConfig{Bin: "/usr/bin/ffmpeg"},
+			HLS:    config.HLSConfig{Root: "/tmp/hls"},
+		},
+	})
+
+	res, err := svc.ResolvePlaybackInfo(context.Background(), PlaybackInfoRequest{
+		SubjectID:   "1:0:1:2B66:3F3:1:C00000:0:0:0:",
+		SubjectKind: PlaybackSubjectLive,
+		APIVersion:  "v3.1",
+		SchemaType:  "live",
+		RequestID:   "req-live-aged-within-window",
+	})
+	require.Nil(t, err)
+	require.NotNil(t, res.Decision)
+	assert.Equal(t, "ts", res.Truth.Container)
+	assert.Equal(t, "h264", res.Truth.VideoCodec)
+	assert.Equal(t, "aac", res.Truth.AudioCodec)
+	assert.Equal(t, 1, truthSource.calls)
+	assert.Equal(t, 0, truthSource.probeCalls)
 }


### PR DESCRIPTION
## Problem

The live-playback truth resolver (`resolveSubjectTruth`) treats scan/media truth older than `liveTruthFreshnessWindow` as **stale** and re-verifies it with a **synchronous** `ProbeCapability` before serving playback. The window was **2h**.

But media truth (container / codecs / resolution / fps) is **stable per channel for weeks**, so nearly every cold start past 2h paid a blocking re-probe. On stream-relay / pay-TV channels that probe races the receiver cold tune through several **failing** fallbacks (`:17999`→EOF, `:8001`→scrambled, web fallback, extended budget), taking **~20s+**, and then falls back to the very same persisted truth anyway.

**Observed on staging (ORF1, cold):** ~23s in the re-probe alone → ~44s to first frame + buffering, which on the Safari client surfaced as **many errors and no autoplay**. Warm (truth fresh) the same start is ~8s.

## Fix

Widen the default freshness window **2h → 7 days** (`defaultLiveTruthFreshnessWindow`, still overridable via `SetLiveTruthFreshnessWindow`). Stale truth is still re-verified — just at a sane weekly cadence instead of every 2h — so channels played within the week start fast. The deliberate **fail-closed-on-stale** and the **missing/partial/failed** synchronous-probe paths are unchanged.

## Tests
- `LiveAgedTruthWithinWindowServedWithoutProbe` — load-bearing; **negative-control proven**: narrowing the window back toward 2h makes the resolver probe and the test goes red.
- The two existing stale tests (`LiveStaleScanTruthUsesTargetedProbe`, `...FailsClosedWithoutFreshProbe`) now pin the window explicitly, so they stay valid independent of the default.
- Full `recordings` package green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
