### PR TITLE
fix(ci): accept typed one-line UI variables

### DIFF
--- a/backend/scripts/check-ui-contract.sh
+++ b/backend/scripts/check-ui-contract.sh
@@ -199,9 +199,11 @@ if [ "$IS_SCOPED" = true ]; then
     if [[ "$file" == *.tsx ]]; then
       clean_file="${file#frontend/webui/src/}"
       
-      # Step 1: Check for multi-line style props (FAIL immediately)
+      # Step 1: Check for multi-line style props (FAIL immediately).
+      # TypeScript custom-property objects commonly close as
+      # `} as CSSProperties}`; that is still a single-line style prop.
       multiline_check=$(grep -n "style={{" "$clean_file" | while read -r line; do
-         if [[ ! "$line" =~ \}\} ]]; then
+         if [[ ! "$line" =~ \}[[:space:]]*(as[[:space:]]+[[:alnum:]_.]+)?[[:space:]]*\} ]]; then
             echo "$line"
          fi
       done || true)


### PR DESCRIPTION
## Summary
- recognize one-line custom-property objects closed with `as CSSProperties` in the scoped UI contract parser
- retain rejection of genuinely multi-line `style={{` blocks

## Verification
- exact scoped file list from failed main run `29614593425`
- full `./backend/scripts/check-ui-contract.sh`
- `bash -n backend/scripts/check-ui-contract.sh`