### PR TITLE
fix(ci): bump v3 fan-out baseline 103→104 for llhls import (#629)

### DIFF
--- a/backend/scripts/check-fanout.sh
+++ b/backend/scripts/check-fanout.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Guardrail for the v3 package decomposition: block fan-out regressions.
-# Baseline 103 reflects the current intentional v3 composition:
+# Baseline 104 reflects the current intentional v3 composition:
 # - original 79-import hardening baseline (strict JWT verification + hwaccel enforcement)
 # - internal/admission for receiver/session admission state tracking
 # - internal/control/middleware + net for trusted-proxy HTTPS enforcement on session exchange
@@ -15,12 +15,13 @@ set -euo pipefail
 #   (crypto/rand, syscall, runtime/debug)
 # - Go 1.25 stdlib modernization: maps (maps.Copy in intent_client_request),
 #   slices (slices.Backward, slices.Contains, slices.ContainsFunc, slices.Sort)
+# - llhls: internal/hls/llhls for EXT-X-PART / blocking-reload playlist synthesis (#629)
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}/backend"
 
-MAX_V3_FANOUT="${MAX_V3_FANOUT:-103}"
+MAX_V3_FANOUT="${MAX_V3_FANOUT:-104}"
 ACTUAL_IMPORTS_RAW="$(go list -f '{{join .Imports "\n"}}' ./internal/control/http/v3 | sort)"
 mapfile -t ACTUAL_IMPORTS <<< "${ACTUAL_IMPORTS_RAW}"
 ACTUAL_V3_FANOUT="${#ACTUAL_IMPORTS[@]}"


### PR DESCRIPTION
## Summary

**Root cause**: Commit `b54245c6` (feat(llhls): Low-Latency HLS packaging layer, #629) introduced `internal/hls/llhls` as a new import in the v3 package (for EXT-X-PART / blocking-reload playlist synthesis), pushing fan-out from 103→104.

**Fix**: Bump `MAX_V3_FANOUT` from 103→104 with an updated rationale comment noting the llhls import.

## Verification
- `scripts/check-fanout.sh` now passes: `OK: internal/control/http/v3 fan-out is 104 (max: 104)`
- All `./internal/control/http/v3/...` tests pass

## Related
- Fixes #632 ([CI Nightly] Scheduled run failed: 28641870759)
- Fixes #634 ([CI Nightly] Scheduled run failed: 28696919318)

Both issues are duplicates of the same fan-out regression caused by #629 landing on main.