### PR TITLE
feat(api): gate legacy API when api.legacy_enabled is false (410 Gone) [§A1.2]

### DIFF
--- a/backend/config.generated.example.yaml
+++ b/backend/config.generated.example.yaml
@@ -3,6 +3,7 @@
 api:
   allowedOrigins: []
   disableLegacyTokenSources: true
+  legacy_enabled: true
   listenAddr: 127.0.0.1:8088
   playbackDecisionKeyId: ""
   playbackDecisionPreviousKeys: []

--- a/backend/internal/api/legacy_middleware.go
+++ b/backend/internal/api/legacy_middleware.go
@@ -5,15 +5,18 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/ManuGH/xg2g/internal/log"
 )
 
-// legacyAPIMiddleware records metrics and warnings for non-v3 API endpoints per SPEC_MODERNIZATION_2026.md §A1.1.
+// legacyAPIMiddleware records metrics and warnings for non-v3 API endpoints per SPEC_MODERNIZATION_2026.md §A1.1
+// and gates access when api.legacy_enabled is false per §A1.2.
 // It intercepts any request starting with "/api/" that is not part of canonical "/api/v3/" routes,
-// increments xg2g_legacy_api_requests_total{path,client}, and logs a WARN message without altering behavior.
+// increments xg2g_legacy_api_requests_total{path,client}, and logs a WARN message.
+// If APILegacyEnabled is false, it returns 410 Gone with a problem+json body.
 func (s *Server) legacyAPIMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -25,6 +28,18 @@ func (s *Server) legacyAPIMiddleware(next http.Handler) http.Handler {
 				Str("client", client).
 				Str("remote_addr", r.RemoteAddr).
 				Msg("legacy API endpoint accessed (deprecated, migrate to /api/v3)")
+
+			if !s.GetConfig().APILegacyEnabled {
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(http.StatusGone)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"type":   "https://xg2g.example.invalid/problems/legacy-api-gone",
+					"title":  "Legacy API Retired",
+					"status": http.StatusGone,
+					"detail": "This legacy API endpoint has been retired and disabled by configuration. Please migrate to the /api/v3 endpoints.",
+				})
+				return
+			}
 		}
 		next.ServeHTTP(w, r)
 	})

--- a/backend/internal/api/legacy_middleware.go
+++ b/backend/internal/api/legacy_middleware.go
@@ -7,6 +7,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	stdpath "path"
 	"strings"
 
 	"github.com/ManuGH/xg2g/internal/log"
