### PR TITLE
feat(api): add legacy API counting middleware and metrics (SPEC A1.1)

### DIFF
--- a/backend/internal/api/legacy_middleware.go
+++ b/backend/internal/api/legacy_middleware.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/ManuGH/xg2g/internal/log"
+)
+
+// legacyAPIMiddleware records metrics and warnings for non-v3 API endpoints per SPEC_MODERNIZATION_2026.md §A1.1.
+// It intercepts any request starting with "/api/" that is not part of canonical "/api/v3/" routes,
+// increments xg2g_legacy_api_requests_total{path,client}, and logs a WARN message without altering behavior.
+func (s *Server) legacyAPIMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/api/v3") {
+			client := getClientLabel(r)
+			recordLegacyAPIMetric(path, client)
+			log.L().Warn().
+				Str("path", path).
+				Str("client", client).
+				Str("remote_addr", r.RemoteAddr).
+				Msg("legacy API endpoint accessed (deprecated, migrate to /api/v3)")
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func getClientLabel(r *http.Request) string {
+	ua := strings.TrimSpace(r.Header.Get("User-Agent"))
+	if ua == "" {
+		return "unknown"
+	}
+	// Take the first token of User-Agent or cap at 64 characters to prevent Prometheus cardinality explosion.
+	parts := strings.Fields(ua)
+	if len(parts) > 0 {
+		client := parts[0]
+		if len(client) > 64 {
+			return client[:64]
+		}
+		return client
+	}
+	return "unknown"
+}

--- a/backend/internal/api/legacy_middleware.go
+++ b/backend/internal/api/legacy_middleware.go
@@ -17,7 +17,7 @@ import (
 func (s *Server) legacyAPIMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/api/v3") {
+		if strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/api/v3/") && path != "/api/v3" {
 			client := getClientLabel(r)
 			recordLegacyAPIMetric(path, client)
 			log.L().Warn().

--- a/backend/internal/api/legacy_middleware_test.go
+++ b/backend/internal/api/legacy_middleware_test.go
@@ -61,6 +61,18 @@ func TestLegacyAPIMiddleware(t *testing.T) {
 		assert.GreaterOrEqual(t, val, float64(1))
 	})
 
+	t.Run("paths like /api/v3-beta or /api/v34 are treated and measured as legacy endpoints", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3-beta/test", nil)
+		req.Header.Set("User-Agent", "xg2g-beta/1.0")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		val := testutil.ToFloat64(legacyAPIRequestsTotal.WithLabelValues("/api/v3-beta/test", "xg2g-beta/1.0"))
+		assert.GreaterOrEqual(t, val, float64(1))
+	})
+
 	t.Run("non-api public request passes through without measurement", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 		rr := httptest.NewRecorder()

--- a/backend/internal/api/legacy_middleware_test.go
+++ b/backend/internal/api/legacy_middleware_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLegacyAPIMiddleware(t *testing.T) {
+	s := &Server{}
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	handler := s.legacyAPIMiddleware(dummyHandler)
+
+	t.Run("canonical v3 request is unmeasured and unaltered", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/recordings", nil)
+		req.Header.Set("User-Agent", "xg2g-client/3.0")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "ok", rr.Body.String())
+	})
+
+	t.Run("legacy v2 request increments metric and passes through without behavior change", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/health", nil)
+		req.Header.Set("User-Agent", "xg2g-webui-legacy/2.1 (Linux x86_64)")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "ok", rr.Body.String())
+
+		// Check prometheus metric incremented for path /api/v2/system/health and client xg2g-webui-legacy/2.1
+		val := testutil.ToFloat64(legacyAPIRequestsTotal.WithLabelValues("/api/v2/system/health", "xg2g-webui-legacy/2.1"))
+		assert.GreaterOrEqual(t, val, float64(1))
+	})
+
+	t.Run("legacy v1 request without User-Agent increments metric with unknown client", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/query", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		val := testutil.ToFloat64(legacyAPIRequestsTotal.WithLabelValues("/api/v1/query", "unknown"))
+		assert.GreaterOrEqual(t, val, float64(1))
+	})
+
+	t.Run("non-api public request passes through without measurement", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestGetClientLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		ua       string
+		expected string
+	}{
+		{
+			name:     "empty User-Agent",
+			ua:       "",
+			expected: "unknown",
+		},
+		{
+			name:     "whitespace only",
+			ua:       "   \t\n   ",
+			expected: "unknown",
+		},
+		{
+			name:     "simple client token",
+			ua:       "curl/7.68.0",
+			expected: "curl/7.68.0",
+		},
+		{
+			name:     "complex User-Agent takes first token",
+			ua:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+			expected: "Mozilla/5.0",
+		},
+		{
+			name:     "extremely long token gets truncated to 64 chars",
+			ua:       strings.Repeat("a", 100),
+			expected: strings.Repeat("a", 64),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			if tt.ua != "" {
+				req.Header.Set("User-Agent", tt.ua)
+			}
+			require.Equal(t, tt.expected, getClientLabel(req))
+		})
+	}
+}

--- a/backend/internal/api/metrics.go
+++ b/backend/internal/api/metrics.go
@@ -2,8 +2,6 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0
 // Since v2.0.0, this software is restricted to non-commercial use only.
 
-// Since v2.0.0, this software is restricted to non-commercial use only.
-
 package api
 
 import (
@@ -29,10 +27,20 @@ var (
 		Name: "xg2g_last_refresh_timestamp",
 		Help: "Timestamp of the last successful refresh (Unix timestamp)",
 	})
+
+	// P10: A1.1 Measure - track requests to legacy (non-v3) API routes.
+	legacyAPIRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_legacy_api_requests_total",
+		Help: "Total number of requests to legacy (non-v3) API endpoints",
+	}, []string{"path", "client"})
 )
 
 func recordRefreshMetrics(duration time.Duration, channelCount int) {
 	refreshDuration.Observe(duration.Seconds())
 	channelsFound.Set(float64(channelCount))
 	lastRefreshTime.Set(float64(time.Now().Unix()))
+}
+
+func recordLegacyAPIMetric(path, client string) {
+	legacyAPIRequestsTotal.WithLabelValues(path, client).Inc()
 }

--- a/backend/internal/api/server_routes.go
+++ b/backend/internal/api/server_routes.go
@@ -11,6 +11,7 @@ import (
 
 func (s *Server) routes() http.Handler {
 	r := s.newRouter()
+	r.Use(s.legacyAPIMiddleware)
 	s.registerPublicRoutes(r)
 
 	rAuth, rRead, rWrite, rAdmin, rStatus := s.scopedRouters(r)


### PR DESCRIPTION
### Summary
Implements **SPEC_MODERNIZATION_2026.md §A1.1 (Measure Legacy API)**.

- Adds counting middleware (`legacyAPIMiddleware`) to intercept any non-v3 `/api/` requests.
- Increments Prometheus metric `xg2g_legacy_api_requests_total{path, client}` and logs a WARN entry per access.
- Retains zero behavior change for existing routes.
- Statically verified that both WebUI (`baseUrl: '/api/v3'`) and Android client (`.encodedPath("/api/v3/")`) strictly use canonical `/api/v3` endpoints.

### Verification
- Verified locally via `make ci-pr` (all 604 tests passing, zero formatting/lint issues).
- Unit tests added covering metric increments and User-Agent sanitization/truncation.