### PR TITLE
fix(log): cut steady-state log noise (receiver polling, ffmpeg storms)

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter_logparse.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse.go
@@ -382,6 +382,53 @@ func ffmpegLogLevel(line string) zerolog.Level {
 	return zerolog.InfoLevel
 }
 
+// ffmpegLogDeduper suppresses consecutive identical ffmpeg log lines so a
+// degraded stream that repeats the same decode warning per frame (e.g.
+// "corrupt decoded frame" on bad reception) cannot flood the log. The first
+// occurrence passes through immediately; repeats are counted and emitted as a
+// single summary line when a different line arrives, the flush window
+// elapses mid-storm, or the stream ends (flush).
+type ffmpegLogDeduper struct {
+	window    time.Duration
+	now       func() time.Time
+	lastLine  string
+	lastLevel zerolog.Level
+	repeats   int
+	windowAt  time.Time
+}
+
+func newFFmpegLogDeduper(window time.Duration) *ffmpegLogDeduper {
+	return &ffmpegLogDeduper{window: window, now: time.Now}
+}
+
+// observe processes one sanitized log line. emit is called with repeats == 0
+// for a line that should be logged verbatim, or with repeats > 0 for a
+// summary covering that many suppressed duplicates of line.
+func (d *ffmpegLogDeduper) observe(line string, level zerolog.Level, emit func(level zerolog.Level, line string, repeats int)) {
+	if line == d.lastLine {
+		d.repeats++
+		if d.now().Sub(d.windowAt) >= d.window {
+			emit(d.lastLevel, d.lastLine, d.repeats)
+			d.repeats = 0
+			d.windowAt = d.now()
+		}
+		return
+	}
+	d.flush(emit)
+	emit(level, line, 0)
+	d.lastLine = line
+	d.lastLevel = level
+	d.windowAt = d.now()
+}
+
+// flush emits a pending summary for suppressed duplicates, if any.
+func (d *ffmpegLogDeduper) flush(emit func(level zerolog.Level, line string, repeats int)) {
+	if d.repeats > 0 {
+		emit(d.lastLevel, d.lastLine, d.repeats)
+		d.repeats = 0
+	}
+}
+
 func isFFmpegProgressLine(lower string) bool {
 	switch {
 	case strings.HasPrefix(lower, "frame="),

--- a/backend/internal/infra/media/ffmpeg/adapter_logparse.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse.go
@@ -389,12 +389,13 @@ func ffmpegLogLevel(line string) zerolog.Level {
 // single summary line when a different line arrives, the flush window
 // elapses mid-storm, or the stream ends (flush).
 type ffmpegLogDeduper struct {
-	window    time.Duration
-	now       func() time.Time
-	lastLine  string
-	lastLevel zerolog.Level
-	repeats   int
-	windowAt  time.Time
+	window      time.Duration
+	now         func() time.Time
+	initialized bool
+	lastLine    string
+	lastLevel   zerolog.Level
+	repeats     int
+	windowAt    time.Time
 }
 
 func newFFmpegLogDeduper(window time.Duration) *ffmpegLogDeduper {
@@ -405,6 +406,16 @@ func newFFmpegLogDeduper(window time.Duration) *ffmpegLogDeduper {
 // for a line that should be logged verbatim, or with repeats > 0 for a
 // summary covering that many suppressed duplicates of line.
 func (d *ffmpegLogDeduper) observe(line string, level zerolog.Level, emit func(level zerolog.Level, line string, repeats int)) {
+	if !d.initialized {
+		// Without this guard an empty first line would match the
+		// zero-value lastLine and be summarized instead of passed through.
+		d.initialized = true
+		emit(level, line, 0)
+		d.lastLine = line
+		d.lastLevel = level
+		d.windowAt = d.now()
+		return
+	}
 	if line == d.lastLine {
 		d.repeats++
 		if d.now().Sub(d.windowAt) >= d.window {

--- a/backend/internal/infra/media/ffmpeg/adapter_logparse_dedup_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse_dedup_test.go
@@ -1,0 +1,131 @@
+package ffmpeg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type dedupEmission struct {
+	level   zerolog.Level
+	line    string
+	repeats int
+}
+
+func collectEmissions(emissions *[]dedupEmission) func(zerolog.Level, string, int) {
+	return func(level zerolog.Level, line string, repeats int) {
+		*emissions = append(*emissions, dedupEmission{level: level, line: line, repeats: repeats})
+	}
+}
+
+func TestFFmpegLogDeduperPassesDistinctLines(t *testing.T) {
+	var got []dedupEmission
+	emit := collectEmissions(&got)
+	d := newFFmpegLogDeduper(10 * time.Second)
+
+	d.observe("line a", zerolog.WarnLevel, emit)
+	d.observe("line b", zerolog.InfoLevel, emit)
+	d.observe("line c", zerolog.DebugLevel, emit)
+	d.flush(emit)
+
+	want := []dedupEmission{
+		{zerolog.WarnLevel, "line a", 0},
+		{zerolog.InfoLevel, "line b", 0},
+		{zerolog.DebugLevel, "line c", 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d emissions, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("emission %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFFmpegLogDeduperSuppressesRepeatsUntilLineChanges(t *testing.T) {
+	var got []dedupEmission
+	emit := collectEmissions(&got)
+	d := newFFmpegLogDeduper(10 * time.Second)
+
+	const storm = "corrupt decoded frame"
+	d.observe(storm, zerolog.WarnLevel, emit)
+	for i := 0; i < 140; i++ {
+		d.observe(storm, zerolog.WarnLevel, emit)
+	}
+	d.observe("stream ended", zerolog.InfoLevel, emit)
+
+	want := []dedupEmission{
+		{zerolog.WarnLevel, storm, 0},
+		{zerolog.WarnLevel, storm, 140},
+		{zerolog.InfoLevel, "stream ended", 0},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d emissions, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("emission %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFFmpegLogDeduperFlushEmitsPendingSummary(t *testing.T) {
+	var got []dedupEmission
+	emit := collectEmissions(&got)
+	d := newFFmpegLogDeduper(10 * time.Second)
+
+	d.observe("packet corrupt", zerolog.WarnLevel, emit)
+	d.observe("packet corrupt", zerolog.WarnLevel, emit)
+	d.observe("packet corrupt", zerolog.WarnLevel, emit)
+	d.flush(emit)
+	// A second flush must not emit again.
+	d.flush(emit)
+
+	want := []dedupEmission{
+		{zerolog.WarnLevel, "packet corrupt", 0},
+		{zerolog.WarnLevel, "packet corrupt", 2},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d emissions, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("emission %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFFmpegLogDeduperEmitsInterimSummaryWhenWindowElapses(t *testing.T) {
+	var got []dedupEmission
+	emit := collectEmissions(&got)
+
+	current := time.Unix(0, 0)
+	d := newFFmpegLogDeduper(10 * time.Second)
+	d.now = func() time.Time { return current }
+
+	const storm = "corrupt decoded frame"
+	d.observe(storm, zerolog.WarnLevel, emit) // passes through, windowAt = t0
+	for i := 0; i < 5; i++ {
+		d.observe(storm, zerolog.WarnLevel, emit) // suppressed
+	}
+	current = current.Add(11 * time.Second)
+	d.observe(storm, zerolog.WarnLevel, emit) // window elapsed -> interim summary
+	d.observe(storm, zerolog.WarnLevel, emit) // suppressed again
+	d.flush(emit)
+
+	want := []dedupEmission{
+		{zerolog.WarnLevel, storm, 0},
+		{zerolog.WarnLevel, storm, 6},
+		{zerolog.WarnLevel, storm, 1},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d emissions, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("emission %d: got %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/adapter_logparse_dedup_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_logparse_dedup_test.go
@@ -97,6 +97,25 @@ func TestFFmpegLogDeduperFlushEmitsPendingSummary(t *testing.T) {
 	}
 }
 
+func TestFFmpegLogDeduperFirstLineEmptyPassesThrough(t *testing.T) {
+	var got []dedupEmission
+	emit := collectEmissions(&got)
+	d := newFFmpegLogDeduper(10 * time.Second)
+
+	// An empty first line must not match the zero-value lastLine and be
+	// misreported as a duplicate summary.
+	d.observe("", zerolog.DebugLevel, emit)
+	d.flush(emit)
+
+	want := []dedupEmission{{zerolog.DebugLevel, "", 0}}
+	if len(got) != len(want) {
+		t.Fatalf("got %d emissions, want %d: %+v", len(got), len(want), got)
+	}
+	if got[0] != want[0] {
+		t.Errorf("got %+v, want %+v", got[0], want[0])
+	}
+}
+
 func TestFFmpegLogDeduperEmitsInterimSummaryWhenWindowElapses(t *testing.T) {
 	var got []dedupEmission
 	emit := collectEmissions(&got)

--- a/backend/internal/infra/media/ffmpeg/adapter_process.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_process.go
@@ -357,6 +357,15 @@ func (a *LocalAdapter) monitorProcessWithStartTimeout(parentCtx context.Context,
 		firstSegmentLogged := false
 		outputObserverStarted := false
 
+		logFFmpegLine := func(level zerolog.Level, line string, repeats int) {
+			evt := a.Logger.WithLevel(level).Str("sessionId", sessionID).Str("ffmpeg_log", line)
+			if repeats > 0 {
+				evt = evt.Int("repeated", repeats)
+			}
+			evt.Msg("ffmpeg output")
+		}
+		dedup := newFFmpegLogDeduper(10 * time.Second)
+
 		for scanner.Scan() {
 			line := scanner.Text()
 			if !firstFrameLogged {
@@ -407,16 +416,10 @@ func (a *LocalAdapter) monitorProcessWithStartTimeout(parentCtx context.Context,
 					}
 				}
 			}
-			switch ffmpegLogLevel(sanitizedLine) {
-			case zerolog.WarnLevel:
-				a.Logger.Warn().Str("sessionId", sessionID).Str("ffmpeg_log", sanitizedLine).Msg("ffmpeg output")
-			case zerolog.InfoLevel:
-				a.Logger.Info().Str("sessionId", sessionID).Str("ffmpeg_log", sanitizedLine).Msg("ffmpeg output")
-			default:
-				a.Logger.Debug().Str("sessionId", sessionID).Str("ffmpeg_log", sanitizedLine).Msg("ffmpeg output")
-			}
+			dedup.observe(sanitizedLine, ffmpegLogLevel(sanitizedLine), logFFmpegLine)
 			wd.ParseLine(line)
 		}
+		dedup.flush(logFFmpegLine)
 		if scanErr := scanner.Err(); scanErr != nil {
 			a.Logger.Warn().Err(scanErr).Str("sessionId", sessionID).Msg("ffmpeg stderr scan failed")
 		}

--- a/backend/internal/openwebif/transport.go
+++ b/backend/internal/openwebif/transport.go
@@ -15,6 +15,11 @@ import (
 	"time"
 )
 
+// slowRequestInfoThreshold is the duration above which a successful receiver
+// request is still logged at info level; faster successes go to debug since
+// metrics already cover them.
+const slowRequestInfoThreshold = 500 * time.Millisecond
+
 func (c *Client) isTechnicalError(err error) bool {
 	if err == nil {
 		return false
@@ -195,7 +200,14 @@ func (c *Client) logAttempt(
 	}
 	logger := builder.Logger()
 	if err == nil && status == http.StatusOK {
-		logger.Info().Msg("openwebif request completed")
+		// Success metrics are already recorded by recordAttemptMetrics; keep the
+		// steady-state polling traffic out of the info log and only surface
+		// unusually slow requests there.
+		evt := logger.Debug()
+		if duration >= slowRequestInfoThreshold {
+			evt = logger.Info()
+		}
+		evt.Msg("openwebif request completed")
 		return
 	}
 	if retry {
@@ -224,8 +236,14 @@ func recordAttemptMetrics(operation string, attempt, status int, duration time.D
 func (c *Client) get(ctx context.Context, path, operation string, decorate func(*zerolog.Context)) ([]byte, error) {
 	// Apply receiver rate limiting before making request
 	if err := c.receiverLimiter.Wait(ctx); err != nil {
-		c.loggerFor(ctx).Warn().
-			Err(err).
+		// A cancelled context is expected during shutdown or when a batch
+		// (e.g. EPG refresh) is aborted; every queued request fails at once,
+		// so warn-level logging would flood the log with one line per request.
+		evt := c.loggerFor(ctx).Warn()
+		if errors.Is(err, context.Canceled) {
+			evt = c.loggerFor(ctx).Debug()
+		}
+		evt.Err(err).
 			Str("event", "openwebif.rate_limit").
 			Str("operation", operation).
 			Msg("rate limit wait cancelled")

--- a/backend/internal/openwebif/transport.go
+++ b/backend/internal/openwebif/transport.go
@@ -202,10 +202,13 @@ func (c *Client) logAttempt(
 	if err == nil && status == http.StatusOK {
 		// Success metrics are already recorded by recordAttemptMetrics; keep the
 		// steady-state polling traffic out of the info log and only surface
-		// unusually slow requests there.
-		evt := logger.Debug()
+		// unusually slow requests there. Initialize the event conditionally:
+		// an overwritten zerolog event would leak from the internal pool.
+		var evt *zerolog.Event
 		if duration >= slowRequestInfoThreshold {
 			evt = logger.Info()
+		} else {
+			evt = logger.Debug()
 		}
 		evt.Msg("openwebif request completed")
 		return
@@ -239,9 +242,13 @@ func (c *Client) get(ctx context.Context, path, operation string, decorate func(
 		// A cancelled context is expected during shutdown or when a batch
 		// (e.g. EPG refresh) is aborted; every queued request fails at once,
 		// so warn-level logging would flood the log with one line per request.
-		evt := c.loggerFor(ctx).Warn()
+		// Initialize conditionally: an overwritten zerolog event would leak
+		// from the internal pool.
+		var evt *zerolog.Event
 		if errors.Is(err, context.Canceled) {
 			evt = c.loggerFor(ctx).Debug()
+		} else {
+			evt = c.loggerFor(ctx).Warn()
 		}
 		evt.Err(err).
 			Str("event", "openwebif.rate_limit").


### PR DESCRIPTION
## Summary
Runtime analysis of the staging instance showed three dominant noise sources in an otherwise healthy 6h window:

| Source | Volume | Fix |
|---|---|---|
| \`openwebif request completed\` at info | 712 lines/6h | debug for fast successes, info only >=500ms (metrics already cover success rates) |
| \`rate limit wait cancelled\` warn per queued request on batch abort | 104 lines from one restart | \`context.Canceled\` -> debug |
| ffmpeg stderr logged 1:1 per line | 141 identical \"corrupt decoded frame\" warns in 2.5min from one session | consecutive-duplicate deduper with \`repeated\` count summary (on line change / every 10s / at stream end) |

## Test plan
- [x] New unit tests for the deduper (pass-through, suppression+summary, flush idempotence, interim window flush with injected clock)
- [x] \`go test ./internal/openwebif/ ./internal/infra/media/ffmpeg/\` green
- [x] gofmt/vet clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)