### PR TITLE
refactor(vod): implement SQLite FSM dual-write adapter & divergence metric (Epic R2 Slice R2.2)

### DIFF
--- a/backend/internal/control/vod/build.go
+++ b/backend/internal/control/vod/build.go
@@ -38,7 +38,7 @@ func (m *Manager) markReadyFromBuild(jobID string, metaID string, spec Spec, fin
 		meta.State = ArtifactStateFailed
 		meta.Error = "build completed without artifact path"
 	}
-	m.touch(&meta)
+	m.touch(metaID, &meta)
 	m.metadata[metaID] = meta
 
 	log.Info().Str(xlog.FieldJobID, jobID).Str(xlog.FieldMetaID, metaID).Str(xlog.FieldOldState, string(oldState)).Str(xlog.FieldNewState, string(meta.State)).Str(xlog.FieldPlaylistPath, meta.PlaylistPath).Uint64("stateGen", meta.StateGen).Msg("VOD manager: metadata updated")
@@ -59,7 +59,7 @@ func (m *Manager) markFailedFromBuild(jobID string, metaID string, reason string
 	oldState := meta.State
 	meta.State = ArtifactStateFailed
 	meta.Error = reason
-	m.touch(&meta)
+	m.touch(metaID, &meta)
 	m.metadata[metaID] = meta
 
 	log.Info().Str(xlog.FieldJobID, jobID).Str(xlog.FieldMetaID, metaID).Str(xlog.FieldOldState, string(oldState)).Str(xlog.FieldNewState, string(meta.State)).Str("error", meta.Error).Uint64("stateGen", meta.StateGen).Msg("VOD manager: metadata updated to FAILED")

--- a/backend/internal/control/vod/build.go
+++ b/backend/internal/control/vod/build.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/ManuGH/xg2g/internal/domain/playbackprofile/ports"
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
 	xlog "github.com/ManuGH/xg2g/internal/log"
 	"github.com/rs/zerolog/log"
 	"strings"
@@ -40,6 +41,7 @@ func (m *Manager) markReadyFromBuild(jobID string, metaID string, spec Spec, fin
 	}
 	m.touch(metaID, &meta)
 	m.metadata[metaID] = meta
+	m.dispatchFSMShadow(metaID, fsm.EventCompleteBuild, "", finalPath, meta.State)
 
 	log.Info().Str(xlog.FieldJobID, jobID).Str(xlog.FieldMetaID, metaID).Str(xlog.FieldOldState, string(oldState)).Str(xlog.FieldNewState, string(meta.State)).Str(xlog.FieldPlaylistPath, meta.PlaylistPath).Uint64("stateGen", meta.StateGen).Msg("VOD manager: metadata updated")
 
@@ -61,6 +63,7 @@ func (m *Manager) markFailedFromBuild(jobID string, metaID string, reason string
 	meta.Error = reason
 	m.touch(metaID, &meta)
 	m.metadata[metaID] = meta
+	m.dispatchFSMShadow(metaID, fsm.EventFailBuild, reason, "", meta.State)
 
 	log.Info().Str(xlog.FieldJobID, jobID).Str(xlog.FieldMetaID, metaID).Str(xlog.FieldOldState, string(oldState)).Str(xlog.FieldNewState, string(meta.State)).Str("error", meta.Error).Uint64("stateGen", meta.StateGen).Msg("VOD manager: metadata updated to FAILED")
 

--- a/backend/internal/control/vod/manager.go
+++ b/backend/internal/control/vod/manager.go
@@ -4,32 +4,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"golang.org/x/sync/singleflight"
 	"sort"
 	"sync"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
 )
 
 // Manager handles VOD build jobs.
 type Manager struct {
-	runner     Runner
-	prober     Prober
-	mu         sync.Mutex
-	jobs       map[string]*BuildMonitor
-	metadata   map[string]Metadata // Cached artifact metadata
-	probeCh    chan probeRequest
-	workerWg   sync.WaitGroup
-	buildWg    sync.WaitGroup
-	sfg        singleflight.Group
-	pathMapper PathMapper
-	started    bool
-	ctx        context.Context
-	cancel     context.CancelFunc
+	runner        Runner
+	prober        Prober
+	mu            sync.Mutex
+	jobs          map[string]*BuildMonitor
+	metadata      map[string]Metadata // Cached artifact metadata
+	artifactStore ArtifactStore       // SQLite FSM store (dual-write)
+	probeCh       chan probeRequest
+	workerWg      sync.WaitGroup
+	buildWg       sync.WaitGroup
+	sfg           singleflight.Group
+	pathMapper    PathMapper
+	started       bool
+	ctx           context.Context
+	cancel        context.CancelFunc
 }
 
 // PathMapper abstracts local path resolution.
 type PathMapper interface {
 	ResolveLocalExisting(receiverPath string) (string, bool)
+}
+
+// ArtifactStore abstracts artifact state persistence for dual-write.
+type ArtifactStore interface {
+	UpsertArtifact(ctx context.Context, a *fsm.Artifact) error
+	GetArtifact(ctx context.Context, recordingRef, variantHash string) (*fsm.Artifact, error)
+	DeleteArtifact(ctx context.Context, recordingRef, variantHash string) error
 }
 
 func NewManager(runner Runner, prober Prober, pathMapper PathMapper) (*Manager, error) {
@@ -53,6 +63,13 @@ func NewManager(runner Runner, prober Prober, pathMapper PathMapper) (*Manager, 
 	}
 
 	return m, nil
+}
+
+// SetArtifactStore configures the SQLite artifact state store for dual-write.
+func (m *Manager) SetArtifactStore(store ArtifactStore) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.artifactStore = store
 }
 
 // Shutdown stops the manager and cancels all background contexts.

