### PR TITLE
feat(config): flip recordings.strict_target_required default to true (R0 Prerequisite Item 2)

### DIFF
--- a/backend/config.generated.example.yaml
+++ b/backend/config.generated.example.yaml
@@ -152,7 +152,7 @@ recording_playback:
   stable_window: 10s
 recording_roots: {}
 recordings:
-  strict_target_required: false
+  strict_target_required: true
   target_signing_key: ""
   target_signing_key_previous: ""
 server:

--- a/backend/internal/config/registry.go
+++ b/backend/internal/config/registry.go
@@ -268,7 +268,7 @@ func buildRegistry() (*Registry, error) {
 		{Path: "recording_playback.playback_policy", Env: "XG2G_RECORDING_PLAYBACK_POLICY", FieldPath: "RecordingPlaybackPolicy", Profile: ProfileAdvanced, Status: StatusActive, Default: "auto"},
 		{Path: "recording_playback.stable_window", Env: "XG2G_RECORDING_STABLE_WINDOW", FieldPath: "RecordingStableWindow", Profile: ProfileAdvanced, Status: StatusActive, Default: 10 * time.Second},
 		{Path: "recording_playback.mappings", Env: "XG2G_RECORDINGS_MAP", FieldPath: "RecordingPathMappings", Profile: ProfileAdvanced, Status: StatusActive},
-		{Path: "recordings.strict_target_required", Env: "XG2G_RECORDINGS_STRICT_TARGET_REQUIRED", FieldPath: "RecordingStrictTargetRequired", Profile: ProfileAdvanced, Status: StatusActive, Default: false},
+		{Path: "recordings.strict_target_required", Env: "XG2G_RECORDINGS_STRICT_TARGET_REQUIRED", FieldPath: "RecordingStrictTargetRequired", Profile: ProfileAdvanced, Status: StatusActive, Default: true},
 		{Path: "recordings.target_signing_key", Env: "XG2G_RECORDINGS_TARGET_SIGNING_KEY", FieldPath: "RecordingTargetSigningKey", Profile: ProfileAdvanced, Status: StatusActive, Default: ""},
 		{Path: "recordings.target_signing_key_previous", Env: "XG2G_RECORDINGS_TARGET_SIGNING_KEY_PREVIOUS", FieldPath: "RecordingTargetSigningKeyPrevious", Profile: ProfileAdvanced, Status: StatusActive, Default: ""},
 

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -303,7 +303,7 @@ Legacy YAML section `openWebIF.*` is rejected at load time; use `enigma2.*`.
 
 | Path | Env | Default | Status | Profile |
 | --- | --- | --- | --- | --- |
-| `recordings.strict_target_required` | `XG2G_RECORDINGS_STRICT_TARGET_REQUIRED` | `false` | Active | Advanced |
+| `recordings.strict_target_required` | `XG2G_RECORDINGS_STRICT_TARGET_REQUIRED` | `true` | Active | Advanced |
 | `recordings.target_signing_key` | `XG2G_RECORDINGS_TARGET_SIGNING_KEY` | `""` | Active | Advanced |
 | `recordings.target_signing_key_previous` | `XG2G_RECORDINGS_TARGET_SIGNING_KEY_PREVIOUS` | `""` | Active | Advanced |
 

--- a/docs/guides/config.schema.json
+++ b/docs/guides/config.schema.json
@@ -990,7 +990,7 @@
     "recordings": {
       "properties": {
         "strict_target_required": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "target_signing_key": {


### PR DESCRIPTION
### R0 Prerequisite Item 2 — Strict Target Default Flip

Per [`SPEC_MODERNIZATION_2026.md`](docs/arch/SPEC_MODERNIZATION_2026.md) Section R0:
- Flips `recordings.strict_target_required` default from `false` to `true`.
- To be merged only after verifying production fallback metrics (`xg2g_target_fallback_total`) at zero for one deploy cycle.