### PR TITLE
chore(deps): cap typescript below 6.1 until typescript-eslint catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,13 @@ updates:
       npm-deps:
         patterns:
           - "*"
+    ignore:
+      # typescript-eslint (latest: 8.65.0) declares peer typescript ">=4.8.4 <6.1.0".
+      # Anything at or above 6.1 makes `npm ci` fail with ERESOLVE, so the whole
+      # grouped PR becomes uninstallable. Lift this cap once typescript-eslint
+      # ships a release that accepts the newer major.
+      - dependency-name: "typescript"
+        versions: [">=6.1.0"]
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
PR #775 (grouped npm bump) zieht `typescript` von 5.9.3 auf **7.0.2**. `typescript-eslint` deklariert in seiner aktuellsten Version 8.65.0 immer noch `peer typescript ">=4.8.4 <6.1.0"` — es gibt schlicht keine Version mit TS-7-Support.

Folge: `npm ci` bricht mit `ERESOLVE` ab, und daran sterben in #775 gleich fünf Checks (webui-lint, PR Gate, Required Gates, check-migrations, Trivy Image Scan). Ein Rebase heilt das nicht — der Konflikt ist Upstream.

Deshalb ein `ignore`-Eintrag bei `>=6.1.0` statt eines pauschalen Major-Ignores: TypeScript 6.0.x darf weiter durchlaufen, weil typescript-eslint das abdeckt. Der Eintrag kommt raus, sobald typescript-eslint den neueren Major akzeptiert.

Danach kann Dependabot die Gruppe ohne den TS-Sprung neu vorschlagen; #775 wird geschlossen.