### PR TITLE
fix(linux): make installed verification converge

### DIFF
--- a/backend/scripts/verify-installation-contract.sh
+++ b/backend/scripts/verify-installation-contract.sh
@@ -316,6 +316,8 @@ verify_install_tree() {
   assert_file "${srv_root}/scripts/verify-systemd-runtime-contract.sh"
   assert_mode "${srv_root}/scripts/verify-systemd-runtime-contract.sh" "755" "systemd runtime verifier mode"
   assert_executable "${srv_root}/scripts/verify-systemd-runtime-contract.sh" "systemd runtime verifier executable"
+  "${srv_root}/scripts/verify-systemd-runtime-contract.sh" >/dev/null ||
+    fail "installed systemd runtime verifier must execute from the canonical install bundle"
 
   assert_file "${srv_root}/scripts/verify-installation-contract.sh"
   assert_mode "${srv_root}/scripts/verify-installation-contract.sh" "755" "installation verifier mode"

--- a/backend/scripts/verify-linux-setup-wizard.sh
+++ b/backend/scripts/verify-linux-setup-wizard.sh
@@ -29,6 +29,8 @@ assert_contains() {
 bash -n "${SETUP}"
 help_output="$("${SETUP}" --help)"
 grep -Fq -- "never partitions, formats, mounts, or deletes" <<< "${help_output}"
+assert_contains "${SETUP}" 'readiness_deadline=$((SECONDS + 300))'
+assert_contains "${SETUP}" 'readiness did not converge within 5 minutes'
 
 shared_root="$(mktemp -d)"
 TEMP_DIRS+=("${shared_root}")

--- a/backend/scripts/verify-runtime-contract.sh
+++ b/backend/scripts/verify-runtime-contract.sh
@@ -10,7 +10,7 @@ fake_bin="${tmp_dir}/bin"
 mkdir -p "${repo_root}/backend" "$fake_bin"
 printf 'v3.8.1\n' > "${repo_root}/backend/VERSION"
 printf '{"releases":{"v3.8.1":{"digest":"pending"}}}\n' > "${repo_root}/DIGESTS.lock"
-printf '{"active_version":"v3.8.1"}\n' > "${tmp_dir}/runtime_state.json"
+printf '{"active_version":"v3.1.7"}\n' > "${tmp_dir}/runtime_state.json"
 
 cat > "${fake_bin}/docker" <<'EOF'
 #!/usr/bin/env bash
@@ -30,14 +30,14 @@ case "${1:-} ${2:-}" in
   "image inspect")
     template="${4:-}"
     case "$template" in
-      *org.opencontainers.image.version*) printf '%s\n' "${FAKE_DOCKER_VERSION:-v3.8.1}" ;;
+      *org.opencontainers.image.version*) printf '%s\n' "${FAKE_DOCKER_VERSION:-3.8.1}" ;;
       *RepoDigests*) ;;
       *) exit 2 ;;
     esac
     ;;
   "exec xg2g")
     if [[ "${4:-}" == "--version" ]]; then
-      printf '%s (commit: test, built: test)\n' "${FAKE_DOCKER_VERSION:-v3.8.1}"
+      printf '%s (commit: test, built: test)\n' "${FAKE_DOCKER_VERSION:-3.8.1}"
       exit 0
     fi
     if [[ "${4:-}" == "healthcheck" ]]; then
@@ -74,10 +74,10 @@ if FAKE_DOCKER_HEALTHCHECK_FAIL=1 run_verifier >"${tmp_dir}/health-error" 2>&1; 
 fi
 grep -Fq "live API healthcheck failed" "${tmp_dir}/health-error"
 
-if FAKE_DOCKER_VERSION=v3.7.2 run_verifier >"${tmp_dir}/version-error" 2>&1; then
+if FAKE_DOCKER_VERSION=3.7.2 run_verifier >"${tmp_dir}/version-error" 2>&1; then
   echo "ERROR: runtime verifier accepted a stale image version" >&2
   exit 1
 fi
-grep -Fq "expected 'v3.8.1'" "${tmp_dir}/version-error"
+grep -Fq "expected '3.8.1'" "${tmp_dir}/version-error"
 
 echo "OK: runtime verifier fails closed on user, health, and version drift."

--- a/backend/scripts/verify-runtime.sh
+++ b/backend/scripts/verify-runtime.sh
@@ -4,7 +4,17 @@
 
 set -euo pipefail
 
-REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${REPO_ROOT:-}" ]]; then
+    if REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null)"; then
+        :
+    elif [[ -f "${SCRIPT_DIR}/../VERSION" && -f "${SCRIPT_DIR}/../DIGESTS.lock" ]]; then
+        REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+    else
+        echo "❌ FAIL: unable to locate repository or installed runtime truth" >&2
+        exit 1
+    fi
+fi
 VERSION_FILE="${REPO_ROOT}/backend/VERSION"
 LOCK_FILE="${REPO_ROOT}/DIGESTS.lock"
 RUNTIME_SNAPSHOT="${XG2G_RUNTIME_SNAPSHOT:-/var/lib/xg2g/runtime_state.json}"
@@ -18,11 +28,12 @@ fail() {
 }
 
 command -v docker >/dev/null 2>&1 || fail "docker is required"
-command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 [[ -f "$VERSION_FILE" ]] || fail "version file is missing: $VERSION_FILE"
 [[ -f "$LOCK_FILE" ]] || fail "digest lock is missing: $LOCK_FILE"
 
-TARGET_VERSION="$(tr -d '[:space:]' < "$VERSION_FILE")"
+TARGET_RELEASE_TAG="$(tr -d '[:space:]' < "$VERSION_FILE")"
+TARGET_VERSION="${TARGET_RELEASE_TAG#v}"
 [[ -n "$TARGET_VERSION" ]] || fail "canonical version is empty"
 echo "🔍 Verifying Runtime Truth against ${TARGET_VERSION}..."
 
@@ -56,8 +67,18 @@ docker exec "$CONTAINER_NAME" xg2g healthcheck \
     --timeout=5s >/dev/null || fail "live API healthcheck failed"
 echo "✅ Live API healthcheck passed"
 
-EXPECTED_DIGEST="$(jq -r --arg version "$TARGET_VERSION" '.releases[$version].digest // empty' "$LOCK_FILE")"
-[[ -n "$EXPECTED_DIGEST" ]] || fail "DIGESTS.lock has no entry for ${TARGET_VERSION}"
+EXPECTED_DIGEST="$(
+    python3 - "$LOCK_FILE" "$TARGET_RELEASE_TAG" <<'PY'
+import json
+import sys
+
+path, version = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(payload.get("releases", {}).get(version, {}).get("digest", ""))
+PY
+)"
+[[ -n "$EXPECTED_DIGEST" ]] || fail "DIGESTS.lock has no entry for ${TARGET_RELEASE_TAG}"
 
 LIVE_DIGEST="$(
     docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "$image_id" 2>/dev/null |
@@ -100,10 +121,21 @@ CURRENT_FINGERPRINT="$(calculate_config_hash)"
 echo "✅ Configuration fingerprint: ${CURRENT_FINGERPRINT}"
 
 if [[ -f "$RUNTIME_SNAPSHOT" ]]; then
-    SNAPSHOT_VERSION="$(jq -r '.active_version // empty' "$RUNTIME_SNAPSHOT")"
-    [[ "$SNAPSHOT_VERSION" == "$TARGET_VERSION" ]] || \
-        fail "node truth '${SNAPSHOT_VERSION:-missing}' differs from repo truth '${TARGET_VERSION}'"
-    echo "✅ Node truth version: ${SNAPSHOT_VERSION}"
+    SNAPSHOT_VERSION="$(
+        python3 - "$RUNTIME_SNAPSHOT" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(payload.get("active_version", ""))
+PY
+    )" || SNAPSHOT_VERSION=""
+    if [[ -n "$SNAPSHOT_VERSION" && "${SNAPSHOT_VERSION#v}" == "$TARGET_VERSION" ]]; then
+        echo "✅ Recovery metadata version: ${SNAPSHOT_VERSION}"
+    else
+        echo "⚠️  Stale recovery metadata ignored; live container identity remains authoritative."
+    fi
 fi
 
 echo "✨ Runtime Identity Verified."

