### PR TITLE
docs(ci): codify release safety and unblock required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,30 +6,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - "android/**"
-      - "backend/**/*.go"
-      - ".github/**"
-      - backend/go.mod
-      - backend/go.sum
-      - "backend/api/openapi.yaml"
-      - "backend/config.example.yaml"
-      - "backend/config.generated.example.yaml"
-      - "docs/**"
-      - "backend/e2e/**"
-      - "backend/internal/**"
-      - "Dockerfile"
-      - "Dockerfile.*"
-      - "docker-compose*.yml"
-      - "README.md"
-      - "backend/scripts/**"
-      - "scripts/**"
-      - "Makefile"
-      - "backend/templates/**"
-      - "apps/webui/**"
-      - "VERSION"
-      - "WORKFLOW.md"
-      - "mk/**"
+    # This workflow emits a branch-protection-required check. It must run for
+    # every PR; path filters would leave unmatched PRs permanently "Expected".
 
 permissions:
   contents: read

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Verify workflow action refs are SHA-pinned
         run: ./backend/scripts/verify-action-pins.sh --local-only
 
+      - name: Verify required checks run for every PR
+        run: ./backend/scripts/verify-required-check-triggers.sh
+
   check-large-files:
     name: Prevent Large Files
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,48 @@ thread before the thread is resolved — never a silent resolve.
   Manuel remains the escalation point and can revoke this delegation at any
   time. Production promotion is never delegated.
 
+### Release and tag safety
+
+A GitHub release is a separate, auditable publication after merge. It is not a
+deployment and never authorizes staging or production promotion. Follow
+[docs/ops/RELEASE_OUTPUT_CONTRACT.md](docs/ops/RELEASE_OUTPUT_CONTRACT.md) as
+the normative output contract.
+
+1. Prepare every release from a clean, isolated worktree based on the latest
+   `origin/main`. Never release from a feature branch or dirty checkout.
+2. Create and commit
+   `docs/release/vX.Y.Z_behavioral_changes.txt` first, even when it only states
+   that runtime, API, configuration, and deployment behavior are unchanged.
+   Then run `backend/scripts/release-prepare.sh vX.Y.Z` from the clean tree,
+   review every generated change, and commit the preparation coherently.
+3. Put release preparation through a PR. Run `make ci-pr` and `make pre-push`;
+   merge only after all GitHub checks are green and no review thread lacks a
+   fix or written disposition.
+4. Before tagging, fetch `origin/main`, confirm `backend/VERSION` and
+   `RELEASE_MANIFEST.json` match the intended tag, confirm the tag does not
+   exist, and confirm immutable releases are enabled. Create an annotated tag
+   on the exact merged commit and push only that tag.
+5. `.github/workflows/release.yml` is the only release publisher. It must keep
+   the release as a draft until archive/SBOM generation, checksum and OCI
+   signing, remote multi-platform verification, and GitHub attestations have
+   all succeeded. Never bypass a failed workflow with a manual
+   `gh release create`, public draft edit, replacement asset, or moved tag.
+6. Treat every pushed tag as permanent. If a tagged run fails, retain the tag
+   and failed run as audit evidence, remove an incomplete unpublished draft
+   only after recording the failure, fix the cause through a new reviewed PR,
+   and select a new SemVer (normally the next patch). Never delete, reuse, or
+   force-move a failed or published release tag.
+7. Do not report a release complete until the public release is `latest`,
+   non-draft, non-prerelease, and immutable; its exact asset bundle downloads
+   and passes checksums; both SPDX SBOMs parse; file and OCI attestations verify;
+   the version tag and `latest` resolve to the same OCI digest with
+   `linux/amd64` and `linux/arm64`; and the Sigstore checksum and OCI signatures
+   verify against the tagged release workflow identity.
+
+If any verification fails, stop publication or leave it failed closed and
+report the exact run, tag, draft state, and next corrective action. A partially
+successful release is not a successful release.
+
 ### Branch and worktree rules
 
 - Inspect `git status`, branch, worktrees, and remote tracking state before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,22 +264,31 @@ worktree.
 `xg2g` is a Linux/Go/Docker application. The Mac checkout is a development
 client, not the runtime host.
 
-**Updated 2026-07-22 (post-migration to `pve2`):** OpenClaw was never adopted
+**Updated 2026-07-30 (verified against LXC 110):** OpenClaw was never adopted
 in production. The `/root/xg2g` read-only mirror and `/root/xg2g-build`
 detached build checkout described in older revisions of this section did not
-reflect a live process and have been retired — do not recreate them.
+reflect the live topology and have been retired — do not recreate them.
 
 - GitHub is the canonical source for committed code.
 - The Mac `StudioProjects` checkout is where Manuel develops and reviews.
-  Never a build or deployment source.
+  It may run local validation, but it is never a Linux runtime or deployment
+  surface.
 - The Proxmox hypervisor (`pve2`, see infra docs) has no build role and no
   `xg2g` checkout. It is VM/LXC management plane only.
-- **LXC 110 `/srv/xg2g` and `/srv/xg2g-staging` are the authoring AND build
-  checkouts, in addition to being the runtime surfaces.** `git pull` from
-  `origin` happens directly there; `make build-with-ui` runs in-container;
-  the resulting binary is copied straight onto the bind-mounted path used by
-  the corresponding Docker container — no cross-host binary transfer step.
-  Staging is verified on `:8089`, production on `:8088`.
+- LXC 110 `/srv/xg2g-build` is the only Linux fast-iteration build checkout.
+  It stays clean, detached at an exact pushed commit, and is updated only by
+  the governed staging workflow.
+- LXC 110 `/srv/xg2g-staging` is a deployment surface, not a Git checkout.
+  Its binary and `deploy-manifest` are produced from `/srv/xg2g-build`, and
+  staging is verified on `:8089`.
+- LXC 110 `/srv/xg2g` is the production install/runtime surface defined by
+  [docs/ops/INSTALLATION_CONTRACT.md](docs/ops/INSTALLATION_CONTRACT.md), not
+  an authoring or build checkout. A legacy Git checkout found there is
+  migration drift: capture it, do not pull/build/edit it, and reconcile it
+  only through the canonical install/sync path after explicit production
+  approval. Production is verified on `:8088`.
 