--- a/backend/internal/control/vod/manager_dualwrite_test.go
+++ b/backend/internal/control/vod/manager_dualwrite_test.go
@@ -54,3 +54,47 @@ func TestManager_DualWriteToSQLiteStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fsm.StateReady, updated.State)
 }
+
+func TestManager_PureFSMShadowDivergenceTracking(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	store := sqlite.NewArtifactStore(db)
+	require.NoError(t, store.InitSchema(ctx))
+
+	mgr, err := NewManager(&mockRunner{}, &mockProber{}, nil)
+	require.NoError(t, err)
+	mgr.SetArtifactStore(store)
+
+	metaID := "rec-div-1:h264"
+	mgr.SeedMetadata(metaID, Metadata{
+		State:        ArtifactStatePreparing,
+		ResolvedPath: "/tmp/rec-div-1.ts",
+		UpdatedAt:    time.Now().UnixNano(),
+	})
+
+	// Simulate build completion -> Pure FSM moves to READY
+	mgr.MarkProbed(metaID, "/tmp/rec-div-1.ts", &StreamInfo{
+		Container: "mpegts",
+		Video:     VideoStreamInfo{CodecName: "h264"},
+	}, nil)
+
+	art, err := store.GetArtifact(ctx, "rec-div-1", "h264")
+	require.NoError(t, err)
+	require.Equal(t, fsm.StateReady, art.State)
+
+	// Now simulate a legacy code path trying to call MarkFailure on a READY artifact
+	mgr.MarkFailure(metaID, ArtifactStateFailed, "transcode error", "/tmp/rec-div-1.ts", nil)
+
+	// Pure FSM rule: cannot FailBuild directly from READY without returning to PREPARING/retry.
+	// FSM transition fails, FSM remains READY, whereas legacy set state to FAILED -> Divergence detected!
+	fsmArt, err := store.GetArtifact(ctx, "rec-div-1", "h264")
+	require.NoError(t, err)
+	require.Equal(t, fsm.StateReady, fsmArt.State)
+
+	legacyMeta, ok := mgr.GetMetadata(metaID)
+	require.True(t, ok)
+	require.Equal(t, ArtifactStateFailed, legacyMeta.State)
+}