--- a/backend/scripts/verify-systemd-runtime-contract.sh
+++ b/backend/scripts/verify-systemd-runtime-contract.sh
@@ -2,13 +2,27 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+INSTALLED_MODE=false
+if git -C "${SCRIPT_DIR}" rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+elif [[ -f "${SCRIPT_DIR}/../docs/ops/xg2g.service" ]]; then
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  INSTALLED_MODE=true
+else
+  echo "ERROR: unable to locate repository or installed systemd contract bundle" >&2
+  exit 1
+fi
 
 UNIT_TEMPLATE="${REPO_ROOT}/backend/templates/docs/ops/xg2g.service.tmpl"
 CANONICAL_DEPLOY_UNIT="${REPO_ROOT}/infra/systemd/xg2g.service"
 RUNBOOK="${REPO_ROOT}/docs/ops/RUNBOOK_SYSTEMD_COMPOSE.md"
 COMPOSE_HELPER="${REPO_ROOT}/backend/scripts/compose-xg2g.sh"
 COMPOSE_CONTRACT="${REPO_ROOT}/backend/scripts/verify-compose-contract.sh"
+if [[ "${INSTALLED_MODE}" == "true" ]]; then
+  CANONICAL_DEPLOY_UNIT="${REPO_ROOT}/docs/ops/xg2g.service"
+  COMPOSE_HELPER="${REPO_ROOT}/scripts/compose-xg2g.sh"
+  COMPOSE_CONTRACT="${REPO_ROOT}/scripts/verify-compose-contract.sh"
+fi
 
 CANONICAL_ROOT="/srv/xg2g"
 CANONICAL_ENV_FILE="/etc/xg2g/xg2g.env"
@@ -166,13 +180,23 @@ main() {
       ;;
   esac
 
-  verify_unit_render_sync
+  if [[ "${INSTALLED_MODE}" == "false" ]]; then
+    verify_unit_render_sync
+  fi
   verify_unit_semantics "${CANONICAL_DEPLOY_UNIT}"
   verify_helper_semantics
-  verify_runbook_semantics
-  verify_negative_drift_guard
+  if [[ "${INSTALLED_MODE}" == "false" ]]; then
+    verify_runbook_semantics
+  fi
+  if [[ "${INSTALLED_MODE}" == "false" ]]; then
+    verify_negative_drift_guard
+  fi
 
-  echo "OK: systemd runtime contract holds."
+  if [[ "${INSTALLED_MODE}" == "true" ]]; then
+    echo "OK: installed systemd runtime contract holds."
+  else
+    echo "OK: systemd runtime contract holds."
+  fi
 }
 
 main "$@"

--- a/infra/systemd/setup-linux.sh
+++ b/infra/systemd/setup-linux.sh
@@ -846,7 +846,8 @@ run_sync() {
 }
 
 start_service() {
-  local helper attempt ca_cert headers_file connectivity_file
+  local helper attempt ca_cert headers_file connectivity_file readiness_deadline
+  local local_readiness=0
   local curl_tls=()
   [[ "${NO_START}" -eq 0 ]] || {
     info "installation prepared but not started (--no-start)"
@@ -870,8 +871,16 @@ start_service() {
     systemctl enable --now xg2g-caddy.service
   fi
   "${helper}" --storage-layout
-  curl -fsS --max-time 10 http://127.0.0.1:8088/readyz >/dev/null ||
-    fail "xg2g started but readiness failed; run: journalctl -u xg2g -n 100 --no-pager"
+  readiness_deadline=$((SECONDS + 300))
+  while [[ "${SECONDS}" -lt "${readiness_deadline}" ]]; do
+    if curl -fsS --max-time 10 http://127.0.0.1:8088/readyz >/dev/null 2>&1; then
+      local_readiness=1
+      break
+    fi
+    sleep 2
+  done
+  [[ "${local_readiness}" -eq 1 ]] ||
+    fail "xg2g started but readiness did not converge within 5 minutes; run: journalctl -u xg2g -n 100 --no-pager"
   if [[ -n "${HTTPS_ORIGIN}" ]]; then
     ca_cert="/var/lib/xg2g-caddy/data/caddy/pki/authorities/local/root.crt"
     attempt=0


### PR DESCRIPTION
## Summary
- wait up to five minutes for first-refresh readiness during Linux setup
- make installed runtime and systemd verifiers resolve the canonical bundle without Git or jq
- normalize release-tag versus OCI label versions and treat legacy recovery metadata as non-authoritative
- execute the installed systemd verifier in the installation contract

## Validation
- make ci-pr
- make pre-push
- candidate verifiers exercised against production LXC 110 without modifying the installed bundle