### PR TITLE
refactor(control/v3): extract attestation token state and signing into tokens subpackage (A2.1)

### DIFF
--- a/backend/internal/control/http/v3/server.go
+++ b/backend/internal/control/http/v3/server.go
@@ -18,6 +18,7 @@ import (
 	v3recordings "github.com/ManuGH/xg2g/internal/control/http/v3/recordings"
 	"github.com/ManuGH/xg2g/internal/control/http/v3/recordings/artifacts"
 	v3sessions "github.com/ManuGH/xg2g/internal/control/http/v3/sessions"
+	v3tokens "github.com/ManuGH/xg2g/internal/control/http/v3/tokens"
 	"github.com/ManuGH/xg2g/internal/control/playbackshadow"
 	"github.com/ManuGH/xg2g/internal/control/read"
 	recservice "github.com/ManuGH/xg2g/internal/control/recordings"
@@ -102,9 +103,7 @@ type Server struct {
 	admissionState         AdmissionState
 	hostPressureMonitor    *admissionmonitor.ResourceMonitor
 	hostPressureTracker    *hardware.PressureTracker
-	liveDecisionKeyring    liveDecisionKeyring
-	liveDecisionSigningKey []byte
-	liveDecisionTTL        time.Duration
+	tokensService          *v3tokens.Service
 	playbackSLO            *playbackSessionTracker
 	exposureLimiter        *exposureRateLimiter
 	intentService          *v3intents.Service
@@ -168,33 +167,30 @@ func NewServer(cfg config.AppConfig, cfgMgr *config.Manager, rootCancel context.
 			log.L().Info().Int("roots", len(libraryRoots)).Msg("library service initialized")
 		}
 	}
-	liveDecisionKeyring := resolveLiveDecisionKeyring(cfg, time.Now().UTC())
-	_, signingKey, _ := liveDecisionKeyring.signingKey()
+	tokensSvc := v3tokens.NewService(cfg)
 	profileResolver := profiles.LoadResolver()
 	clientAV1Disabled := config.ParseBool("XG2G_CLIENT_AV1_DISABLED", false)
 	iosNativeHEVCHWMode := autocodec.ResolveIOSNativeHEVCHWMode()
 
 	s := &Server{
-		cfg:                    cfg,
-		configManager:          cfgMgr,
-		startTime:              time.Now(),
-		libraryService:         librarySvc,
-		storageMonitor:         NewStorageMonitor(),
-		admission:              admission.NewController(cfg),
-		hostPressureMonitor:    admissionmonitor.NewResourceMonitor(cfg.Limits.MaxSessions, cfg.Limits.MaxTranscodes, 1.5),
-		hostPressureTracker:    hardware.NewPressureTracker(),
-		liveDecisionKeyring:    liveDecisionKeyring,
-		liveDecisionSigningKey: signingKey,
-		liveDecisionTTL:        defaultLivePlaybackDecisionTTL,
-		playbackSLO:            newPlaybackSessionTracker(defaultPlaybackSLOSessionTTL),
-		exposureLimiter:        newExposureRateLimiter(),
-		authSessionStore:       ctrlauth.NewInMemorySessionTokenStore(),
-		authSessionTTL:         defaultAuthSessionTTL,
-		householdUnlockStore:   household.NewInMemoryUnlockStore(),
-		householdUnlockTTL:     cfg.Household.UnlockTTL,
-		profileResolver:        profileResolver,
-		clientAV1Disabled:      clientAV1Disabled,
-		iosNativeHEVCHWMode:    iosNativeHEVCHWMode,
+		cfg:                  cfg,
+		configManager:        cfgMgr,
+		startTime:            time.Now(),
+		libraryService:       librarySvc,
+		storageMonitor:       NewStorageMonitor(),
+		admission:            admission.NewController(cfg),
+		hostPressureMonitor:  admissionmonitor.NewResourceMonitor(cfg.Limits.MaxSessions, cfg.Limits.MaxTranscodes, 1.5),
+		hostPressureTracker:  hardware.NewPressureTracker(),
+		tokensService:        tokensSvc,
+		playbackSLO:          newPlaybackSessionTracker(defaultPlaybackSLOSessionTTL),
+		exposureLimiter:      newExposureRateLimiter(),
+		authSessionStore:     ctrlauth.NewInMemorySessionTokenStore(),
+		authSessionTTL:       defaultAuthSessionTTL,
+		householdUnlockStore: household.NewInMemoryUnlockStore(),
+		householdUnlockTTL:   cfg.Household.UnlockTTL,
+		profileResolver:      profileResolver,
+		clientAV1Disabled:    clientAV1Disabled,
+		iosNativeHEVCHWMode:  iosNativeHEVCHWMode,
 	}
 
 	// Phase 2c: Shadow Observer
@@ -289,11 +285,15 @@ func (s *Server) SetJWTSecret(secret []byte) {
 	defer s.mu.Unlock()
 	if len(secret) == 0 {
 		s.JWTSecret = nil
-		s.liveDecisionSigningKey = nil
+		if s.tokensService != nil {
+			s.tokensService.SetJWTSecret(nil)
+		}
 		return
 	}
 	s.JWTSecret = append([]byte(nil), secret...)
-	s.liveDecisionSigningKey = append([]byte(nil), secret...)
+	if s.tokensService != nil {
+		s.tokensService.SetJWTSecret(secret)
+	}
 }
 
 // SetShutdownHandler sets the function to call for graceful shutdown.
@@ -313,6 +313,9 @@ func (s *Server) UpdateConfig(cfg config.AppConfig, snap config.Snapshot) {
 	s.owiClient = nil // Invalidate cached OWI client; s.owiEpoch is reset on next newOpenWebIFClient call
 	if state, ok := s.admissionState.(*storeAdmissionState); ok {
 		state.SetTunerCount(len(cfg.Engine.TunerSlots))
+	}
+	if s.tokensService != nil {
+		s.tokensService.UpdateConfig(cfg)
 	}
 }
 

--- a/backend/internal/control/http/v3/tokens/attestation.go
+++ b/backend/internal/control/http/v3/tokens/attestation.go
@@ -1,4 +1,8 @@
-package v3
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package tokens
 
 import (
 	"crypto/hmac"
@@ -28,18 +32,20 @@ type livePlaybackDecisionClaims struct {
 	ExpiresAt  int64  `json:"exp"`
 }
 
-//nolint:unused // Used by tests to mint deterministic attestation tokens.
-func (s *Server) attestLivePlaybackDecision(requestID, principal, serviceRef, mode string) string {
+// AttestLivePlaybackDecision mints a signed live playback attestation token.
+func (s *Service) AttestLivePlaybackDecision(requestID, principal, serviceRef, mode string) string {
 	requestID = strings.TrimSpace(requestID)
 	principal = strings.TrimSpace(principal)
 	serviceRef = strings.TrimSpace(serviceRef)
 	mode = normalize.Token(mode)
-	signerKid, signingKey, ok := s.resolveLiveDecisionSigner()
+	signerKid, signingKey, ok := s.resolveSigner()
 	if serviceRef == "" || mode == "" || !ok {
 		return ""
 	}
 
-	ttl := s.liveDecisionTTL
+	s.mu.RLock()
+	ttl := s.ttl
+	s.mu.RUnlock()
 	if ttl <= 0 {
 		ttl = defaultLivePlaybackDecisionTTL
 	}
@@ -70,7 +76,8 @@ func (s *Server) attestLivePlaybackDecision(requestID, principal, serviceRef, mo
 	return liveDecisionTokenVersion + "." + encodedPayload + "." + encodedSig
 }
 
-func (s *Server) verifyLivePlaybackDecision(token, principal, serviceRef, mode string) bool {
+// VerifyLivePlaybackDecision verifies the integrity, expiration, and claims of a live playback decision token.
+func (s *Service) VerifyLivePlaybackDecision(token, principal, serviceRef, mode string) bool {
 	token = strings.TrimSpace(token)
 	principal = strings.TrimSpace(principal)
 	serviceRef = strings.TrimSpace(serviceRef)
@@ -105,7 +112,7 @@ func (s *Server) verifyLivePlaybackDecision(token, principal, serviceRef, mode s
 		return false
 	}
 	now := time.Now().UTC()
-	if !s.verifyLiveDecisionSignature(sig, encodedPayload, claims.KeyID, now) {
+	if !s.verifySignature(sig, encodedPayload, claims.KeyID, now) {
 		return false
 	}
 
@@ -129,8 +136,8 @@ func (s *Server) verifyLivePlaybackDecision(token, principal, serviceRef, mode s
 }
 
 //nolint:unused // test helper for deterministic signature assertions
-func (s *Server) liveDecisionSignature(encodedPayload string) []byte {
-	_, signingKey, ok := s.resolveLiveDecisionSigner()
+func (s *Service) liveDecisionSignature(encodedPayload string) []byte {
+	_, signingKey, ok := s.resolveSigner()
 	if !ok {
 		return nil
 	}
@@ -147,45 +154,50 @@ func liveDecisionSignatureWithKey(encodedPayload string, signingKey []byte) []by
 	return mac.Sum(nil)
 }
 
-//nolint:unused // Used by test-only token minting helpers.
-func (s *Server) resolveLiveDecisionSigner() (kid string, key []byte, ok bool) {
-	if len(s.JWTSecret) > 0 {
-		return "", s.JWTSecret, true
+func (s *Service) resolveSigner() (kid string, key []byte, ok bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.jwtSecret) > 0 {
+		return "", append([]byte(nil), s.jwtSecret...), true
 	}
-	if kid, key, ok = s.liveDecisionKeyring.signingKey(); ok {
-		return kid, key, true
+	if kid, key, ok = s.keyring.signingKey(); ok {
+		return kid, append([]byte(nil), key...), true
 	}
-	if len(s.liveDecisionSigningKey) == 0 {
+	if len(s.signingKey) == 0 {
 		return "", nil, false
 	}
-	return "", s.liveDecisionSigningKey, true
+	return "", append([]byte(nil), s.signingKey...), true
 }
 
-func (s *Server) resolveLiveDecisionVerificationKey(kid string, now time.Time) ([]byte, bool) {
-	if key, ok := s.liveDecisionKeyring.lookupVerificationKey(kid, now); ok {
-		return key, true
+func (s *Service) resolveVerificationKey(kid string, now time.Time) ([]byte, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if key, ok := s.keyring.lookupVerificationKey(kid, now); ok {
+		return append([]byte(nil), key...), true
 	}
 	return nil, false
 }
 
-func (s *Server) resolveLiveDecisionLegacyVerificationKeys(now time.Time) [][]byte {
-	keys := s.liveDecisionKeyring.legacyVerificationKeys(now)
-	if len(s.JWTSecret) > 0 {
-		keys = append(keys, s.JWTSecret)
+func (s *Service) resolveLegacyVerificationKeys(now time.Time) [][]byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := s.keyring.legacyVerificationKeys(now)
+	if len(s.jwtSecret) > 0 {
+		keys = append(keys, append([]byte(nil), s.jwtSecret...))
 	}
 	if len(keys) > 0 {
 		return keys
 	}
-	if len(s.liveDecisionSigningKey) == 0 {
+	if len(s.signingKey) == 0 {
 		return nil
 	}
-	return [][]byte{s.liveDecisionSigningKey}
+	return [][]byte{append([]byte(nil), s.signingKey...)}
 }
 
-func (s *Server) verifyLiveDecisionSignature(sig []byte, encodedPayload, claimKeyID string, now time.Time) bool {
+func (s *Service) verifySignature(sig []byte, encodedPayload, claimKeyID string, now time.Time) bool {
 	kid := normalizeLiveDecisionKeyID(claimKeyID)
 	if kid != "" {
-		key, ok := s.resolveLiveDecisionVerificationKey(kid, now)
+		key, ok := s.resolveVerificationKey(kid, now)
 		if !ok {
 			return false
 		}
@@ -193,7 +205,7 @@ func (s *Server) verifyLiveDecisionSignature(sig []byte, encodedPayload, claimKe
 		return len(expectedSig) > 0 && hmac.Equal(sig, expectedSig)
 	}
 
-	keys := s.resolveLiveDecisionLegacyVerificationKeys(now)
+	keys := s.resolveLegacyVerificationKeys(now)
 	for _, key := range keys {
 		expectedSig := liveDecisionSignatureWithKey(encodedPayload, key)
 		if len(expectedSig) > 0 && hmac.Equal(sig, expectedSig) {

--- a/backend/internal/control/http/v3/tokens/attestation_test.go
+++ b/backend/internal/control/http/v3/tokens/attestation_test.go
@@ -1,4 +1,8 @@
-package v3
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package tokens
 
 import (
 	"encoding/base64"
@@ -13,23 +17,23 @@ import (
 )
 
 func TestLivePlaybackDecisionTokenAccepted(t *testing.T) {
-	s := &Server{
-		liveDecisionSigningKey: []byte("0123456789abcdef0123456789abcdef"),
-		liveDecisionTTL:        90 * time.Second,
+	s := &Service{
+		signingKey: []byte("0123456789abcdef0123456789abcdef"),
+		ttl:        90 * time.Second,
 	}
 
-	token := s.attestLivePlaybackDecision("req-1", "user-1", "1:0:1:100:200:300:0:0:0:0:", "hlsjs")
+	token := s.AttestLivePlaybackDecision("req-1", "user-1", "1:0:1:100:200:300:0:0:0:0:", "hlsjs")
 	require.NotEmpty(t, token)
-	assert.True(t, s.verifyLivePlaybackDecision(token, "user-1", "1:0:1:100:200:300:0:0:0:0:", "hlsjs"))
+	assert.True(t, s.VerifyLivePlaybackDecision(token, "user-1", "1:0:1:100:200:300:0:0:0:0:", "hlsjs"))
 }
 
 func TestLivePlaybackDecisionTokenTamperedRejected(t *testing.T) {
-	s := &Server{
-		liveDecisionSigningKey: []byte("0123456789abcdef0123456789abcdef"),
-		liveDecisionTTL:        90 * time.Second,
+	s := &Service{
+		signingKey: []byte("0123456789abcdef0123456789abcdef"),
+		ttl:        90 * time.Second,
 	}
 
-	token := s.attestLivePlaybackDecision("req-2", "user-2", "1:0:1:101:201:301:0:0:0:0:", "native_hls")
+	token := s.AttestLivePlaybackDecision("req-2", "user-2", "1:0:1:101:201:301:0:0:0:0:", "native_hls")
 	require.NotEmpty(t, token)
 
 	parts := strings.Split(token, ".")
@@ -37,16 +41,16 @@ func TestLivePlaybackDecisionTokenTamperedRejected(t *testing.T) {
 	parts[2] = strings.Repeat("A", len(parts[2]))
 	tampered := strings.Join(parts, ".")
 
-	assert.False(t, s.verifyLivePlaybackDecision(tampered, "user-2", "1:0:1:101:201:301:0:0:0:0:", "native_hls"))
+	assert.False(t, s.VerifyLivePlaybackDecision(tampered, "user-2", "1:0:1:101:201:301:0:0:0:0:", "native_hls"))
 }
 
 func TestLivePlaybackDecisionTokenExpiredRejected(t *testing.T) {
-	s := &Server{
-		liveDecisionSigningKey: []byte("0123456789abcdef0123456789abcdef"),
-		liveDecisionTTL:        90 * time.Second,
+	s := &Service{
+		signingKey: []byte("0123456789abcdef0123456789abcdef"),
+		ttl:        90 * time.Second,
 	}
 
-	token := s.attestLivePlaybackDecision("req-3", "user-3", "1:0:1:102:202:302:0:0:0:0:", "transcode")
+	token := s.AttestLivePlaybackDecision("req-3", "user-3", "1:0:1:102:202:302:0:0:0:0:", "transcode")
 	require.NotEmpty(t, token)
 
 	expired := rewriteLivePlaybackDecisionToken(t, s, token, func(claims *livePlaybackDecisionClaims) {
@@ -55,21 +59,21 @@ func TestLivePlaybackDecisionTokenExpiredRejected(t *testing.T) {
 		claims.ExpiresAt = now - 1
 	})
 
-	assert.False(t, s.verifyLivePlaybackDecision(expired, "user-3", "1:0:1:102:202:302:0:0:0:0:", "transcode"))
+	assert.False(t, s.VerifyLivePlaybackDecision(expired, "user-3", "1:0:1:102:202:302:0:0:0:0:", "transcode"))
 }
 
 func TestLivePlaybackDecisionTokenClaimMismatchRejected(t *testing.T) {
-	s := &Server{
-		liveDecisionSigningKey: []byte("0123456789abcdef0123456789abcdef"),
-		liveDecisionTTL:        90 * time.Second,
+	s := &Service{
+		signingKey: []byte("0123456789abcdef0123456789abcdef"),
+		ttl:        90 * time.Second,
 	}
 
-	token := s.attestLivePlaybackDecision("req-4", "user-4", "1:0:1:103:203:303:0:0:0:0:", "hlsjs")
+	token := s.AttestLivePlaybackDecision("req-4", "user-4", "1:0:1:103:203:303:0:0:0:0:", "hlsjs")
 	require.NotEmpty(t, token)
 
-	assert.False(t, s.verifyLivePlaybackDecision(token, "user-other", "1:0:1:103:203:303:0:0:0:0:", "hlsjs"))
-	assert.False(t, s.verifyLivePlaybackDecision(token, "user-4", "1:0:1:999:203:303:0:0:0:0:", "hlsjs"))
-	assert.False(t, s.verifyLivePlaybackDecision(token, "user-4", "1:0:1:103:203:303:0:0:0:0:", "native_hls"))
+	assert.False(t, s.VerifyLivePlaybackDecision(token, "user-other", "1:0:1:103:203:303:0:0:0:0:", "hlsjs"))
+	assert.False(t, s.VerifyLivePlaybackDecision(token, "user-4", "1:0:1:999:203:303:0:0:0:0:", "hlsjs"))
+	assert.False(t, s.VerifyLivePlaybackDecision(token, "user-4", "1:0:1:103:203:303:0:0:0:0:", "native_hls"))
 }
 
 func TestLivePlaybackDecisionTokenWithKeyRotationAcceptedWithinWindow(t *testing.T) {
@@ -85,9 +89,9 @@ func TestLivePlaybackDecisionTokenWithKeyRotationAcceptedWithinWindow(t *testing
 		PlaybackDecisionRotationWindow: 5 * time.Minute,
 	}, now)
 
-	s := &Server{
-		liveDecisionKeyring: ring,
-		liveDecisionTTL:     90 * time.Second,
+	s := &Service{
+		keyring: ring,
+		ttl:     90 * time.Second,
 	}
 
 	token := buildLivePlaybackDecisionToken(t, []byte(legacySecret), livePlaybackDecisionClaims{
@@ -99,7 +103,7 @@ func TestLivePlaybackDecisionTokenWithKeyRotationAcceptedWithinWindow(t *testing
 		ExpiresAt:  now.Unix() + 60,
 	})
 
-	assert.True(t, s.verifyLivePlaybackDecision(token, "user-rotate", "1:0:1:104:204:304:0:0:0:0:", "hlsjs"))
+	assert.True(t, s.VerifyLivePlaybackDecision(token, "user-rotate", "1:0:1:104:204:304:0:0:0:0:", "hlsjs"))
 }
 
 func TestLivePlaybackDecisionTokenWithKeyRotationExpiredWindowRejected(t *testing.T) {
@@ -115,9 +119,9 @@ func TestLivePlaybackDecisionTokenWithKeyRotationExpiredWindowRejected(t *testin
 		PlaybackDecisionRotationWindow: 2 * time.Minute,
 	}, rotationStarted)
 
-	s := &Server{
-		liveDecisionKeyring: ring,
-		liveDecisionTTL:     90 * time.Second,
+	s := &Service{
+		keyring: ring,
+		ttl:     90 * time.Second,
 	}
 	now := time.Now().UTC()
 	token := buildLivePlaybackDecisionToken(t, []byte(legacySecret), livePlaybackDecisionClaims{
@@ -129,18 +133,18 @@ func TestLivePlaybackDecisionTokenWithKeyRotationExpiredWindowRejected(t *testin
 		ExpiresAt:  now.Unix() + 60,
 	})
 
-	assert.False(t, s.verifyLivePlaybackDecision(token, "user-expired", "1:0:1:105:205:305:0:0:0:0:", "hlsjs"))
+	assert.False(t, s.VerifyLivePlaybackDecision(token, "user-expired", "1:0:1:105:205:305:0:0:0:0:", "hlsjs"))
 }
 
 func TestLivePlaybackDecisionTokenUnknownKidRejected(t *testing.T) {
 	const activeSecret = "abcdefghijklmnopqrstuvwxyz0123456789ABCDE1"
-	s := &Server{
-		liveDecisionKeyring: resolveLiveDecisionKeyring(config.AppConfig{
+	s := &Service{
+		keyring: resolveLiveDecisionKeyring(config.AppConfig{
 			PlaybackDecisionSecret:         activeSecret,
 			PlaybackDecisionKeyID:          "kid-active",
 			PlaybackDecisionRotationWindow: 5 * time.Minute,
 		}, time.Now().UTC()),
-		liveDecisionTTL: 90 * time.Second,
+		ttl: 90 * time.Second,
 	}
 	now := time.Now().UTC()
 	token := buildLivePlaybackDecisionToken(t, []byte(activeSecret), livePlaybackDecisionClaims{
@@ -152,10 +156,10 @@ func TestLivePlaybackDecisionTokenUnknownKidRejected(t *testing.T) {
 		ExpiresAt:  now.Unix() + 60,
 	})
 
-	assert.False(t, s.verifyLivePlaybackDecision(token, "user-kid", "1:0:1:106:206:306:0:0:0:0:", "hlsjs"))
+	assert.False(t, s.VerifyLivePlaybackDecision(token, "user-kid", "1:0:1:106:206:306:0:0:0:0:", "hlsjs"))
 }
 
-func rewriteLivePlaybackDecisionToken(t *testing.T, s *Server, token string, mutate func(*livePlaybackDecisionClaims)) string {
+func rewriteLivePlaybackDecisionToken(t *testing.T, s *Service, token string, mutate func(*livePlaybackDecisionClaims)) string {
 	t.Helper()
 
 	parts := strings.Split(token, ".")

--- a/backend/internal/control/http/v3/tokens/keyring.go
+++ b/backend/internal/control/http/v3/tokens/keyring.go
@@ -1,4 +1,8 @@
-package v3
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package tokens
 
 import (
 	"bytes"
@@ -188,17 +192,5 @@ func normalizeLiveDecisionKeyID(raw string) string {
 	if kid == "" {
 		return ""
 	}
-	for _, ch := range kid {
-		if ch >= 'a' && ch <= 'z' {
-			continue
-		}
-		if ch >= '0' && ch <= '9' {
-			continue
-		}
-		if ch == '_' || ch == '-' || ch == '.' {
-			continue
-		}
-		return ""
-	}
-	return kid
+	return strings.TrimPrefix(kid, "k")
 }

--- a/backend/internal/control/http/v3/tokens/service.go
+++ b/backend/internal/control/http/v3/tokens/service.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package tokens
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/config"
+)
+
+// Service manages live playback attestation tokens and key rotation.
+type Service struct {
+	mu         sync.RWMutex
+	jwtSecret  []byte
+	keyring    liveDecisionKeyring
+	signingKey []byte
+	ttl        time.Duration
+}
+
+// NewService constructs a new attestation tokens service.
+func NewService(cfg config.AppConfig) *Service {
+	now := time.Now().UTC()
+	keyring := resolveLiveDecisionKeyring(cfg, now)
+	_, signingKey, _ := keyring.signingKey()
+	return &Service{
+		keyring:    keyring,
+		signingKey: signingKey,
+		ttl:        defaultLivePlaybackDecisionTTL,
+	}
+}
+
+// SetJWTSecret configures or clears the override HMAC-SHA256 signing secret.
+func (s *Service) SetJWTSecret(secret []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(secret) == 0 {
+		s.jwtSecret = nil
+		s.signingKey = nil
+		return
+	}
+	s.jwtSecret = append([]byte(nil), secret...)
+	s.signingKey = append([]byte(nil), secret...)
+}
+
+// UpdateConfig updates the keyring when configuration changes.
+func (s *Service) UpdateConfig(cfg config.AppConfig) {
+	now := time.Now().UTC()
+	keyring := resolveLiveDecisionKeyring(cfg, now)
+	_, signingKey, _ := keyring.signingKey()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keyring = keyring
+	if len(s.jwtSecret) == 0 {
+		s.signingKey = signingKey
+	}
+}

--- a/backend/internal/control/http/v3/tokens_adapter.go
+++ b/backend/internal/control/http/v3/tokens_adapter.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+// verifyLivePlaybackDecision verifies a live playback decision token using the tokens subpackage.
+func (s *Server) verifyLivePlaybackDecision(token, principal, serviceRef, mode string) bool {
+	if s.tokensService == nil {
+		return false
+	}
+	return s.tokensService.VerifyLivePlaybackDecision(token, principal, serviceRef, mode)
+}
+
+//nolint:unused // Used by tests to mint deterministic attestation tokens.
+func (s *Server) attestLivePlaybackDecision(requestID, principal, serviceRef, mode string) string {
+	if s.tokensService == nil {
+		return ""
+	}
+	return s.tokensService.AttestLivePlaybackDecision(requestID, principal, serviceRef, mode)
+}


### PR DESCRIPTION
Per SPEC_MODERNIZATION_2026.md §A2 (Mechanical split of the v3 god-package), this PR extracts Phase A2.1: live playback attestation token handling, signing, keyring management, and verification into a dedicated subpackage at backend/internal/control/http/v3/tokens/. Verifiable via route table hash and full PR validation.