### PR TITLE
chore(lint): make transitional debt visible and enforce marker invariants (A5)

### DIFF
--- a/backend/cmd/xg2g-soak/main.go
+++ b/backend/cmd/xg2g-soak/main.go
@@ -105,7 +105,7 @@ func main() {
 		Evidence:  []string{},
 	}
 
-	// TODO: Implement scenario execution
+	// TODO(Soak): Implement scenario execution
 	switch cfg.Profile {
 	case "smoke":
 		fmt.Println("Running smoke profile (quick validation)...")

--- a/backend/internal/control/http/v3/recordings/artifacts/resolver.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver.go
@@ -335,6 +335,7 @@ func (r *DefaultResolver) recordingTarget(profile, variant string, intent *ports
 		if r.cfg.RecordingStrictTargetRequired {
 			return nil, "", &ArtifactError{Code: CodeInvalid, Detail: "playback-info handshake required"}
 		}
+		// TODO(SPEC_MODERNIZATION_2026 §A1.3): Copy-default fallback in recordingTarget() dies when strict flag flips default.
 		log.L().Warn().Str("profile", profile).Str("variant", variant).Msg("VOD target fallback triggered")
 		metrics.IncTargetFallback("missing_target")
 
@@ -367,6 +368,7 @@ func (r *DefaultResolver) ResolvePlaylistState(ctx context.Context, recordingID,
 	}
 
 	if variant == "" {
+		// TODO(SPEC_MODERNIZATION_2026 §R2): Empty-variant default in ResolvePlaylistState has legacy semantics; revisit in R2 artifact FSM.
 		target := recordingTargetProfile("")
 		if target == nil {
 			target = &playbackprofile.TargetPlaybackProfile{

--- a/backend/internal/control/http/v3/recordings/cache.go
+++ b/backend/internal/control/http/v3/recordings/cache.go
@@ -137,7 +137,7 @@ func DecodeTargetProfileQuery(raw, primaryKey, previousKey string, strictTargetR
 		}, nil
 	}
 
-	// TODO(Spec: Payload-Migration): Remove legacy bare TargetPlaybackProfile fallback after a full deploy cycle.
+	// TODO(SPEC_MODERNIZATION_2026 §R0): Remove legacy bare TargetPlaybackProfile fallback after a full deploy cycle.
 	// Legacy unsigned/nackte Target-JSON fallback
 	var target playbackprofile.TargetPlaybackProfile
 	if err := json.Unmarshal(b, &target); err != nil {

--- a/backend/internal/infra/ffmpeg/builder.go
+++ b/backend/internal/infra/ffmpeg/builder.go
@@ -214,6 +214,7 @@ func hlsOutputArgs(workDir, outputPath string, target *ports.TargetPlaybackProfi
 			"-hls_segment_filename", filepath.Join(workDir, "seg_%05d.m4s"),
 		)
 	default:
+		// TODO(SPEC_MODERNIZATION_2026 §R3): TS packaging path is superseded by R3 CMAF/fMP4 delivery.
 		args = append(args, "-hls_segment_filename", filepath.Join(workDir, "seg_%05d.ts"))
 	}
 

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -215,6 +215,7 @@ func (a *LocalAdapter) appendLiveHLSArgs(args []string, spec ports.StreamSpec, l
 	if len(audioSel) > 0 {
 		sel = audioSel[0]
 	}
+	// TODO(SPEC_MODERNIZATION_2026 §R3): TS segment packaging path is superseded by R3 CMAF/fMP4 delivery.
 	segmentType := "mpegts"
 	sessionDir := ports.SessionHLSDirForPolicy(a.HLSRoot, spec.SessionID, spec.Profile.DVRWindowSec)
 	segmentFilename := filepath.Join(sessionDir, "seg_%06d.ts")

--- a/mk/quality.mk
+++ b/mk/quality.mk
@@ -20,14 +20,14 @@ lint-fix: ## Run golangci-lint with automatic fixes
 lint-invariants: ## Run repository lint invariants enforced in CI
 	@echo "Running lint invariants..."
 	@echo "Scanning for direct environment access outside internal/config..."
-	@VIOLATIONS=$$(grep -RIn --include='*.go' --exclude='*_test.go' -E '\b(os|syscall)\.(Getenv|LookupEnv|Environ|ExpandEnv|Expand)\b' $(BACKEND_DIR)/internal/ $(BACKEND_DIR)/cmd/ | grep -vE '^$(BACKEND_DIR)/internal/config/' || true); \
+	@VIOLATIONS=$$(grep -RIn --exclude-dir=vendor --exclude-dir=node_modules --exclude-dir=.git --include='*.go' --exclude='*_test.go' -E '\b(os|syscall)\.(Getenv|LookupEnv|Environ|ExpandEnv|Expand)\b' $(BACKEND_DIR)/internal/ $(BACKEND_DIR)/cmd/ | grep -vE '^$(BACKEND_DIR)/internal/config/' || true); \
 	if [ -n "$$VIOLATIONS" ]; then \
 		echo "❌ Direct environment access detected outside authorized packages:"; \
 		echo "$$VIOLATIONS"; \
 		exit 1; \
 	fi
 	@echo "Scanning for naked TODO/FIXME comments without (reference)..."
-	@VIOLATIONS=$$(grep -RIn --include='*.go' --include='*.ts' --include='*.tsx' -E '^[[:space:]]*//[[:space:]]*(TODO|FIXME)([^a-zA-Z0-9(]|$$)' $(BACKEND_DIR)/ $(FRONTEND_DIR)/webui/src/ | grep -vE '(\.gen\.ts|_gen\.go|vendor/|node_modules/|\.spec\.|\_test\.go)' || true); \
+	@VIOLATIONS=$$(grep -RIn --exclude-dir=vendor --exclude-dir=node_modules --exclude-dir=.git --include='*.go' --include='*.ts' --include='*.tsx' -E '^[[:space:]]*//[[:space:]]*(TODO|FIXME)([^a-zA-Z0-9(]|$$)' $(BACKEND_DIR)/ $(FRONTEND_DIR)/webui/src/ | grep -vE '(\.gen\.ts|_gen\.go|\.spec\.|\_test\.go)' || true); \
 	if [ -n "$$VIOLATIONS" ]; then \
 		echo "❌ Naked TODO/FIXME detected without reference parentheses (e.g. // TODO(reference): ...):"; \
 		echo "$$VIOLATIONS"; \

--- a/mk/quality.mk
+++ b/mk/quality.mk
@@ -26,6 +26,13 @@ lint-invariants: ## Run repository lint invariants enforced in CI
 		echo "$$VIOLATIONS"; \
 		exit 1; \
 	fi
+	@echo "Scanning for naked TODO/FIXME comments without (reference)..."
+	@VIOLATIONS=$$(grep -RIn --include='*.go' --include='*.ts' --include='*.tsx' -E '^[[:space:]]*//[[:space:]]*(TODO|FIXME)([^a-zA-Z0-9(]|$$)' $(BACKEND_DIR)/ $(FRONTEND_DIR)/webui/src/ | grep -vE '(\.gen\.ts|_gen\.go|vendor/|node_modules/|\.spec\.|\_test\.go)' || true); \
+	if [ -n "$$VIOLATIONS" ]; then \
+		echo "❌ Naked TODO/FIXME detected without reference parentheses (e.g. // TODO(reference): ...):"; \
+		echo "$$VIOLATIONS"; \
+		exit 1; \
+	fi
 	@$(PYTHON) $(BACKEND_DIR)/scripts/check_deprecations.py
 	@cd $(FRONTEND_DIR)/webui && npm run lint
 	@echo "✅ Lint invariants passed"


### PR DESCRIPTION
### Summary
Implements **Epic A5** from the 2026 Modernization Program (`SPEC_MODERNIZATION_2026.md §A5`).

#### 1. Transitional Debt Markers
Adds exact `// TODO(SPEC_MODERNIZATION_2026 §...)` annotations at the 4 live transitional mechanisms across the codebase:
- **§R0 Legacy Payload Fallback:** `cache.go` (`TargetPlaybackProfile` bare-JSON decode fallback).
- **§A1.3 Copy-Default Fallback:** `resolver.go` (`recordingTarget()` fallback when target is nil/empty).
- **§R2 Empty-Variant Default:** `resolver.go` (`ResolvePlaylistState()` default variant logic).
- **§R3 TS Packaging Path:** `builder.go` and `plan_output.go` (legacy MPEG-TS segment output paths).

#### 2. Linter Invariant Extension
- Extends `lint-invariants` in `mk/quality.mk` to reject any naked `// TODO` or `// FIXME` comments across non-generated `.go`, `.ts`, and `.tsx` files without reference parentheses (e.g., `TODO(reference): ...`).
- Fixes the 1 pre-existing naked TODO in `cmd/xg2g-soak/main.go` to `TODO(Soak):`.

### Verification
- `make lint-invariants` verified clean ().
- `make ci-pr` verified clean (, 604 unit/integration tests passed).