### PR TITLE
fix(cli): restore release container entrypoint

### DIFF
--- a/backend/cmd/daemon/main.go
+++ b/backend/cmd/daemon/main.go
@@ -40,6 +40,7 @@ func printMainUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Usage:")
 	_, _ = fmt.Fprintln(w, "  xg2g [--config path] [--version]")
+	_, _ = fmt.Fprintln(w, "  xg2g daemon run [--config path]")
 	_, _ = fmt.Fprintln(w, "  xg2g version")
 	_, _ = fmt.Fprintln(w, "  xg2g config <command> [flags]")
 	_, _ = fmt.Fprintln(w, "  xg2g entitlements <command> [flags]")
@@ -52,6 +53,7 @@ func printMainUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  xg2g help [command]")
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Commands:")
+	_, _ = fmt.Fprintln(w, "  daemon       Run the long-lived xg2g service")
 	_, _ = fmt.Fprintln(w, "  version      Print version and build metadata")
 	_, _ = fmt.Fprintln(w, "  config       Validate, dump, and migrate config files")
 	_, _ = fmt.Fprintln(w, "  entitlements Inspect and manage commercial unlock overrides")
@@ -72,6 +74,7 @@ func printMainUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Examples:")
 	_, _ = fmt.Fprintln(w, "  xg2g --config /etc/xg2g/config.yaml")
+	_, _ = fmt.Fprintln(w, "  xg2g daemon run --config /etc/xg2g/config.yaml")
 	_, _ = fmt.Fprintln(w, "  xg2g version")
 	_, _ = fmt.Fprintln(w, "  xg2g config validate -f /etc/xg2g/config.yaml")
 	_, _ = fmt.Fprintln(w, "  xg2g entitlements list --token $XG2G_API_TOKEN --principal-id viewer")
@@ -105,7 +108,7 @@ func handleImmediateMainCommand(stdout, stderr io.Writer, args []string) (bool, 
 		}
 		printVersion(stdout)
 		return true, 0
-	case "help", "config", "entitlements", "storage", "preflight",
+	case "daemon", "help", "config", "entitlements", "storage", "preflight",
 		"healthcheck", "diagnostic", "status", "report":
 		return false, 0
 	default:
@@ -113,6 +116,18 @@ func handleImmediateMainCommand(stdout, stderr io.Writer, args []string) (bool, 
 		printMainUsage(stderr)
 		return true, 2
 	}
