### PR TITLE
fix(ci): allow tracked scripts/ and testdata/ in root purity gate

### DIFF
--- a/backend/scripts/ci_gate_root_purity.sh
+++ b/backend/scripts/ci_gate_root_purity.sh
@@ -61,6 +61,10 @@ ALLOWLIST=(
     "backend/"
     "frontend/"
     "hack/"
+    "scripts/"
+
+    # Test fixtures (canonical location enforced by ci/check-test-assets-location.sh)
+    "testdata/"
 
     # Infrastructure & deployment
     "deploy/"
@@ -112,7 +116,7 @@ for item in *; do
     if git check-ignore --no-index -q -- "$item"; then
         continue
     fi
-    
+
     if [[ ! "$item" =~ $ALLOWLIST_REGEX ]]; then
         echo "❌ VIOLATION: Forbidden item in root: $item"
         VIOLATIONS=$((VIOLATIONS + 1))


### PR DESCRIPTION
## Problem

The nightly has failed every night since 2026-07-18 — nine identical issues (#673, #675, #685, #695, #699, #702, #716, #725, #726) — on this:

```
❌ VIOLATION: Forbidden item in root: scripts
❌ VIOLATION: Forbidden item in root: testdata
🚨 FAIL: Root purity check failed with 2 violations.
make: *** [mk/verify.mk:100: gate-repo-hygiene] Error 1
```

The allowlist in `ci_gate_root_purity.sh` never contained `scripts/` or `testdata/`. Both have been tracked for months — `scripts/` since 2025-12, `testdata/` since 2026-01 — and both are actively maintained (`scripts/fast_deploy.sh` was last touched 2026-07-24). The allowlist itself was last maintained in 2026-04.

Two gates in the same make target also contradicted each other: `ci/check-test-assets-location.sh` instructs *"Move these files into testdata/"* while `ci_gate_root_purity.sh` rejected exactly that directory.

The repository layout was never wrong. The allowlist was stale.

## Impact

Root purity is the **first** check in `gate-repo-hygiene`, so everything behind it has not run for nine days: `gate-v3-contract`, `gate-a`, `gate-webui`, `lint-invariants`, `lint`, `test-cover`, `security-vulncheck`, `webui-test`.

This PR unblocks that pipeline. It does not predict what those gates will report once they run again for the first time since 2026-07-18.

## Change

Adds `scripts/` and `testdata/` to the allowlist, plus one pre-existing trailing-whitespace fix applied by the repo's own `trailing-whitespace` hook.

## Verification

Against a clean checkout (`git archive HEAD`, matching what CI sees) all four checks in `gate-repo-hygiene` pass:

```
✅ PASS: Repository Root is Pure.
OK: no large files detected
OK: no root-level test assets found
✅ Repository Hygiene: PASS (no artifacts tracked)
```

`pre-commit run --files backend/scripts/ci_gate_root_purity.sh` is clean.

The nine nightly issues are intentionally left open until a nightly run actually goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)