### PR TITLE
docs: close release-manifest drift and document real deploy path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify release manifest matches tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version_file="$(tr -d '[:space:]' < backend/VERSION)"
+          manifest_version="$(jq -r '.version' RELEASE_MANIFEST.json)"
+          if [[ "${version_file}" != "${tag}" ]]; then
+            echo "::error::backend/VERSION (${version_file}) does not match tag ${tag}." >&2
+            exit 1
+          fi
+          if [[ "${manifest_version}" != "${tag}" ]]; then
+            echo "::error::RELEASE_MANIFEST.json version (${manifest_version}) does not match tag ${tag}. Run backend/scripts/release-prepare.sh ${tag} before tagging." >&2
+            exit 1
+          fi
+          if ! jq -e --arg t "${tag}" '.releases[$t]' DIGESTS.lock > /dev/null; then
+            echo "::error::DIGESTS.lock has no entry for ${tag}. Run backend/scripts/release-prepare.sh ${tag} before tagging." >&2
+            exit 1
+          fi
+          echo "Release manifest and digest lock agree with tag ${tag}."
+
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,181 @@
 
 ## Unreleased
 
+> Reconstructed 2026-07-07 from `git log v3.8.0..main` (mechanical grouping by
+> commit type, not hand-authored impact prose — see PR numbers for detail).
+
+### Release Notes
+
+- Low-Latency HLS shipped end-to-end: real LL-HLS packaging with `EXT-X-PART`
+  and blocking playlist reload (#629), gated on observed parts so plain
+  playlists serve until real parts exist (#638), `temp_file` dropped from the
+  LL path (#637), and a CMAF stream segmenter for genuine LL-HLS parts (#640).
+- Session leases no longer expire under active playback: the lease now
+  renews from HLS playlist consumption, not only the JS heartbeat, closing a
+  failure mode where a failed channel zap orphaned the still-playing session
+  until the reaper killed it (#646).
+- Live truth resolution gained stale-while-revalidate plus an LL-HLS sliding
+  window (#641); a spurious `plan_mismatch` warning on the LL-HLS CMAF pipe
+  path was fixed (#642).
+- HLS session start hardened: session-ready floor, atomic playlist
+  publication, last-known-good guard (#636).
+- Player: in-player channel list/zapper (#619), cold-start freeze fixed via
+  leading-gap seek (#613), SSE subscribe-before-replay race fixed (#645).
+- Recordings: continue-watching rail with cross-device resume deep-links
+  (#626), timeline hover preview frames for VOD scrubbing (#628).
+- WebUI: PWA installability, icon set, polling/asset polish (#623).
+- Live truth freshness window widened 2h→7d to kill cold-start re-probe
+  (#609); periodic capability cache refresh added to drain cold channels
+  (#606) — a reconnect-tolerance variant of this was tried and reverted after
+  disproving on staging (#607/#608).
+
+### Technical Notes
+
+- `perf`: stream-relay reconnect backoff cap tightened 5s→2s (#602);
+  preflight clear-lead fast path skips a 752KB descrambler-lock read for FTA
+  relay sources (#601).
+- Steady-state log noise cut (receiver polling, ffmpeg storms) (#621);
+  embedded WebUI dist build no longer stamps `-dirty` on regeneration (#622).
+
+## [v3.7.2] - 2026-06-15
+
+> Reconstructed 2026-07-07 from `git log v3.7.1..v3.7.2`.
+
+### Release Notes
+
+- Backend medium/low and frontend audit findings merged onto main (#588).
+
+### Technical Notes
+
+- De-flaked `TestTruthProvider_ProbeFailure_PersistsState` (#586).
+
+## [v3.7.1] - 2026-06-13
+
+> Reconstructed 2026-07-07 from `git log v3.7.0..v3.7.1`. Most of this
+> release is a bundle of "ultrareview" audit fixes (#567–#573).
+
+### Release Notes
+
+- Fixed a config-interval startup panic and a Trivy config-scan finding
+  (#567).
+- GPU encoder runtime failure accounting no longer counts deliberate stops
+  (#568) or excludes the watchdog-nil/parentCtx-cancel race path from
+  demotion (#571) as false failures.
+- Recordings: black-render code 242 now counts as a decode warning, not an
+  error (#569).
+- WebUI: fixed two long-running-session memory leaks (#570); the recovering
+  state now surfaces in the UI instead of a silent black frame (#576).
+- Auth: fixed empty-token wipe and a media legacy-cookie bypass (#573).
+- XMLTV writes are now durable — stopped nesting `epg.WriteXMLTV` inside a
+  retry that could tear the file (#572).
+- FFmpeg: stopped force-appending `+igndts` on live ingest, fixing judder
+  (#584).
+- Stream-relay probe override keys allowlisted in config (#580).
+- README now states PolyForm NC is source-available, not OSI open-source
+  (#574).
+
+## [v3.7.0] - 2026-06-08
+
+> Reconstructed 2026-07-07 from `git log v3.6.0..v3.7.0`.
+
+### Release Notes
+
+- Live 50p motion is now preserved for interlaced sources when the host can
+  sustain it, gated on an adaptive host-capability benchmark rather than a
+  fixed default (#557–#560).
+- Stream-relay transcode probe depth is now configurable; default startup
+  dropped 21s→9.8s (#557).
+- Player now rides over bad-DTS broadcast gaps instead of stalling (#556);
+  DVR timeline gained a current-position readout and hover preview (#543).
+- HTTP/HTTPS posture hardened: TLS, COOP/CORP, compression (#548); WebUI
+  warns when opened over an insecure context (#552); FE↔BE connection made
+  resilient to flaky networks (#549).
+- Reverse-proxy/HTTPS deployment guides rewritten newcomer-first, covering
+  every exposure scenario (#550, #551, #554).
+
+### Technical Notes
+
+- Maintainer-private data scrubbed from the public repo (#553).
+
+## [v3.6.0] - 2026-06-04
+
+> Reconstructed 2026-07-07 from `git log v3.5.1..v3.6.0`. This range mixes a
+> large feature recovery with a large mechanical refactor wave; both are
+> summarized rather than itemized per PR.
+
+### Release Notes
+
+- Playback-truth rebuild recovered and landed (28 commits): AV1 10-bit
+  (p010le), adaptive bitrate ceiling, mobile player and resume (#476, #477).
+- GPU hardware-encoder capability is now observed at runtime with automatic
+  demotion on encoder-open failure (#517, #518), decode-verify with a
+  three-state verdict (#519), and AV1 verification at production bit depth
+  (#521).
+- Safari now routes to hls.js + ManagedMediaSource instead of native HLS, so
+  the app owns the buffer (#534); session failure reasons are localized
+  instead of showing raw `R_` codes (#539); resume recovery observes state
+  before acting (#533).
+- Opt-in OpenTelemetry tracing wired at startup: ffmpeg spawn → first HLS
+  segment, and the playback decision/probe step.
+- Documentation portal re-cut into User/Operator/Contributor lanes; Getting
+  Started and Troubleshooting guides added.
+
+### Technical Notes
+
+- Large internal refactor wave (~45 PRs, #480–#516): split multiple
+  1000+-line "god files" (ffmpeg LocalAdapter, health runtime_snapshot,
+  openwebif client, session orchestrator, v3 server) into focused
+  per-concern files. No intended behavior change; covered by existing tests.
+- `interface{}` modernized to `any` across the backend (Go 1.18+ idiom,
+  #478).
+
+## [v3.5.1] - 2026-06-03
+
+> Reconstructed 2026-07-07 from `git log v3.5.0..v3.5.1`.
+
+### Technical Notes
+
+- FFmpeg pinned version bumped 8.1→8.1.1 (#473).
+- Release pipeline migrated from GoReleaser `dockers`/`docker_manifests` to
+  `dockers_v2`; FFmpeg base image now builds multi-arch natively, dropping
+  QEMU (#468–#471).
+- GoReleaser `GOOS` restricted to linux; AI-attribution footer dropped from
+  `backend/.goreleaser.yml`.
+
+## [v3.5.0] - 2026-06-02
+
+> Reconstructed 2026-07-07 from `git log v3.4.8..v3.5.0`. A `v3.4.9` was
+> prepared (see the WebUI-refresh and playback-integration prep commits in
+> this range) but never tagged or released — the work rolled forward
+> directly into this release instead. The `v3.4.9` entry below predates this
+> reconstruction and describes what actually shipped under that heading in
+> practice.
+
+### Release Notes
+
+- Live player: rolling DVR, now-playing EPG, black-screen and seek fixes,
+  MediaSource Extensions groundwork (#467).
+- Central request-body size backstop added; PIN-unlock throttle proven under
+  test (#452).
+- FFmpeg: sub-720p AV1 upscaled to ≥720p for Apple hardware decode; session
+  lease TTL lowered to 120s and made configurable (#2fea2327); transcode
+  start budget raised to 30s for live broadcast joins.
+- Security: ffmpeg URL userinfo stripped from argv, CORS `Allow-*` gated on
+  origin (#462); M3U injection from upstream channel names neutralized.
+- Monitoring: tuner-leak alert re-pointed to the live session gauge; alerts
+  now fire only on live metrics, dropping dead-admission false positives
+  (#461).
+- WebUI: deep links now resolve under the `/ui` base path (#453); fonts
+  self-hosted, real favicon added (#449); EmptyState primitive added and
+  migrated across Timers/Logs/Recordings (#404).
+
+### Technical Notes
+
+- Dead code removed: `internal/cache`, `internal/v3`, Redis dependency
+  dropped (#d051b130).
+- `usePlaybackOrchestrator` split into focused modules across several
+  phases (#b32e184b, #4f139650, #58f0bc0e, #1e11436b).
+
 ## [v3.8.0] - 2026-06-22
 
 ### Behavioral Changes

--- a/DIGESTS.lock
+++ b/DIGESTS.lock
@@ -47,6 +47,18 @@
     "v3.7.0": {
       "digest": "pending",
       "published_at": "pending"
+    },
+    "v3.7.1": {
+      "digest": "pending",
+      "published_at": "pending"
+    },
+    "v3.7.2": {
+      "digest": "pending",
+      "published_at": "pending"
+    },
+    "v3.8.0": {
+      "digest": "pending",
+      "published_at": "pending"
     }
   }
 }

--- a/RELEASE_MANIFEST.json
+++ b/RELEASE_MANIFEST.json
@@ -1,10 +1,10 @@
 {
-  "version": "v3.7.0",
-  "git_sha": "217e8f56a60e55829e3915c68012a88cf72d6346",
+  "version": "v3.8.0",
+  "git_sha": "46b952f34665e5c98671d9432a3859e12d3c80b8",
   "image": "ghcr.io/manugh/xg2g",
-  "tag": "v3.7.0",
+  "tag": "v3.8.0",
   "digest": null,
-  "build_time_utc": "2026-06-08T06:37:48Z",
+  "build_time_utc": "2026-06-22T16:23:38Z",
   "provenance_ref": null,
   "sbom_ref": null
 }

--- a/TECHNICAL_DEBT_2026.md
+++ b/TECHNICAL_DEBT_2026.md
@@ -147,3 +147,121 @@
   - `.github/workflows/pr-required-gates.yml`
   - `.github/workflows/phase4-guardrails.yml`
   - `.github/workflows/ci-deep-scheduled.yml`
+
+---
+
+## P5 — Release/Docs Governance Drift (found 2026-07-07)
+
+### P5.1 RELEASE_MANIFEST.json / DIGESTS.lock silently stale for 3 releases
+**Status:** Completed on 2026-07-07.
+
+**Target:** `RELEASE_MANIFEST.json` and `DIGESTS.lock` reflect the actual
+latest tag, and cannot silently drift again.
+
+**Root Cause**
+- `backend/scripts/release-prepare.sh` is the only thing that updates these
+  files, and it is a manual, opt-in script. Nothing in CI enforces it.
+- Tag commits for v3.7.1 (#584), v3.7.2 (#588), and v3.8.0 (#600) each only
+  bumped `backend/VERSION` and re-rendered docs; none touched
+  `RELEASE_MANIFEST.json` or `DIGESTS.lock`. The files were frozen at v3.7.0
+  (2026-06-08) while three more tags shipped.
+
+**Exit-Criteria**
+- `RELEASE_MANIFEST.json.version` and a `DIGESTS.lock` entry match the
+  latest tag.
+- `.github/workflows/release.yml` fails the build on a tag push if they
+  don't match.
+
+**Result**
+- Backfilled both files to `v3.8.0` (correct `git_sha` from the tag).
+- Added a gate step to `release.yml`, before GoReleaser runs, that checks
+  `backend/VERSION`, `RELEASE_MANIFEST.json`, and `DIGESTS.lock` all agree
+  with `GITHUB_REF_NAME` and fails loudly (pointing at
+  `release-prepare.sh`) if not.
+- `backend/scripts/verify-digest-lock.sh` and
+  `backend/scripts/verify-release-output-contract.sh` both pass against the
+  backfilled files.
+
+**Verification Note**
+- The registry `digest` field itself has never been populated with a real
+  value for any release in this project's history (every entry back to
+  `3.1.7` reads `"pending"`) — that part of the contract was aspirational
+  from the start and is unresolved by this fix. Left as-is rather than
+  fabricating digests.
+
+### P5.2 `docs/ops/DEPLOYMENT.md` described a process nobody follows
+**Status:** Completed on 2026-07-07.
+
+**Target:** The documented deployment path matches what actually runs in
+production.
+
+**Root Cause**
+- `DEPLOYMENT.md` stated the only supported path is `deploy/sync.sh` and
+  that manual `/srv/xg2g` drift is unsupported. Live forensics on LXC 110
+  (`docker inspect`, `pct exec`, `/root/xg2g` git log) showed both running
+  instances actually execute a binary built ad-hoc on the host and pushed
+  via `pct push` — the exact workflow the doc called unsupported — and at
+  the time of the audit that binary was 6 commits ahead of
+  `origin/fix/lease-consumption-renewal`, i.e. running unpushed code.
+
+**Exit-Criteria**
+- The doc names both real paths (tagged-release/OCI for anyone outside the
+  maintainer's own host, fast-iteration `pct push` for the maintainer's own
+  host) instead of pretending only one exists.
+
+**Result**
+- Added a "Fast Iteration Path (maintainer's own host only)" section to
+  `DEPLOYMENT.md` documenting the `pct push` workflow as sanctioned, with
+  the one rule that actually matters for it: nothing gets deployed that
+  isn't already pushed to `origin` (a clean `git status` on the build host
+  is not sufficient evidence of that).
+
+**Verification Note**
+- Per `AGENTS.md`'s own rule ("update `RUNBOOK_SYSTEMD_COMPOSE.md` with the
+  exact observed delta"), the specific observed facts (image label vs.
+  runtime binary mismatch, unpushed commit running in prod) were also added
+  there as an "Observed live-host delta on July 7, 2026" entry, matching the
+  existing March/April 2026 entries' format. `DEPLOYMENT.md` carries the
+  policy change (the path is sanctioned); the runbook carries the forensic
+  record of what was actually found.
+
+### P5.3 CHANGELOG.md missing six tagged releases
+**Status:** Completed on 2026-07-07.
+
+**Target:** Every tagged release from `v3.5.0` through `v3.8.0` has a
+`CHANGELOG.md` entry, and `Unreleased` reflects work merged since.
+
+**Root Cause**
+- `CHANGELOG.md` jumped directly from `[v3.8.0]` to `[v3.4.9]` — a version
+  that was itself never tagged or released (the `v3.4.9` prep commits rolled
+  forward into `v3.5.0` instead). `v3.5.0`, `v3.5.1`, `v3.6.0`, `v3.7.0`,
+  `v3.7.1`, and `v3.7.2` — six real releases per `gh release list` — had no
+  entry at all, and `Unreleased` was empty despite 46 merged commits since
+  `v3.8.0`.
+
+**Exit-Criteria**
+- All six missing releases and `Unreleased` have entries.
+
+**Result**
+- Added all six entries plus `Unreleased`, each reconstructed from
+  `git log <prev-tag>..<tag>` and marked as mechanically reconstructed
+  rather than hand-authored impact prose (see each entry's provenance
+  note).
+
+**Verification Note**
+- These entries are commit-subject groupings, not independently verified
+  user-impact claims the way `v3.8.0`'s hand-written "Behavioral Changes"
+  section is. Treat them as a factual index into the PR history, not as a
+  substitute for reading the linked PRs if precision matters.
+
+### P5.4 Minor cleanup found during the same pass
+**Status:** Completed on 2026-07-07 (P5.4a); tracked, not actioned (P5.4b).
+
+- **P5.4a:** `backend/scripts/verify-digest-lock.sh` printed `vv3.8.0`
+  (double `v`) in its log line, because `backend/VERSION` already includes
+  the `v` prefix and the script prepended another. Fixed.
+- **P5.4b:** `/srv/xg2g` on LXC 110 has five files (`IDENTITY.md`,
+  `SOUL.md`, `USER.md`, `HEARTBEAT.md`, `TOOLS.md`) with zero history
+  anywhere in this repo's git — orphaned artifacts on that host's stale
+  checkout, not a repo issue. Needs a decision on the live host, not a
+  commit; not actioned here.

--- a/backend/scripts/verify-digest-lock.sh
+++ b/backend/scripts/verify-digest-lock.sh
@@ -14,7 +14,7 @@ if [[ ! -f "$LOCK_FILE" ]]; then
     exit 1
 fi
 
-echo "🔍 Validating Digest Stability for v${VERSION}..."
+echo "🔍 Validating Digest Stability for ${VERSION}..."
 
 # 1. Structural Validation (Basic YAML/JSON check)
 # Check if VERSION exists in releases
@@ -50,7 +50,7 @@ DIGEST_VAL=$(grep -A 1 "\"${VERSION}\":" "$LOCK_FILE" | grep "digest" | sed 's/.
 IMAGE_REPO=$(grep "\"image\":" "$LOCK_FILE" | sed 's/.*"image":[[:space:]]*//' | tr -d '"' | tr -d '[:space:]' | tr -d ',')
 
 if [[ -z "$DIGEST_VAL" ]]; then
-    echo "❌ Could not extract digest for v${VERSION} from DIGESTS.lock"
+    echo "❌ Could not extract digest for ${VERSION} from DIGESTS.lock"
     exit 1
 fi
 

--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -61,7 +61,7 @@ edit/verify loops):
 1. Build on the host that has the real working copy (not a laptop clone):
    `make build-with-ui` produces `bin/xg2g`.
 2. Push the binary into the running container's bind mount (e.g.
-   `pct push <ctid> bin/xg2g /srv/xg2g/xg2g-dev-binary.new && mv` into place —
+   `pct push <ctid> bin/xg2g /srv/xg2g/xg2g-dev-binary.new && pct exec <ctid> -- mv /srv/xg2g/xg2g-dev-binary.new /srv/xg2g/xg2g-dev-binary` into place —
    never overwrite the in-use file directly, some container runtimes return
    success on a busy-file write while leaving the old binary running).
 3. Restart the service (`systemctl restart xg2g`, or

--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -46,4 +46,38 @@ Deployment artifacts:
 - `deploy/xg2g.service` — systemd unit
 
 Direct host edits, ad-hoc file copies, and manual `/srv/xg2g` drift are not
-supported deployment workflows.
+supported deployment workflows for tagged releases, and are never acceptable
+on any host other than the maintainer's own.
+
+## Fast Iteration Path (maintainer's own host only)
+
+The tag-and-image path above is the only supported way to run xg2g anywhere
+outside the maintainer's own infrastructure, and the only path that produces
+an artifact anyone else can pull or audit. On the maintainer's own LXC/VM,
+day-to-day iteration instead uses a sanctioned fast path that skips the
+container image build (CI + FFmpeg image builds are too slow for tight
+edit/verify loops):
+
+1. Build on the host that has the real working copy (not a laptop clone):
+   `make build-with-ui` produces `bin/xg2g`.
+2. Push the binary into the running container's bind mount (e.g.
+   `pct push <ctid> bin/xg2g /srv/xg2g/xg2g-dev-binary.new && mv` into place —
+   never overwrite the in-use file directly, some container runtimes return
+   success on a busy-file write while leaving the old binary running).
+3. Restart the service (`systemctl restart xg2g`, or
+   `docker compose up -d --force-recreate` for containers that only read env
+   at recreate time, not at `docker restart`).
+4. Verify the deployed commit before considering this done: compare
+   `curl <host>/healthz` (`version` field, a `git describe` string) against
+   `git log origin/<branch>..HEAD` on the host that built it.
+
+**Non-negotiable rule:** every commit reachable from a binary running on this
+path must already be pushed to `origin` before it is deployed. A clean
+`git status` is not sufficient evidence of this — a fully committed branch
+can still be several commits ahead of `origin/<branch>` and thus invisible to
+anyone but the person who built it. Deploying unpushed commits means the
+running system's actual code has no record anywhere reviewable.
+
+This path is never used for the OCI image or GHCR tags — those are produced
+exclusively by `.github/workflows/release.yml` from a pushed, tagged commit,
+per the [Release Output Contract](RELEASE_OUTPUT_CONTRACT.md).

--- a/docs/ops/RUNBOOK_SYSTEMD_COMPOSE.md
+++ b/docs/ops/RUNBOOK_SYSTEMD_COMPOSE.md
@@ -234,6 +234,12 @@ Observed live-host delta on April 1, 2026 (runtime outage via stopped CT):
   - container startup logs still emitted `version":"v3.3.0"` and `commit":"dev"`
 - Operational rule: for outages fronted by Caddy, check Proxmox guest state before assuming an app-level regression. A stopped CT can surface as proxy `502/503` even when the in-guest systemd unit, Compose file, and Docker health gates are all correct once the guest is up.
 
+Observed live-host delta on July 7, 2026 (image tag is not runtime truth on this host):
+- `/srv/xg2g/deploy/docker-compose.yml` declares `image: ghcr.io/manugh/xg2g:v3.7.2`, but `docker ps`/`docker inspect` on the running `xg2g` container (port 8088) showed image `xg2g:staging` — a locally built tag, not the GHCR release — resolved through a `docker-compose.staging.yml` overlay merged in by `compose-xg2g.sh` even for the `xg2g.service`-managed instance. `xg2g-staging` (port 8089) resolved to a separate local tag `xg2g:staging-ctl3`. The two containers' `org.opencontainers.image.version` labels disagreed (`v3.5.1` vs `v3.8.0-ctl3`).
+- Neither label was the real answer: both containers bind-mount a raw host binary (`/srv/xg2g/xg2g-dev-binary:/usr/local/bin/xg2g:ro`) over whatever the image ships, per the maintainer's fast-iteration workflow (`docs/ops/DEPLOYMENT.md` § Fast Iteration Path). `curl :8088/healthz` and `curl :8089/healthz` both reported the same real running version (`version` field, a `git describe` string) — identical on both ports, and unrelated to either image label.
+- That real version corresponded to a commit that did not exist in `origin/<branch>` at audit time — it existed only on `/root/xg2g` (the host's real working copy), 6 commits ahead of the last push.
+- Operational rule: on this host, `docker inspect`'s image/label fields and the compose file's `image:` line are not runtime truth for the daemon binary — only `curl <host>/healthz` (`version` field) is. When checking what's actually deployed, always cross-reference that version string against `git log origin/<branch>..HEAD` on `/root/xg2g`, not against the compose file or image labels.
+
 If you see the March 11 metrics-only health mismatch, fix the live env first by setting:
 
 ```bash


### PR DESCRIPTION
## Summary

Audit pass (2026-07-07) found that several governance docs and files had drifted from what actually happens/runs, and this PR closes the drift:

- `RELEASE_MANIFEST.json`/`DIGESTS.lock` were frozen at v3.7.0 while three more releases (v3.7.1, v3.7.2, v3.8.0) shipped without running `backend/scripts/release-prepare.sh` — nothing enforced it. Backfilled to v3.8.0 and added a `release.yml` gate that fails a tag build if `backend/VERSION`/`RELEASE_MANIFEST.json`/`DIGESTS.lock` disagree with the pushed tag.
- `docs/ops/DEPLOYMENT.md` described `deploy/sync.sh` as the only supported path and called manual `/srv/xg2g` drift unsupported. Live forensics on LXC 110 showed both running instances actually execute an ad-hoc host-built binary pushed via `pct push` — at audit time, 6 commits ahead of `origin`. Documented that path as sanctioned for the maintainer's own host, with the one rule that matters: nothing deploys that isn't already pushed.
- `CHANGELOG.md` jumped from `[v3.8.0]` straight to `[v3.4.9]` (a version that was prepared but never tagged) — six real releases (v3.5.0 through v3.7.2) had no entry, and `Unreleased` was empty despite 46 merged commits. Backfilled all of them from `git log <prev-tag>..<tag>`, explicitly marked as mechanically reconstructed rather than hand-authored impact prose.
- `TECHNICAL_DEBT_2026.md` gets a new P5 section recording all of the above in the doc's existing format.
- `docs/ops/RUNBOOK_SYSTEMD_COMPOSE.md` gets an "Observed live-host delta on July 7, 2026" entry (image label vs. actual runtime binary, unpushed commit running in prod), per `AGENTS.md`'s own rule for this kind of finding.
- `backend/scripts/verify-digest-lock.sh`: fixed a cosmetic double-`v` in its log output (`vv3.8.0` → `v3.8.0`).

## Test plan

- [x] `bash backend/scripts/verify-digest-lock.sh` passes against the backfilled `RELEASE_MANIFEST.json`/`DIGESTS.lock`
- [x] `bash backend/scripts/verify-release-output-contract.sh` passes
- [x] `RELEASE_MANIFEST.json`/`DIGESTS.lock` validated as well-formed JSON
- [ ] New `release.yml` gate step is untested against a real tag push (can't dry-run a tag-triggered workflow locally) — worth a close look before the next real release tag