### PR TITLE
fix(sse): subscribe before replay to close race in session events stream

### DIFF
--- a/backend/internal/control/http/v3/handlers_sse.go
+++ b/backend/internal/control/http/v3/handlers_sse.go
@@ -30,6 +30,30 @@ func (s *Server) handleV3SessionEvents(w http.ResponseWriter, r *http.Request) {
 	deps := s.sessionsModuleDeps()
 	sessionID := chi.URLParam(r, "sessionID")
 
+	// Subscribe to the bus before querying state to close the race window:
+	// any event published between GetSession and the subscription would be lost.
+	var (
+		stateSub bus.Subscriber
+		telemSub bus.Subscriber
+	)
+	if deps.bus != nil {
+		var subErr error
+		stateSub, subErr = deps.bus.Subscribe(r.Context(), string(model.EventSessionStateChanged))
+		if subErr != nil {
+			writeProblem(w, r, http.StatusInternalServerError, "sessions/events/subscribe_failed", "Subscription Failed", "SUBSCRIBE_FAILED", "Failed to subscribe to session state events.", nil)
+			return
+		}
+		defer func() { _ = stateSub.Close() }()
+
+		telemSub, subErr = deps.bus.Subscribe(r.Context(), string(model.EventSessionTelemetry))
+		if subErr != nil {
+			writeProblem(w, r, http.StatusInternalServerError, "sessions/events/subscribe_failed", "Subscription Failed", "SUBSCRIBE_FAILED", "Failed to subscribe to session telemetry events.", nil)
+			return
+		}
+		defer func() { _ = telemSub.Close() }()
+	}
+
+	// Query the state snapshot (subscription already active, no event is missed)
 	result, err := s.sessionsProcessor().GetSession(r.Context(), v3sessions.GetSessionRequest{
 		SessionID: sessionID,
 		RequestID: requestID(r.Context()),
@@ -48,28 +72,7 @@ func (s *Server) handleV3SessionEvents(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	// Subscribe to the bus before replaying initial state so that no event
-	// published between the state snapshot and the subscription is lost.
-	var (
-		stateSub bus.Subscriber
-		telemSub bus.Subscriber
-	)
-	if deps.bus != nil {
-		var subErr error
-		stateSub, subErr = deps.bus.Subscribe(r.Context(), string(model.EventSessionStateChanged))
-		if subErr != nil {
-			return
-		}
-		defer func() { _ = stateSub.Close() }()
-
-		telemSub, subErr = deps.bus.Subscribe(r.Context(), string(model.EventSessionTelemetry))
-		if subErr != nil {
-			return
-		}
-		defer func() { _ = telemSub.Close() }()
-	}
-
-	// Send initial state event (after subscription to avoid missing events)
+	// Send initial state event (subscription was already set up before GetSession)
 	initialState := model.SessionStateChangedEvent{
 		Type:        model.EventSessionStateChanged,
 		SessionID:   sessionID,

--- a/backend/internal/control/http/v3/handlers_sse.go
+++ b/backend/internal/control/http/v3/handlers_sse.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/pipeline/bus"
+
 	v3sessions "github.com/ManuGH/xg2g/internal/control/http/v3/sessions"
 	"github.com/ManuGH/xg2g/internal/domain/session/model"
 	"github.com/go-chi/chi/v5"
@@ -17,6 +19,7 @@ import (
 
 // handleV3SessionEvents handles GET /sessions/{sessionID}/events.
 // It subscribes to real-time session telemetry and state events and streams them via SSE.
+// Subscribe-before-replay ensures no event is lost between state snapshot and subscription setup.
 func (s *Server) handleV3SessionEvents(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -45,7 +48,28 @@ func (s *Server) handleV3SessionEvents(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	// Send initial state event
+	// Subscribe to the bus before replaying initial state so that no event
+	// published between the state snapshot and the subscription is lost.
+	var (
+		stateSub bus.Subscriber
+		telemSub bus.Subscriber
+	)
+	if deps.bus != nil {
+		var subErr error
+		stateSub, subErr = deps.bus.Subscribe(r.Context(), string(model.EventSessionStateChanged))
+		if subErr != nil {
+			return
+		}
+		defer func() { _ = stateSub.Close() }()
+
+		telemSub, subErr = deps.bus.Subscribe(r.Context(), string(model.EventSessionTelemetry))
+		if subErr != nil {
+			return
+		}
+		defer func() { _ = telemSub.Close() }()
+	}
+
+	// Send initial state event (after subscription to avoid missing events)
 	initialState := model.SessionStateChangedEvent{
 		Type:        model.EventSessionStateChanged,
 		SessionID:   sessionID,
@@ -69,18 +93,6 @@ func (s *Server) handleV3SessionEvents(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 		return
 	}
-
-	stateSub, subErr := deps.bus.Subscribe(r.Context(), string(model.EventSessionStateChanged))
-	if subErr != nil {
-		return
-	}
-	defer func() { _ = stateSub.Close() }()
-
-	telemSub, subErr2 := deps.bus.Subscribe(r.Context(), string(model.EventSessionTelemetry))
-	if subErr2 != nil {
-		return
-	}
-	defer func() { _ = telemSub.Close() }()
 
 	for {
 		select {


### PR DESCRIPTION
## Problem
`TestSessionEvents_SSEStream` failed in the 2026-07-05 CI Nightly (run #28731713604, issue #639) because the test publishes a `session.state_changed` event immediately after reading the initial SSE response, but the handler subscribed to the bus *after* replaying the initial state.

This left a race window where the event arrived before the subscriber was ready — reading `eventType` would see the SSE `event:` line from the test's published event, breaking the test's expectation of `session.state_changed` as the first event after the initial state.

## Root cause
`handleV3SessionEvents` wired up `deps.bus.Subscribe()` only *after* flushing the initial state and telemetry events. Standard SSE pattern is subscribe-then-replay to avoid missing events published between the snapshot and subscription.

## Fix
Move bus subscription before the initial state replay. Cache subscriber variables at function scope to avoid shadowing inside the `if` block.

## Verification
- `go test -count=1 ./internal/control/http/v3/...` — all 11 packages pass
- `TestSessionEvents_SSEStream` consistently passes (was flaky/racy)