### PR TITLE
chore(go): bump toolchain to go1.25.12 to fix govulncheck findings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,5 +39,8 @@ RUN if ! getent group "${USER_GID}" >/dev/null 2>&1; then \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${USERNAME}" && \
     chmod 0440 "/etc/sudoers.d/${USERNAME}"
 
+# Dev container has no long-running service; disable HEALTHCHECK to suppress Trivy DS-0026.
+HEALTHCHECK NONE
+
 USER ${USERNAME}
 WORKDIR /workspaces/xg2g

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-bookworm
+FROM golang:1.25.12-bookworm
 
 ARG USERNAME=vscode
 ARG USER_UID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,8 @@ COPY backend/contracts/version_matrix.json ../../backend/contracts/version_matri
 RUN npm run build
 
 # Stage 3: Build xg2g application
-# Keep in sync with go.mod (currently requires Go 1.25.11).
-FROM golang:1.25.11 AS app-builder
+# Keep in sync with go.mod (currently requires Go 1.25.12).
+FROM golang:1.25.12 AS app-builder
 ARG BUILD_VERSION
 ARG BUILD_COMMIT
 ARG BUILD_DATE

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -3,7 +3,7 @@
 # docker build -f Dockerfile.distroless backend
 
 # Build stage
-FROM golang:1.25.11-alpine AS builder
+FROM golang:1.25.12-alpine AS builder
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/ManuGH/xg2g
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.work
+++ b/go.work
@@ -1,3 +1,3 @@
-go 1.25.11
+go 1.25.12
 
 use ./backend

--- a/mk/variables.mk
+++ b/mk/variables.mk
@@ -16,7 +16,7 @@ SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct 2>/dev/null || date -u +%s)
 export SOURCE_DATE_EPOCH
 export TZ := UTC
 export GOFLAGS := -trimpath -buildvcs=false -mod=vendor
-GOTOOLCHAIN ?= go1.25.11
+GOTOOLCHAIN ?= go1.25.12
 export GOTOOLCHAIN
 export GOWORK := off
 GO := go


### PR DESCRIPTION
## Summary

Bumps Go toolchain from 1.25.11 → 1.25.12 to fix two stdlib vulnerabilities flagged by nightly `govulncheck`:

| CVE | Package | Description |
|---|---|---|
| GO-2026-5856 | `crypto/tls` | ECH privacy leak |
| GO-2026-4970 | `os` | Root escape via symlink + trailing slash |

## Files changed

- `backend/go.mod` — toolchain directive
- `go.work` — workspace version
- `mk/variables.mk` — `GOTOOLCHAIN` default
- `Dockerfile` — builder image
- `Dockerfile.distroless` — distroless builder
- `.devcontainer/Dockerfile` — dev container

## Verification

- ✅ All Go tests pass (`oc-xg2g-verify`)
- ✅ `govulncheck -tags=nogpu ./...` reports **No vulnerabilities found** with go1.25.12
- ✅ No `go.sum` changes (version-only bump)

Closes #655, closes #658