### PR TITLE
chore(start-surface): docs/tooling polish after best-practices merge

### DIFF
--- a/backend/scripts/safe-shutdown.sh
+++ b/backend/scripts/safe-shutdown.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # Targets only local xg2g development processes.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-backend_pattern="(^|/)bin/xg2g(-dev)?([[:space:]]|$)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+backend_pattern="^${REPO_ROOT}/bin/xg2g(-dev)?$"
 
 echo "Initiating safe process termination..."
 

--- a/backend/scripts/safe-shutdown.sh
+++ b/backend/scripts/safe-shutdown.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-backend_pattern="^${REPO_ROOT}/bin/xg2g(-dev)?$"
+backend_pattern="^${REPO_ROOT}/bin/xg2g(-dev)?([[:space:]]|$)"
 
 echo "Initiating safe process termination..."
 


### PR DESCRIPTION
## Summary
- Uncommitted dev-workflow polish that was left in the worktree after the parent
  chore/dev-start-surface branch was already merged (#597)
- Adds backend/scripts/dev-compose.sh and verify-start-surface.sh helper scripts
- Touches dev docs (SETUP, DEVELOPMENT, GETTING_STARTED), Makefile/mk/*.mk targets,
  and dev scripts (compose-xg2g, safe-shutdown, dev-install, verify-compose-resolver)
- safe-shutdown.sh: anchors the backend-process pattern to this worktree's REPO_ROOT
  instead of a loose `bin/xg2g` suffix match — needed because this repo runs several
  parallel git worktrees, each with its own bin/xg2g binary; the old pattern could
  match and kill a different worktree's dev process

## Test plan
- [ ] Run `make backend-dev-ui` / `run_ui_dev.sh` locally to confirm scripts still work
- [ ] Verify safe-shutdown.sh only stops the backend from this worktree when multiple are running