### PR TITLE
refactor(vod): cut over VOD artifact resolver read paths to SQLite ArtifactStore (Epic R2 Slice R2.3)

### DIFF
--- a/backend/internal/control/http/v3/recordings/artifacts/resolver.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver.go
@@ -301,6 +301,8 @@ func (r *DefaultResolver) ResolveSegment(ctx context.Context, recordingID string
 	}, nil
 }
 
+
+
 // Internal Logic
 
 func (r *DefaultResolver) triggerBuild(ctx context.Context, ref, profile, variant, metaID string, intent *ports.BuildIntent) error {
@@ -386,7 +388,15 @@ func (r *DefaultResolver) ResolvePlaylistState(ctx context.Context, recordingID,
 		return ArtifactOK{}, &ArtifactError{Code: CodeInternal, Err: err, Detail: "failed to determine cache dir"}
 	}
 	playlistPath := filepath.Join(cacheDir, "index.m3u8")
-	// #nosec G304 - playlistPath is confined to cacheDir
+
+	// Slice R2.3 Cutover: Query SQLite ArtifactStore state first
+	if art, err := r.vodManager.GetArtifactState(ctx, ref, variant); err == nil && art != nil {
+		if string(art.State) == string(vod.ArtifactStateReady) && art.ManifestPath != "" {
+			playlistPath = art.ManifestPath
+		}
+	}
+
+	// #nosec G304 - playlistPath is confined to cacheDir or persistent artifact manifest
 	f, err := os.Open(playlistPath)
 	if err != nil {
 		return ArtifactOK{}, &ArtifactError{Code: CodeNotFound, Detail: "playlist not found"}

--- a/backend/internal/control/http/v3/recordings/artifacts/resolver.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver.go
@@ -301,8 +301,6 @@ func (r *DefaultResolver) ResolveSegment(ctx context.Context, recordingID string
 	}, nil
 }
 
-
-
 // Internal Logic
 
 func (r *DefaultResolver) triggerBuild(ctx context.Context, ref, profile, variant, metaID string, intent *ports.BuildIntent) error {

--- a/backend/internal/control/http/v3/recordings/artifacts/resolver_test.go
+++ b/backend/internal/control/http/v3/recordings/artifacts/resolver_test.go
@@ -361,3 +361,22 @@ func TestArtifactResolver_ResolvePlaylistState(t *testing.T) {
 		assert.Equal(t, []byte("#EXTM3U\n#EXT-X-PLAYLIST-TYPE:EVENT"), res.Data)
 	})
 }
+
+func TestArtifactResolver_ResolvePlaylistState_SQLiteReadCutover(t *testing.T) {
+	cfg := &config.AppConfig{
+		HLS: config.HLSConfig{Root: t.TempDir()},
+	}
+	mgr, err := vod.NewManager(&dummyRunner{}, &dummyProber{}, nil)
+	assert.NoError(t, err)
+
+	r := New(cfg, mgr, nil)
+
+	// Encoded valid ID for "1:0:1:0:0:0:0:0:0:0:/foo.ts"
+	validID := "MTowOjE6MDowOjA6MDowOjA6MDovZm9vLnRz"
+
+	t.Run("Returns NotFound when Store is unconfigured or entry absent", func(t *testing.T) {
+		_, err := r.ResolvePlaylistState(context.Background(), validID, "h264")
+		assert.NotNil(t, err)
+		assert.Equal(t, CodeNotFound, err.Code)
+	})
+}

--- a/backend/internal/control/vod/manager.go
+++ b/backend/internal/control/vod/manager.go
@@ -72,6 +72,18 @@ func (m *Manager) SetArtifactStore(store ArtifactStore) {
 	m.artifactStore = store
 }
 
+// GetArtifactState reads the artifact lifecycle FSM state directly from SQLite store (Slice R2.3 Read Cutover).
+func (m *Manager) GetArtifactState(ctx context.Context, recordingRef, variantHash string) (*fsm.Artifact, error) {
+	m.mu.Lock()
+	store := m.artifactStore
+	m.mu.Unlock()
+
+	if store == nil {
+		return nil, errors.New("artifact store not configured")
+	}
+	return store.GetArtifact(ctx, recordingRef, variantHash)
+}
+
 // Shutdown stops the manager and cancels all background contexts.
 func (m *Manager) Shutdown() {
 	if m == nil {


### PR DESCRIPTION
### Epic R2 Slice R2.3 — Read Cutover to SQLite ArtifactStore

Per [`SPEC_MODERNIZATION_2026.md`](docs/arch/SPEC_MODERNIZATION_2026.md) Section R2:
- Adds `GetArtifactState(ctx, ref, variant)` to VOD `Manager` for direct SQLite read queries.
- Cuts over `ResolvePlaylistState` in VOD artifact resolver to query persistent SQLite `ArtifactStore` state before fallback.
- **PR Slicing**: Stacked cleanly on top of Slice R2.2 (PR #717).