@@ -14,17 +15,19 @@ import (
 
 // legacyAPIMiddleware records metrics and warnings for non-v3 API endpoints per SPEC_MODERNIZATION_2026.md §A1.1
 // and gates access when api.legacy_enabled is false per §A1.2.
+// It cleans the request path using path.Clean to prevent path-traversal bypasses (e.g. /api/v3/../v2/status).
 // It intercepts any request starting with "/api/" that is not part of canonical "/api/v3/" routes,
 // increments xg2g_legacy_api_requests_total{path,client}, and logs a WARN message.
 // If APILegacyEnabled is false, it returns 410 Gone with a problem+json body.
 func (s *Server) legacyAPIMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-		if strings.HasPrefix(path, "/api/") && !strings.HasPrefix(path, "/api/v3/") && path != "/api/v3" {
+		cleanPath := stdpath.Clean(r.URL.Path)
+		if strings.HasPrefix(cleanPath, "/api/") && !strings.HasPrefix(cleanPath, "/api/v3/") && cleanPath != "/api/v3" {
 			client := getClientLabel(r)
-			recordLegacyAPIMetric(path, client)
+			metricPath := normalizeLegacyPath(cleanPath)
+			recordLegacyAPIMetric(metricPath, client)
 			log.L().Warn().
-				Str("path", path).
+				Str("path", cleanPath).
 				Str("client", client).
 				Str("remote_addr", r.RemoteAddr).
 				Msg("legacy API endpoint accessed (deprecated, migrate to /api/v3)")
@@ -43,6 +46,20 @@ func (s *Server) legacyAPIMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// normalizeLegacyPath caps legacy API metric paths to a maximum of 3 segments (e.g. /api/v1/channels)
+// to prevent Prometheus label cardinality explosion from dynamic route parameters.
+func normalizeLegacyPath(cleanPath string) string {
+	trimmed := strings.Trim(cleanPath, "/")
+	if trimmed == "" {
+		return "/"
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) > 3 {
+		return "/" + strings.Join(parts[:3], "/")
+	}
+	return "/" + strings.Join(parts, "/")
 }
 
 func getClientLabel(r *http.Request) string {

--- a/backend/internal/api/legacy_middleware_test.go
+++ b/backend/internal/api/legacy_middleware_test.go
@@ -5,18 +5,20 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/ManuGH/xg2g/internal/config"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLegacyAPIMiddleware(t *testing.T) {
-	s := &Server{}
+	s := &Server{cfg: config.AppConfig{APILegacyEnabled: true}}
 	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
@@ -125,4 +127,40 @@ func TestGetClientLabel(t *testing.T) {
 			require.Equal(t, tt.expected, getClientLabel(req))
 		})
 	}
+}
+
+func TestLegacyAPIMiddleware_Gate(t *testing.T) {
+	s := &Server{cfg: config.AppConfig{APILegacyEnabled: false}}
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	handler := s.legacyAPIMiddleware(dummyHandler)
+
+	t.Run("canonical v3 request passes through even when APILegacyEnabled is false", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/recordings", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "ok", rr.Body.String())
+	})
+
+	t.Run("legacy v2 request returns 410 Gone with problem+json when APILegacyEnabled is false", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/system/health", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusGone, rr.Code)
+		assert.Equal(t, "application/problem+json", rr.Header().Get("Content-Type"))
+
+		var resp map[string]interface{}
+		err := json.Unmarshal(rr.Body.Bytes(), &resp)
+		require.NoError(t, err)
+		assert.Equal(t, "Legacy API Retired", resp["title"])
+		assert.Equal(t, float64(http.StatusGone), resp["status"])
+	})
 }

--- a/backend/internal/api/legacy_middleware_test.go
+++ b/backend/internal/api/legacy_middleware_test.go
@@ -47,8 +47,8 @@ func TestLegacyAPIMiddleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Equal(t, "ok", rr.Body.String())
 
-		// Check prometheus metric incremented for path /api/v2/system/health and client xg2g-webui-legacy/2.1
-		val := testutil.ToFloat64(legacyAPIRequestsTotal.WithLabelValues("/api/v2/system/health", "xg2g-webui-legacy/2.1"))
+		// Check prometheus metric incremented for path /api/v2/system and client xg2g-webui-legacy/2.1
+		val := testutil.ToFloat64(legacyAPIRequestsTotal.WithLabelValues("/api/v2/system", "xg2g-webui-legacy/2.1"))
 		assert.GreaterOrEqual(t, val, float64(1))
 	})
 
@@ -129,6 +129,24 @@ func TestGetClientLabel(t *testing.T) {
 	}
 }
 
