### PR TITLE
feat(recordings): enforce strict planner targets and remove legacy edge fallbacks (Phase 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,22 @@ For every review comment, use this sequence:
 Outdated comments are not silently treated as fixed. They are either answered
 with the commit that superseded them or explicitly documented as obsolete.
 
+This lifecycle applies to every agent and every mode, including the Dynamic
+Fallback role. Resolving a thread via API (`resolveReviewThread` mutation or
+otherwise) without a fix commit on the PR head or a written reply in the
+thread is prohibited. Bot reviewers (e.g. gemini-code-assist) count as
+reviewers: their findings get a fix or a one-sentence justification in the
+thread before the thread is resolved — never a silent resolve.
+
+### Merge policy
+
+- Admin merge (`gh pr merge --admin`) may bypass the review-approval gate —
+  this is accepted solo-repo reality — but it must NEVER bypass CI. Admin
+  merge is allowed only after all required checks have completed green;
+  merging over pending or failing checks is prohibited.
+- Before any merge, confirm there are no unresolved review threads that lack
+  a fix or a written reply (see lifecycle above).
+
 ### Branch and worktree rules
 
 - Inspect `git status`, branch, worktrees, and remote tracking state before

--- a/backend/config.generated.example.yaml
+++ b/backend/config.generated.example.yaml
@@ -150,6 +150,8 @@ recording_playback:
   playback_policy: auto
   stable_window: 10s
 recording_roots: {}
+recordings:
+  strict_target_required: false
 server:
   idleTimeout: 2m
   maxHeaderBytes: 1048576

--- a/backend/internal/config/merge_env.go
+++ b/backend/internal/config/merge_env.go
@@ -351,6 +351,7 @@ func (l *Loader) mergeEnvRecordings(cfg *AppConfig) {
 		l.envString("XG2G_RECORDINGS_MAP", ""),
 		cfg.RecordingPathMappings,
 	)
+	cfg.RecordingStrictTargetRequired = l.envBool("XG2G_RECORDINGS_STRICT_TARGET_REQUIRED", cfg.RecordingStrictTargetRequired)
 }
 
 func (l *Loader) mergeEnvVerification(cfg *AppConfig) {

--- a/backend/internal/config/registry.go
+++ b/backend/internal/config/registry.go
@@ -259,6 +259,7 @@ func buildRegistry() (*Registry, error) {
 		{Path: "recording_playback.playback_policy", Env: "XG2G_RECORDING_PLAYBACK_POLICY", FieldPath: "RecordingPlaybackPolicy", Profile: ProfileAdvanced, Status: StatusActive, Default: "auto"},
 		{Path: "recording_playback.stable_window", Env: "XG2G_RECORDING_STABLE_WINDOW", FieldPath: "RecordingStableWindow", Profile: ProfileAdvanced, Status: StatusActive, Default: 10 * time.Second},
 		{Path: "recording_playback.mappings", Env: "XG2G_RECORDINGS_MAP", FieldPath: "RecordingPathMappings", Profile: ProfileAdvanced, Status: StatusActive},
+		{Path: "recordings.strict_target_required", Env: "XG2G_RECORDINGS_STRICT_TARGET_REQUIRED", FieldPath: "RecordingStrictTargetRequired", Profile: ProfileAdvanced, Status: StatusActive, Default: false},
 
 		// --- VOD (Typed Config) ---
 		{Path: "vod.probeSize", Env: "", FieldPath: "VOD.ProbeSize", Profile: ProfileAdvanced, Status: StatusActive, Default: "50M"},

--- a/backend/internal/config/types.go
+++ b/backend/internal/config/types.go
@@ -60,6 +60,7 @@ type FileConfig struct {
 	RateLimit      *RateLimitConfig          `yaml:"rateLimit,omitempty"`
 	Sessions       *SessionsConfig           `yaml:"sessions,omitempty"`
 	Store          *StoreConfig              `yaml:"store,omitempty"`
+	Recordings     *RecordingsFileConfig     `yaml:"recordings,omitempty"`
 	Streaming      *StreamingConfig          `yaml:"streaming,omitempty"`
 	Playback       *PlaybackFileConfig       `yaml:"playback,omitempty"`
 	PlannerShadow  *PlannerShadowFileConfig  `yaml:"plannerShadow,omitempty"`
@@ -143,6 +144,10 @@ type RecordingPlaybackConfig struct {
 	PlaybackPolicy string                 `yaml:"playback_policy,omitempty"` // "auto" (default), "local_only", "receiver_only"
 	StableWindow   string                 `yaml:"stable_window,omitempty"`   // Duration string (e.g., "2s")
 	Mappings       []RecordingPathMapping `yaml:"mappings,omitempty"`
+}
+
+type RecordingsFileConfig struct {
+	StrictTargetRequired *bool `yaml:"strict_target_required,omitempty"`
 }
 
 // RecordingPathMapping defines Receiver→Local path mapping
@@ -580,9 +585,10 @@ type AppConfig struct {
 	RecordingRoots map[string]string // ID -> Absolute Path (e.g. "hdd" -> "/media/hdd/movie")
 
 	// Recording Playback Configuration
-	RecordingPlaybackPolicy string                 // "auto" (default), "local_only", "receiver_only"
-	RecordingStableWindow   time.Duration          // File stability check duration (default: 2s)
-	RecordingPathMappings   []RecordingPathMapping // Receiver→Local path mappings
+	RecordingPlaybackPolicy       string                 // "auto" (default), "local_only", "receiver_only"
+	RecordingStableWindow         time.Duration          // File stability check duration (default: 2s)
+	RecordingPathMappings         []RecordingPathMapping // Receiver→Local path mappings
+	RecordingStrictTargetRequired bool                   // Phase 2 target rollout guard
 
 	// VOD Optimization (Legacy flat fields - kept for backwards compatibility)
 	VODProbeSize       string        // ffmpeg probesize (e.g. "50M")

--- a/backend/internal/control/http/v3/handlers_hls_test.go
+++ b/backend/internal/control/http/v3/handlers_hls_test.go
@@ -42,50 +42,12 @@ func (m *MockArtifactResolver) ResolveSegment(ctx context.Context, recordingID s
 	return args.Get(0).(artifacts.ArtifactOK), err
 }
 
-func TestHLS_ProfilePropagation(t *testing.T) {
-	tests := []struct {
-		name            string
-		requestPath     string
-		userAgent       string
-		expectedProfile string
-	}{
-		{
-			name:            "Safari_Mac",
-			requestPath:     "/api/v3/recordings/rec1/playlist.m3u8",
-			userAgent:       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15",
-			expectedProfile: "safari",
-		},
-		{
-			name:            "Generic_Chrome",
-			requestPath:     "/api/v3/recordings/rec1/playlist.m3u8",
-			userAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-			expectedProfile: "generic",
-		},
-		{
-			name:            "Explicit_AndroidTVNative_Query",
-			requestPath:     "/api/v3/recordings/rec1/playlist.m3u8?profile=android_native",
-			userAgent:       "Mozilla/5.0 (Linux; Android 15; sdk_gphone64_arm64 Build/AE3A.240806.005) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/141.0.0.0 Mobile Safari/537.36",
-			expectedProfile: "android_native",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc := new(MockArtifactResolver)
-			svc.On("ResolvePlaylist", mock.Anything, "rec1", tt.expectedProfile, "", mock.Anything).Return(artifacts.ArtifactOK{Data: []byte("ok"), Kind: artifacts.ArtifactKindPlaylist}, (*artifacts.ArtifactError)(nil))
-
-			s := &Server{artifacts: svc}
-			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", tt.requestPath, nil)
-			r.Header.Set("User-Agent", tt.userAgent)
-
-			s.GetRecordingHLSPlaylist(w, r, "rec1")
-
-			assert.Equal(t, http.StatusOK, w.Code)
-			svc.AssertExpectations(t)
-		})
-	}
+func (m *MockArtifactResolver) ResolvePlaylistState(ctx context.Context, recordingID, variant string) (artifacts.ArtifactOK, *artifacts.ArtifactError) {
+	args := m.Called(ctx, recordingID, variant)
+	err, _ := args.Get(1).(*artifacts.ArtifactError)
+	return args.Get(0).(artifacts.ArtifactOK), err
 }
+
 
 func TestHLSHandlers_Matrix(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/backend/internal/control/http/v3/handlers_playback_info_p3_4_test.go
+++ b/backend/internal/control/http/v3/handlers_playback_info_p3_4_test.go
@@ -41,6 +41,14 @@ func (m *MockArtifactsResolver) ResolveTimeshift(ctx context.Context, recordingI
 	return artifacts.ArtifactOK{}, nil
 }
 
+func (m *MockArtifactsResolver) ResolvePlaylistState(ctx context.Context, recordingID, variant string) (artifacts.ArtifactOK, *artifacts.ArtifactError) {
+	args := m.Called(ctx, recordingID, variant)
+	if args.Get(1) != nil {
+		return artifacts.ArtifactOK{}, args.Get(1).(*artifacts.ArtifactError)
+	}
+	return args.Get(0).(artifacts.ArtifactOK), nil
+}
+
 func createTestServerP34(svc recservice.Service, art artifacts.Resolver) *Server {
 	cfg := config.AppConfig{}
 	cfg.FFmpeg.Bin = "/usr/bin/ffmpeg"
@@ -109,7 +117,7 @@ func TestGetRecordingPlaybackInfo_P3_4_SegmentTruth(t *testing.T) {
 seg1.ts`
 
 		art := new(MockArtifactsResolver)
-		art.On("ResolvePlaylist", mock.Anything, recordingID, "", "", mock.Anything).Return(artifacts.ArtifactOK{
+		art.On("ResolvePlaylistState", mock.Anything, recordingID, "").Return(artifacts.ArtifactOK{
 			Data: []byte(playlist),
 		}, nil)
 
@@ -146,7 +154,7 @@ seg1.ts
 seg2.ts`
 
 		art := new(MockArtifactsResolver)
-		art.On("ResolvePlaylist", mock.Anything, recordingID, "", "", mock.Anything).Return(artifacts.ArtifactOK{
+		art.On("ResolvePlaylistState", mock.Anything, recordingID, "").Return(artifacts.ArtifactOK{
 			Data: []byte(playlist),
 		}, nil)
 
@@ -184,7 +192,7 @@ seg2.ts
 #EXT-X-ENDLIST`
 
 		art := new(MockArtifactsResolver)
-		art.On("ResolvePlaylist", mock.Anything, recordingID, "", "", mock.Anything).Return(artifacts.ArtifactOK{
+		art.On("ResolvePlaylistState", mock.Anything, recordingID, "").Return(artifacts.ArtifactOK{
 			Data: []byte(playlist),
 		}, nil)
 
@@ -227,7 +235,7 @@ seg1.ts
 seg2.ts`
 
 		art := new(MockArtifactsResolver)
-		art.On("ResolvePlaylist", mock.Anything, recordingID, "", "", mock.Anything).Return(artifacts.ArtifactOK{
+		art.On("ResolvePlaylistState", mock.Anything, recordingID, "").Return(artifacts.ArtifactOK{
 			Data: []byte(playlist),
 		}, nil)
 

--- a/backend/internal/control/http/v3/playback_info_runtime_state.go
+++ b/backend/internal/control/http/v3/playback_info_runtime_state.go
@@ -57,7 +57,7 @@ func resolvePlaybackSegmentTruth(ctx context.Context, resolver artifacts.Resolve
 		return nil, false
 	}
 
-	artifact, artifactErr := resolver.ResolvePlaylist(ctx, recordingID, "", "", nil)
+	artifact, artifactErr := resolver.ResolvePlaylistState(ctx, recordingID, "")
 	if artifactErr != nil {
 		return nil, false
 	}

--- a/backend/internal/control/http/v3/recordings/artifacts/resolver.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver.go
@@ -357,10 +357,22 @@ func (r *DefaultResolver) ResolvePlaylistState(ctx context.Context, recordingID,
 		return ArtifactOK{}, &ArtifactError{Code: CodeInvalid, Detail: "invalid recording id"}
 	}
 
-	variant = v3recordings.NormalizeVariantHash(variant)
+	if variant == "" {
+		target := recordingTargetProfile("")
+		if target == nil {
+			target = &playbackprofile.TargetPlaybackProfile{
+				Video: playbackprofile.VideoTarget{Mode: playbackprofile.MediaModeCopy},
+			}
+		}
+		canonical := playbackprofile.CanonicalizeTarget(*target)
+		variant = canonical.Hash()
+	} else {
+		variant = v3recordings.NormalizeVariantHash(variant)
+	}
+
 	cacheDir, err := v3recordings.RecordingVariantCacheDir(r.cfg.HLS.Root, ref, variant)
 	if err != nil {
-		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Detail: "failed to determine cache dir"}
+		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err, Detail: "failed to determine cache dir"}
 	}
 	playlistPath := filepath.Join(cacheDir, "index.m3u8")
 	// #nosec G304 - playlistPath is confined to cacheDir
@@ -372,11 +384,11 @@ func (r *DefaultResolver) ResolvePlaylistState(ctx context.Context, recordingID,
 
 	info, err := f.Stat()
 	if err != nil {
-		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err}
+		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err, Detail: "failed to stat playlist"}
 	}
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err}
+		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err, Detail: "failed to read playlist"}
 	}
 
 	rewritten := v3recordings.RewritePlaylist(string(data), "EVENT", variant)

--- a/backend/internal/control/http/v3/recordings/artifacts/resolver.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver.go
@@ -16,6 +16,8 @@ import (
 	recservice "github.com/ManuGH/xg2g/internal/control/recordings"
 	"github.com/ManuGH/xg2g/internal/control/vod"
 	"github.com/ManuGH/xg2g/internal/domain/playbackprofile"
+	"github.com/ManuGH/xg2g/internal/log"
+	"github.com/ManuGH/xg2g/internal/metrics"
 	"github.com/ManuGH/xg2g/internal/platform/fs"
 	"github.com/ManuGH/xg2g/internal/recordings"
 )
@@ -24,6 +26,7 @@ type Resolver interface {
 	ResolvePlaylist(ctx context.Context, recordingID, profile, variant string, target *playbackprofile.TargetPlaybackProfile) (ArtifactOK, *ArtifactError)
 	ResolveTimeshift(ctx context.Context, recordingID, profile, variant string, target *playbackprofile.TargetPlaybackProfile) (ArtifactOK, *ArtifactError)
 	ResolveSegment(ctx context.Context, recordingID string, segment string, variant string) (ArtifactOK, *ArtifactError)
+	ResolvePlaylistState(ctx context.Context, recordingID, variant string) (ArtifactOK, *ArtifactError)
 }
 
 type DefaultResolver struct {
@@ -48,7 +51,7 @@ func (r *DefaultResolver) ResolvePlaylist(ctx context.Context, recordingID, prof
 		return ArtifactOK{}, &ArtifactError{Code: CodeInvalid, Detail: "invalid recording id"}
 	}
 	variant = v3recordings.NormalizeVariantHash(variant)
-	targetProfile, resolvedVariant, artErr := recordingTarget(profile, variant, target)
+	targetProfile, resolvedVariant, artErr := r.recordingTarget(profile, variant, target)
 	if artErr != nil {
 		return ArtifactOK{}, artErr
 	}
@@ -186,7 +189,7 @@ func (r *DefaultResolver) ResolveTimeshift(ctx context.Context, recordingID, pro
 		return ArtifactOK{}, &ArtifactError{Code: CodeInvalid, Detail: "invalid recording id"}
 	}
 	variant = v3recordings.NormalizeVariantHash(variant)
-	targetProfile, resolvedVariant, artErr := recordingTarget(profile, variant, target)
+	targetProfile, resolvedVariant, artErr := r.recordingTarget(profile, variant, target)
 	if artErr != nil {
 		return ArtifactOK{}, artErr
 	}
@@ -316,12 +319,7 @@ func (r *DefaultResolver) triggerBuild(ctx context.Context, ref, profile, varian
 	finalPath := filepath.Join(cacheDir, "index.m3u8")
 
 	if targetProfile == nil {
-		targetProfile = recordingTargetProfile(profile)
-	}
-	if targetProfile == nil {
-		targetProfile = &playbackprofile.TargetPlaybackProfile{
-			Video: playbackprofile.VideoTarget{Mode: playbackprofile.MediaModeCopy},
-		}
+		return errors.New("target profile is required but was nil")
 	}
 
 	// Using EnsureSpec to start/resume build
@@ -330,13 +328,20 @@ func (r *DefaultResolver) triggerBuild(ctx context.Context, ref, profile, varian
 	return err
 }
 
-func recordingTarget(profile, variant string, target *playbackprofile.TargetPlaybackProfile) (*playbackprofile.TargetPlaybackProfile, string, *ArtifactError) {
+func (r *DefaultResolver) recordingTarget(profile, variant string, target *playbackprofile.TargetPlaybackProfile) (*playbackprofile.TargetPlaybackProfile, string, *ArtifactError) {
 	variant = v3recordings.NormalizeVariantHash(variant)
 	if target == nil {
+		if r.cfg.RecordingStrictTargetRequired {
+			return nil, "", &ArtifactError{Code: CodeInvalid, Detail: "playback-info handshake required"}
+		}
+		log.L().Warn().Str("profile", profile).Str("variant", variant).Msg("VOD target fallback triggered")
+		metrics.IncTargetFallback()
 		target = recordingTargetProfile(profile)
 	}
 	if target == nil {
-		return nil, variant, nil
+		target = &playbackprofile.TargetPlaybackProfile{
+			Video: playbackprofile.VideoTarget{Mode: playbackprofile.MediaModeCopy},
+		}
 	}
 	canonical := playbackprofile.CanonicalizeTarget(*target)
 	resolvedVariant := canonical.Hash()
@@ -344,6 +349,42 @@ func recordingTarget(profile, variant string, target *playbackprofile.TargetPlay
 		return nil, "", &ArtifactError{Code: CodeInvalid, Detail: "playback variant mismatch"}
 	}
 	return &canonical, resolvedVariant, nil
+}
+
+func (r *DefaultResolver) ResolvePlaylistState(ctx context.Context, recordingID, variant string) (ArtifactOK, *ArtifactError) {
+	ref, ok := decodeRef(recordingID)
+	if !ok {
+		return ArtifactOK{}, &ArtifactError{Code: CodeInvalid, Detail: "invalid recording id"}
+	}
+
+	variant = v3recordings.NormalizeVariantHash(variant)
+	cacheDir, err := v3recordings.RecordingVariantCacheDir(r.cfg.HLS.Root, ref, variant)
+	if err != nil {
+		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Detail: "failed to determine cache dir"}
+	}
+	playlistPath := filepath.Join(cacheDir, "index.m3u8")
+	// #nosec G304 - playlistPath is confined to cacheDir
+	f, err := os.Open(playlistPath)
+	if err != nil {
+		return ArtifactOK{}, &ArtifactError{Code: CodeNotFound, Detail: "playlist not found"}
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err}
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err}
+	}
+
+	rewritten := v3recordings.RewritePlaylist(string(data), "EVENT", variant)
+	return ArtifactOK{
+		Data:    []byte(rewritten),
+		ModTime: info.ModTime(),
+		Kind:    ArtifactKindPlaylist,
+	}, nil
 }
 
 func (r *DefaultResolver) resolveSource(serviceRef string) (string, string, string, error) {

--- a/backend/internal/control/http/v3/recordings/artifacts/resolver_test.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver_test.go
@@ -2,10 +2,13 @@ package artifacts
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ManuGH/xg2g/internal/config"
@@ -251,4 +254,84 @@ func TestArtifactResolver_ResolvePlaylist_RejectsVariantMismatch(t *testing.T) {
 	if artifactErr.Code != CodeInvalid {
 		t.Fatalf("expected invalid artifact error, got %#v", artifactErr)
 	}
+}
+
+func getFallbackMetricValue() float64 {
+	mfs, _ := prometheus.DefaultGatherer.Gather()
+	for _, mf := range mfs {
+		if mf.GetName() == "xg2g_recordings_target_fallback_total" {
+			if len(mf.GetMetric()) > 0 {
+				return mf.GetMetric()[0].GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func TestArtifactResolver_StrictTargetEnforcement_Fails(t *testing.T) {
+	cfg := &config.AppConfig{
+		RecordingStrictTargetRequired: true,
+	}
+	mgr, _ := vod.NewManager(&dummyRunner{}, &dummyProber{}, nil)
+	r := New(cfg, mgr, nil)
+
+	validID := "MTowOjE6MDowOjA6MDowOjA6MDovZm9vLnRz"
+	_, err := r.ResolvePlaylist(context.Background(), validID, "safari", "", nil)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, CodeInvalid, err.Code)
+	assert.Contains(t, err.Detail, "handshake required")
+	assert.Empty(t, mgr.ActiveJobIDs(), "no build job should be triggered when target is missing in strict mode")
+}
+
+func TestArtifactResolver_LegacyFallback_Metrics(t *testing.T) {
+	cfg := &config.AppConfig{
+		HLS: config.HLSConfig{Root: t.TempDir()},
+		RecordingStrictTargetRequired: false,
+	}
+	runner := &captureRunner{}
+	mgr, _ := vod.NewManager(runner, &dummyProber{}, nil)
+	r := New(cfg, mgr, nil)
+
+	validID := "MTowOjE6MDowOjA6MDowOjA6MDovZm9vLnRz"
+
+	before := getFallbackMetricValue()
+
+	_, err := r.ResolvePlaylist(context.Background(), validID, "safari", "", nil)
+	assert.NotNil(t, err)
+	assert.Equal(t, CodePreparing, err.Code)
+
+	after := getFallbackMetricValue()
+	assert.Equal(t, float64(1), after-before, "fallback metric should increment by 1")
+}
+
+func TestArtifactResolver_ResolvePlaylistState(t *testing.T) {
+	cfg := &config.AppConfig{
+		HLS: config.HLSConfig{Root: t.TempDir()},
+	}
+	mgr, _ := vod.NewManager(&dummyRunner{}, &dummyProber{}, nil)
+	r := New(cfg, mgr, nil)
+
+	ref := "1:0:1:0:0:0:0:0:0:0:/foo.ts"
+	validID := "MTowOjE6MDowOjA6MDowOjA6MDovZm9vLnRz"
+	variant := "v1"
+
+	t.Run("Missing Playlist -> CodeNotFound", func(t *testing.T) {
+		_, err := r.ResolvePlaylistState(context.Background(), validID, variant)
+		assert.NotNil(t, err)
+		assert.Equal(t, CodeNotFound, err.Code)
+		assert.Empty(t, mgr.ActiveJobIDs(), "state query should not trigger a build job")
+	})
+
+	t.Run("Existing Playlist -> Returns Content", func(t *testing.T) {
+		dir, _ := v3recordings.RecordingVariantCacheDir(cfg.HLS.Root, ref, variant)
+		os.MkdirAll(dir, 0755)
+		os.WriteFile(filepath.Join(dir, "index.m3u8"), []byte("#EXTM3U"), 0644)
+
+		res, err := r.ResolvePlaylistState(context.Background(), validID, variant)
+		assert.Nil(t, err)
+		assert.Equal(t, ArtifactKindPlaylist, res.Kind)
+		assert.Equal(t, []byte("#EXTM3U\n#EXT-X-PLAYLIST-TYPE:EVENT"), res.Data)
+		assert.Empty(t, mgr.ActiveJobIDs(), "state query should not trigger a build job")
+	})
 }

--- a/backend/internal/control/http/v3/recordings_hls.go
+++ b/backend/internal/control/http/v3/recordings_hls.go
@@ -38,7 +38,6 @@ func (s *Server) serveHLSPlaylist(w http.ResponseWriter, r *http.Request, record
 	if _, ok := s.requireHouseholdRecordingAccess(w, r, recordingId); !ok {
 		return
 	}
-	profile := detectClientProfile(r)
 	variant := v3recordings.NormalizeVariantHash(r.URL.Query().Get("variant"))
 	target, err := v3recordings.DecodeTargetProfileQuery(r.URL.Query().Get("target"))
 	if err != nil {
@@ -50,9 +49,9 @@ func (s *Server) serveHLSPlaylist(w http.ResponseWriter, r *http.Request, record
 	var artErr *artifacts.ArtifactError
 
 	if isTimeshift {
-		artifact, artErr = s.artifacts.ResolveTimeshift(r.Context(), recordingId, string(profile), variant, target)
+		artifact, artErr = s.artifacts.ResolveTimeshift(r.Context(), recordingId, "", variant, target)
 	} else {
-		artifact, artErr = s.artifacts.ResolvePlaylist(r.Context(), recordingId, string(profile), variant, target)
+		artifact, artErr = s.artifacts.ResolvePlaylist(r.Context(), recordingId, "", variant, target)
 	}
 
 	if artErr != nil {

--- a/backend/internal/metrics/business.go
+++ b/backend/internal/metrics/business.go
@@ -347,6 +347,11 @@ var (
 		Help: "Total number of VOD metadata entries pruned",
 	}, []string{"reason"}) // reason=ttl|max_entries
 
+	recordingsTargetFallbackTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "xg2g_recordings_target_fallback_total",
+		Help: "Total number of recording requests requiring legacy target fallback",
+	})
+
 	vodBuildDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "xg2g_vod_build_duration_seconds",
 		Help:    "Duration of VOD build attempts",
@@ -453,4 +458,8 @@ func ObserveVODBuildDuration(result string, duration float64) {
 
 func IncVODRemuxStall(strategy string) {
 	vodRemuxStallsTotal.WithLabelValues(strategy).Inc()
+}
+
+func IncTargetFallback() {
+	recordingsTargetFallbackTotal.Inc()
 }

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -298,6 +298,12 @@ Legacy YAML section `openWebIF.*` is rejected at load time; use `enigma2.*`.
 | `recording_playback.playback_policy` | `XG2G_RECORDING_PLAYBACK_POLICY` | `auto` | Active | Advanced |
 | `recording_playback.stable_window` | `XG2G_RECORDING_STABLE_WINDOW` | `10s` | Active | Advanced |
 
+### recordings
+
+| Path | Env | Default | Status | Profile |
+| --- | --- | --- | --- | --- |
+| `recordings.strict_target_required` | `XG2G_RECORDINGS_STRICT_TARGET_REQUIRED` | `false` | Active | Advanced |
+
 ### root
 
 | Path | Env | Default | Status | Profile |

--- a/docs/guides/config.schema.json
+++ b/docs/guides/config.schema.json
@@ -983,6 +983,15 @@
     "recording_roots": {
       "type": "object"
     },
+    "recordings": {
+      "properties": {
+        "strict_target_required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "server": {
       "properties": {
         "idleTimeout": {


### PR DESCRIPTION
This PR completes Step 2 of the VOD planner cutover. It introduces the `RecordingStrictTargetRequired` config and `xg2g_recordings_target_fallback_total` metric, and enforces that the builder always runs on a valid planner-issued target when strict mode is enabled. It replaces profile detection and fallback synthesis, failing closed instead.