### PR TITLE
fix(llhls): gate LL playlist advertising on observed parts

### DIFF
--- a/backend/internal/control/http/v3/handlers_llhls.go
+++ b/backend/internal/control/http/v3/handlers_llhls.go
@@ -51,6 +51,13 @@ func (s *Server) serveLLHLSPlaylist(w http.ResponseWriter, r *http.Request, deps
 	dir := paths.LiveSessionDir(deps.cfg.HLS.Root, sessionID)
 	tracker := llhlsRegistry().Get(dir, sessionID)
 
+	// Serve the plain playlist until the tracker has indexed real parts (see
+	// Tracker.HasParts). Clients that never saw the LL tags do plain reloads
+	// at standard latency instead of starving behind a part-sized hold-back.
+	if !tracker.HasParts() {
+		return false
+	}
+
 	msn, part := parseBlockingReloadParams(r)
 	out, err := tracker.AwaitAndRender(r.Context(), msn, part, time.Now().Add(llhlsBlockingReloadTimeout))
 	if err != nil {

--- a/backend/internal/hls/llhls/tracker.go
+++ b/backend/internal/hls/llhls/tracker.go
@@ -23,11 +23,12 @@ type Tracker struct {
 	dir          string
 	partTargetMs int
 
-	mu      sync.Mutex
-	cond    *sync.Cond
-	base    basePlaylist
-	current openSegment
-	closed  bool
+	mu           sync.Mutex
+	cond         *sync.Cond
+	base         basePlaylist
+	current      openSegment
+	closed       bool
+	everHadParts bool
 }
 
 type basePlaylist struct {
@@ -127,6 +128,7 @@ func (t *Tracker) run(ctx context.Context) {
 				if t.current.name == cur.name {
 					t.current.parts = append(t.current.parts, frags...)
 					t.current.scanOffset = next
+					t.everHadParts = true
 					changed = true
 				}
 				t.mu.Unlock()
@@ -196,6 +198,20 @@ func readBasePlaylist(path string) (basePlaylist, error) {
 		return basePlaylist{}, fmt.Errorf("playlist has no segments yet")
 	}
 	return base, nil
+}
+
+// HasParts reports whether the tracker has ever indexed a CMAF fragment in
+// this session. Until that happens the LL playlist must not be served:
+// advertising CAN-BLOCK-RELOAD and PART-HOLD-BACK without ever delivering
+// EXT-X-PART entries locks native players into full-segment blocking
+// reloads at a part-sized hold-back, which drains their buffer into
+// periodic stalls. FFmpeg's hls muxer buffers each fMP4 segment in memory
+// and writes it only on completion, so parts appear on disk only when the
+// segment pipeline actually streams fragments (e.g. via the ingest server).
+func (t *Tracker) HasParts() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.everHadParts
 }
 
 // snapshot returns a consistent view for rendering.

--- a/backend/internal/hls/llhls/tracker.go
+++ b/backend/internal/hls/llhls/tracker.go
@@ -79,7 +79,15 @@ func (t *Tracker) run(ctx context.Context) {
 	}()
 
 	repaired := false
-	poll := time.NewTicker(100 * time.Millisecond)
+
+	// Start with slow polling (1s) for standard HLS: FFmpeg's hls muxer
+	// writes each fMP4 segment to disk only on completion, so a fast scan
+	// would never find fragments — only waste CPU and disk I/O. Once the
+	// tracker actually indexes a real CMAF fragment (via the ingest server
+	// or another streaming source), the poll speeds up to 100ms.
+	const slowInterval = 1 * time.Second
+	const fastInterval = 100 * time.Millisecond
+	poll := time.NewTicker(slowInterval)
 	defer poll.Stop()
 	for {
 		select {
@@ -128,7 +136,10 @@ func (t *Tracker) run(ctx context.Context) {
 				if t.current.name == cur.name {
 					t.current.parts = append(t.current.parts, frags...)
 					t.current.scanOffset = next
-					t.everHadParts = true
+					if !t.everHadParts {
+						t.everHadParts = true
+						poll.Reset(fastInterval)
+					}
 					changed = true
 				}
 				t.mu.Unlock()

--- a/backend/internal/hls/llhls/tracker_test.go
+++ b/backend/internal/hls/llhls/tracker_test.go
@@ -100,6 +100,55 @@ func TestTrackerEndToEnd(t *testing.T) {
 	}
 }
 
+// TestTrackerHasParts covers the LL-advertising gate: as long as the open
+// segment never shows a flushed fragment on disk (FFmpeg's hls muxer writes
+// fMP4 segments only on completion), HasParts must stay false so the
+// handler keeps serving the plain playlist. Once a fragment appears,
+// HasParts flips true and stays true.
+func TestTrackerHasParts(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, data []byte) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ftyp := mkBox("ftyp", make([]byte, 16))
+	moov := mkBox("moov", make([]byte, 32))
+	styp := mkBox("styp", make([]byte, 16))
+
+	// Clean init (no leak), one complete segment, no open-segment file at
+	// all — the completed-segments-only pattern stock FFmpeg produces.
+	write("init.mp4", append(append([]byte{}, ftyp...), moov...))
+	write("seg_000000.m4s", append(append([]byte{}, styp...), mkFragment(true, 64)...))
+	write("index.m3u8", []byte(strings.Join([]string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:7",
+		"#EXT-X-TARGETDURATION:2",
+		"#EXT-X-MEDIA-SEQUENCE:0",
+		`#EXT-X-MAP:URI="init.mp4"`,
+		"#EXTINF:2.000000,",
+		"seg_000000.m4s",
+		"",
+	}, "\n")))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tr := NewTracker(ctx, dir, 500)
+
+	// Give the poll loop several cycles: no open segment ever appears, so
+	// no parts may be indexed.
+	time.Sleep(600 * time.Millisecond)
+	if tr.HasParts() {
+		t.Fatal("HasParts must stay false while no fragment was ever indexed")
+	}
+
+	// The open segment appears with one flushed fragment: gate must open.
+	write("seg_000001.m4s", append(append([]byte{}, styp...), mkFragment(true, 80)...))
+	waitFor(t, 3*time.Second, func() bool { return tr.HasParts() })
+}
+
 func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)


### PR DESCRIPTION
## Problem

Follow-up to #637. Even with `temp_file` removed, staging shows the open segment **never exists as a growing file**: FFmpeg's hls muxer buffers each fMP4 segment in memory and writes it to disk only on completion (verified live: `seg_N.m4s` appears atomically at full size every 2s, directory watched at 0.7s granularity while `frag_duration=500000` was active and segments were properly fragmented — styp+sidx+moof chains).

The part scanner therefore never indexes fragments, yet `renderLLPlaylist` advertises `CAN-BLOCK-RELOAD=YES` + `PART-HOLD-BACK=1.5s` unconditionally. Safari enters LL mode, does ~2s full-segment blocking reloads, tries to play 1.5s behind live edge, and starves — the stutter persists.

## Fix

`Tracker.HasParts()` — true once the tracker has indexed at least one real CMAF fragment. `serveLLHLSPlaylist` falls back to the plain playlist path until then. Result:

- Stock FFmpeg pipeline (today): plain playlist, standard-latency reloads (~5ms measured on staging), no stutter.
- If the segment pipeline ever streams fragments (e.g. via the in-memory ingest server), LL activates automatically — no config change.

## Test

`TestTrackerHasParts`: completed-segments-only pattern (what stock FFmpeg produces) keeps the gate closed; the gate opens once a fragment appears in the open segment.

## Open follow-up

True LL-HLS needs the packager fed from a streaming source instead of scanning completed files — tracked as the ingest/ringbuffer path (#632 infra). Until then `XG2G_HLS_LOW_LATENCY=1` is safe but effectively standard HLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)