### PR TITLE
refactor(vod): implement pure artifact FSM & SQLite state store (Epic R2 Slice R2.1)

### DIFF
--- a/backend/internal/domain/vod/fsm/fsm.go
+++ b/backend/internal/domain/vod/fsm/fsm.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package fsm
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// NewArtifact initializes a new artifact in the PREPARING state.
+func NewArtifact(id, recordingRef, variantHash, manifestPath, segmentPattern string, now time.Time) (*Artifact, error) {
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("artifact ID cannot be empty")
+	}
+	if strings.TrimSpace(recordingRef) == "" {
+		return nil, fmt.Errorf("recording ref cannot be empty")
+	}
+	if strings.TrimSpace(variantHash) == "" {
+		return nil, fmt.Errorf("variant hash cannot be empty")
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	return &Artifact{
+		ID:             id,
+		RecordingRef:   recordingRef,
+		VariantHash:    variantHash,
+		State:          StatePreparing,
+		ManifestPath:   manifestPath,
+		SegmentPattern: segmentPattern,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}, nil
+}
+
+// CompleteBuild transitions an artifact from PREPARING to READY.
+func CompleteBuild(a *Artifact, now time.Time) error {
+	if a == nil {
+		return ErrArtifactNotFound
+	}
+	if a.State != StatePreparing {
+		return &InvalidTransitionError{
+			FromState: a.State,
+			Event:     EventCompleteBuild,
+			Reason:    "only artifacts in PREPARING state can complete build",
+		}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	a.State = StateReady
+	a.FailureReason = ""
+	a.UpdatedAt = now
+	return nil
+}
+
+// FailBuild transitions an artifact from PREPARING to FAILED.
+func FailBuild(a *Artifact, reason string, now time.Time) error {
+	if a == nil {
+		return ErrArtifactNotFound
+	}
+	if a.State != StatePreparing {
+		return &InvalidTransitionError{
+			FromState: a.State,
+			Event:     EventFailBuild,
+			Reason:    "only artifacts in PREPARING state can fail build",
+		}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	a.State = StateFailed
+	a.FailureReason = reason
+	a.UpdatedAt = now
+	return nil
+}
+
+// RetryBuild transitions an artifact from FAILED back to PREPARING for a retry attempt.
+func RetryBuild(a *Artifact, now time.Time) error {
+	if a == nil {
+		return ErrArtifactNotFound
+	}
+	if a.State != StateFailed {
+		return &InvalidTransitionError{
+			FromState: a.State,
+			Event:     EventRetryBuild,
+			Reason:    "only artifacts in FAILED state can be retried",
+		}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	a.State = StatePreparing
+	a.FailureReason = ""
+	a.UpdatedAt = now
+	return nil
+}
+
+// EvictArtifact transitions an artifact from READY or FAILED to DELETED.
+func EvictArtifact(a *Artifact, now time.Time) error {
+	if a == nil {
+		return ErrArtifactNotFound
+	}
+	if a.State != StateReady && a.State != StateFailed {
+		return &InvalidTransitionError{
+			FromState: a.State,
+			Event:     EventEvictArtifact,
+			Reason:    "only READY or FAILED artifacts can be evicted",
+		}
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	a.State = StateDeleted
+	a.UpdatedAt = now
+	return nil
+}

--- a/backend/internal/domain/vod/fsm/fsm_test.go
+++ b/backend/internal/domain/vod/fsm/fsm_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package fsm
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewArtifact_Valid(t *testing.T) {
+	now := time.Now()
+	a, err := NewArtifact("art-123", "rec-456", "var-789", "/tmp/m.m3u8", "/tmp/seg-*.ts", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if a.ID != "art-123" {
+		t.Errorf("ID = %q, want art-123", a.ID)
+	}
+	if a.State != StatePreparing {
+		t.Errorf("State = %s, want PREPARING", a.State)
+	}
+}
+
+func TestNewArtifact_Validation(t *testing.T) {
+	now := time.Now()
+	if _, err := NewArtifact("", "rec-456", "var-789", "", "", now); err == nil {
+		t.Error("expected error for empty ID")
+	}
+	if _, err := NewArtifact("art-123", "", "var-789", "", "", now); err == nil {
+		t.Error("expected error for empty recordingRef")
+	}
+	if _, err := NewArtifact("art-123", "rec-456", "", "", "", now); err == nil {
+		t.Error("expected error for empty variantHash")
+	}
+}
+
+func TestStateTransitions_Valid(t *testing.T) {
+	now := time.Now()
+	a, _ := NewArtifact("art-1", "rec-1", "var-1", "/m.m3u8", "/s-*.ts", now)
+
+	// PREPARING -> READY
+	if err := CompleteBuild(a, now); err != nil {
+		t.Fatalf("CompleteBuild failed: %v", err)
+	}
+	if a.State != StateReady {
+		t.Errorf("State = %s, want READY", a.State)
+	}
+
+	// READY -> DELETED
+	if err := EvictArtifact(a, now); err != nil {
+		t.Fatalf("EvictArtifact failed: %v", err)
+	}
+	if a.State != StateDeleted {
+		t.Errorf("State = %s, want DELETED", a.State)
+	}
+}
+
+func TestStateTransitions_FailureAndRetry(t *testing.T) {
+	now := time.Now()
+	a, _ := NewArtifact("art-2", "rec-2", "var-2", "/m.m3u8", "/s-*.ts", now)
+
+	// PREPARING -> FAILED
+	if err := FailBuild(a, "transcode crashed", now); err != nil {
+		t.Fatalf("FailBuild failed: %v", err)
+	}
+	if a.State != StateFailed {
+		t.Errorf("State = %s, want FAILED", a.State)
+	}
+	if a.FailureReason != "transcode crashed" {
+		t.Errorf("FailureReason = %q, want 'transcode crashed'", a.FailureReason)
+	}
+
+	// FAILED -> PREPARING
+	if err := RetryBuild(a, now); err != nil {
+		t.Fatalf("RetryBuild failed: %v", err)
+	}
+	if a.State != StatePreparing {
+		t.Errorf("State = %s, want PREPARING", a.State)
+	}
+	if a.FailureReason != "" {
+		t.Errorf("FailureReason = %q, want empty after retry", a.FailureReason)
+	}
+}
+
+func TestStateTransitions_Invalid(t *testing.T) {
+	now := time.Now()
+	a, _ := NewArtifact("art-3", "rec-3", "var-3", "/m.m3u8", "/s-*.ts", now)
+
+	// Cannot retry PREPARING artifact
+	err := RetryBuild(a, now)
+	if err == nil {
+		t.Error("expected error for RetryBuild on PREPARING artifact")
+	}
+	if !errors.Is(err, ErrInvalidStateTransition) {
+		t.Errorf("expected ErrInvalidStateTransition, got %v", err)
+	}
+
+	// Transition to READY
+	_ = CompleteBuild(a, now)
+
+	// Cannot CompleteBuild on READY artifact
+	err = CompleteBuild(a, now)
+	if err == nil {
+		t.Error("expected error for CompleteBuild on READY artifact")
+	}
+	if !errors.Is(err, ErrInvalidStateTransition) {
+		t.Errorf("expected ErrInvalidStateTransition, got %v", err)
+	}
+}
+
+func TestStateTransitions_NilArtifact(t *testing.T) {
+	now := time.Now()
+	if err := CompleteBuild(nil, now); !errors.Is(err, ErrArtifactNotFound) {
+		t.Errorf("expected ErrArtifactNotFound, got %v", err)
+	}
+}

--- a/backend/internal/domain/vod/fsm/types.go
+++ b/backend/internal/domain/vod/fsm/types.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package fsm
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// State represents the lifecycle state of a VOD artifact.
+type State string
+
+const (
+	StatePreparing State = "PREPARING"
+	StateReady     State = "READY"
+	StateFailed    State = "FAILED"
+	StateDeleted   State = "DELETED"
+)
+
+// Event represents an action that triggers a state transition.
+type Event string
+
+const (
+	EventCreateArtifact Event = "CreateArtifact"
+	EventCompleteBuild  Event = "CompleteBuild"
+	EventFailBuild      Event = "FailBuild"
+	EventRetryBuild     Event = "RetryBuild"
+	EventEvictArtifact  Event = "EvictArtifact"
+)
+
+var (
+	ErrInvalidStateTransition = errors.New("invalid artifact state transition")
+	ErrArtifactNotFound       = errors.New("artifact not found")
+)
+
+// InvalidTransitionError represents a detailed state transition failure.
+type InvalidTransitionError struct {
+	FromState State
+	Event     Event
+	Reason    string
+}
+
+func (e *InvalidTransitionError) Error() string {
+	return fmt.Sprintf("cannot trigger event %s from state %s: %s", e.Event, e.FromState, e.Reason)
+}
+
+func (e *InvalidTransitionError) Is(target error) bool {
+	return target == ErrInvalidStateTransition
+}
+
+// Artifact represents the core domain artifact entity.
+type Artifact struct {
+	ID             string    `json:"id"`
+	RecordingRef   string    `json:"recordingRef"`
+	VariantHash    string    `json:"variantHash"`
+	State          State     `json:"state"`
+	FailureReason  string    `json:"failureReason,omitempty"`
+	ManifestPath   string    `json:"manifestPath"`
+	SegmentPattern string    `json:"segmentPattern"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+}

--- a/backend/internal/persistence/sqlite/artifact_store.go
+++ b/backend/internal/persistence/sqlite/artifact_store.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
+)
+
+// ArtifactStore manages persistent FSM state in SQLite.
+type ArtifactStore interface {
+	InitSchema(ctx context.Context) error
+	UpsertArtifact(ctx context.Context, a *fsm.Artifact) error
+	GetArtifact(ctx context.Context, recordingRef, variantHash string) (*fsm.Artifact, error)
+	ListByRecordingRef(ctx context.Context, recordingRef string) ([]*fsm.Artifact, error)
+	DeleteArtifact(ctx context.Context, recordingRef, variantHash string) error
+}
+
+type SQLiteArtifactStore struct {
+	db *sql.DB
+}
+
+// NewArtifactStore creates a new SQLite artifact FSM store instance.
+func NewArtifactStore(db *sql.DB) *SQLiteArtifactStore {
+	return &SQLiteArtifactStore{db: db}
+}
+
+// InitSchema ensures the artifact_state table and indices exist.
+func (s *SQLiteArtifactStore) InitSchema(ctx context.Context) error {
+	query := `
+	CREATE TABLE IF NOT EXISTS artifact_state (
+		id TEXT PRIMARY KEY,
+		recording_ref TEXT NOT NULL,
+		variant_hash TEXT NOT NULL,
+		state TEXT NOT NULL CHECK(state IN ('PREPARING', 'READY', 'FAILED', 'DELETED')),
+		failure_reason TEXT,
+		manifest_path TEXT NOT NULL,
+		segment_pattern TEXT NOT NULL,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL,
+		UNIQUE(recording_ref, variant_hash)
+	);
+	CREATE INDEX IF NOT EXISTS idx_artifact_state_rec_ref ON artifact_state(recording_ref);
+	`
+	_, err := s.db.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to init artifact_state schema: %w", err)
+	}
+	return nil
+}
+
+// UpsertArtifact inserts or updates an artifact's state in SQLite.
+func (s *SQLiteArtifactStore) UpsertArtifact(ctx context.Context, a *fsm.Artifact) error {
+	if a == nil {
+		return errors.New("cannot upsert nil artifact")
+	}
+
+	query := `
+	INSERT INTO artifact_state (
+		id, recording_ref, variant_hash, state, failure_reason, manifest_path, segment_pattern, created_at, updated_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	ON CONFLICT(recording_ref, variant_hash) DO UPDATE SET
+		state = excluded.state,
+		failure_reason = excluded.failure_reason,
+		manifest_path = excluded.manifest_path,
+		segment_pattern = excluded.segment_pattern,
+		updated_at = excluded.updated_at
+	`
+
+	_, err := s.db.ExecContext(ctx, query,
+		a.ID,
+		a.RecordingRef,
+		a.VariantHash,
+		string(a.State),
+		a.FailureReason,
+		a.ManifestPath,
+		a.SegmentPattern,
+		a.CreatedAt.UTC().Format(time.RFC3339Nano),
+		a.UpdatedAt.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upsert artifact state: %w", err)
+	}
+	return nil
+}
+
+// GetArtifact fetches an artifact by recording ref and variant hash.
+func (s *SQLiteArtifactStore) GetArtifact(ctx context.Context, recordingRef, variantHash string) (*fsm.Artifact, error) {
+	query := `
+	SELECT id, recording_ref, variant_hash, state, failure_reason, manifest_path, segment_pattern, created_at, updated_at
+	FROM artifact_state
+	WHERE recording_ref = ? AND variant_hash = ?
+	`
+
+	row := s.db.QueryRowContext(ctx, query, recordingRef, variantHash)
+
+	var a fsm.Artifact
+	var stateStr, createdAtStr, updatedAtStr string
+	err := row.Scan(
+		&a.ID,
+		&a.RecordingRef,
+		&a.VariantHash,
+		&stateStr,
+		&a.FailureReason,
+		&a.ManifestPath,
+		&a.SegmentPattern,
+		&createdAtStr,
+		&updatedAtStr,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fsm.ErrArtifactNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan artifact: %w", err)
+	}
+
+	a.State = fsm.State(stateStr)
+	if t, err := time.Parse(time.RFC3339Nano, createdAtStr); err == nil {
+		a.CreatedAt = t
+	}
+	if t, err := time.Parse(time.RFC3339Nano, updatedAtStr); err == nil {
+		a.UpdatedAt = t
+	}
+
+	return &a, nil
+}
+
+// ListByRecordingRef lists all artifacts associated with a recording reference.
+func (s *SQLiteArtifactStore) ListByRecordingRef(ctx context.Context, recordingRef string) ([]*fsm.Artifact, error) {
+	query := `
+	SELECT id, recording_ref, variant_hash, state, failure_reason, manifest_path, segment_pattern, created_at, updated_at
+	FROM artifact_state
+	WHERE recording_ref = ?
+	ORDER BY created_at ASC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query, recordingRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query artifacts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []*fsm.Artifact
+	for rows.Next() {
+		var a fsm.Artifact
+		var stateStr, createdAtStr, updatedAtStr string
+		if err := rows.Scan(
+			&a.ID,
+			&a.RecordingRef,
+			&a.VariantHash,
+			&stateStr,
+			&a.FailureReason,
+			&a.ManifestPath,
+			&a.SegmentPattern,
+			&createdAtStr,
+			&updatedAtStr,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan artifact row: %w", err)
+		}
+
+		a.State = fsm.State(stateStr)
+		if t, err := time.Parse(time.RFC3339Nano, createdAtStr); err == nil {
+			a.CreatedAt = t
+		}
+		if t, err := time.Parse(time.RFC3339Nano, updatedAtStr); err == nil {
+			a.UpdatedAt = t
+		}
+		results = append(results, &a)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration error: %w", err)
+	}
+
+	return results, nil
+}
+
+// DeleteArtifact removes an artifact entry by recording ref and variant hash.
+func (s *SQLiteArtifactStore) DeleteArtifact(ctx context.Context, recordingRef, variantHash string) error {
+	query := `DELETE FROM artifact_state WHERE recording_ref = ? AND variant_hash = ?`
+	_, err := s.db.ExecContext(ctx, query, recordingRef, variantHash)
+	if err != nil {
+		return fmt.Errorf("failed to delete artifact state: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/persistence/sqlite/artifact_store_test.go
+++ b/backend/internal/persistence/sqlite/artifact_store_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
+	_ "modernc.org/sqlite"
+)
+
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory sqlite db: %v", err)
+	}
+	return db
+}
+
+func TestArtifactStore_InitAndUpsert(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	store := NewArtifactStore(db)
+
+	if err := store.InitSchema(ctx); err != nil {
+		t.Fatalf("InitSchema failed: %v", err)
+	}
+
+	now := time.Now().Truncate(time.Millisecond)
+	art, err := fsm.NewArtifact("art-1", "rec-100", "var-h264", "/tmp/manifest.m3u8", "/tmp/seg-*.ts", now)
+	if err != nil {
+		t.Fatalf("NewArtifact failed: %v", err)
+	}
+
+	// Insert
+	if err := store.UpsertArtifact(ctx, art); err != nil {
+		t.Fatalf("UpsertArtifact failed: %v", err)
+	}
+
+	// Retrieve
+	fetched, err := store.GetArtifact(ctx, "rec-100", "var-h264")
+	if err != nil {
+		t.Fatalf("GetArtifact failed: %v", err)
+	}
+
+	if fetched.ID != "art-1" {
+		t.Errorf("ID = %q, want art-1", fetched.ID)
+	}
+	if fetched.State != fsm.StatePreparing {
+		t.Errorf("State = %s, want PREPARING", fetched.State)
+	}
+
+	// Update transition to READY
+	_ = fsm.CompleteBuild(art, now.Add(time.Second))
+	if err := store.UpsertArtifact(ctx, art); err != nil {
+		t.Fatalf("UpsertArtifact update failed: %v", err)
+	}
+
+	updated, err := store.GetArtifact(ctx, "rec-100", "var-h264")
+	if err != nil {
+		t.Fatalf("GetArtifact failed after update: %v", err)
+	}
+	if updated.State != fsm.StateReady {
+		t.Errorf("State = %s, want READY", updated.State)
+	}
+}
+
+func TestArtifactStore_NotFound(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	store := NewArtifactStore(db)
+	_ = store.InitSchema(ctx)
+
+	_, err := store.GetArtifact(ctx, "nonexistent", "var")
+	if !errors.Is(err, fsm.ErrArtifactNotFound) {
+		t.Errorf("expected ErrArtifactNotFound, got %v", err)
+	}
+}
+
+func TestArtifactStore_ListAndDelete(t *testing.T) {
+	db := newTestDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	store := NewArtifactStore(db)
+	_ = store.InitSchema(ctx)
+
+	now := time.Now().Truncate(time.Millisecond)
+	art1, _ := fsm.NewArtifact("art-1", "rec-200", "var-720p", "/m1.m3u8", "/s1-*.ts", now)
+	art2, _ := fsm.NewArtifact("art-2", "rec-200", "var-1080p", "/m2.m3u8", "/s2-*.ts", now.Add(time.Second))
+
+	_ = store.UpsertArtifact(ctx, art1)
+	_ = store.UpsertArtifact(ctx, art2)
+
+	list, err := store.ListByRecordingRef(ctx, "rec-200")
+	if err != nil {
+		t.Fatalf("ListByRecordingRef failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("list length = %d, want 2", len(list))
+	}
+
+	// Delete art1
+	if err := store.DeleteArtifact(ctx, "rec-200", "var-720p"); err != nil {
+		t.Fatalf("DeleteArtifact failed: %v", err)
+	}
+
+	remaining, _ := store.ListByRecordingRef(ctx, "rec-200")
+	if len(remaining) != 1 {
+		t.Errorf("remaining length = %d, want 1", len(remaining))
+	}
+}


### PR DESCRIPTION
### Epic R2 Slice R2.1 — Pure Artifact FSM & SQLite Store

Per [`SPEC_EPIC_R2_FSM.md`](docs/arch/SPEC_EPIC_R2_FSM.md):
- Introduced pure domain FSM package `internal/domain/vod/fsm/` (`PREPARING`, `READY`, `FAILED`, `DELETED`).
- Implemented SQLite artifact state store `internal/persistence/sqlite/artifact_store.go` (`artifact_state` table).
- Added comprehensive domain transition tests (`fsm_test.go`) and SQLite store unit tests (`artifact_store_test.go`).
- Zero filesystem state-derived heuristics or side effects.