### PR TITLE
fix(llhls): drop temp_file hls_flag on the LL-HLS path

### DIFF
--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -186,7 +186,7 @@ func (a *LocalAdapter) appendLiveHLSArgs(args []string, spec ports.StreamSpec, l
 		}
 	}
 	hlsFlags := "delete_segments+append_list+independent_segments+program_date_time"
-	if !(a.LowLatencyHLS && segmentType == "fmp4") {
+	if !a.LowLatencyHLS || segmentType != "fmp4" {
 		// temp_file hides the growing segment behind a .tmp rename. The LL-HLS
 		// packager (internal/hls/llhls) must scan exactly that open segment to
 		// cut EXT-X-PART entries, so the flag stays off on the LL path;

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -185,10 +185,19 @@ func (a *LocalAdapter) appendLiveHLSArgs(args []string, spec ports.StreamSpec, l
 			segmentFilename = fmt.Sprintf("http://127.0.0.1:%d/ingest/%s/seg_%%06d.ts", a.ingestPort, spec.SessionID)
 		}
 	}
+	hlsFlags := "delete_segments+append_list+independent_segments+program_date_time"
+	if !(a.LowLatencyHLS && segmentType == "fmp4") {
+		// temp_file hides the growing segment behind a .tmp rename. The LL-HLS
+		// packager (internal/hls/llhls) must scan exactly that open segment to
+		// cut EXT-X-PART entries, so the flag stays off on the LL path;
+		// playlist consistency there is covered by the atomic playlist
+		// publication guard instead.
+		hlsFlags += "+temp_file"
+	}
 	args = append(args,
 		"-hls_time", strconv.Itoa(layout.segmentDurationSec),
 		"-hls_list_size", strconv.Itoa(layout.listSize),
-		"-hls_flags", "delete_segments+append_list+independent_segments+program_date_time+temp_file",
+		"-hls_flags", hlsFlags,
 		"-hls_segment_type", segmentType,
 	)
 	if a.inMemoryIngest && a.ingestPort > 0 {

--- a/backend/internal/infra/media/ffmpeg/plan_output_llhls_flags_test.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output_llhls_flags_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/rs/zerolog"
+)
+
+// The LL-HLS packager (internal/hls/llhls) scans the segment FFmpeg is
+// currently writing to cut EXT-X-PART entries. With temp_file the open
+// segment only exists as seg_N.m4s.tmp until it completes, so the packager
+// never sees parts and Safari degrades to full-segment blocking reloads.
+// temp_file must therefore stay off exactly when the LL path is active.
+func TestAppendLiveHLSArgs_TempFileFlag(t *testing.T) {
+	cases := []struct {
+		name         string
+		lowLatency   bool
+		container    string
+		wantTempFile bool
+	}{
+		{name: "llhls fmp4 drops temp_file", lowLatency: true, container: "fmp4", wantTempFile: false},
+		{name: "standard fmp4 keeps temp_file", lowLatency: false, container: "fmp4", wantTempFile: true},
+		{name: "llhls mpegts keeps temp_file", lowLatency: true, container: "ts", wantTempFile: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &LocalAdapter{
+				HLSRoot:       t.TempDir(),
+				LowLatencyHLS: tc.lowLatency,
+				Logger:        zerolog.Nop(),
+			}
+			spec := ports.StreamSpec{
+				SessionID: "test-sess-llhls",
+				Profile:   ports.ProfileSpec{Container: tc.container},
+			}
+			layout := liveSegmentLayout{segmentDurationSec: 2, listSize: 6}
+
+			args := adapter.appendLiveHLSArgs(nil, spec, layout)
+
+			var flags string
+			for i, a := range args {
+				if a == "-hls_flags" && i+1 < len(args) {
+					flags = args[i+1]
+					break
+				}
+			}
+			if flags == "" {
+				t.Fatalf("no -hls_flags in args: %v", args)
+			}
+
+			hasTempFile := strings.Contains(flags, "temp_file")
+			if hasTempFile != tc.wantTempFile {
+				t.Errorf("temp_file in hls_flags = %v, want %v (flags: %q)", hasTempFile, tc.wantTempFile, flags)
+			}
+			for _, required := range []string{"delete_segments", "append_list", "independent_segments", "program_date_time"} {
+				if !strings.Contains(flags, required) {
+					t.Errorf("hls_flags missing %q (flags: %q)", required, flags)
+				}
+			}
+
+			argStr := strings.Join(args, " ")
+			wantFrag := tc.lowLatency && tc.container == "fmp4"
+			if hasFrag := strings.Contains(argStr, "frag_duration"); hasFrag != wantFrag {
+				t.Errorf("frag_duration present = %v, want %v (args: %s)", hasFrag, wantFrag, argStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Live streams stutter when `XG2G_HLS_LOW_LATENCY=1` is enabled: playback starts but stalls periodically.

**Root cause:** #629 (LL-HLS packager) and #636 (`temp_file` in hls_flags for atomic publication) collide.

- The LL-HLS tracker cuts EXT-X-PART entries by scanning the segment FFmpeg is currently writing (`seg_N.m4s`).
- With `temp_file`, that open segment only exists as `seg_N.m4s.tmp` until it completes — the tracker never sees any parts.
- The playlist still advertises `CAN-BLOCK-RELOAD=YES` and `PART-HOLD-BACK=1.5s`, so Safari enters LL-HLS mode, blocks a full segment duration (~2s) on every playlist reload, and tries to play 1.5s behind the live edge while data only arrives in 2s bursts → periodic buffer underruns.

**Measured on staging** (v3.8.0-hls-readyfix, `XG2G_HLS_LOW_LATENCY=1`): `index.m3u8` requests held 1.7–2.1s each, segments served in ~2ms, zero encoder errors (`speed=1.02x`, `drop_frames=0`).

## Fix

Build `hls_flags` conditionally: keep `temp_file` on the standard path, drop it exactly when the LL path is active (`LowLatencyHLS` + fmp4 — the same condition that sets `frag_duration`). The LL packager *needs* visibility into the growing segment; playlist consistency on that path is already covered by the atomic playlist publication guard from #636.

## Test

`TestAppendLiveHLSArgs_TempFileFlag` covers the three combinations:
- LL-HLS + fmp4 → no `temp_file`, `frag_duration` set
- standard fmp4 → `temp_file` kept
- LL-HLS + mpegts → `temp_file` kept (LL only applies to fmp4)

`go build ./...` and `go test ./internal/infra/media/ffmpeg/ ./internal/hls/llhls/` green.

## Verification plan

After merge/deploy to staging: confirm `index.m3u8` contains `EXT-X-PART` entries and playlist request durations drop from ~2s to ~500ms part cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)