+}
+
+func normalizeDaemonArgs(stderr io.Writer, args []string) ([]string, int) {
+	if len(args) == 0 || args[0] != "daemon" {
+		return args, 0
+	}
+	if len(args) < 2 || args[1] != "run" {
+		_, _ = fmt.Fprintln(stderr, "Usage: xg2g daemon run [--config path]")
+		printMainUsage(stderr)
+		return nil, 2
+	}
+	return args[2:], 0
 }
 
 func rejectDaemonPositionals(stderr io.Writer, args []string) int {
@@ -200,7 +215,8 @@ func exitCodeForErr(err error) int {
 }
 
 func main() {
-	if handled, code := handleImmediateMainCommand(os.Stdout, os.Stderr, os.Args[1:]); handled {
+	cliArgs := os.Args[1:]
+	if handled, code := handleImmediateMainCommand(os.Stdout, os.Stderr, cliArgs); handled {
 		os.Exit(code)
 	}
 
@@ -233,12 +249,20 @@ func main() {
 		}
 	}
 
+	var code int
+	cliArgs, code = normalizeDaemonArgs(os.Stderr, cliArgs)
+	if code != 0 {
+		os.Exit(code)
+	}
+
 	flag.Usage = func() {
 		printMainUsage(flag.CommandLine.Output())
 	}
 	showVersion := flag.Bool("version", false, "print version and exit")
 	configPath := flag.String("config", "", "path to config file (YAML)")
-	flag.Parse()
+	if err := flag.CommandLine.Parse(cliArgs); err != nil {
+		os.Exit(2)
+	}
 
 	if code := rejectDaemonPositionals(os.Stderr, flag.Args()); code != 0 {
 		os.Exit(code)

--- a/backend/cmd/daemon/main_test.go
+++ b/backend/cmd/daemon/main_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -89,7 +90,7 @@ func TestMainUsageListsExecutableCommands(t *testing.T) {
 	var out bytes.Buffer
 	printMainUsage(&out)
 
-	for _, command := range []string{"version", "status", "report"} {
+	for _, command := range []string{"daemon", "version", "status", "report"} {
 		if !strings.Contains(out.String(), "  "+command) {
 			t.Fatalf("main help does not list %q:\n%s", command, out.String())
 		}
@@ -132,6 +133,11 @@ func TestHandleImmediateMainCommand(t *testing.T) {
 			wantHandled: false,
 		},
 		{
+			name:        "daemon command continues to normalizer",
+			args:        []string{"daemon", "run"},
+			wantHandled: false,
+		},
+		{
 			name:        "daemon flags continue to flag parser",
 			args:        []string{"--config", "/etc/xg2g/config.yaml"},
 			wantHandled: false,
@@ -160,6 +166,76 @@ func TestHandleImmediateMainCommand(t *testing.T) {
 				t.Fatalf("stderr missing %q: %q", tt.wantStderr, stderr.String())
 			}
 		})
+	}
+}
+
+func TestNormalizeDaemonArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantArgs   []string
+		wantCode   int
+		wantStderr string
+	}{
+		{
+			name:     "container entrypoint",
+			args:     []string{"daemon", "run"},
+			wantArgs: nil,
+		},
+		{
+			name:     "explicit daemon flags",
+			args:     []string{"daemon", "run", "--config", "/etc/xg2g/config.yaml"},
+			wantArgs: []string{"--config", "/etc/xg2g/config.yaml"},
+		},
+		{
+			name:     "legacy no argument daemon",
+			args:     nil,
+			wantArgs: nil,
+		},
+		{
+			name:       "missing run action",
+			args:       []string{"daemon"},
+			wantCode:   2,
+			wantStderr: "Usage: xg2g daemon run",
+		},
+		{
+			name:       "unknown daemon action",
+			args:       []string{"daemon", "stop"},
+			wantCode:   2,
+			wantStderr: "Usage: xg2g daemon run",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			gotArgs, gotCode := normalizeDaemonArgs(&stderr, tt.args)
+			if gotCode != tt.wantCode {
+				t.Fatalf("normalizeDaemonArgs(%q) code = %d, want %d", tt.args, gotCode, tt.wantCode)
+			}
+			if strings.Join(gotArgs, "\x00") != strings.Join(tt.wantArgs, "\x00") {
+				t.Fatalf("normalizeDaemonArgs(%q) args = %q, want %q", tt.args, gotArgs, tt.wantArgs)
+			}
+			if tt.wantStderr != "" && !strings.Contains(stderr.String(), tt.wantStderr) {
+				t.Fatalf("stderr missing %q: %q", tt.wantStderr, stderr.String())
+			}
+		})
+	}
+}
+
+func TestReleaseContainerCommandUsesSupportedDaemonCommand(t *testing.T) {
+	dockerfile, err := os.ReadFile("../../../infra/docker/Dockerfile.release")
+	if err != nil {
+		t.Fatalf("read release Dockerfile: %v", err)
+	}
+	if !strings.Contains(string(dockerfile), `CMD ["daemon", "run"]`) {
+		t.Fatalf("release Dockerfile does not declare the governed daemon command")
+	}
+
+	var stderr bytes.Buffer
+	args, code := normalizeDaemonArgs(&stderr, []string{"daemon", "run"})
+	if code != 0 || len(args) != 0 || stderr.Len() != 0 {
+		t.Fatalf("release container command rejected: args=%q code=%d stderr=%q", args, code, stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Change contract

Fixed: accept the governed OCI command daemon run so the published container starts normally.
Improved: couple the release Dockerfile command to a CLI regression test.
New: no runtime feature; daemon run is an explicit alias for the existing no-argument daemon mode.
Removed: nothing.
Unchanged: unknown commands and invalid daemon actions still fail closed with exit code 2; API, configuration, storage, and streaming behavior are unchanged.
Risk: argument normalization could accidentally admit unsupported positionals.
Acceptance: targeted CLI tests, Linux amd64 smoke, make ci-pr, and make pre-push pass.
Exit condition: merge after green CI, then publish a new immutable patch release because v3.9.5 is already immutable.

## Evidence

- Reproduced on the official v3.9.5 OCI image: image CMD daemon run exited as an unknown command.
- Added direct release-Dockerfile-to-CLI coverage.
- make ci-pr: PASS, including 604 WebUI tests and full Go gate.
- make pre-push: PASS.
- Linux amd64 candidate: daemon run --version succeeds; daemon stop remains exit 2.

Production remains stopped while this correction is reviewed. Staging is unchanged and healthy.