### PR TITLE
fix(trace): classify LL-HLS cmaf pipe argv as fmp4, kill spurious plan_mismatch

### DIFF
--- a/backend/internal/infra/media/ffmpeg/executed_plan.go
+++ b/backend/internal/infra/media/ffmpeg/executed_plan.go
@@ -17,10 +17,26 @@ import (
 // packaging, video/audio mode+codec, and hardware acceleration.
 func executedFFmpegPlanFromArgs(args []string) ports.ExecutedFFmpegPlan {
 	var segmentType, segmentFile, hwaccel, vcodec, acodec string
+	var outFormat, movFlags string
+	fragmented := false
 	hasVaapiDevice := false
 
 	for i := range args {
 		switch args[i] {
+		case "-f":
+			if i+1 < len(args) {
+				outFormat = args[i+1]
+			}
+		case "-i":
+			// A -f seen before an -i described that INPUT's demuxer, not the
+			// output muxer. Only the -f after the last input names the output.
+			outFormat = ""
+		case "-movflags":
+			if i+1 < len(args) {
+				movFlags = args[i+1]
+			}
+		case "-frag_duration":
+			fragmented = true
 		case "-hls_segment_type":
 			if i+1 < len(args) {
 				segmentType = args[i+1]
@@ -46,7 +62,7 @@ func executedFFmpegPlanFromArgs(args []string) ports.ExecutedFFmpegPlan {
 		}
 	}
 
-	container, packaging := classifyContainerArgs(segmentType, segmentFile)
+	container, packaging := classifyContainerArgs(segmentType, segmentFile, outFormat, movFlags, fragmented)
 	videoMode, videoCodec := classifyVideoCodecArg(vcodec)
 	audioMode, audioCodec := classifyAudioCodecArg(acodec)
 
@@ -61,13 +77,26 @@ func executedFFmpegPlanFromArgs(args []string) ports.ExecutedFFmpegPlan {
 	}
 }
 
-// classifyContainerArgs maps the real HLS segment type to the container/packaging
-// labels. It falls back to the segment filename extension when the segment type
-// flag is implicit (.m4s -> fmp4, otherwise mpegts).
-func classifyContainerArgs(segmentType, segmentFile string) (container, packaging string) {
+// classifyContainerArgs maps the real output muxer flags to container/packaging
+// labels. HLS-muxer runs are classified by segment type (or the .m4s filename
+// when the type flag is implicit). The LL-HLS pipe mode never touches the hls
+// muxer: ffmpeg writes one fragmented MP4 stream ("-f mp4" with frag movflags)
+// to stdout and the in-process cmaf segmenter packages it into fMP4 segments —
+// that argv must classify as fmp4, not fall back to mpegts (a wrong fallback
+// here made the executed plan lie and fired a spurious plan_mismatch warning
+// on every LL-HLS session). A plain, unfragmented "-f mp4" (VOD-style output)
+// stays "mp4". Everything else is the mpegts stream path.
+func classifyContainerArgs(segmentType, segmentFile, outFormat, movFlags string, fragmented bool) (container, packaging string) {
 	if strings.EqualFold(strings.TrimSpace(segmentType), "fmp4") ||
 		strings.EqualFold(filepath.Ext(segmentFile), ".m4s") {
 		return "fmp4", "fmp4"
+	}
+	if strings.EqualFold(strings.TrimSpace(outFormat), "mp4") {
+		flags := strings.ToLower(movFlags)
+		if fragmented || strings.Contains(flags, "empty_moov") || strings.Contains(flags, "frag_") {
+			return "fmp4", "fmp4"
+		}
+		return "mp4", "mp4"
 	}
 	return "mpegts", "ts"
 }

--- a/backend/internal/infra/media/ffmpeg/executed_plan.go
+++ b/backend/internal/infra/media/ffmpeg/executed_plan.go
@@ -28,9 +28,12 @@ func executedFFmpegPlanFromArgs(args []string) ports.ExecutedFFmpegPlan {
 				outFormat = args[i+1]
 			}
 		case "-i":
-			// A -f seen before an -i described that INPUT's demuxer, not the
-			// output muxer. Only the -f after the last input names the output.
+			// Options seen before an -i (-f, -movflags, -frag_duration)
+			// described that INPUT, not the output muxer. Only the flags
+			// after the last input describe the output.
 			outFormat = ""
+			movFlags = ""
+			fragmented = false
 		case "-movflags":
 			if i+1 < len(args) {
 				movFlags = args[i+1]

--- a/backend/internal/infra/media/ffmpeg/executed_plan_test.go
+++ b/backend/internal/infra/media/ffmpeg/executed_plan_test.go
@@ -138,6 +138,63 @@ func TestExecutedFFmpegPlanFromArgs(t *testing.T) {
 				AudioMode: "copy", AudioCodec: "copy",
 			},
 		},
+		{
+			// LL-HLS pipe mode: no hls muxer flags at all — ffmpeg streams one
+			// fragmented MP4 to stdout for the in-process cmaf segmenter. Must
+			// classify as fmp4, not fall back to mpegts (that fallback fired a
+			// spurious plan_mismatch on every LL-HLS session).
+			name: "llhls cmaf pipe (fragmented mp4 on stdout)",
+			args: []string{
+				"-vaapi_device", "/dev/dri/renderD128",
+				"-i", "http://tuner/x",
+				"-c:v", "av1_vaapi",
+				"-c:a", "aac",
+				"-f", "mp4",
+				"-movflags", "empty_moov+default_base_moof+skip_trailer+frag_keyframe",
+				"-frag_duration", "500000",
+				"-flush_packets", "1",
+				"pipe:1",
+			},
+			want: ports.ExecutedFFmpegPlan{
+				Container: "fmp4", Packaging: "fmp4", HWAccel: "vaapi_encode_only",
+				VideoMode: "transcode", VideoCodec: "av1",
+				AudioMode: "transcode", AudioCodec: "aac",
+			},
+		},
+		{
+			// An input-side -f names the demuxer of the FOLLOWING -i and must
+			// not leak into the output classification.
+			name: "input -f does not leak into output format",
+			args: []string{
+				"-f", "mpegts",
+				"-i", "http://tuner/x",
+				"-c:v", "copy",
+				"-c:a", "aac",
+				"-f", "mp4",
+				"-movflags", "empty_moov+frag_keyframe",
+				"pipe:1",
+			},
+			want: ports.ExecutedFFmpegPlan{
+				Container: "fmp4", Packaging: "fmp4", HWAccel: "none",
+				VideoMode: "copy", VideoCodec: "copy",
+				AudioMode: "transcode", AudioCodec: "aac",
+			},
+		},
+		{
+			name: "plain unfragmented mp4 output stays mp4",
+			args: []string{
+				"-i", "http://tuner/x",
+				"-c:v", "copy",
+				"-c:a", "aac",
+				"-f", "mp4",
+				"/x/out.mp4",
+			},
+			want: ports.ExecutedFFmpegPlan{
+				Container: "mp4", Packaging: "mp4", HWAccel: "none",
+				VideoMode: "copy", VideoCodec: "copy",
+				AudioMode: "transcode", AudioCodec: "aac",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/backend/internal/infra/media/ffmpeg/executed_plan_test.go
+++ b/backend/internal/infra/media/ffmpeg/executed_plan_test.go
@@ -181,6 +181,25 @@ func TestExecutedFFmpegPlanFromArgs(t *testing.T) {
 			},
 		},
 		{
+			// Input-side frag options (before -i) must not mark the OUTPUT
+			// as fragmented.
+			name: "input-side movflags do not leak into output",
+			args: []string{
+				"-movflags", "frag_keyframe",
+				"-f", "mp4",
+				"-i", "/x/in.mp4",
+				"-c:v", "copy",
+				"-c:a", "aac",
+				"-f", "mp4",
+				"/x/out.mp4",
+			},
+			want: ports.ExecutedFFmpegPlan{
+				Container: "mp4", Packaging: "mp4", HWAccel: "none",
+				VideoMode: "copy", VideoCodec: "copy",
+				AudioMode: "transcode", AudioCodec: "aac",
+			},
+		},
+		{
 			name: "plain unfragmented mp4 output stays mp4",
 			args: []string{
 				"-i", "http://tuner/x",


### PR DESCRIPTION
## Summary

Every LL-HLS session logged a spurious warning:

```
ffmpeg executed plan diverges from finalized profile prediction
plan_mismatch: container:fmp4!=mpegts packaging:fmp4!=ts
```

The executed-plan parser (`executedFFmpegPlanFromArgs`) only knew the hls-muxer flags (`-hls_segment_type` / `-hls_segment_filename`). The LL-HLS pipe mode never touches the hls muxer — ffmpeg streams one fragmented MP4 (`-f mp4 -movflags empty_moov+…+frag_keyframe pipe:1`) to stdout and the in-process CMAF segmenter packages it into fMP4 segments — so the parser fell back to `mpegts/ts`. The "un-lie-able" executed plan was itself lying, and the stats-integrity check fired on a pipeline that was working exactly as designed.

## Fix

Classify the output `-f` muxer: input-side `-f` flags are reset at each `-i`, fragmented mp4 (frag movflags or `-frag_duration`) maps to `fmp4/fmp4`, plain mp4 output stays `mp4/mp4`, everything else keeps the mpegts fallback.

## Tests

3 new table cases: LL-HLS cmaf pipe argv (the real production argv), input-side `-f` leak guard, plain unfragmented mp4. `go test -race` green for `infra/media/ffmpeg` and `domain/session/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)