--- a/backend/internal/control/vod/manager_dualwrite_test.go
+++ b/backend/internal/control/vod/manager_dualwrite_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package vod
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
+	"github.com/ManuGH/xg2g/internal/persistence/sqlite"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func TestManager_DualWriteToSQLiteStore(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+	store := sqlite.NewArtifactStore(db)
+	require.NoError(t, store.InitSchema(ctx))
+
+	mgr, err := NewManager(&mockRunner{}, &mockProber{}, nil)
+	require.NoError(t, err)
+
+	mgr.SetArtifactStore(store)
+
+	metaID := "rec-test-100:h264"
+	mgr.SeedMetadata(metaID, Metadata{
+		State:        ArtifactStatePreparing,
+		ResolvedPath: "/tmp/rec-test-100.ts",
+		UpdatedAt:    time.Now().UnixNano(),
+	})
+
+	// Verify dual-write created entry in SQLite ArtifactStore
+	fetched, err := store.GetArtifact(ctx, "rec-test-100", "h264")
+	require.NoError(t, err)
+	require.Equal(t, "rec-test-100", fetched.RecordingRef)
+	require.Equal(t, "h264", fetched.VariantHash)
+	require.Equal(t, fsm.StatePreparing, fetched.State)
+
+	// Transition state to READY via MarkProbed
+	mgr.MarkProbed(metaID, "/tmp/rec-test-100.ts", &StreamInfo{
+		Container: "mpegts",
+		Video:     VideoStreamInfo{CodecName: "h264", Width: 1920, Height: 1080},
+	}, nil)
+
+	// Verify SQLite ArtifactStore state is updated to READY
+	updated, err := store.GetArtifact(ctx, "rec-test-100", "h264")
+	require.NoError(t, err)
+	require.Equal(t, fsm.StateReady, updated.State)
+}

--- a/backend/internal/control/vod/manager_race_test.go
+++ b/backend/internal/control/vod/manager_race_test.go
@@ -26,7 +26,7 @@ func TestStateGenGuard_Deterministic(t *testing.T) {
 		State:    ArtifactStatePreparing,
 		StateGen: 10,
 	}
-	mgr.touch(&meta) // Becomes Gen 11
+	mgr.touch(id, &meta) // Becomes Gen 11
 	mgr.metadata[id] = meta
 	capturedGen := meta.StateGen // 11
 	mgr.mu.Unlock()
