### PR TITLE
fix(playback): make recording probe lifetime request-independent

### DIFF
--- a/backend/internal/control/recordings/manager.go
+++ b/backend/internal/control/recordings/manager.go
@@ -60,8 +60,9 @@ func newProbeManager(rootCtx context.Context, mgr MetadataManager, probeFn func(
 
 // ensureProbed checks if a probe is already active or in cooling.
 // If needed, it triggers a new probe asynchronously (Gate R2).
+// Probe lifetime is owned exclusively by rootCtx; request contexts are deliberately not accepted.
 // Returns the current ProbeState and recommended retry interval in seconds.
-func (pm *probeManager) ensureProbed(ctx context.Context, serviceRef string, sourceURL string, localPath string) (ProbeState, int) {
+func (pm *probeManager) ensureProbed(serviceRef string, sourceURL string, localPath string) (ProbeState, int) {
 	if pm == nil {
 		return "", 0
 	}

--- a/backend/internal/control/recordings/manager_lifecycle_test.go
+++ b/backend/internal/control/recordings/manager_lifecycle_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/config"
+	"github.com/ManuGH/xg2g/internal/control/playback"
 	"github.com/ManuGH/xg2g/internal/control/vod"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +55,7 @@ func TestProbeManager_ExpiredBlockedEntryIsRetried(t *testing.T) {
 	}
 	pm.mu.Unlock()
 
-	state, _ := pm.ensureProbed(context.Background(), serviceRef, "file:///tmp/movie.ts", "/tmp/movie.ts")
+	state, _ := pm.ensureProbed(serviceRef, "file:///tmp/movie.ts", "/tmp/movie.ts")
 	assert.Equal(t, ProbeStateQueued, state)
 
 	select {
@@ -86,7 +88,7 @@ func TestProbeManager_UsesRootContextForCancellation(t *testing.T) {
 	}
 
 	pm := newProbeManager(rootCtx, mgr, nil, nil)
-	_, _ = pm.ensureProbed(context.Background(), "service:ref", "file:///tmp/movie.ts", "/tmp/movie.ts")
+	_, _ = pm.ensureProbed("service:ref", "file:///tmp/movie.ts", "/tmp/movie.ts")
 
 	select {
 	case <-started:
@@ -101,6 +103,73 @@ func TestProbeManager_UsesRootContextForCancellation(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("probe context was not canceled by root context")
 	}
+}
+
+func TestPlaybackResolver_RequestCancellationDoesNotPoisonBackgroundProbe(t *testing.T) {
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	mgr := &mockManager{data: make(map[string]vod.Metadata)}
+	cfg := &config.AppConfig{
+		Enigma2: config.Enigma2Settings{
+			BaseURL:    "http://receiver:80",
+			StreamPort: 8001,
+		},
+		RecordingPlaybackPolicy: config.PlaybackPolicyReceiverOnly,
+	}
+	resolver, err := NewResolver(cfg, mgr, ResolverOptions{
+		ProbeRootContext: context.Background(),
+		ProbeFn: func(ctx context.Context, serviceRef, sourceURL string) (*vod.StreamInfo, error) {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-release:
+				return &vod.StreamInfo{
+					Container: "mp4",
+					Video:     vod.VideoStreamInfo{CodecName: "h264", Duration: 120},
+					Audio:     vod.AudioStreamInfo{CodecName: "aac"},
+				}, nil
+			}
+		},
+	})
+	require.NoError(t, err)
+
+	serviceRef := "1:0:0:0:0:0:0:0:0:0:/media/hdd/movie/request-canceled.ts"
+	truth, err := resolver.GetMediaTruth(requestCtx, serviceRef)
+	require.NoError(t, err)
+	require.Equal(t, playback.MediaStatusPreparing, truth.Status)
+	require.Equal(t, playback.ProbeStateQueued, truth.ProbeState)
+	require.Equal(t, 5, truth.RetryAfter)
+
+	// Returning the first HTTP 503 cancels its request context. The background
+	// probe must remain owned by ProbeRootContext so a retry can consume its truth.
+	select {
+	case <-started:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("probe did not start")
+	}
+
+	cancelRequest()
+	close(release)
+
+	require.Eventually(t, func() bool {
+		meta, ok := mgr.GetMetadata(serviceRef)
+		return ok && meta.State == vod.ArtifactStateReady
+	}, time.Second, 20*time.Millisecond, "request cancellation must not poison the background probe result")
+
+	retryTruth, err := resolver.GetMediaTruth(context.Background(), serviceRef)
+	require.NoError(t, err)
+	assert.Equal(t, playback.MediaStatusReady, retryTruth.Status)
+	assert.Equal(t, "mp4", retryTruth.Container)
+	assert.Equal(t, "h264", retryTruth.VideoCodec)
+	assert.Equal(t, "aac", retryTruth.AudioCodec)
 }
 
 func TestProbeManager_PersistFailureFailClosed(t *testing.T) {
@@ -121,7 +190,7 @@ func TestProbeManager_PersistFailureFailClosed(t *testing.T) {
 
 	pm := newProbeManager(context.Background(), mgr, nil, persistor)
 	serviceRef := "service:ref"
-	_, _ = pm.ensureProbed(context.Background(), serviceRef, "file:///tmp/movie.ts", "/tmp/movie.ts")
+	_, _ = pm.ensureProbed(serviceRef, "file:///tmp/movie.ts", "/tmp/movie.ts")
 
 	select {
 	case <-persistor.called:
@@ -159,7 +228,7 @@ func TestProbeManager_CooldownBlockedMetric(t *testing.T) {
 	}
 	pm.mu.Unlock()
 
-	state, _ := pm.ensureProbed(context.Background(), serviceRef, "file:///tmp/movie.ts", "/tmp/movie.ts")
+	state, _ := pm.ensureProbed(serviceRef, "file:///tmp/movie.ts", "/tmp/movie.ts")
 	assert.Equal(t, ProbeStateBlocked, state)
 	assert.Greater(t, testutil.ToFloat64(recordingsProbeBlockedTotal.WithLabelValues(probeBlockedReasonCooldown)), beforeCooldown)
 }
@@ -187,7 +256,7 @@ func TestProbeManager_DedupedMetric(t *testing.T) {
 	}
 
 	pm := newProbeManager(context.Background(), mgr, nil, nil)
-	_, _ = pm.ensureProbed(context.Background(), "service:ref:1", "file:///tmp/shared.ts", "/tmp/shared.ts")
+	_, _ = pm.ensureProbed("service:ref:1", "file:///tmp/shared.ts", "/tmp/shared.ts")
 
 	select {
 	case <-probeEntered:
@@ -199,7 +268,7 @@ func TestProbeManager_DedupedMetric(t *testing.T) {
 		return testutil.ToFloat64(recordingsProbeInflight) >= beforeInflight+1
 	}, time.Second, 20*time.Millisecond)
 
-	_, _ = pm.ensureProbed(context.Background(), "service:ref:2", "file:///tmp/shared.ts", "/tmp/shared.ts")
+	_, _ = pm.ensureProbed("service:ref:2", "file:///tmp/shared.ts", "/tmp/shared.ts")
 	time.Sleep(40 * time.Millisecond)
 	close(releaseProbe)
 

--- a/backend/internal/control/recordings/resolver.go
+++ b/backend/internal/control/recordings/resolver.go
@@ -264,7 +264,7 @@ func (r *PlaybackInfoResolver) GetMediaTruth(ctx context.Context, serviceRef str
 		if !isDisabled {
 			// Trigger idempotent orchestration
 			_, source, localPath, _ := r.truth.ResolveSource(ctx, serviceRef)
-			state, retryAfter := r.probeMgr.ensureProbed(ctx, serviceRef, source, localPath)
+			state, retryAfter := r.probeMgr.ensureProbed(serviceRef, source, localPath)
 			truth.ProbeState = playback.ProbeState(state)
 			truth.RetryAfter = retryAfter
 		}


### PR DESCRIPTION
## What changed

- removed the HTTP/request context parameter from the internal recording probe scheduler
- made the server-root-context ownership of asynchronous probes explicit in the API and code comment
- added a resolver-level regression test covering `preparing/queued` → request cancellation → successful background probe → `READY` on retry

## Why

A queued recording probe must outlive the request that caused the initial `503`; otherwise cancellation can mark probe truth as failed and turn the next playback request into a `502`.

The current runtime implementation already derives the actual probe timeout from `ProbeRootContext`, so the reported failure could not be reproduced on current `main`. However, `ensureProbed` still accepted the request context even though it was intentionally unused, leaving the lifetime contract implicit and easy to regress. This change makes the invariant structural and locks the observed sequence with a test.

## Impact

Playback response contracts are unchanged: cold truth remains `503`/retryable while queued, probes still stop on server shutdown or the three-minute timeout, and a client disconnect no longer has any path into background probe ownership.

## Validation

- regression test repeated 20 times
- `go test ./internal/control/recordings ./internal/control/http/v3/recordings ./internal/api`
- `go test -race ./internal/control/recordings`
- `make ci-pr`
- `make pre-push`

## Deployment

No deployment performed. Staging remains a separate operator action.