### PR TITLE
fix(deploy): resolve production binary mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - "docker-compose*.yml"
       - "README.md"
       - "backend/scripts/**"
+      - "scripts/**"
       - "Makefile"
       - "backend/templates/**"
       - "frontend/webui/**"

--- a/scripts/promote_production.sh
+++ b/scripts/promote_production.sh
@@ -15,11 +15,21 @@ ssh "${REMOTE_HOST}" bash -s -- "${CTID}" <<'REMOTE'
 set -euo pipefail
 ctid="$1"
 staging_binary="/srv/xg2g-staging/xg2g-staging-binary"
-production_binary="/srv/xg2g/xg2g"
-rollback_binary="/srv/xg2g/xg2g.rollback"
-next_binary="/srv/xg2g/xg2g.next"
 rollback_armed=0
 old_sha=""
+
+production_binary="$(
+  pct exec "${ctid}" -- docker inspect --format '{{range .Mounts}}{{if eq .Destination "/usr/local/bin/xg2g"}}{{println .Source}}{{end}}{{end}}' xg2g |
+    awk 'NF'
+)"
+[[ "${production_binary}" =~ ^/srv/xg2g/xg2g([A-Za-z0-9._-]*)$ ]] || {
+  echo "ERROR: production container has no trusted /usr/local/bin/xg2g host mount: ${production_binary:-missing}" >&2
+  exit 1
+}
+pct exec "${ctid}" -- test -f "${production_binary}"
+rollback_binary="${production_binary}.rollback"
+next_binary="${production_binary}.next"
+echo "Production binary mount resolved: ${production_binary}"
 
 wait_ready() {
   local port="$1" container="$2" i status


### PR DESCRIPTION
## What changed

Resolve the host source mounted at `/usr/local/bin/xg2g` from the running production container and use that exact path for promotion and rollback. The resolved path is restricted to the trusted `/srv/xg2g/xg2g*` namespace and must exist before any write occurs.

## Why

Production binds `/srv/xg2g/xg2g-production-binary`, while the promotion script hardcoded `/srv/xg2g/xg2g`. The first promotion therefore updated an unused file; the post-restart hash guard detected the mismatch and safely rolled back.

## Impact

Promotions now update and roll back the binary actually mounted by production, while retaining fail-closed validation and hash verification.

## Validation

- `bash -n scripts/promote_production.sh`
- `shellcheck scripts/promote_production.sh`
- Read-only resolution against the production container returned `/srv/xg2g/xg2g-production-binary` and verified the file exists
- `git diff --check`
- `make ci-pr` (including 604 WebUI tests)