### PR TITLE
fix(http): make rate limiting proxy-aware and cover preflights

### DIFF
--- a/backend/internal/control/http/v3/exposure_security.go
+++ b/backend/internal/control/http/v3/exposure_security.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"net"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -161,39 +160,20 @@ func (s *Server) exposureRateLimitWhitelisted(r *http.Request, cfg config.AppCon
 	return ip != nil && middleware.IsIPAllowed(ip, allowed)
 }
 
+// exposureClientKey identifies the caller for per-class exposure rate limiting.
+// It delegates to the shared resolver so this limiter, the global API limiter
+// and LANGuard can never disagree about who a request came from — three
+// slightly different copies of the trusted-proxy walk is how that drifts.
 func (s *Server) exposureClientKey(r *http.Request, cfg config.AppConfig) string {
-	remoteIP := requestRemoteIP(r)
-	if remoteIP == nil {
+	trusted, err := middleware.ParseCIDRs(splitCSVNonEmpty(cfg.TrustedProxies))
+	if err != nil {
+		trusted = nil // Unparseable config: trust nothing, fall back to the socket peer.
+	}
+	ip := middleware.ResolveClientIP(r, trusted)
+	if ip == nil {
 		return "unknown"
 	}
-
-	trusted, err := middleware.ParseCIDRs(splitCSVNonEmpty(cfg.TrustedProxies))
-	if err != nil || !middleware.IsIPAllowed(remoteIP, trusted) {
-		return remoteIP.String()
-	}
-
-	for _, candidate := range forwardedForIPs(r.Header.Get("X-Forwarded-For")) {
-		if !middleware.IsIPAllowed(candidate, trusted) {
-			return candidate.String()
-		}
-	}
-	for _, candidate := range forwardedForIPs(r.Header.Get("X-Forwarded-For")) {
-		return candidate.String()
-	}
-	return remoteIP.String()
-}
-
-func forwardedForIPs(raw string) []net.IP {
-	parts := strings.Split(raw, ",")
-	out := make([]net.IP, 0, len(parts))
-	for _, v := range slices.Backward(parts) {
-		candidate := net.ParseIP(strings.TrimSpace(v))
-		if candidate == nil {
-			continue
-		}
-		out = append(out, candidate)
-	}
-	return out
+	return ip.String()
 }
 
 func (s *Server) logExposureRateLimit(r *http.Request, operationID string, policy authz.ExposurePolicy) {

--- a/backend/internal/control/middleware/clientip.go
+++ b/backend/internal/control/middleware/clientip.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// ParseCIDRs converts a list of CIDR blocks or bare IP addresses into IPNets.
+// A bare IP becomes a host route (/32 or /128). Empty entries are skipped.
+func ParseCIDRs(cidrs []string) ([]*net.IPNet, error) {
+	var nets []*net.IPNet
+	for _, c := range cidrs {
+		trimmed := strings.TrimSpace(c)
+		if trimmed == "" {
+			continue
+		}
+		if _, n, err := net.ParseCIDR(trimmed); err == nil {
+			nets = append(nets, n)
+			continue
+		}
+
+		ip := net.ParseIP(trimmed)
+		if ip == nil {
+			return nil, &net.ParseError{Type: "CIDR or IP address", Text: trimmed}
+		}
+		bits := 32
+		if ip.To4() == nil {
+			bits = 128
+		}
+		nets = append(nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+	}
+	return nets, nil
+}
+
+// IsIPAllowed reports whether ip falls inside any of the given subnets.
+func IsIPAllowed(ip net.IP, subnets []*net.IPNet) bool {
+	ip = ip.To16()
+	if ip == nil {
+		return false
+	}
+	for _, n := range subnets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveClientIP determines the originating client IP for a request and is the
+// single source of truth for "which IP is this request actually from".
+//
+// The trust model is deliberately strict, because getting this wrong in either
+// direction is a real vulnerability:
+//
+//   - Trusting X-Forwarded-For unconditionally lets any client pick its own
+//     identity — it can evade rate limits and forge audit trails.
+//   - Ignoring X-Forwarded-For entirely collapses every client behind a reverse
+//     proxy onto the proxy's IP, so one abusive client rate-limits everyone else.
+//
+// The rules:
+//
+//  1. Start from the socket peer (RemoteAddr). If it cannot be parsed, give up
+//     and return nil — a caller must treat that as "unidentifiable".
+//  2. If no trusted proxies are configured, or the peer is not one of them,
+//     return the peer and ignore all forwarding headers. A direct client cannot
+//     talk its way into a different identity.
+//  3. Otherwise walk X-Forwarded-For right-to-left. Each entry that is itself a
+//     trusted proxy is another hop and is skipped; the first entry that is not
+//     ends the trusted chain and IS the client.
+//  4. An unparseable entry breaks the chain: everything to its left was appended
+//     by something we can no longer vouch for, so fall back to the socket peer.
+//  5. Only if the walk runs out of entries — i.e. every entry including the
+//     leftmost is configured trusted infrastructure — does the header name no
+//     client at all, and the socket peer is the conservative answer.
+//
+// Rule 5 is narrow, and worth being precise about because getting it wrong
+// reintroduces the very collapse this function exists to prevent. A chain whose
+// intermediate hops are all trusted is the NORMAL case for a CDN deployment:
+//
+//	Client 203.0.113.50 -> Cloudflare 198.51.100.20 -> Nginx 10.0.0.10 -> xg2g
+//	RemoteAddr:      10.0.0.10        (trusted)
+//	X-Forwarded-For: 203.0.113.50, 198.51.100.20
+//
+// Here rule 3 fires, not rule 5: the walk skips Cloudflare and stops at
+// 203.0.113.50, because that entry is not trusted infrastructure. Rule 5 would
+// only apply if 203.0.113.50 were itself in the trusted list. Returning the peer
+// for the chain above would put every user of the deployment back into one
+// Nginx-shaped bucket. See TestResolveClientIP_MultiHopCDNChain.
+//
+// X-Real-IP is intentionally NOT consulted. It carries a single value with no
+// chain, so it cannot be validated hop-by-hop: a proxy that appends to
+// X-Forwarded-For but passes a client-supplied X-Real-IP through unchanged would
+// hand every client a free identity of its choosing.
+//
+// Operator caveat inherent to any trusted-hop model: an entry vouched for by a
+// trusted proxy is only as good as that proxy's own hygiene. A proxy that
+// appends to X-Forwarded-For without sanitizing what the client sent lets a
+// client prepend an arbitrary IP and be identified as it — so only put proxies
+// that normalize the header into TrustedProxies.
+func ResolveClientIP(r *http.Request, trustedProxies []*net.IPNet) net.IP {
+	if r == nil {
+		return nil
+	}
+
+	peer := remoteAddrIP(r.RemoteAddr)
+	if peer == nil {
+		return nil
+	}
+
+	// Rule 2: forwarding headers are only meaningful from a trusted peer.
+	if len(trustedProxies) == 0 || !IsIPAllowed(peer, trustedProxies) {
+		return peer
+	}
+
+	xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
+	if xff == "" {
+		return peer
+	}
+
+	// Rules 3-4: right-to-left along the trusted chain.
+	for _, raw := range slices.Backward(strings.Split(xff, ",")) {
+		hop := net.ParseIP(strings.TrimSpace(raw))
+		if hop == nil {
+			// Rule 4: chain integrity is gone, trust only the socket.
+			return peer
+		}
+		if !IsIPAllowed(hop, trustedProxies) {
+			return hop
+		}
+	}
+
+	// Rule 5: the whole chain was proxies we trust.
+	return peer
+}
+
+// remoteAddrIP parses the IP out of a "host:port" RemoteAddr, tolerating a bare
+// host (httptest and some transports omit the port).
+func remoteAddrIP(remoteAddr string) net.IP {
+	addr := strings.TrimSpace(remoteAddr)
+	if addr == "" {
+		return nil
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		addr = host
+	}
+	return net.ParseIP(strings.Trim(addr, "[]"))
+}
+
+// ClientIPKey renders an IP as a stable rate-limit bucket key.
+//
+// IPv4 (including IPv4-mapped IPv6 such as ::ffff:203.0.113.7) collapses to the
+// dotted-quad form, so the same host cannot occupy two buckets by switching
+// representation. IPv6 is masked to its /64 prefix, because a single subscriber
+// is routinely handed a whole /64 and per-address buckets would make the limiter
+// trivially evadable. This matches httprate's own canonicalization, so switching
+// the key function does not silently change IPv6 bucketing.
+func ClientIPKey(ip net.IP) string {
+	if ip == nil {
+		return "unknown"
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).String()
+}
+
+// KeyByTrustedProxyChain builds an httprate key function that buckets by the
+// resolved client IP rather than by the socket peer. Behind a reverse proxy this
+// is the difference between per-client limits and one shared bucket for the
+// entire internet.
+func KeyByTrustedProxyChain(trustedProxies []*net.IPNet) func(*http.Request) (string, error) {
+	return func(r *http.Request) (string, error) {
+		return ClientIPKey(ResolveClientIP(r, trustedProxies)), nil
+	}
+}

--- a/backend/internal/control/middleware/clientip_test.go
+++ b/backend/internal/control/middleware/clientip_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func mustCIDRs(t *testing.T, entries ...string) []*net.IPNet {
+	t.Helper()
+	nets, err := ParseCIDRs(entries)
+	if err != nil {
+		t.Fatalf("ParseCIDRs(%v): %v", entries, err)
+	}
+	return nets
+}
+
+func reqFrom(remoteAddr, xff string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r.RemoteAddr = remoteAddr
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	return r
+}
+
+func TestResolveClientIP(t *testing.T) {
+	proxies := []string{"172.20.0.0/16", "10.8.0.1"}
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		xRealIP    string
+		trusted    []string
+		want       string
+	}{
+		{
+			// The core anti-spoofing invariant: a client talking to us directly
+			// cannot rename itself via a header.
+			name:       "direct client with forged XFF stays at RemoteAddr",
+			remoteAddr: "203.0.113.9:44321",
+			xff:        "1.2.3.4",
+			trusted:    proxies,
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "no trusted proxies configured ignores XFF entirely",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "198.51.100.7",
+			trusted:    nil,
+			want:       "172.20.0.5",
+		},
+		{
+			name:       "trusted proxy honors the client it forwarded",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "198.51.100.7",
+			trusted:    proxies,
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "multiple trusted hops peel back to the real client",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "198.51.100.7, 10.8.0.1, 172.20.0.9",
+			trusted:    proxies,
+			want:       "198.51.100.7",
+		},
+		{
+			// Everything left of an untrusted hop was appended by something we
+			// do not vouch for, so the untrusted hop is where trust stops.
+			name:       "unknown hop terminates the trust chain",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "1.1.1.1, 203.0.113.50, 172.20.0.9",
+			trusted:    proxies,
+			want:       "203.0.113.50",
+		},
+		{
+			name:       "malformed XFF entry falls back to the socket peer",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "198.51.100.7, not-an-ip",
+			trusted:    proxies,
+			want:       "172.20.0.5",
+		},
+		{
+			name:       "empty XFF entry falls back to the socket peer",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "198.51.100.7, ",
+			trusted:    proxies,
+			want:       "172.20.0.5",
+		},
+		{
+			name:       "chain of only trusted proxies falls back to the socket peer",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "10.8.0.1, 172.20.0.9",
+			trusted:    proxies,
+			want:       "172.20.0.5",
+		},
+		{
+			// X-Real-IP carries no chain and cannot be validated hop by hop, so
+			// it must never be able to override the socket peer.
+			name:       "X-Real-IP is ignored even from a trusted proxy",
+			remoteAddr: "172.20.0.5:1234",
+			xRealIP:    "198.51.100.7",
+			trusted:    proxies,
+			want:       "172.20.0.5",
+		},
+		{
+			name:       "IPv6 peer without XFF",
+			remoteAddr: "[2001:db8::1]:9999",
+			trusted:    proxies,
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "IPv6 client behind a trusted proxy",
+			remoteAddr: "172.20.0.5:1234",
+			xff:        "2001:db8:abcd:1234::5",
+			trusted:    proxies,
+			want:       "2001:db8:abcd:1234::5",
+		},
+		{
+			name:       "RemoteAddr without a port is still parsed",
+			remoteAddr: "203.0.113.9",
+			trusted:    proxies,
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "IPv4-mapped IPv6 peer resolves to its IPv4 form",
+			remoteAddr: "[::ffff:203.0.113.9]:44321",
+			trusted:    proxies,
+			want:       "203.0.113.9",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := reqFrom(tc.remoteAddr, tc.xff)
+			if tc.xRealIP != "" {
+				r.Header.Set("X-Real-IP", tc.xRealIP)
+			}
+			got := ResolveClientIP(r, mustCIDRs(t, tc.trusted...))
+			if got == nil {
+				t.Fatalf("ResolveClientIP returned nil, want %s", tc.want)
+			}
+			if !got.Equal(net.ParseIP(tc.want)) {
+				t.Errorf("ResolveClientIP = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveClientIP_MultiHopCDNChain pins the exact topology where a wrong
+// fallback would silently recreate the proxy collapse this resolver exists to
+// fix: a real CDN chain where EVERY hop that appears in X-Forwarded-For is
+// trusted infrastructure, and only the leftmost entry is the actual client.
+//
+//	Client 203.0.113.50 -> Cloudflare 198.51.100.20 -> Nginx 10.0.0.10 -> xg2g
+//	RemoteAddr:      10.0.0.10
+//	X-Forwarded-For: 203.0.113.50, 198.51.100.20
+//
+// The answer must be the client. Falling back to the socket peer here would put
+// every user of the deployment back into a single Nginx-shaped bucket.
+func TestResolveClientIP_MultiHopCDNChain(t *testing.T) {
+	trusted := mustCIDRs(t, "10.0.0.10", "198.51.100.20")
+
+	r := reqFrom("10.0.0.10:41234", "203.0.113.50, 198.51.100.20")
+	got := ResolveClientIP(r, trusted)
+
+	if got == nil || !got.Equal(net.ParseIP("203.0.113.50")) {
+		t.Fatalf("ResolveClientIP = %v, want 203.0.113.50 (client behind CDN+reverse proxy)", got)
+	}
+
+	// And the collapse itself: distinct clients over the identical hop chain
+	// must not share a bucket.
+	keyFn := KeyByTrustedProxyChain(trusted)
+	a, _ := keyFn(reqFrom("10.0.0.10:1", "203.0.113.50, 198.51.100.20"))
+	b, _ := keyFn(reqFrom("10.0.0.10:2", "203.0.113.51, 198.51.100.20"))
+	if a == b {
+		t.Errorf("two clients over the same CDN chain share a bucket: %q", a)
+	}
+	if a != "203.0.113.50" {
+		t.Errorf("bucket key = %q, want the client IP", a)
+	}
+}
+
+// TestResolveClientIP_ChainWithoutAnyClient covers the one case that does fall
+// back to the socket peer: every X-Forwarded-For entry, including the leftmost,
+// is configured trusted infrastructure, so the header names no client at all.
+// There is nothing to identify, and the conservative answer is the peer.
+//
+// This is deliberately NOT the same as TestResolveClientIP_MultiHopCDNChain,
+// where the leftmost entry is an untrusted client and must win.
+func TestResolveClientIP_ChainWithoutAnyClient(t *testing.T) {
+	trusted := mustCIDRs(t, "10.0.0.10", "198.51.100.20")
+
+	r := reqFrom("10.0.0.10:41234", "198.51.100.20, 198.51.100.20")
+	got := ResolveClientIP(r, trusted)
+
+	if got == nil || !got.Equal(net.ParseIP("10.0.0.10")) {
+		t.Fatalf("ResolveClientIP = %v, want the socket peer 10.0.0.10", got)
+	}
+}
+
+// TestResolveClientIP_AdversarialChainFailsClosed covers a trusted peer with an
+// X-Forwarded-For an attacker has stuffed with junk. The chain cannot be
+// interpreted safely, so identification falls back to the socket peer rather
+// than guessing at an entry.
+func TestResolveClientIP_AdversarialChainFailsClosed(t *testing.T) {
+	trusted := mustCIDRs(t, "10.0.0.10", "198.51.100.20")
+
+	adversarial := []string{
+		"::1, <script>, 198.51.100.20",
+		"203.0.113.50, 999.999.999.999, 198.51.100.20",
+		"203.0.113.50, , 198.51.100.20",
+		"203.0.113.50, 10.0.0.10/8, 198.51.100.20",
+		"' OR 1=1--, 198.51.100.20",
+	}
+
+	for _, xff := range adversarial {
+		t.Run(xff, func(t *testing.T) {
+			got := ResolveClientIP(reqFrom("10.0.0.10:41234", xff), trusted)
+			if got == nil || !got.Equal(net.ParseIP("10.0.0.10")) {
+				t.Errorf("ResolveClientIP(%q) = %v, want the socket peer 10.0.0.10", xff, got)
+			}
+		})
+	}
+}
+
+func TestResolveClientIP_UnparseablePeer(t *testing.T) {
+	r := reqFrom("garbage-peer", "198.51.100.7")
+	if got := ResolveClientIP(r, mustCIDRs(t, "172.20.0.0/16")); got != nil {
+		t.Errorf("expected nil for unparseable RemoteAddr, got %s", got)
+	}
+}
+
+func TestClientIPKey_Canonicalization(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want string
+	}{
+		{"ipv4", "203.0.113.9", "203.0.113.9"},
+		// Both spellings of the same host must land in one bucket, otherwise a
+		// client gets two rate-limit budgets for free.
+		{"ipv4-mapped ipv6 collapses to ipv4", "::ffff:203.0.113.9", "203.0.113.9"},
+		// A subscriber typically owns a whole /64, so per-address buckets would
+		// make the limiter trivially evadable.
+		{"ipv6 masked to /64", "2001:db8:abcd:1234:5678::1", "2001:db8:abcd:1234::"},
+		{"ipv6 same /64 shares a bucket", "2001:db8:abcd:1234:ffff::9", "2001:db8:abcd:1234::"},
+		{"ipv6 different /64 is a distinct bucket", "2001:db8:abcd:9999::1", "2001:db8:abcd:9999::"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClientIPKey(net.ParseIP(tc.ip)); got != tc.want {
+				t.Errorf("ClientIPKey(%s) = %q, want %q", tc.ip, got, tc.want)
+			}
+		})
+	}
+
+	if got := ClientIPKey(nil); got != "unknown" {
+		t.Errorf("ClientIPKey(nil) = %q, want %q", got, "unknown")
+	}
+}
+
+func TestKeyByTrustedProxyChain_DistinctKeysBehindOneProxy(t *testing.T) {
+	keyFn := KeyByTrustedProxyChain(mustCIDRs(t, "172.20.0.0/16"))
+
+	a, _ := keyFn(reqFrom("172.20.0.5:1", "198.51.100.7"))
+	b, _ := keyFn(reqFrom("172.20.0.5:2", "198.51.100.8"))
+	if a == b {
+		t.Fatalf("two clients behind one proxy share a bucket: %q", a)
+	}
+
+	// Same client, different proxy source ports: one bucket.
+	c, _ := keyFn(reqFrom("172.20.0.5:3", "198.51.100.7"))
+	if a != c {
+		t.Errorf("same client got two buckets: %q vs %q", a, c)
+	}
+}
+
+func TestKeyByTrustedProxyChain_SpoofedXFFCannotSplitBucket(t *testing.T) {
+	// No trusted proxies: a direct client must not be able to mint a new bucket
+	// per request by rotating X-Forwarded-For.
+	keyFn := KeyByTrustedProxyChain(nil)
+
+	first, _ := keyFn(reqFrom("203.0.113.9:1", "1.1.1.1"))
+	second, _ := keyFn(reqFrom("203.0.113.9:2", "2.2.2.2"))
+	if first != second {
+		t.Errorf("spoofed XFF split the bucket: %q vs %q", first, second)
+	}
+	if first != "203.0.113.9" {
+		t.Errorf("expected socket peer as key, got %q", first)
+	}
+}
+
+func TestParseCIDRs_RejectsGarbage(t *testing.T) {
+	if _, err := ParseCIDRs([]string{"not-a-cidr"}); err == nil {
+		t.Fatal("expected an error for a malformed entry")
+	}
+	nets, err := ParseCIDRs([]string{"10.0.0.0/8", "", "  ", "192.168.1.1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nets) != 2 {
+		t.Fatalf("expected 2 nets (blank entries skipped), got %d", len(nets))
+	}
+	if !IsIPAllowed(net.ParseIP("192.168.1.1"), nets) {
+		t.Error("bare IP should become a host route")
+	}
+	if IsIPAllowed(net.ParseIP("192.168.1.2"), nets) {
+		t.Error("bare IP must not widen into a subnet")
+	}
+}

--- a/backend/internal/control/middleware/cors.go
+++ b/backend/internal/control/middleware/cors.go
@@ -7,11 +7,49 @@ package middleware
 import (
 	"net/http"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
 )
 
-// CORS returns a middleware that sets Cross-Origin Resource Sharing headers.
-// It supports a strict allowed origins list.
-func CORS(allowedOrigins []string, allowCredentials bool) func(http.Handler) http.Handler {
+// corsAllowedHeaders / corsExposedHeaders are the request and response header
+// surfaces advertised to allowed cross-origin callers.
+const (
+	corsAllowedHeaders = "Content-Type, X-Request-ID, X-API-Token, Authorization"
+	corsExposedHeaders = "Retry-After, Content-Length, Date, X-Request-ID"
+	corsMaxAgeSeconds  = "600"
+)
+
+// fallbackPreflightMethods is the method list used when the preflight responder
+// has no router to ask. It is deliberately the last resort: a route-aware
+// preflight (see Preflight) advertises only the methods a path really accepts.
+var fallbackPreflightMethods = []string{
+	http.MethodGet, http.MethodPost, http.MethodOptions,
+	http.MethodDelete, http.MethodPut, http.MethodPatch,
+}
+
+// preflightProbeMethods are the methods probed against the router to compute a
+// path's true Allow set.
+var preflightProbeMethods = []string{
+	http.MethodGet, http.MethodHead, http.MethodPost,
+	http.MethodPut, http.MethodPatch, http.MethodDelete,
+}
+
+// RouteMatcher is the slice of chi.Mux the preflight responder needs to discover
+// which methods a path actually accepts. *chi.Mux satisfies it.
+type RouteMatcher interface {
+	Match(rctx *chi.Context, method, path string) bool
+}
+
+// CORSHeaders returns a middleware that stamps Cross-Origin Resource Sharing
+// response headers. It never short-circuits — answering preflights is the job of
+// Preflight, which runs later in the stack.
+//
+// Splitting header-stamping from preflight-answering is what lets a rate-limit
+// rejection still carry correct CORS headers. If CORS answered and returned in
+// one step, any middleware after it that produced a 429 would emit a response
+// the browser could only report as an opaque network error, hiding the real
+// cause from the UI.
+func CORSHeaders(allowedOrigins []string, allowCredentials bool) func(http.Handler) http.Handler {
 	// Create map for O(1) lookup
 	allowed := make(map[string]bool)
 	for _, origin := range allowedOrigins {
@@ -22,20 +60,13 @@ func CORS(allowedOrigins []string, allowCredentials bool) func(http.Handler) htt
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
-			// Logic:
-			// 1. If origin matches allowed list -> Allow
-			// 2. If valid origin but not in list -> Block (don't set headers)
-			// 3. If no origin header -> Allow (direct tools, same-origin)
-			// However, for browser security, we only set Allow-Origin if Origin header is present.
-
-			// Special case: "*" in configuration allows all origins (with optional credentials).
+			// Special case: "*" in configuration allows all origins.
 			allowAll := allowed["*"]
 
 			// Only emit CORS response headers when the origin is actually allowed.
-			// Access-Control-Allow-Methods/Headers/Expose-Headers/Max-Age are only
+			// Access-Control-Allow-Headers/Expose-Headers/Max-Age are only
 			// meaningful alongside an allowed Allow-Origin; emitting them for
-			// disallowed or origin-less callers leaks the API's method/header
-			// surface and is what "Allow-* on disallowed origins" flagged.
+			// disallowed or origin-less callers leaks the API's header surface.
 			if origin != "" && (allowAll || allowed[origin]) {
 				if allowAll {
 					// Wildcard: emit * instead of reflecting the request Origin.
@@ -52,29 +83,107 @@ func CORS(allowedOrigins []string, allowCredentials bool) func(http.Handler) htt
 						w.Header().Set("Access-Control-Allow-Credentials", "true")
 					}
 				}
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, PUT, PATCH")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Request-ID, X-API-Token, Authorization")
-				w.Header().Set("Access-Control-Expose-Headers", "Retry-After, Content-Length, Date, X-Request-ID")
-				w.Header().Set("Access-Control-Max-Age", "600")
+				w.Header().Set("Access-Control-Allow-Headers", corsAllowedHeaders)
+				w.Header().Set("Access-Control-Expose-Headers", corsExposedHeaders)
+				w.Header().Set("Access-Control-Max-Age", corsMaxAgeSeconds)
 			}
 
 			// Always set Vary: Origin to prevent cache poisoning/confusion
 			vary := w.Header().Get("Vary")
 			if vary == "" {
 				w.Header().Set("Vary", "Origin, Access-Control-Request-Method, Access-Control-Request-Headers")
-			} else {
-				if !strings.Contains(vary, "Origin") {
-					w.Header().Set("Vary", vary+", Origin")
-				}
-			}
-
-			if r.Method == http.MethodOptions {
-				w.Header().Set("Allow", "GET, POST, OPTIONS, DELETE, PUT, PATCH")
-				w.WriteHeader(http.StatusNoContent)
-				return
+			} else if !strings.Contains(vary, "Origin") {
+				w.Header().Set("Vary", vary+", Origin")
 			}
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// Preflight answers CORS preflight (OPTIONS) requests.
+//
+// When given a router it asks which methods the requested path actually accepts
+// and advertises exactly those, instead of a blanket list identical for every
+// URL. Two consequences:
+//
+//   - A path that accepts only GET no longer claims to accept DELETE and PATCH.
+//   - A path the router does not know at all falls through to the router's own
+//     NotFound handling, so an unknown URL does not get a success-shaped 204 the
+//     way a blanket preflight responder would hand out.
+//
+// Access-Control-Allow-Methods is emitted only when CORSHeaders already accepted
+// the origin. A disallowed origin therefore gets a 204 with no method list,
+// which is exactly what makes the browser fail the preflight — without ever
+// disclosing the method surface.
+func Preflight(router RouteMatcher) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodOptions {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			methods := preflightAllowedMethods(router, r.URL.Path)
+			if len(methods) == 0 {
+				// Unknown route: let the router answer (404) rather than
+				// fabricating a successful preflight.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			allow := strings.Join(methods, ", ")
+			w.Header().Set("Allow", allow)
+			if w.Header().Get("Access-Control-Allow-Origin") != "" {
+				w.Header().Set("Access-Control-Allow-Methods", allow)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
+}
+
+// preflightAllowedMethods reports the methods path accepts. With no router it
+// returns the static fallback list; a nil result means "route unknown".
+//
+// Probing cannot see through a sub-router: a path mounted as a catch-all (chi's
+// Handle registers every method) reports the full set, so paths under such a
+// mount still get a broad list. Narrowing those would mean binding a preflight
+// responder inside the sub-router as well. Routes registered directly on this
+// router — health, static, operator endpoints — do get an exact list.
+//
+// An explicitly registered OPTIONS route is deliberately NOT detected and
+// skipped here: chi's Handle registers OPTIONS alongside every other method, so
+// such a check cannot tell a deliberate r.Options() from an ordinary catch-all
+// mount, and it fired on every mounted subtree. Preflights are therefore
+// answered here in all cases — the same thing the previous CORS middleware did
+// unconditionally, so nothing that used to reach a handler stops reaching it.
+func preflightAllowedMethods(router RouteMatcher, path string) []string {
+	if router == nil {
+		return fallbackPreflightMethods
+	}
+
+	methods := make([]string, 0, len(preflightProbeMethods)+1)
+	for _, m := range preflightProbeMethods {
+		// chi mutates the RouteContext while matching, so each probe gets a
+		// fresh one and the request's real routing context stays untouched.
+		if router.Match(chi.NewRouteContext(), m, path) {
+			methods = append(methods, m)
+		}
+	}
+	if len(methods) == 0 {
+		return nil
+	}
+	return append(methods, http.MethodOptions)
+}
+
+// CORS wires header-stamping and preflight-answering together with no router
+// binding. Retained for callers (and tests) that want CORS as a single
+// middleware; the server stack composes the two halves itself so it can slot a
+// preflight rate limiter between them.
+func CORS(allowedOrigins []string, allowCredentials bool) func(http.Handler) http.Handler {
+	headers := CORSHeaders(allowedOrigins, allowCredentials)
+	preflight := Preflight(nil)
+	return func(next http.Handler) http.Handler {
+		return headers(preflight(next))
 	}
 }

--- a/backend/internal/control/middleware/lan_guard.go
+++ b/backend/internal/control/middleware/lan_guard.go
@@ -1,22 +1,29 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
 package middleware
 
 import (
-	"fmt"
 	"net"
 	"net/http"
-	"slices"
-	"strings"
 
 	"github.com/ManuGH/xg2g/internal/log"
 )
 
+// LANGuardConfig configures a client-IP allowlist gate.
+//
+// NOTE: LANGuard is currently exercised only by tests (internal/control/http/v3
+// auth_strict_test.go); no production route mounts RequireLAN. Wiring it would
+// add a LAN restriction the daemon does not have today, so that decision is
+// deliberately left to the operator rather than made here.
 type LANGuardConfig struct {
-	// allowedCIDRs defines which CLIENT IPs can access the protected resource.
-	// If empty, defaults to RFC1918 ranges.
+	// AllowedCIDRs defines which CLIENT IPs can access the protected resource.
+	// If empty, defaults to RFC1918 ranges plus loopback.
 	AllowedCIDRs []string
 
-	// trustedProxyCIDRs defines which UPSTREAM IPs (RemoteAddr) are trusted to set X-Forwarded-For.
-	// If empty, X-Forwarded-For is ALWAYS IGNORED.
+	// TrustedProxyCIDRs defines which UPSTREAM IPs (RemoteAddr) are trusted to
+	// set X-Forwarded-For. If empty, X-Forwarded-For is ALWAYS IGNORED.
 	TrustedProxyCIDRs []string
 }
 
@@ -26,7 +33,6 @@ type LANGuard struct {
 }
 
 func NewLANGuard(cfg LANGuardConfig) (*LANGuard, error) {
-	// Parse Allowed Clients (LAN)
 	clientCIDRs := cfg.AllowedCIDRs
 	if len(clientCIDRs) == 0 {
 		clientCIDRs = []string{
@@ -41,7 +47,6 @@ func NewLANGuard(cfg LANGuardConfig) (*LANGuard, error) {
 		return nil, err
 	}
 
-	// Parse Trusted Proxies
 	trustedProxies, err := ParseCIDRs(cfg.TrustedProxyCIDRs)
 	if err != nil {
 		return nil, err
@@ -50,40 +55,11 @@ func NewLANGuard(cfg LANGuardConfig) (*LANGuard, error) {
 	return &LANGuard{allowedClient: allowedClients, trustedProxy: trustedProxies}, nil
 }
 
-func ParseCIDRs(cidrs []string) ([]*net.IPNet, error) {
-	var nets []*net.IPNet
-	for _, c := range cidrs {
-		if strings.TrimSpace(c) == "" {
-			continue
-		}
-		// Try CIDR first
-		_, n, err := net.ParseCIDR(c)
-		if err == nil {
-			nets = append(nets, n)
-			continue
-		}
-
-		// Try single IP
-		ip := net.ParseIP(strings.TrimSpace(c))
-		if ip != nil {
-			bits := 32
-			if ip.To4() == nil {
-				bits = 128
-			}
-			mask := net.CIDRMask(bits, bits)
-			n = &net.IPNet{IP: ip, Mask: mask}
-			nets = append(nets, n)
-			continue
-		}
-
-		return nil, fmt.Errorf("invalid CIDR or IP: %s", c)
-	}
-	return nets, nil
-}
-
 func (g *LANGuard) RequireLAN(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip := g.resolveClientIP(r)
+		// Client-IP resolution is shared with the rate limiter so the two can
+		// never disagree about who a request came from — see ResolveClientIP.
+		ip := ResolveClientIP(r, g.trustedProxy)
 		logger := log.WithComponentFromContext(r.Context(), "authz.lan")
 
 		if ip == nil {
@@ -99,80 +75,4 @@ func (g *LANGuard) RequireLAN(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-func IsIPAllowed(ip net.IP, subnets []*net.IPNet) bool {
-	ip = ip.To16()
-	if ip == nil {
-		return false
-	}
-	for _, n := range subnets {
-		if n.Contains(ip) {
-			return true
-		}
-	}
-	return false
-}
-
-// resolveClientIP determines the true client IP using right-to-left traversal.
-// Policy:
-// 1. Start with RemoteAddr.
-// 2. If RemoteAddr is NOT in TrustedProxyCIDRs, return RemoteAddr.
-// 3. If RemoteAddr IS Trusted, parse X-Forwarded-For.
-// 4. Iterate XFF IPs from Right-to-Left.
-// 5. Skip IPs that are present in TrustedProxyCIDRs.
-// 6. Return the first non-trusted IP found.
-// 7. If all XFF IPs are trusted, fallback to RemoteAddr (or the leftmost trusted).
-func (g *LANGuard) resolveClientIP(r *http.Request) net.IP {
-	remoteIPStr, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
-	if err != nil {
-		remoteIPStr = strings.TrimSpace(r.RemoteAddr)
-	}
-	remoteIP := net.ParseIP(remoteIPStr)
-	if remoteIP == nil {
-		return nil
-	}
-
-	// If RemoteAddr is NOT trusted, we must ignore headers
-	if !IsIPAllowed(remoteIP, g.trustedProxy) {
-		return remoteIP
-	}
-
-	// Remote is trusted; inspect XFF
-	xff := r.Header.Get("X-Forwarded-For")
-	if xff == "" {
-		// Try X-Real-IP as a fallback for single-proxy setups
-		// But only if XFF is missing, to avoid confusion
-		xrip := r.Header.Get("X-Real-IP")
-		if xrip != "" {
-			ip := net.ParseIP(strings.TrimSpace(xrip))
-			if ip != nil {
-				return ip
-			}
-		}
-		return remoteIP
-	}
-
-	// Parse XFF list
-	parts := strings.Split(xff, ",")
-	// Traverse Right-to-Left
-	for _, v := range slices.Backward(parts) {
-		ipPart := strings.TrimSpace(v)
-		ip := net.ParseIP(ipPart)
-		if ip == nil {
-			continue
-		}
-
-		// If this IP is trusted, it's just another proxy hop -> skip
-		if IsIPAllowed(ip, g.trustedProxy) {
-			continue
-		}
-
-		// Found the first non-trusted IP -> The Real Client
-		return ip
-	}
-
-	// If we get here, all IPs in XFF were trusted.
-	// Fallback to RemoteAddr (or could be construed as the 'edge' trusted proxy).
-	return remoteIP
 }

--- a/backend/internal/control/middleware/ratelimit.go
+++ b/backend/internal/control/middleware/ratelimit.go
@@ -22,20 +22,30 @@ type RateLimitConfig struct {
 	RequestLimit int
 	// WindowSize is the time window for rate limiting
 	WindowSize time.Duration
-	// KeyFunc extracts the rate limit key from the request (e.g., IP address)
-	// If nil, defaults to IP-based rate limiting
+	// KeyFunc extracts the rate limit key from the request (e.g., IP address).
+	// If nil, the key is the client IP resolved via TrustedProxies.
 	KeyFunc func(r *http.Request) (string, error)
 	// Whitelist is a list of IPs or CIDRs to exempt from rate limiting
 	Whitelist []string
+	// TrustedProxies are the upstream hops allowed to assert a client's identity
+	// via X-Forwarded-For. Empty means forwarding headers are ignored entirely
+	// and the socket peer is the key.
+	TrustedProxies []*net.IPNet
 }
 
 // RateLimit creates a rate limiting middleware using the httprate library.
 // It uses a sliding window counter algorithm for accurate rate limiting.
+//
+// The default key is ResolveClientIP, NOT httprate.KeyByIP or
+// httprate.KeyByRealIP. KeyByIP buckets by the socket peer, which behind a
+// reverse proxy puts every client on the planet into one shared bucket — one
+// abusive client then rate-limits everybody. KeyByRealIP reads X-Forwarded-For
+// with no trust boundary at all, which lets any client forge a fresh identity
+// per request. Only a trusted-chain walk avoids both failure modes.
 func RateLimit(cfg RateLimitConfig) func(http.Handler) http.Handler {
-	// Default to IP-based rate limiting if no key function provided
 	keyFunc := cfg.KeyFunc
 	if keyFunc == nil {
-		keyFunc = httprate.KeyByIP
+		keyFunc = KeyByTrustedProxyChain(cfg.TrustedProxies)
 	}
 
 	whitelistIPs, whitelistNets := parseWhitelist(cfg.Whitelist)
@@ -62,9 +72,12 @@ func RateLimit(cfg RateLimitConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		limitedNext := limiter(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Check whitelist
+			// Check whitelist against the same resolved identity the limiter
+			// buckets by, so an exemption cannot be claimed by a spoofed header
+			// or missed because a proxy masked the real client.
 			if len(whitelistIPs) > 0 || len(whitelistNets) > 0 {
-				if clientIP := requestIP(r); clientIP != nil && isWhitelisted(clientIP, whitelistIPs, whitelistNets) {
+				if clientIP := ResolveClientIP(r, cfg.TrustedProxies); clientIP != nil &&
+					isWhitelisted(clientIP, whitelistIPs, whitelistNets) {
 					next.ServeHTTP(w, r)
 					return
 				}
@@ -89,7 +102,7 @@ func RefreshRateLimit() func(http.Handler) http.Handler {
 // capacity to configure. The former api.rateLimit.burst knob is deprecated and inert — see
 // DeprecatedBurstWarning. (The working burst lives elsewhere, on the Enigma2 client's
 // x/time/rate token bucket, and is unrelated to this API limiter.)
-func APIRateLimit(enabled bool, rps int, whitelist []string) func(http.Handler) http.Handler {
+func APIRateLimit(enabled bool, rps int, whitelist []string, trustedProxies []*net.IPNet) func(http.Handler) http.Handler {
 	if !enabled {
 		// Passthrough if disabled
 		return func(next http.Handler) http.Handler {
@@ -98,7 +111,7 @@ func APIRateLimit(enabled bool, rps int, whitelist []string) func(http.Handler) 
 	}
 
 	if rps <= 0 {
-		rps = 100 // Default safety net
+		rps = defaultAPIRateLimitRPS // Default safety net
 	}
 
 	// Sliding window logic: Window is 1 minute.
@@ -106,10 +119,63 @@ func APIRateLimit(enabled bool, rps int, whitelist []string) func(http.Handler) 
 	limit := rps * 60
 
 	return RateLimit(RateLimitConfig{
-		RequestLimit: limit,
-		WindowSize:   time.Minute,
-		Whitelist:    whitelist,
+		RequestLimit:   limit,
+		WindowSize:     time.Minute,
+		Whitelist:      whitelist,
+		TrustedProxies: trustedProxies,
 	})
+}
+
+// defaultAPIRateLimitRPS is the fallback when no API rate limit is configured.
+const defaultAPIRateLimitRPS = 100
+
+// PreflightRateLimitMultiplier sets how much more headroom CORS preflights get
+// than ordinary API calls.
+//
+// Preflights need their own, much larger budget rather than sharing the API
+// bucket. A browser issues one preflight per non-simple cross-origin request, so
+// a single legitimate page load can emit a burst of them; charged against the
+// API budget, an active UI would throttle itself out of its own backend. They
+// still must not be unlimited — before this split they bypassed rate limiting
+// entirely, because the CORS middleware answered and returned before the limiter
+// ever ran, leaving an unmetered amplification path open to anyone.
+const PreflightRateLimitMultiplier = 10
+
+// PreflightRateLimit returns a rate limiter sized for CORS preflight traffic.
+// Mount it so that only OPTIONS requests reach it.
+func PreflightRateLimit(enabled bool, rps int, whitelist []string, trustedProxies []*net.IPNet) func(http.Handler) http.Handler {
+	if !enabled {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+
+	if rps <= 0 {
+		rps = defaultAPIRateLimitRPS
+	}
+
+	return RateLimit(RateLimitConfig{
+		RequestLimit:   rps * PreflightRateLimitMultiplier * 60,
+		WindowSize:     time.Minute,
+		Whitelist:      whitelist,
+		TrustedProxies: trustedProxies,
+	})
+}
+
+// OnlyMethod applies mw exclusively to requests using the given method, letting
+// everything else pass straight through. It is what keeps the preflight limiter
+// from metering ordinary API traffic.
+func OnlyMethod(method string, mw func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		wrapped := mw(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == method {
+				wrapped.ServeHTTP(w, r)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // DeprecatedAPIRateLimitBurstDefault is the historical default of the now-inert
@@ -154,19 +220,9 @@ func parseWhitelist(entries []string) ([]net.IP, []*net.IPNet) {
 	return ips, nets
 }
 
-func requestIP(r *http.Request) net.IP {
-	if ipStr, err := httprate.KeyByIP(r); err == nil && ipStr != "" {
-		if ip := net.ParseIP(ipStr); ip != nil {
-			return ip
-		}
-	}
-
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-	return net.ParseIP(host)
-}
+// requestIP was the old socket-peer-only lookup used for whitelist checks.
+// Client identity now comes from ResolveClientIP so the whitelist and the
+// limiter bucket agree; see RateLimit.
 
 func isWhitelisted(ip net.IP, ips []net.IP, nets []*net.IPNet) bool {
 	for _, allowed := range ips {

--- a/backend/internal/control/middleware/ratelimit_test.go
+++ b/backend/internal/control/middleware/ratelimit_test.go
@@ -146,7 +146,7 @@ func TestAPIRateLimit_Configuration(t *testing.T) {
 
 	// Apply API rate limiter: Enabled=true, RPS=1 (60 RPM), Whitelist=nil. No burst param —
 	// the window limiter has no burst capacity (see DeprecatedBurstWarning).
-	limitedHandler := APIRateLimit(true, 1, nil)(handler)
+	limitedHandler := APIRateLimit(true, 1, nil, nil)(handler)
 
 	// Make 60 requests (at limit)
 	for i := 0; i < 60; i++ {

--- a/backend/internal/control/middleware/stack.go
+++ b/backend/internal/control/middleware/stack.go
@@ -6,6 +6,7 @@ package middleware
 
 import (
 	"net"
+	"net/http"
 
 	xglog "github.com/ManuGH/xg2g/internal/log"
 	"github.com/go-chi/chi/v5"
@@ -37,6 +38,10 @@ type StackConfig struct {
 
 	// Rate limiting (API). No burst field: the API limiter is a window counter (httprate)
 	// with no burst capacity; the api.rateLimit.burst knob is deprecated/inert.
+	//
+	// TrustedProxies (above) doubles as the limiter's trust boundary: it decides
+	// whether a request is bucketed by its socket peer or by the client IP that
+	// its proxy chain vouches for. See ResolveClientIP.
 	EnableRateLimit    bool
 	RateLimitEnabled   bool
 	RateLimitGlobalRPS int
@@ -54,44 +59,83 @@ func NewRouter(cfg StackConfig) *chi.Mux {
 }
 
 // ApplyStack applies the canonical middleware stack to r.
+//
+// Ordering is load-bearing, in particular around CORS and rate limiting:
+//
+//   - Security headers and the request ID are stamped before anything can
+//     reject a request, so a 429 is as well-formed and as traceable as a 200.
+//   - CORS response headers are stamped before both limiters, so a rate-limit
+//     rejection reaches the browser as a readable 429 rather than an opaque
+//     CORS failure that hides the real cause from the UI.
+//   - Preflights are metered by their own generous limiter and answered
+//     afterwards. Previously CORS answered OPTIONS and returned at this point in
+//     the chain, so preflights never reached the limiter at all — an unmetered
+//     path anyone could amplify.
+//   - The API limiter stays innermost, metering only what actually continues on
+//     to the router, so browser preflight volume cannot consume the budget that
+//     real API calls depend on.
+//
+// If r is a *chi.Mux the preflight responder is bound to it and advertises the
+// methods each path genuinely accepts; otherwise it falls back to a static list.
 func ApplyStack(r chi.Router, cfg StackConfig) {
 	// 1. Recoverer (outermost safety net)
 	r.Use(Recoverer)
 	// 2. RequestID (correlation early)
 	r.Use(RequestID)
-	// 2b. Body-size backstop (bound memory before any handler reads the body)
+	// 3. Body-size backstop (bound memory before any handler reads the body)
 	if cfg.MaxRequestBodyBytes > 0 {
 		r.Use(MaxBodyBytes(cfg.MaxRequestBodyBytes))
 	}
-	// 2c. Compression (response transform; only touches text-ish content types,
+	// 4. Compression (response transform; only touches text-ish content types,
 	// never media segments, so it sits outside the per-request logic below).
 	if cfg.EnableCompression {
 		r.Use(Compression())
 	}
-	// 3. CORS (so OPTIONS and browser clients behave)
-	if cfg.EnableCORS {
-		r.Use(CORS(cfg.AllowedOrigins, cfg.CORSAllowCredentials))
-	}
-	// 4. CSRF (fail-closed for state-changing requests)
-	r.Use(CSRFProtection(cfg.AllowedOrigins))
-	// 5. Security headers
+	// 5. Security headers (before any rejection, so 4xx/5xx carry them too)
 	if cfg.EnableSecurityHeaders {
 		r.Use(SecurityHeaders(cfg.CSP, cfg.TrustedProxies))
 	}
-	// 6. Metrics (track all requests)
+	// 6. CORS response headers (stamp only; never short-circuits)
+	if cfg.EnableCORS {
+		r.Use(CORSHeaders(cfg.AllowedOrigins, cfg.CORSAllowCredentials))
+	}
+	// 7. Preflight rate limit (OPTIONS only, separate generous budget)
+	if cfg.EnableRateLimit {
+		r.Use(OnlyMethod(http.MethodOptions, PreflightRateLimit(
+			cfg.RateLimitEnabled, cfg.RateLimitGlobalRPS, cfg.RateLimitWhitelist, cfg.TrustedProxies,
+		)))
+	}
+	// 8. Preflight responder (answers OPTIONS, route-aware where possible)
+	if cfg.EnableCORS {
+		r.Use(Preflight(routeMatcherFor(r)))
+	}
+	// 9. CSRF (fail-closed for state-changing requests)
+	r.Use(CSRFProtection(cfg.AllowedOrigins))
+	// 10. Metrics (track all requests)
 	if cfg.EnableMetrics {
 		r.Use(Metrics())
 	}
-	// 7. Tracing (distributed tracing with OpenTelemetry)
+	// 11. Tracing (distributed tracing with OpenTelemetry)
 	if cfg.TracingService != "" {
 		r.Use(Tracing(cfg.TracingService))
 	}
-	// 8. Logging (wraps handlers, captures full latency)
+	// 12. Logging (wraps handlers, captures full latency)
 	if cfg.EnableLogging {
 		r.Use(xglog.Middleware())
 	}
-	// 9. Rate limit (global protection)
+	// 13. Rate limit (global protection, keyed by resolved client IP)
 	if cfg.EnableRateLimit {
-		r.Use(APIRateLimit(cfg.RateLimitEnabled, cfg.RateLimitGlobalRPS, cfg.RateLimitWhitelist))
+		r.Use(APIRateLimit(
+			cfg.RateLimitEnabled, cfg.RateLimitGlobalRPS, cfg.RateLimitWhitelist, cfg.TrustedProxies,
+		))
 	}
+}
+
+// routeMatcherFor returns r as a RouteMatcher when it can answer route queries,
+// or nil to make the preflight responder fall back to its static method list.
+func routeMatcherFor(r chi.Router) RouteMatcher {
+	if m, ok := r.(RouteMatcher); ok {
+		return m
+	}
+	return nil
 }

--- a/backend/internal/control/middleware/stack_ingress_regression_test.go
+++ b/backend/internal/control/middleware/stack_ingress_regression_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package middleware
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ingressStack builds the canonical stack the API server uses, with a low rate
+// limit so budgets are reachable inside a test.
+func ingressStack(t *testing.T, rps int, trusted []*net.IPNet) http.Handler {
+	t.Helper()
+	r := NewRouter(StackConfig{
+		EnableCORS:            true,
+		AllowedOrigins:        []string{"https://app.example"},
+		EnableSecurityHeaders: true,
+		CSP:                   DefaultCSP,
+		TrustedProxies:        trusted,
+		EnableCompression:     true,
+		EnableRateLimit:       true,
+		RateLimitEnabled:      true,
+		RateLimitGlobalRPS:    rps,
+		MaxRequestBodyBytes:   DefaultMaxRequestBodyBytes,
+	})
+	r.Get("/api/v3/things", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	r.Post("/api/v3/things", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	return r
+}
+
+// Regression: before the shared client-IP resolver, the limiter keyed on the
+// socket peer. Behind a reverse proxy every client collapsed into one bucket, so
+// a single abusive client rate-limited everybody else.
+func TestIngress_RateLimitDoesNotCollapseBehindProxy(t *testing.T) {
+	trusted, err := ParseCIDRs([]string{"172.20.0.0/16"})
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	h := ingressStack(t, 1, trusted) // 1 rps => 60 requests/minute per client
+
+	// Must exceed the per-bucket budget (60/min), otherwise a collapsed shared
+	// bucket would still fit inside it and the test would pass against the bug.
+	const clients = 150
+	blocked := 0
+	for i := range clients {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/things", nil)
+		req.RemoteAddr = "172.20.0.5:5555" // one shared proxy
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("198.51.100.%d", i+1))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			blocked++
+		}
+	}
+	if blocked != 0 {
+		t.Errorf("%d/%d distinct clients behind one proxy were rate limited; buckets collapsed", blocked, clients)
+	}
+
+	// The limit must still bite per client.
+	over := 0
+	for range 100 {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/things", nil)
+		req.RemoteAddr = "172.20.0.5:5555"
+		req.Header.Set("X-Forwarded-For", "198.51.100.200")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			over++
+		}
+	}
+	if over == 0 {
+		t.Error("a single client exceeding its budget was never rate limited")
+	}
+}
+
+// Regression: an untrusted caller must not be able to mint a fresh bucket per
+// request by rotating X-Forwarded-For. This is the failure mode that switching
+// to httprate.KeyByRealIP would have introduced.
+func TestIngress_SpoofedXFFCannotEvadeRateLimit(t *testing.T) {
+	trusted, err := ParseCIDRs([]string{"172.20.0.0/16"})
+	if err != nil {
+		t.Fatalf("ParseCIDRs: %v", err)
+	}
+	h := ingressStack(t, 1, trusted)
+
+	blocked := 0
+	for i := range 100 {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/things", nil)
+		req.RemoteAddr = "203.0.113.77:44321" // NOT a trusted proxy
+		req.Header.Set("X-Forwarded-For", fmt.Sprintf("198.51.100.%d", i+1))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			blocked++
+		}
+	}
+	if blocked == 0 {
+		t.Error("rotating X-Forwarded-For evaded the rate limit entirely")
+	}
+}
+
+// Regression: CORS used to answer OPTIONS and return before the limiter ever
+// ran, leaving preflights completely unmetered.
+func TestIngress_PreflightIsRateLimited(t *testing.T) {
+	h := ingressStack(t, 1, nil)
+	// Preflight budget is 1 rps * multiplier * 60s; exceed it decisively.
+	total := PreflightRateLimitMultiplier*60 + 200
+
+	blocked := 0
+	for range total {
+		req := httptest.NewRequest(http.MethodOptions, "/api/v3/things", nil)
+		req.RemoteAddr = "198.51.100.42:1234"
+		req.Header.Set("Origin", "https://app.example")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			blocked++
+		}
+	}
+	if blocked == 0 {
+		t.Errorf("preflight flood of %d was never rate limited", total)
+	}
+}
+
+// Preflights get their own budget, so browser preflight volume cannot starve
+// real API calls — the reason for a separate limiter rather than reordering.
+func TestIngress_PreflightBudgetIsSeparateFromAPIBudget(t *testing.T) {
+	h := ingressStack(t, 1, nil)
+	const client = "198.51.100.43:1234"
+
+	// Burn well past the API budget (60/min) using preflights only.
+	for range 300 {
+		req := httptest.NewRequest(http.MethodOptions, "/api/v3/things", nil)
+		req.RemoteAddr = client
+		req.Header.Set("Origin", "https://app.example")
+		h.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v3/things", nil)
+	req.RemoteAddr = client
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("preflights consumed the API budget: GET got %d, want 200", rec.Code)
+	}
+}
+
+// A rate-limit rejection must still carry CORS headers, or the browser reports
+// an opaque network error and the UI cannot tell throttling from an outage.
+func TestIngress_RateLimitedResponseKeepsCORSAndSecurityHeaders(t *testing.T) {
+	h := ingressStack(t, 1, nil)
+
+	var throttled *httptest.ResponseRecorder
+	for range 200 {
+		req := httptest.NewRequest(http.MethodGet, "/api/v3/things", nil)
+		req.RemoteAddr = "198.51.100.44:1234"
+		req.Header.Set("Origin", "https://app.example")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code == http.StatusTooManyRequests {
+			throttled = rec
+			break
+		}
+	}
+	if throttled == nil {
+		t.Fatal("never produced a 429 to inspect")
+	}
+	if got := throttled.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example" {
+		t.Errorf("429 missing CORS origin header, got %q", got)
+	}
+	if got := throttled.Header().Get("Content-Security-Policy"); got == "" {
+		t.Error("429 missing security headers")
+	}
+	if got := throttled.Header().Get("X-Request-ID"); got == "" {
+		t.Error("429 missing request ID; the rejection is untraceable")
+	}
+}
+
+// The preflight responder advertises what a path really accepts instead of one
+// blanket list for every URL.
+func TestIngress_PreflightAdvertisesRealMethods(t *testing.T) {
+	r := NewRouter(StackConfig{
+		EnableCORS:     true,
+		AllowedOrigins: []string{"https://app.example"},
+	})
+	r.Get("/read-only", func(w http.ResponseWriter, _ *http.Request) {})
+	r.Get("/both", func(w http.ResponseWriter, _ *http.Request) {})
+	r.Delete("/both", func(w http.ResponseWriter, _ *http.Request) {})
+
+	check := func(path, want string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodOptions, path, nil)
+		req.Header.Set("Origin", "https://app.example")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("%s: got %d, want 204", path, rec.Code)
+		}
+		if got := rec.Header().Get("Access-Control-Allow-Methods"); got != want {
+			t.Errorf("%s: Allow-Methods = %q, want %q", path, got, want)
+		}
+	}
+
+	check("/read-only", "GET, OPTIONS")
+	check("/both", "GET, DELETE, OPTIONS")
+}
+
+// An unknown path must not get a success-shaped preflight.
+func TestIngress_PreflightOnUnknownPathIsNot204(t *testing.T) {
+	r := NewRouter(StackConfig{
+		EnableCORS:     true,
+		AllowedOrigins: []string{"https://app.example"},
+	})
+	r.Get("/known", func(w http.ResponseWriter, _ *http.Request) {})
+
+	req := httptest.NewRequest(http.MethodOptions, "/definitely/not/here", nil)
+	req.Header.Set("Origin", "https://app.example")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNoContent {
+		t.Error("unknown path produced a successful preflight")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "" {
+		t.Errorf("unknown path leaked a method surface: %q", got)
+	}
+}
+
+// A disallowed origin gets no method surface, which is what makes the browser
+// fail the preflight.
+func TestIngress_PreflightWithheldFromDisallowedOrigin(t *testing.T) {
+	h := ingressStack(t, 100, nil)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/v3/things", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "" {
+		t.Errorf("disallowed origin was told the method surface: %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("disallowed origin got an Allow-Origin: %q", got)
+	}
+}
+
+// Ordering guard: every rejection the stack can emit must still be traceable and
+// carry security headers.
+func TestIngress_SecurityHeadersPrecedeRejections(t *testing.T) {
+	h := ingressStack(t, 100, nil)
+
+	// CSRF rejection (no Origin on an unsafe method).
+	req := httptest.NewRequest(http.MethodPost, "/api/v3/things", strings.NewReader("{}"))
+	req.RemoteAddr = "198.51.100.45:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 from CSRF, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Security-Policy"); got == "" {
+		t.Error("CSRF rejection missing security headers")
+	}
+	if got := rec.Header().Get("X-Request-ID"); got == "" {
+		t.Error("CSRF rejection missing request ID")
+	}
+}


### PR DESCRIPTION
## Problem

Two ingress defects found during an HTTP audit, both verified by measurement rather than inspection.

**Rate limiting collapsed behind a reverse proxy.** The API limiter keyed on `httprate.KeyByIP`, i.e. the socket peer. Every client arriving through one proxy shared a single bucket, so one abusive client rate-limited everybody else. Measured: **90 of 150 distinct clients** behind one proxy IP received 429.

**CORS preflights bypassed rate limiting entirely.** The CORS middleware answered `OPTIONS` and returned at position 3 of the stack; the limiter sat at position 9. Measured: **800 preflights against a 60/min budget, zero throttled**.

## Approach

`httprate.KeyByRealIP` was rejected — it would have traded the collapse for XFF spoofing, letting any client mint a fresh bucket per request.

Instead, `ResolveClientIP` becomes the single trusted-chain resolver:

- No trusted proxy configured, or peer not trusted → socket peer, forwarding headers ignored.
- Trusted peer → walk `X-Forwarded-For` right-to-left, skipping trusted hops; the first untrusted hop **is** the client.
- Unparseable entry → fail closed to the socket peer.
- Only a chain whose *leftmost* entry is also configured infrastructure names no client at all, and falls back to the peer.

The ordinary CDN case resolves to the client, not the proxy:

```
Client 203.0.113.50 → Cloudflare 198.51.100.20 → Nginx 10.0.0.10 → xg2g
RemoteAddr:      10.0.0.10
X-Forwarded-For: 203.0.113.50, 198.51.100.20
                 → 203.0.113.50
```

Three near-copies of that walk existed — `LANGuard.resolveClientIP`, `exposureClientKey`, and the limiter's socket-peer lookup — each behaving differently on malformed input and on fully-trusted chains. All three now delegate to the shared resolver, and the rate-limit whitelist is checked against the same resolved identity the limiter buckets by.

For preflights, reordering alone was rejected: it would charge browser preflights to the API budget, letting an active UI throttle itself out of its own backend, and a 429 emitted before CORS headers reaches the browser as an opaque network error. So `CORS` is split into header-stamping and preflight-answering, with a separate 10× preflight limiter between them and the API limiter innermost.

## Changes

- Central trusted-proxy client-IP resolution (`ResolveClientIP`, `ClientIPKey`, `KeyByTrustedProxyChain`).
- Rate-limit key, whitelist check and exposure key all use it.
- Removed `LANGuard`'s `X-Real-IP` fallback — a single value with no chain cannot be validated hop by hop, so a proxy that appends to XFF while passing a client-supplied `X-Real-IP` through would hand out free identities.
- Separate, generous preflight bucket (`PreflightRateLimit`, `OnlyMethod`).
- Security headers and CORS headers now precede every rejection the stack can emit, so a 429 is a readable, traceable 429.
- Route-aware preflight: advertises the methods a path actually accepts; an unknown top-level route no longer gets an unconditional 204 with a broad `Allow` list.
- IPv6 buckets by /64 and IPv4-mapped IPv6 collapses to dotted-quad, matching httprate's canonicalization so IPv6 bucketing does not change silently.

## Why the diff is large for two localized fixes

`+1072 / −211` is more than the two behavioural changes suggest. The breakdown:

| | added | removed |
|---|---|---|
| Tests (`clientip_test.go`, `stack_ingress_regression_test.go`, …) | **+592** | −1 |
| Production code | +480 | −210 |

So **55% of the added lines are tests**, and the production change is a net `+270`. That net splits three ways:

- **Consolidating three client-IP implementations** — `lan_guard.go` is net **−100**; `exposure_security.go` net −20. The duplicated walks (and their diverging edge-case behaviour) are deleted, not added to.
- **`clientip.go` (+181)** — of which **89 lines are comment**, mostly the worked CDN example and the rule-by-rule trust rationale, because this is the file where a plausible-looking "simplification" reintroduces either the collapse or XFF spoofing. 92 lines are actual code.
- **Splitting CORS (+134/−25 in `cors.go`, +58/−14 in `stack.go`)** — mechanically the largest piece. The split is what allows a separate preflight bucket *and* correct CORS headers on rate-limit rejections; a bare middleware reorder achieves neither.

No behavioural change hides in the bulk: the full test suite, `-race`, and `gofmt` are clean, and the two regression tests were confirmed red against the previous code.

## Not solved by this PR

**Method narrowing inside the mounted `/api/v3/*` router is unchanged.** Preflights are now rate-limited and unknown top-level routes no longer receive unconditional broad responses, but route probing cannot see through a catch-all mount (chi's `Handle` registers every method), so paths under the v3 mount still report the full method set. Narrowing those would require binding a preflight responder inside the v3 router as well.

## Base

Targets `main` directly as a single commit. The work was originally authored on top of `refactor/playback-input-intents` (#734), which sits behind `refactor/r5-1-guardrail-linter` (#728) — opening it there would have stacked an unrelated ingress fix three deep behind two large refactors. Of the five production files touched, four are byte-identical between that branch and `main`, so the fix carries no dependency on either PR and was rebased onto `main`.

The one exception, resolved deliberately: `cors.go` on the stack allows an extra CORS request header (`X-XG2G-Profile`) that `main` does not yet know. The extracted `corsAllowedHeaders` constant here keeps **`main`'s** header surface exactly (`Content-Type, X-Request-ID, X-API-Token, Authorization`), so this PR introduces no unrelated behavioural change. When the stack lands it will hit a one-line conflict on that constant, which should be resolved in favour of whichever surface the stack intends.

The full test suite, `-race` and `gofmt` were re-run against the rebased tree on `main`, not only against the original base.

## Verification

Both regression tests were confirmed to **fail against the previous code**:

```
--- FAIL: TestIngress_RateLimitDoesNotCollapseBehindProxy
    90/150 distinct clients behind one proxy were rate limited; buckets collapsed
--- FAIL: TestIngress_PreflightIsRateLimited
    preflight flood of 800 was never rate limited
```

`go build ./...`, `go vet ./internal/...`, full `go test ./...`, `go test -race` on the changed packages, and `gofmt -l` are clean. The one `golangci-lint` hit (`gosec G705` in `internal/control/http/v3/hls/service.go:224`) is pre-existing, confirmed against the unmodified baseline via `git stash -u`; that file is untouched here.

Middleware coverage: **63.5% → 75.0%**.

## Follow-up (out of scope)

`LANGuard` remains unmounted in the current ingress stack. The middleware itself is covered by tests, but there is currently no integration test asserting whether it is part of the production middleware chain. A future change should explicitly decide whether `LANGuard` is intended to be wired into the ingress stack or removed, and add an integration test to lock that decision in.

Deliberately excluded from this PR, per review scope: global write-deadline architecture, cache-policy rework, metrics and HLS-ingest hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
