### PR TITLE
fix(live): stale-while-revalidate for live truth + LL-HLS sliding window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ cosign.bundle
 
 # Red-team / security test matrices (keep local, not in public repo)
 red/
+/openclaw-workspace-state.json
+/update_events.py
+/update_manager.py

--- a/backend/internal/control/http/v3/recordings/live_truth.go
+++ b/backend/internal/control/http/v3/recordings/live_truth.go
@@ -62,6 +62,10 @@ type liveTruthResolution struct {
 	State        liveTruthState
 	Reason       string
 	ProblemFlags []string
+	// Stale marks a verified resolution that was served from a scan-truth entry
+	// older than the freshness window (stale-while-revalidate). The caller is
+	// expected to trigger a detached background re-probe for interactive requests.
+	Stale bool
 }
 
 func (r liveTruthResolution) Verified() bool {
@@ -98,10 +102,32 @@ func resolveLiveTruthCapability(serviceRef string, cap scan.Capability, found bo
 	}
 	if normalized.HasMediaTruth() {
 		if !liveTruthFreshEnough(normalized, now) {
-			return unverifiedLiveTruth(serviceRef, liveTruthStateUnverified, "stale_scan_truth", normalized, []string{
-				"live_truth_unverified",
-				"stale_scan_truth",
-			}, requestContext)
+			// Stale-while-revalidate: complete media truth (container/codecs/
+			// resolution) is stable per channel for weeks, and the on-demand relay
+			// probe can fail exactly when playback would succeed (a cold tune
+			// yields ffprobe I/O errors until the descrambler locks). Blocking the
+			// player behind a 503 here is therefore strictly worse than serving
+			// the cached truth. Serve it immediately and mark the resolution
+			// Stale; interactive callers revalidate via a detached background
+			// probe (refreshLiveTruthAsync).
+			metrics.IncLiveTruthSource("scan", "stale_cache_hit")
+			evt := log.L().Info().
+				Str("event", "live.truth_stale_served").
+				Str("serviceRef", serviceRef).
+				Str("container", normalized.Container).
+				Str("videoCodec", normalized.VideoCodec).
+				Str("audioCodec", normalized.AudioCodec)
+			if requestContext != "" {
+				evt = evt.Str("request_context", requestContext)
+			}
+			evt.Msg("Serving stale scan truth for live playback; revalidating in background")
+			return liveTruthResolution{
+				Truth:  liveTruthFromCapability(normalized, playback.MediaStatusReady),
+				Origin: liveTruthOriginScan,
+				State:  liveTruthStateVerified,
+				Reason: "stale_cache_hit",
+				Stale:  true,
+			}
 		}
 		metrics.IncLiveTruthSource("scan", "cache_hit")
 		evt := log.L().Debug().

--- a/backend/internal/control/http/v3/recordings/playback_info.go
+++ b/backend/internal/control/http/v3/recordings/playback_info.go
@@ -242,6 +242,14 @@ func (s *Service) resolveSubjectTruth(ctx context.Context, req PlaybackInfoReque
 		source := s.deps.ChannelTruthSource()
 		requestContext := PlaybackInfoRequestContext(req)
 		truthResolution := resolveLiveTruthState(subjectID, source, requestContext)
+		if truthResolution.Verified() && truthResolution.Stale && probeAllowedForContext(requestContext) {
+			// Stale-while-revalidate: the cached truth is being served, so only
+			// kick a detached background probe to re-verify it. epg_badge fan-out
+			// stays excluded (probeAllowedForContext) to avoid relay probe storms.
+			if probeSource, ok := source.(channelTruthProbeSource); ok {
+				s.refreshLiveTruthAsync(ctx, probeSource, subjectID)
+			}
+		}
 		if !truthResolution.Verified() && shouldProbeLiveTruth(truthResolution) && probeAllowedForContext(requestContext) {
 			if probeSource, ok := source.(channelTruthProbeSource); ok {
 				cachedResolution := truthResolution
@@ -333,8 +341,10 @@ func probeAllowedForContext(requestContext string) bool {
 }
 
 func shouldProbeLiveTruth(resolution liveTruthResolution) bool {
+	// stale_scan_truth is intentionally absent: stale-but-complete truth is served
+	// from cache (stale-while-revalidate) and never reaches this unverified path.
 	switch resolution.Reason {
-	case "missing_scan_truth", "partial_scan_truth", "incomplete_scan_truth", "failed_scan_truth", "stale_scan_truth":
+	case "missing_scan_truth", "partial_scan_truth", "incomplete_scan_truth", "failed_scan_truth":
 		return true
 	default:
 		return false
@@ -348,8 +358,6 @@ func playbackInfoErrorForLiveTruth(resolution liveTruthResolution) *PlaybackInfo
 		message = "Live scan truth unavailable"
 	case "missing_scan_truth":
 		message = "Live media truth missing"
-	case "stale_scan_truth":
-		message = "Live media truth stale"
 	case "inactive_event_feed":
 		message = "Live event feed inactive"
 	case "partial_scan_truth", "incomplete_scan_truth":

--- a/backend/internal/control/http/v3/recordings/playback_info_test.go
+++ b/backend/internal/control/http/v3/recordings/playback_info_test.go
@@ -2623,18 +2623,8 @@ func TestService_ResolvePlaybackInfo_LiveTargetedProbeFailureStillFailsClosed(t 
 	assert.Equal(t, 1, truthSource.probeCalls)
 }
 
-func TestService_ResolvePlaybackInfo_LiveStaleScanTruthUsesTargetedProbe(t *testing.T) {
-	prevWindow := liveTruthFreshnessWindow.Load()
-	SetLiveTruthFreshnessWindow(time.Hour)
-	t.Cleanup(func() { liveTruthFreshnessWindow.Store(prevWindow) })
-	recSvc := &stubRecordingsService{
-		getMediaTruthFn: func(context.Context, string) (playback.MediaTruth, error) {
-			t.Fatal("GetMediaTruth must not be called for live playback")
-			return playback.MediaTruth{}, nil
-		},
-	}
-
-	staleCapability := scan.Capability{
+func staleScanTruthTestCapability() scan.Capability {
+	return scan.Capability{
 		ServiceRef:  "1:0:1:2B66:3F3:1:C00000:0:0:0:",
 		State:       scan.CapabilityStateOK,
 		Container:   "ts",
@@ -2648,16 +2638,35 @@ func TestService_ResolvePlaybackInfo_LiveStaleScanTruthUsesTargetedProbe(t *test
 		LastScan:    time.Now().UTC().Add(-3 * time.Hour),
 		LastSuccess: time.Now().UTC().Add(-3 * time.Hour),
 	}
+}
+
+// Stale-while-revalidate: stale-but-complete scan truth is served from cache
+// immediately; the probe fires detached in the background and must not delay or
+// alter the response.
+func TestService_ResolvePlaybackInfo_LiveStaleScanTruthServedFromCacheAndRevalidated(t *testing.T) {
+	prevWindow := liveTruthFreshnessWindow.Load()
+	SetLiveTruthFreshnessWindow(time.Hour)
+	t.Cleanup(func() { liveTruthFreshnessWindow.Store(prevWindow) })
+	recSvc := &stubRecordingsService{
+		getMediaTruthFn: func(context.Context, string) (playback.MediaTruth, error) {
+			t.Fatal("GetMediaTruth must not be called for live playback")
+			return playback.MediaTruth{}, nil
+		},
+	}
+
+	staleCapability := staleScanTruthTestCapability()
 	probedCapability := staleCapability
 	probedCapability.AudioCodec = "ac3"
 	probedCapability.LastScan = time.Now().UTC()
 	probedCapability.LastSuccess = time.Now().UTC()
 
+	probeStarted := make(chan struct{})
 	truthSource := &stubTruthSource{
 		getCapabilityFn: func(serviceRef string) (scan.Capability, bool) {
 			return staleCapability, true
 		},
 		probeCapabilityFn: func(ctx context.Context, serviceRef string) (scan.Capability, bool, error) {
+			close(probeStarted)
 			return probedCapability, true, nil
 		},
 	}
@@ -2676,18 +2685,28 @@ func TestService_ResolvePlaybackInfo_LiveStaleScanTruthUsesTargetedProbe(t *test
 		SubjectKind: PlaybackSubjectLive,
 		APIVersion:  "v3.1",
 		SchemaType:  "live",
-		RequestID:   "req-live-stale-targeted-probe",
+		RequestID:   "req-live-stale-swr",
 	})
 	require.Nil(t, err)
 	require.NotNil(t, res.Decision)
 	assert.Equal(t, "ts", res.Truth.Container)
 	assert.Equal(t, "h264", res.Truth.VideoCodec)
-	assert.Equal(t, "ac3", res.Truth.AudioCodec)
+	// The CACHED truth is served, not the probe result — the probe runs detached.
+	assert.Equal(t, "aac", res.Truth.AudioCodec)
 	assert.Equal(t, 1, truthSource.calls)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale truth must trigger a detached background revalidation probe")
+	}
 	assert.Equal(t, 1, truthSource.probeCalls)
+	assert.Equal(t, "1:0:1:2B66:3F3:1:C00000:0:0:0:", truthSource.lastProbeRef)
 }
 
-func TestService_ResolvePlaybackInfo_LiveStaleScanTruthFailsClosedWithoutFreshProbe(t *testing.T) {
+// Even when the background probe finds nothing fresh (receiver cold, relay I/O
+// error), the stale cache entry keeps serving playback — it must not fail closed.
+func TestService_ResolvePlaybackInfo_LiveStaleScanTruthServedWhenProbeFindsNothing(t *testing.T) {
 	prevWindow := liveTruthFreshnessWindow.Load()
 	SetLiveTruthFreshnessWindow(time.Hour)
 	t.Cleanup(func() { liveTruthFreshnessWindow.Store(prevWindow) })
@@ -2698,24 +2717,15 @@ func TestService_ResolvePlaybackInfo_LiveStaleScanTruthFailsClosedWithoutFreshPr
 		},
 	}
 
-	staleCapability := scan.Capability{
-		ServiceRef:  "1:0:1:2B66:3F3:1:C00000:0:0:0:",
-		State:       scan.CapabilityStateOK,
-		Container:   "ts",
-		VideoCodec:  "h264",
-		AudioCodec:  "aac",
-		Codec:       "h264",
-		Resolution:  "1920x1080",
-		Width:       1920,
-		Height:      1080,
-		FPS:         25,
-		LastScan:    time.Now().UTC().Add(-3 * time.Hour),
-		LastSuccess: time.Now().UTC().Add(-3 * time.Hour),
-	}
-
+	staleCapability := staleScanTruthTestCapability()
+	probeStarted := make(chan struct{})
 	truthSource := &stubTruthSource{
 		getCapabilityFn: func(serviceRef string) (scan.Capability, bool) {
 			return staleCapability, true
+		},
+		probeCapabilityFn: func(ctx context.Context, serviceRef string) (scan.Capability, bool, error) {
+			close(probeStarted)
+			return scan.Capability{}, false, nil
 		},
 	}
 
@@ -2728,20 +2738,74 @@ func TestService_ResolvePlaybackInfo_LiveStaleScanTruthFailsClosedWithoutFreshPr
 		},
 	})
 
-	_, err := svc.ResolvePlaybackInfo(context.Background(), PlaybackInfoRequest{
+	res, err := svc.ResolvePlaybackInfo(context.Background(), PlaybackInfoRequest{
 		SubjectID:   "1:0:1:2B66:3F3:1:C00000:0:0:0:",
 		SubjectKind: PlaybackSubjectLive,
 		APIVersion:  "v3.1",
 		SchemaType:  "live",
-		RequestID:   "req-live-stale-no-fresh-probe",
+		RequestID:   "req-live-stale-probe-empty",
 	})
-	require.NotNil(t, err)
-	assert.Equal(t, PlaybackInfoErrorUnverified, err.Kind)
-	assert.Equal(t, "unverified", err.TruthState)
-	assert.Equal(t, "stale_scan_truth", err.TruthReason)
-	assert.Contains(t, err.ProblemFlags, "stale_scan_truth")
-	assert.Equal(t, 1, truthSource.calls)
+	require.Nil(t, err)
+	require.NotNil(t, res.Decision)
+	assert.Equal(t, "ts", res.Truth.Container)
+	assert.Equal(t, "aac", res.Truth.AudioCodec)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stale truth must trigger a detached background revalidation probe")
+	}
 	assert.Equal(t, 1, truthSource.probeCalls)
+}
+
+// epg_badge requests are passive fan-out over the channel grid: they get the
+// stale cache entry served but must NOT each fire a revalidation probe.
+func TestService_ResolvePlaybackInfo_LiveStaleScanTruthEpgBadgeDoesNotProbe(t *testing.T) {
+	prevWindow := liveTruthFreshnessWindow.Load()
+	SetLiveTruthFreshnessWindow(time.Hour)
+	t.Cleanup(func() { liveTruthFreshnessWindow.Store(prevWindow) })
+	recSvc := &stubRecordingsService{
+		getMediaTruthFn: func(context.Context, string) (playback.MediaTruth, error) {
+			t.Fatal("GetMediaTruth must not be called for live playback")
+			return playback.MediaTruth{}, nil
+		},
+	}
+
+	staleCapability := staleScanTruthTestCapability()
+	truthSource := &stubTruthSource{
+		getCapabilityFn: func(serviceRef string) (scan.Capability, bool) {
+			return staleCapability, true
+		},
+		probeCapabilityFn: func(ctx context.Context, serviceRef string) (scan.Capability, bool, error) {
+			t.Error("epg_badge request must not trigger a revalidation probe")
+			return scan.Capability{}, false, nil
+		},
+	}
+
+	svc := NewService(stubDeps{
+		svc:         recSvc,
+		truthSource: truthSource,
+		cfg: config.AppConfig{
+			FFmpeg: config.FFmpegConfig{Bin: "/usr/bin/ffmpeg"},
+			HLS:    config.HLSConfig{Root: "/tmp/hls"},
+		},
+	})
+
+	res, err := svc.ResolvePlaybackInfo(context.Background(), PlaybackInfoRequest{
+		SubjectID:   "1:0:1:2B66:3F3:1:C00000:0:0:0:",
+		SubjectKind: PlaybackSubjectLive,
+		APIVersion:  "v3.1",
+		SchemaType:  "live",
+		RequestID:   "req-live-stale-epg-badge",
+		Headers:     map[string]string{PlaybackInfoContextHeader: PlaybackInfoContextEpgBadge},
+	})
+	require.Nil(t, err)
+	require.NotNil(t, res.Decision)
+	assert.Equal(t, "ts", res.Truth.Container)
+	assert.Equal(t, "aac", res.Truth.AudioCodec)
+
+	// Give a mistakenly fired detached probe a moment to surface before the test ends.
+	time.Sleep(100 * time.Millisecond)
 }
 
 func TestService_ResolvePlaybackInfo_LiveIncompleteScanTruthFailsClosed(t *testing.T) {

--- a/backend/internal/control/http/v3/recordings/service.go
+++ b/backend/internal/control/http/v3/recordings/service.go
@@ -93,6 +93,23 @@ func (s *Service) probeLiveTruthBounded(ctx context.Context, probeSource channel
 	}
 }
 
+// refreshLiveTruthAsync revalidates stale-but-served scan truth without blocking
+// the playback request (stale-while-revalidate). It shares liveProbeGroup with
+// probeLiveTruthBounded, so a concurrent interactive probe for the same channel
+// collapses into the same relay probe, and it runs on a detached context so it
+// survives the originating request. ProbeCapability persists whatever it learns
+// to the truth store; on failure the (still served) stale entry simply remains.
+func (s *Service) refreshLiveTruthAsync(ctx context.Context, probeSource channelTruthProbeSource, serviceRef string) {
+	bg := context.WithoutCancel(ctx)
+	s.liveProbeGroup.DoChan(serviceRef, func() (any, error) {
+		c, f, e := probeSource.ProbeCapability(bg, serviceRef)
+		if e != nil {
+			log.L().Warn().Err(e).Str("serviceRef", serviceRef).Msg("live truth background revalidation failed")
+		}
+		return liveProbeOutcome{cap: c, found: f, err: e}, nil
+	})
+}
+
 func (s *Service) ResolveClientPlayback(ctx context.Context, itemID string, req ClientPlaybackRequest) (ClientPlaybackResponse, *ClientPlaybackError) {
 	svc := s.deps.RecordingsService()
 	if svc == nil {

--- a/backend/internal/hls/cmaf/segmenter.go
+++ b/backend/internal/hls/cmaf/segmenter.go
@@ -49,6 +49,7 @@ type Config struct {
 	// TargetDurationSec is the nominal segment duration; rotation happens at
 	// the first independent fragment at or past this boundary.
 	TargetDurationSec int
+	ListSize int
 	// Now returns the wall clock for EXT-X-PROGRAM-DATE-TIME stamps.
 	// Defaults to time.Now when nil.
 	Now func() time.Time
@@ -114,7 +115,7 @@ func run(ctx context.Context, r io.Reader, cfg Config) error {
 		Int("init_bytes", len(initBytes)).
 		Msg("cmaf init published")
 
-	pl, err := newPlaylistWriter(cfg.Dir, cfg.TargetDurationSec)
+	pl, err := newPlaylistWriter(cfg.Dir, cfg.TargetDurationSec, cfg.ListSize)
 	if err != nil {
 		return fmt.Errorf("playlist init: %w", err)
 	}
@@ -502,18 +503,22 @@ var segNameRe = regexp.MustCompile(`^seg_(\d+)\.m4s$`)
 type playlistWriter struct {
 	path             string
 	targetDuration   int
+	listSize         int
 	mediaLines       []string
 	nextSegmentIndex int
+	mediaSequence    int
+	discontSequence  int
 }
 
 // newPlaylistWriter continues an existing session playlist when one is on
 // disk (worker restart into the same session dir): prior media entries are
 // preserved, a DISCONTINUITY separates the new encode, and numbering
 // resumes after the highest existing segment.
-func newPlaylistWriter(dir string, targetDuration int) (*playlistWriter, error) {
+func newPlaylistWriter(dir string, targetDuration int, listSize int) (*playlistWriter, error) {
 	pl := &playlistWriter{
 		path:           filepath.Join(dir, "index.m3u8"),
 		targetDuration: targetDuration,
+		listSize:       listSize,
 	}
 	raw, err := os.ReadFile(pl.path) // #nosec G304 -- session-confined path
 	if err != nil {
@@ -527,6 +532,18 @@ func newPlaylistWriter(dir string, targetDuration int) (*playlistWriter, error) 
 	for _, line := range strings.Split(string(raw), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || line == "#EXT-X-ENDLIST" {
+			continue
+		}
+		if strings.HasPrefix(line, "#EXT-X-MEDIA-SEQUENCE:") {
+			if n, err := strconv.Atoi(strings.TrimPrefix(line, "#EXT-X-MEDIA-SEQUENCE:")); err == nil {
+				pl.mediaSequence = n
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "#EXT-X-DISCONTINUITY-SEQUENCE:") {
+			if n, err := strconv.Atoi(strings.TrimPrefix(line, "#EXT-X-DISCONTINUITY-SEQUENCE:")); err == nil {
+				pl.discontSequence = n
+			}
 			continue
 		}
 		if m := segNameRe.FindStringSubmatch(line); m != nil {
@@ -557,6 +574,31 @@ func (p *playlistWriter) appendSegment(name string, duration float64, start time
 		"#EXT-X-PROGRAM-DATE-TIME:"+start.UTC().Format("2006-01-02T15:04:05.000Z07:00"),
 		name,
 	)
+	if p.listSize > 0 {
+		segmentsCount := 0
+		for _, line := range p.mediaLines {
+			if !strings.HasPrefix(line, "#") {
+				segmentsCount++
+			}
+		}
+		for segmentsCount > p.listSize {
+			for len(p.mediaLines) > 0 {
+				line := p.mediaLines[0]
+				p.mediaLines = p.mediaLines[1:]
+				
+				if line == "#EXT-X-DISCONTINUITY" {
+					p.discontSequence++
+				}
+				
+				if !strings.HasPrefix(line, "#") {
+					p.mediaSequence++
+					segmentsCount--
+					_ = os.Remove(filepath.Join(filepath.Dir(p.path), line))
+					break
+				}
+			}
+		}
+	}
 	return p.publish(false)
 }
 

--- a/backend/internal/hls/cmaf/segmenter.go
+++ b/backend/internal/hls/cmaf/segmenter.go
@@ -609,7 +609,10 @@ func (p *playlistWriter) publish(end bool) error {
 	b.WriteString("#EXTM3U\n")
 	b.WriteString("#EXT-X-VERSION:7\n")
 	fmt.Fprintf(&b, "#EXT-X-TARGETDURATION:%d\n", p.targetDuration)
-	b.WriteString("#EXT-X-MEDIA-SEQUENCE:0\n")
+	fmt.Fprintf(&b, "#EXT-X-MEDIA-SEQUENCE:%d\n", p.mediaSequence)
+	if p.discontSequence > 0 {
+		fmt.Fprintf(&b, "#EXT-X-DISCONTINUITY-SEQUENCE:%d\n", p.discontSequence)
+	}
 	b.WriteString("#EXT-X-INDEPENDENT-SEGMENTS\n")
 	b.WriteString("#EXT-X-MAP:URI=\"init.mp4\"\n")
 	for _, line := range p.mediaLines {

--- a/backend/internal/hls/cmaf/segmenter.go
+++ b/backend/internal/hls/cmaf/segmenter.go
@@ -49,7 +49,7 @@ type Config struct {
 	// TargetDurationSec is the nominal segment duration; rotation happens at
 	// the first independent fragment at or past this boundary.
 	TargetDurationSec int
-	ListSize int
+	ListSize          int
 	// Now returns the wall clock for EXT-X-PROGRAM-DATE-TIME stamps.
 	// Defaults to time.Now when nil.
 	Now func() time.Time
@@ -585,11 +585,11 @@ func (p *playlistWriter) appendSegment(name string, duration float64, start time
 			for len(p.mediaLines) > 0 {
 				line := p.mediaLines[0]
 				p.mediaLines = p.mediaLines[1:]
-				
+
 				if line == "#EXT-X-DISCONTINUITY" {
 					p.discontSequence++
 				}
-				
+
 				if !strings.HasPrefix(line, "#") {
 					p.mediaSequence++
 					segmentsCount--

--- a/backend/internal/infra/media/ffmpeg/adapter_process.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_process.go
@@ -229,6 +229,7 @@ func (a *LocalAdapter) Start(ctx context.Context, spec ports.StreamSpec) (ports.
 		segCfg := cmaf.Config{
 			Dir:               ports.SessionHLSDir(a.HLSRoot, spec.SessionID),
 			TargetDurationSec: plan.cmafTargetDurSec,
+			ListSize:          plan.listSize,
 			Logger:            segLogger,
 		}
 		go func(r *os.File) {

--- a/backend/internal/infra/media/ffmpeg/plan_builder.go
+++ b/backend/internal/infra/media/ffmpeg/plan_builder.go
@@ -39,6 +39,7 @@ type outputPlan struct {
 	// session artifacts instead of the hls muxer.
 	cmafSegment      bool
 	cmafTargetDurSec int
+	listSize         int
 }
 
 type finalizedPlan struct {
@@ -48,6 +49,7 @@ type finalizedPlan struct {
 
 	cmafSegment      bool
 	cmafTargetDurSec int
+	listSize         int
 }
 
 type liveSegmentLayout struct {
@@ -93,6 +95,7 @@ func (a *LocalAdapter) buildArgsWithPlan(ctx context.Context, spec ports.StreamS
 		result.effectiveProfile = liveOutput.effectiveProfile
 		result.cmafSegment = liveOutput.cmafSegment
 		result.cmafTargetDurSec = liveOutput.cmafTargetDurSec
+		result.listSize = liveOutput.listSize
 	}
 
 	return result, nil

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -106,7 +106,7 @@ func (a *LocalAdapter) planLiveSegmentLayout(spec ports.StreamSpec) (liveSegment
 	}
 	if a.DVRWindow > 0 {
 		dvrSize := int(math.Ceil(a.DVRWindow.Seconds() / float64(layout.segmentDurationSec)))
-		layout.listSize = max(dvrSize, minSize)
+		layout.listSize = max(dvrSize, layout.listSize, minSize)
 	}
 	return layout, nil
 }

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -59,6 +59,7 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 		out.args = appendLiveCMAFStreamArgs(out.args)
 		out.cmafSegment = true
 		out.cmafTargetDurSec = layout.segmentDurationSec
+		out.listSize = layout.listSize
 	} else {
 		out.args = append(out.args, "-f", "hls")
 		out.args = a.appendLiveHLSArgs(out.args, spec, layout)
@@ -87,7 +88,7 @@ func (a *LocalAdapter) planLiveSegmentLayout(spec ports.StreamSpec) (liveSegment
 	}
 	layout := liveSegmentLayout{
 		segmentDurationSec: a.SegmentSeconds,
-		listSize:           max(10, minSize),
+		listSize:           30, // enforced minimum to prevent stuttering during network retries
 	}
 	if a.LowLatencyHLS && strings.EqualFold(strings.TrimSpace(spec.Profile.Container), "fmp4") && layout.segmentDurationSec > llhlsSegmentSeconds {
 		// LL-HLS: short segments keep the playlist window tight; parts are


### PR DESCRIPTION
## Summary

Two production fixes validated on staging (LXC 110):

**1. LL-HLS sliding window enforcement** (`1575865e` cherry-pick)
Prevents infinite playlist growth and the resulting network stalling on long-running LL-HLS sessions.

**2. Stale-while-revalidate for live scan truth**
Stale-but-complete media truth no longer fails playback closed with 503 `live/stale_truth`. The cached truth is served immediately (`live.truth_stale_served`, metric `stale_cache_hit`) and a detached singleflight probe revalidates in the background. The relay probe can fail exactly when playback would succeed (cold-tune ffprobe I/O errors on 17999/8001), so blocking on it cost interactive zaps 30-60s for no gain. `epg_badge` fan-out is excluded from revalidation to avoid relay probe storms, but now gets cache truth served instead of unverified.

## Production evidence (xg2g-staging)

- Before: `POST /api/v3/live/stream-info` on a stale channel → 503 after 5.0s (requestId 2f290721)
- After: same call → **200 in 6ms**, background probe stored fresh truth 14s later, subsequent requests hit `live.truth_verified`

## Tests

- Rewrote the two stale fail-closed tests to SWR semantics, added epg_badge no-probe test
- `go test -race` green: recordings, v3, hls/..., pipeline/scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)