+func TestNormalizeLegacyPath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/api/v1/channel", "/api/v1/channel"},
+		{"/api/v1/channel/12345/stream", "/api/v1/channel"},
+		{"/api/v2/system/health/details", "/api/v2/system"},
+		{"/api/short", "/api/short"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, normalizeLegacyPath(tt.input))
+		})
+	}
+}
+
 func TestLegacyAPIMiddleware_Gate(t *testing.T) {
 	s := &Server{cfg: config.AppConfig{APILegacyEnabled: false}}
 	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -146,6 +164,15 @@ func TestLegacyAPIMiddleware_Gate(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Equal(t, "ok", rr.Body.String())
+	})
+
+	t.Run("path traversal trick /api/v3/../v2/status is intercepted and blocked", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/../v2/status", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusGone, rr.Code)
 	})
 
 	t.Run("legacy v2 request returns 410 Gone with problem+json when APILegacyEnabled is false", func(t *testing.T) {

--- a/backend/internal/api/test_helpers_test.go
+++ b/backend/internal/api/test_helpers_test.go
@@ -17,6 +17,9 @@ func mustNewServer(t testing.TB, cfg config.AppConfig, cfgMgr *config.Manager, o
 	if cfgMgr == nil {
 		cfgMgr = config.NewManager("")
 	}
+	if cfg.ConfigVersion == "" && !cfg.APILegacyEnabled {
+		cfg.APILegacyEnabled = true
+	}
 	s, err := New(cfg, cfgMgr, opts...)
 	if err != nil {
 		t.Fatalf("failed to initialize api server: %v", err)

--- a/backend/internal/config/merge_env.go
+++ b/backend/internal/config/merge_env.go
@@ -108,6 +108,7 @@ func (l *Loader) mergeEnvAPI(cfg *AppConfig) {
 		cfg.APITokens = tokens
 	}
 	cfg.APIDisableLegacyTokenSources = l.envBool("XG2G_API_DISABLE_LEGACY_TOKEN_SOURCES", cfg.APIDisableLegacyTokenSources)
+	cfg.APILegacyEnabled = l.envBool("XG2G_API_LEGACY_ENABLED", cfg.APILegacyEnabled)
 	if value, ok := decisionSecretValueFromLookup(l.envLookup); ok {
 		cfg.PlaybackDecisionSecret = value
 	}

--- a/backend/internal/config/merge_file.go
+++ b/backend/internal/config/merge_file.go
@@ -327,6 +327,9 @@ func (l *Loader) mergeFileAPI(dst *AppConfig, src *FileConfig) error {
 	if src.API.DisableLegacyTokenSources != nil {
 		dst.APIDisableLegacyTokenSources = *src.API.DisableLegacyTokenSources
 	}
+	if src.API.LegacyEnabled != nil {
+		dst.APILegacyEnabled = *src.API.LegacyEnabled
+	}
 	if src.API.PlaybackDecisionSecret != "" {
 		dst.PlaybackDecisionSecret = expandEnv(src.API.PlaybackDecisionSecret)
 	}

--- a/backend/internal/config/registry.go
+++ b/backend/internal/config/registry.go
@@ -137,6 +137,7 @@ func buildRegistry() (*Registry, error) {
 		{Path: "api.tokenScopes", Env: "XG2G_API_TOKEN_SCOPES", FieldPath: "APITokenScopes", Profile: ProfileAdvanced, Status: StatusActive},
 		{Path: "api.tokens", Env: "XG2G_API_TOKENS", FieldPath: "APITokens", Profile: ProfileAdvanced, Status: StatusActive},
 		{Path: "api.disableLegacyTokenSources", Env: "XG2G_API_DISABLE_LEGACY_TOKEN_SOURCES", FieldPath: "APIDisableLegacyTokenSources", Profile: ProfileAdvanced, Status: StatusActive, Default: true},
+		{Path: "api.legacy_enabled", Env: "XG2G_API_LEGACY_ENABLED", FieldPath: "APILegacyEnabled", Profile: ProfileAdvanced, Status: StatusActive, Default: true},
 		{Path: "api.playbackDecisionSecret", Env: "XG2G_DECISION_SECRET", FieldPath: "PlaybackDecisionSecret", Profile: ProfileAdvanced, Status: StatusActive},
 		{Path: "api.playbackDecisionKeyId", Env: "XG2G_PLAYBACK_DECISION_KID", FieldPath: "PlaybackDecisionKeyID", Profile: ProfileAdvanced, Status: StatusActive},
 		{Path: "api.playbackDecisionPreviousKeys", Env: "XG2G_PLAYBACK_DECISION_PREVIOUS_KEYS", FieldPath: "PlaybackDecisionPreviousKeys", Profile: ProfileAdvanced, Status: StatusActive},

--- a/backend/internal/config/types.go
+++ b/backend/internal/config/types.go
@@ -171,6 +171,7 @@ type APIConfig struct {
 	TokenScopes                    []string        `yaml:"tokenScopes,omitempty"`
 	Tokens                         []ScopedToken   `yaml:"tokens,omitempty"`
 	DisableLegacyTokenSources      *bool           `yaml:"disableLegacyTokenSources,omitempty"`
+	LegacyEnabled                  *bool           `yaml:"legacy_enabled,omitempty"`
 	PlaybackDecisionSecret         string          `yaml:"playbackDecisionSecret,omitempty"`
 	PlaybackDecisionKeyID          string          `yaml:"playbackDecisionKeyId,omitempty"`
 	PlaybackDecisionPreviousKeys   []string        `yaml:"playbackDecisionPreviousKeys,omitempty"`
@@ -532,6 +533,7 @@ type AppConfig struct {
 	APITokenScopes                 []string
 	APITokens                      []ScopedToken
 	APIDisableLegacyTokenSources   bool
+	APILegacyEnabled               bool
 	PlaybackDecisionSecret         string
 	PlaybackDecisionKeyID          string
 	PlaybackDecisionPreviousKeys   []string

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -84,6 +84,7 @@ The core knobs for a typical deployment. Everything in the per-area sections bel
 | --- | --- | --- | --- | --- |
 | `api.allowedOrigins` | `XG2G_ALLOWED_ORIGINS` | - | Active | Advanced |
 | `api.disableLegacyTokenSources` | `XG2G_API_DISABLE_LEGACY_TOKEN_SOURCES` | `true` | Active | Advanced |
+| `api.legacy_enabled` | `XG2G_API_LEGACY_ENABLED` | `true` | Active | Advanced |
 | `api.listenAddr` | `XG2G_LISTEN` | `127.0.0.1:8088` | Active | Simple |
 | `api.playbackDecisionKeyId` | `XG2G_PLAYBACK_DECISION_KID` | - | Active | Advanced |
 | `api.playbackDecisionPreviousKeys` | `XG2G_PLAYBACK_DECISION_PREVIOUS_KEYS` | - | Active | Advanced |

--- a/docs/guides/config.schema.json
+++ b/docs/guides/config.schema.json
@@ -55,6 +55,10 @@
           "default": true,
           "type": "boolean"
         },
+        "legacy_enabled": {
+          "default": true,
+          "type": "boolean"
+        },
         "listenAddr": {
           "default": "127.0.0.1:8088",
           "description": "API server listen address (host:port)",


### PR DESCRIPTION
### Summary
Implements Phase **A1.2** of `SPEC_MODERNIZATION_2026.md`: Gating legacy non-v3 endpoints when `api.legacy_enabled` is set to `false`.

### Changes
1. **Configuration Registry & Structs**: Added `api.legacy_enabled` boolean flag (default `true`) across `types.go`, `registry.go`, `merge_env.go` (`XG2G_API_LEGACY_ENABLED`), and `merge_file.go`.
2. **Middleware Interception**: Updated `legacyAPIMiddleware` in `legacy_middleware.go` to return HTTP status **410 Gone** with `application/problem+json` content type () whenever `api.legacy_enabled == false`.
3. **Verification**:
   - Added  and  in .
   - Updated  test helper to apply  when  is uninitialized, matching standard phase A1.2 production behavior without overriding explicit test setups.
   - Regenerated config surfaces via Generating config surfaces from registry...
✅ Config surfaces generated (, , ).

### Verification & CI Status
- `make ci-pr` passed locally ( WebUI unit tests,  backend tests, linter & config surface verification all green).