@@ -46,7 +46,7 @@ func TestStateGenGuard_Deterministic(t *testing.T) {
 	// Reset to PREPARING
 	mgr.mu.Lock()
 	meta.State = ArtifactStatePreparing
-	mgr.touch(&meta) // Gen increments (lets say 12 -> 13)
+	mgr.touch(id, &meta) // Gen increments (lets say 12 -> 13)
 	mgr.metadata[id] = meta
 	capturedGen = meta.StateGen
 	mgr.mu.Unlock()
@@ -56,7 +56,7 @@ func TestStateGenGuard_Deterministic(t *testing.T) {
 	mgr.mu.Lock()
 	meta = mgr.metadata[id]
 	meta.State = ArtifactStateReady
-	mgr.touch(&meta) // Gen 13 -> 14
+	mgr.touch(id, &meta) // Gen 13 -> 14
 	mgr.metadata[id] = meta
 	expectedFinalGen := meta.StateGen // Capture expected constant (14)
 	mgr.mu.Unlock()
@@ -79,7 +79,7 @@ func TestTouchHelper(t *testing.T) {
 	meta := Metadata{StateGen: 1}
 
 	start := time.Now().UnixNano()
-	mgr.touch(&meta)
+	mgr.touch("test-id", &meta)
 
 	require.Equal(t, uint64(2), meta.StateGen)
 	require.GreaterOrEqual(t, meta.UpdatedAt, start)

--- a/backend/internal/control/vod/metadata.go
+++ b/backend/internal/control/vod/metadata.go
@@ -2,6 +2,7 @@ package vod
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sort"
 	"strings"
@@ -106,7 +107,7 @@ func (m *Manager) SeedMetadata(id string, meta Metadata) {
 		m.metadata = make(map[string]Metadata)
 	}
 	m.metadata[id] = meta
-	m.syncArtifactStore(id, meta)
+	m.dispatchFSMShadow(id, fsm.EventCreateArtifact, "", meta.ResolvedPath, meta.State)
 }
 
 // MarkUnknown safely transitions state to UNKNOWN without wiping other fields.
@@ -173,6 +174,7 @@ func (m *Manager) MarkPreparingIfState(id string, expected ArtifactState, reason
 	}
 	m.touch(id, &meta)
 	m.metadata[id] = meta
+	m.dispatchFSMShadow(id, fsm.EventCreateArtifact, reason, "", meta.State)
 
 	return meta, true
 }
@@ -194,7 +196,7 @@ func (m *Manager) PromoteFailedToReadyIfPlaylist(id string) (Metadata, bool) {
 
 	meta.State = ArtifactStateReady
 	meta.Error = ""
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 
 	return meta, true
@@ -218,11 +220,10 @@ func (m *Manager) SetResolvedPathIfEmpty(id string, resolved string) bool {
 	return true
 }
 
-// touch updates timestamp and generation, and syncs FSM to SQLite store
+// touch updates timestamp and generation
 func (m *Manager) touch(id string, meta *Metadata) {
 	meta.UpdatedAt = time.Now().UnixNano() // Use Nano for higher resolution
 	meta.StateGen++
-	m.syncArtifactStore(id, *meta)
 }
 
 func parseArtifactRef(id string) (string, string) {
@@ -233,46 +234,74 @@ func parseArtifactRef(id string) (string, string) {
 	return id, "default"
 }
 
-func (m *Manager) syncArtifactStore(metaID string, meta Metadata) {
+func (m *Manager) dispatchFSMShadow(metaID string, event fsm.Event, reason string, path string, legacyState ArtifactState) {
 	if m == nil || m.artifactStore == nil {
 		return
 	}
 
 	recordingRef, variantHash := parseArtifactRef(metaID)
-	fsmState := fsm.StatePreparing
-	switch meta.State {
-	case ArtifactStateReady:
-		fsmState = fsm.StateReady
-	case ArtifactStateFailed:
-		fsmState = fsm.StateFailed
-	case ArtifactStatePreparing, ArtifactStateUnknown, ArtifactStateMissing:
-		fsmState = fsm.StatePreparing
-	}
-
-	art := &fsm.Artifact{
-		ID:             metaID,
-		RecordingRef:   recordingRef,
-		VariantHash:    variantHash,
-		State:          fsmState,
-		FailureReason:  meta.Error,
-		ManifestPath:   meta.ResolvedPath,
-		SegmentPattern: meta.PlaylistPath,
-		CreatedAt:      time.Unix(0, meta.UpdatedAt),
-		UpdatedAt:      time.Unix(0, meta.UpdatedAt),
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	if err := m.artifactStore.UpsertArtifact(ctx, art); err != nil {
-		log.Warn().Err(err).Str("id", metaID).Msg("VOD artifact dual-write to SQLite failed")
+	now := time.Now()
+
+	// 1. Fetch current artifact from SQLite FSM store (or create if absent)
+	art, err := m.artifactStore.GetArtifact(ctx, recordingRef, variantHash)
+	if errors.Is(err, fsm.ErrArtifactNotFound) {
+		art, err = fsm.NewArtifact(metaID, recordingRef, variantHash, path, "", now)
+		if err != nil {
+			log.Warn().Err(err).Str("id", metaID).Msg("VOD shadow FSM artifact creation failed")
+			return
+		}
+	} else if err != nil {
+		log.Warn().Err(err).Str("id", metaID).Msg("VOD shadow FSM fetch failed")
+		return
 	}
 
-	// Telemetry divergence check
-	if existing, err := m.artifactStore.GetArtifact(ctx, recordingRef, variantHash); err == nil {
-		if string(existing.State) != string(fsmState) {
-			metrics.IncVODStateDivergence(string(meta.State), string(existing.State))
+	// 2. Execute Pure FSM Transition Function based on Event
+	var transitionErr error
+	switch event {
+	case fsm.EventCreateArtifact:
+		if art.State == fsm.StateFailed {
+			transitionErr = fsm.RetryBuild(art, now)
+		} else if art.State == fsm.StateReady || art.State == fsm.StateDeleted {
+			art.State = fsm.StatePreparing
+			art.FailureReason = ""
+			art.UpdatedAt = now
 		}
+	case fsm.EventCompleteBuild:
+		if path != "" {
+			art.ManifestPath = path
+		}
+		transitionErr = fsm.CompleteBuild(art, now)
+	case fsm.EventFailBuild:
+		transitionErr = fsm.FailBuild(art, reason, now)
+	case fsm.EventRetryBuild:
+		transitionErr = fsm.RetryBuild(art, now)
+	case fsm.EventEvictArtifact:
+		transitionErr = fsm.EvictArtifact(art, now)
+	}
+
+	if transitionErr != nil {
+		log.Debug().Err(transitionErr).Str("id", metaID).Str("event", string(event)).Msg("VOD shadow FSM transition rejected by pure rules")
+	}
+
+	// 3. True Shadow Divergence Check: Compare Legacy state against Pure FSM calculated state
+	fsmStateStr := string(art.State)
+	legacyStateStr := string(legacyState)
+	if legacyStateStr != fsmStateStr {
+		log.Warn().
+			Str("id", metaID).
+			Str("event", string(event)).
+			Str("legacyState", legacyStateStr).
+			Str("fsmState", fsmStateStr).
+			Msg("VOD shadow state divergence detected between Legacy and Pure FSM")
+		metrics.IncVODStateDivergence(legacyStateStr, fsmStateStr)
+	}
+
+	// 4. Save calculated Pure FSM state to SQLite
+	if err := m.artifactStore.UpsertArtifact(ctx, art); err != nil {
+		log.Warn().Err(err).Str("id", metaID).Msg("VOD shadow FSM state save to SQLite failed")
 	}
 }
 
@@ -360,6 +389,7 @@ func (m *Manager) MarkFailure(id string, state ArtifactState, reason string, res
 	}
 	m.touch(id, &meta)
 	m.metadata[id] = meta
+	m.dispatchFSMShadow(id, fsm.EventFailBuild, reason, resolvedPath, meta.State)
 }
 
 // InvalidateTruth clears cached probe truth (codecs, container) to force re-planning.
@@ -456,4 +486,5 @@ func (m *Manager) MarkProbed(id string, resolvedPath string, info *StreamInfo, f
 
 	m.touch(id, &meta)
 	m.metadata[id] = meta
+	m.dispatchFSMShadow(id, fsm.EventCompleteBuild, "", resolvedPath, meta.State)
 }

--- a/backend/internal/control/vod/metadata.go
+++ b/backend/internal/control/vod/metadata.go
@@ -262,13 +262,7 @@ func (m *Manager) dispatchFSMShadow(metaID string, event fsm.Event, reason strin
 	var transitionErr error
 	switch event {
 	case fsm.EventCreateArtifact:
-		if art.State == fsm.StateFailed {
-			transitionErr = fsm.RetryBuild(art, now)
-		} else if art.State == fsm.StateReady || art.State == fsm.StateDeleted {
-			art.State = fsm.StatePreparing
-			art.FailureReason = ""
-			art.UpdatedAt = now
-		}
+		transitionErr = fsm.PrepareArtifact(art, now)
 	case fsm.EventCompleteBuild:
 		if path != "" {
 			art.ManifestPath = path

--- a/backend/internal/control/vod/metadata.go
+++ b/backend/internal/control/vod/metadata.go
@@ -1,10 +1,15 @@
 package vod
 
 import (
+	"context"
 	"math"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
+	"github.com/ManuGH/xg2g/internal/metrics"
+	"github.com/rs/zerolog/log"
 )
 
 // GetMetadata returns cached metadata for an artifact.
@@ -101,6 +106,7 @@ func (m *Manager) SeedMetadata(id string, meta Metadata) {
 		m.metadata = make(map[string]Metadata)
 	}
 	m.metadata[id] = meta
+	m.syncArtifactStore(id, meta)
 }
 
 // MarkUnknown safely transitions state to UNKNOWN without wiping other fields.
@@ -110,13 +116,13 @@ func (m *Manager) MarkUnknown(id string) {
 
 	if meta, ok := m.metadata[id]; ok {
 		meta.State = ArtifactStateUnknown
-		m.touch(&meta)
+		m.touch(id, &meta)
 		m.metadata[id] = meta
 	} else {
 		meta := Metadata{
 			State: ArtifactStateUnknown,
 		}
-		m.touch(&meta)
+		m.touch(id, &meta)
 		m.metadata[id] = meta
 	}
 }
@@ -136,11 +142,11 @@ func (m *Manager) DemoteOnOpenFailure(id string, err error) {
 	// The next loop will see PREPARING and return 503 strictly.
 	meta.State = ArtifactStatePreparing
 	meta.Error = "reconcile: open failed in READY state: " + err.Error()
-	m.touch(&meta)
+	m.touch(id, &meta)
 	if meta.ResolvedPath == "" && m.pathMapper == nil {
 		meta.State = ArtifactStateFailed
 		meta.Error = "reconcile: missing input path for probe"
-		m.touch(&meta)
+		m.touch(id, &meta)
 		m.metadata[id] = meta
 		return
 	}
@@ -165,7 +171,7 @@ func (m *Manager) MarkPreparingIfState(id string, expected ArtifactState, reason
 	if reason != "" {
 		meta.Error = reason
 	}
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 
 	return meta, true
@@ -207,15 +213,67 @@ func (m *Manager) SetResolvedPathIfEmpty(id string, resolved string) bool {
 		return false
 	}
 	meta.ResolvedPath = resolved
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 	return true
 }
 
-// touch updates timestamp and generation
-func (m *Manager) touch(meta *Metadata) {
+// touch updates timestamp and generation, and syncs FSM to SQLite store
+func (m *Manager) touch(id string, meta *Metadata) {
 	meta.UpdatedAt = time.Now().UnixNano() // Use Nano for higher resolution
 	meta.StateGen++
+	m.syncArtifactStore(id, *meta)
+}
+
+func parseArtifactRef(id string) (string, string) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) == 2 && parts[1] != "" {
+		return parts[0], parts[1]
+	}
+	return id, "default"
+}
+
+func (m *Manager) syncArtifactStore(metaID string, meta Metadata) {
+	if m == nil || m.artifactStore == nil {
+		return
+	}
+
+	recordingRef, variantHash := parseArtifactRef(metaID)
+	fsmState := fsm.StatePreparing
+	switch meta.State {
+	case ArtifactStateReady:
+		fsmState = fsm.StateReady
+	case ArtifactStateFailed:
+		fsmState = fsm.StateFailed
+	case ArtifactStatePreparing, ArtifactStateUnknown, ArtifactStateMissing:
+		fsmState = fsm.StatePreparing
+	}
+
+	art := &fsm.Artifact{
+		ID:             metaID,
+		RecordingRef:   recordingRef,
+		VariantHash:    variantHash,
+		State:          fsmState,
+		FailureReason:  meta.Error,
+		ManifestPath:   meta.ResolvedPath,
+		SegmentPattern: meta.PlaylistPath,
+		CreatedAt:      time.Unix(0, meta.UpdatedAt),
+		UpdatedAt:      time.Unix(0, meta.UpdatedAt),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := m.artifactStore.UpsertArtifact(ctx, art); err != nil {
+		log.Warn().Err(err).Str("id", metaID).Msg("VOD artifact dual-write to SQLite failed")
+	}
+
+	// Telemetry divergence check
+	if existing, err := m.artifactStore.GetArtifact(ctx, recordingRef, variantHash); err == nil {
+		if string(existing.State) != string(fsmState) {
+			metrics.IncVODStateDivergence(string(meta.State), string(existing.State))
+		}
+	}
 }
 
 // revertStateGuard atomically reverts state if generation matches (race guard)
@@ -229,7 +287,7 @@ func (m *Manager) revertStateGuard(id string, guardedGen uint64, targetState Art
 		current.StateGen == guardedGen {
 
 		current.State = targetState
-		m.touch(&current)
+		m.touch(id, &current)
 		m.metadata[id] = current
 	}
 }
@@ -247,7 +305,7 @@ func (m *Manager) RevertPreparingIfGen(id string, guardedGen uint64, targetState
 		if reason != "" {
 			current.Error = reason
 		}
-		m.touch(&current)
+		m.touch(id, &current)
 		m.metadata[id] = current
 		return true
 	}
@@ -268,7 +326,7 @@ func (m *Manager) MarkFailed(id string, reason string) {
 
 	meta.State = ArtifactStateFailed
 	meta.Error = reason
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 }
 
@@ -300,7 +358,7 @@ func (m *Manager) MarkFailure(id string, state ArtifactState, reason string, res
 	if fp != nil {
 		meta.Fingerprint = *fp
 	}
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 }
 
@@ -322,7 +380,7 @@ func (m *Manager) InvalidateTruth(id string) {
 	meta.Height = 0
 	meta.FPS = 0
 	meta.Interlaced = false
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 }
 
@@ -396,6 +454,6 @@ func (m *Manager) MarkProbed(id string, resolvedPath string, info *StreamInfo, f
 	// Clear any previous error
 	meta.Error = ""
 
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 }

--- a/backend/internal/control/vod/probe.go
+++ b/backend/internal/control/vod/probe.go
@@ -3,6 +3,8 @@ package vod
 import (
 	"context"
 	"errors"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod/fsm"
 )
 
 // Probe delegates to the infra prober
@@ -60,6 +62,7 @@ func (m *Manager) TriggerProbe(id string, input string) {
 	meta.State = ArtifactStatePreparing
 	m.touch(id, &meta)
 	m.metadata[id] = meta
+	m.dispatchFSMShadow(id, fsm.EventCreateArtifact, "", input, meta.State)
 	capturedGen := meta.StateGen
 	resolvedPath := meta.ResolvedPath // Capture under lock
 	m.mu.Unlock()

--- a/backend/internal/control/vod/probe.go
+++ b/backend/internal/control/vod/probe.go
@@ -51,14 +51,14 @@ func (m *Manager) TriggerProbe(id string, input string) {
 	if input == "" && meta.ResolvedPath == "" && m.pathMapper == nil {
 		meta.State = ArtifactStateFailed
 		meta.Error = "missing input path for probe"
-		m.touch(&meta)
+		m.touch(id, &meta)
 		m.metadata[id] = meta
 		m.mu.Unlock()
 		return
 	}
 
 	meta.State = ArtifactStatePreparing
-	m.touch(&meta)
+	m.touch(id, &meta)
 	m.metadata[id] = meta
 	capturedGen := meta.StateGen
 	resolvedPath := meta.ResolvedPath // Capture under lock

--- a/backend/internal/domain/vod/fsm/fsm.go
+++ b/backend/internal/domain/vod/fsm/fsm.go
@@ -102,6 +102,21 @@ func RetryBuild(a *Artifact, now time.Time) error {
 	return nil
 }
 
+// PrepareArtifact transitions an artifact to PREPARING (fresh build or retry).
+func PrepareArtifact(a *Artifact, now time.Time) error {
+	if a == nil {
+		return ErrArtifactNotFound
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	a.State = StatePreparing
+	a.FailureReason = ""
+	a.UpdatedAt = now
+	return nil
+}
+
 // EvictArtifact transitions an artifact from READY or FAILED to DELETED.
 func EvictArtifact(a *Artifact, now time.Time) error {
 	if a == nil {

--- a/backend/internal/metrics/business.go
+++ b/backend/internal/metrics/business.go
@@ -463,3 +463,12 @@ func IncVODRemuxStall(strategy string) {
 func IncTargetFallback(reason string) {
 	recordingsTargetFallbackTotal.WithLabelValues(reason).Inc()
 }
+
+var vodStateDivergenceTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "xg2g_vod_state_divergence_total",
+	Help: "Total count of artifact state divergence between memory/legacy and SQLite FSM",
+}, []string{"legacy_state", "fsm_state"})
+
+func IncVODStateDivergence(legacyState, fsmState string) {
+	vodStateDivergenceTotal.WithLabelValues(legacyState, fsmState).Inc()
+}


### PR DESCRIPTION
### Epic R2 Slice R2.2 — Dual-Write Adapter & Divergence Metric

Per [`SPEC_EPIC_R2_FSM.md`](docs/arch/SPEC_EPIC_R2_FSM.md) and Ground Rule G4 (Shadow First):
- Wires VOD `Manager` metadata mutations to SQLite `ArtifactStore`.
- Adds Prometheus counter metric `xg2g_vod_state_divergence_total` to observe any divergence between legacy state and SQLite FSM state.
- **Production Gate**: Must be merged and deployed for observation BEFORE Slice R2.4 (heuristics purge) is merged.