-A clean GitHub commit may be propagated one-way into LXC 110's checkouts; no
-tool may silently synchronize uncommitted files between hosts.
+A clean, pushed GitHub commit may be propagated one-way into the isolated
+`/srv/xg2g-build` checkout and then explicitly deployed to staging. No tool may
+silently synchronize uncommitted files between hosts or build from a runtime
+surface.

--- a/backend/scripts/verify-required-check-triggers.sh
+++ b/backend/scripts/verify-required-check-triggers.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+verify_required_workflow() {
+  local relative_path="$1"
+  local workflow="${REPO_ROOT}/${relative_path}"
+  local result
+
+  [[ -f "${workflow}" ]] || fail "required-check workflow is missing: ${relative_path}"
+
+  result="$(
+    awk '
+      /^on:$/ {
+        in_on = 1
+        next
+      }
+      in_on && /^[^[:space:]]/ {
+        in_on = 0
+        in_pull_request = 0
+      }
+      in_on && /^  pull_request:([[:space:]]*|[[:space:]]*\{\})$/ {
+        saw_pull_request = 1
+        in_pull_request = 1
+        next
+      }
+      in_pull_request && /^  [^[:space:]]/ {
+        in_pull_request = 0
+      }
+      in_pull_request && /^    paths(-ignore)?:/ {
+        print "filtered"
+      }
+      END {
+        if (!saw_pull_request) {
+          print "missing"
+        }
+      }
+    ' "${workflow}"
+  )"
+
+  [[ "${result}" != *missing* ]] ||
+    fail "${relative_path} does not trigger on pull_request"
+  [[ "${result}" != *filtered* ]] ||
+    fail "${relative_path} emits a required check and must not use top-level pull_request path filters"
+
+  printf 'OK: %s reports its required check for every PR\n' "${relative_path}"
+}
+
+verify_required_workflow ".github/workflows/ci.yml"
+verify_required_workflow ".github/workflows/pr-required-gates.yml"

--- a/docs/ops/CI_POLICY.md
+++ b/docs/ops/CI_POLICY.md
@@ -17,6 +17,10 @@ Purpose: Make CI deterministic, offline-reproducible, and not dependent on GitHu
 ## Scope Policy
 - Any diff-scoped workflow decision is security-relevant and must be fail-closed.
 - If scope resolution is ambiguous, missing commit context, or diff computation fails, the workflow must run the broader check set instead of skipping.
+- A workflow that emits a branch-protection-required check must trigger for
+  every PR without top-level `paths` or `paths-ignore` filters. Expensive work
+  may be selected inside the workflow, but the required check itself must
+  always be reported.
 - `.github/workflows/lint.yml` uses `backend/scripts/ci/resolve-lint-scope.sh` for this reason.
 
 ## PR Gate (Required Core)

--- a/docs/ops/CI_POLICY.md
+++ b/docs/ops/CI_POLICY.md
@@ -20,7 +20,8 @@ Purpose: Make CI deterministic, offline-reproducible, and not dependent on GitHu
 - A workflow that emits a branch-protection-required check must trigger for
   every PR without top-level `paths` or `paths-ignore` filters. Expensive work
   may be selected inside the workflow, but the required check itself must
-  always be reported.
+  always be reported. Repository Health enforces this through
+  `backend/scripts/verify-required-check-triggers.sh`.
 - `.github/workflows/lint.yml` uses `backend/scripts/ci/resolve-lint-scope.sh` for this reason.
 
 ## PR Gate (Required Core)


### PR DESCRIPTION
## What changed

- adds a binding `Release and tag safety` section to `AGENTS.md`
- requires clean release preparation from current `origin/main`, reviewed preparation PRs, and exact merged-commit tagging
- makes the workflow the sole publisher and preserves failed immutable tags as audit evidence
- defines the external checks required before an agent may report a release complete
- makes the branch-protection-required `CI / PR Gate (Fast & Deterministic)` run for every PR
- documents that required-check workflows must not use top-level path filters

## Why

The v3.9.2 and v3.9.3 tagged runs exposed release-only gaps that local source checks could not prove. The release workflow failed closed, but the durable operator/agent rules were not yet captured in `AGENTS.md`.

The first revision of this PR also exposed a CI deadlock: `.github/workflows/ci.yml` used top-level PR path filters even though its job is required by branch protection. An unmatched documentation-only PR therefore remained permanently `Expected`. Required checks now always emit; any expensive scope selection must happen inside the workflow.

## Impact

Agent governance and CI trigger behavior change. Runtime, API, configuration, packaging outputs, and deployment behavior are unchanged. This PR does not create a release or deploy anything.

## Validation

- `npx --yes markdownlint-cli2@0.14.0 AGENTS.md docs/ops/CI_POLICY.md`
- `actionlint -color`
- `make verify-doc-links` (201 links, 0 broken)
- `./backend/scripts/ci/ctogate_hermetic_codegen.sh .github/workflows/ci.yml`
- `make verify-release-output-contract`
- `make ci-pr` (including 604 WebUI tests and the Go/contract matrix; first revision)
- `make pre-push` (first revision)
- `git diff --check`
