### PR TITLE
fix(webui): limit bearer tokens to browser sessions

### DIFF
--- a/apps/webui/README.md
+++ b/apps/webui/README.md
@@ -74,10 +74,11 @@ Useful overrides:
 
 ## Security Note
 
-Auth tokens are persisted in `localStorage` under `XG2G_API_TOKEN` so the
-session survives browser restarts. Tokens previously written to
-`sessionStorage` by older builds are migrated to `localStorage` on first read
-and then cleared from `sessionStorage`. A boot-token can be injected via the
-URL hash (`#xg2g_boot_token=...`); it is consumed once, persisted, and the
-hash is stripped via `history.replaceState`. Clearing auth state removes the
-stored token and auth headers.
+Auth tokens are stored in `sessionStorage` under `XG2G_API_TOKEN`, limiting a
+bearer token to the current browser tab instead of keeping it across browser
+restarts. Tokens written to `localStorage` by older builds are migrated once to
+`sessionStorage` and then removed from persistent storage. A boot-token can be
+injected via the URL hash (`#xg2g_boot_token=...`); it is consumed once, stored
+for the current tab, and the hash is stripped via `history.replaceState`.
+Clearing auth state removes the token from both storage locations and clears
+auth headers.

--- a/apps/webui/src/utils/tokenStorage.test.ts
+++ b/apps/webui/src/utils/tokenStorage.test.ts
@@ -9,20 +9,29 @@ describe('tokenStorage', () => {
     window.sessionStorage.clear();
   });
 
-  it('persists the API token in localStorage', () => {
+  it('persists the API token only for the browser session', () => {
     setStoredToken('test01');
 
-    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBe('test01');
-    expect(window.sessionStorage.getItem('XG2G_API_TOKEN')).toBeNull();
+    expect(window.sessionStorage.getItem('XG2G_API_TOKEN')).toBe('test01');
+    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBeNull();
     expect(getStoredToken()).toBe('test01');
   });
 
-  it('migrates legacy sessionStorage tokens to localStorage', () => {
-    window.sessionStorage.setItem('XG2G_API_TOKEN', 'legacy-token');
+  it('migrates legacy localStorage tokens to sessionStorage', () => {
+    window.localStorage.setItem('XG2G_API_TOKEN', 'legacy-token');
 
     expect(getStoredToken()).toBe('legacy-token');
-    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBe('legacy-token');
-    expect(window.sessionStorage.getItem('XG2G_API_TOKEN')).toBeNull();
+    expect(window.sessionStorage.getItem('XG2G_API_TOKEN')).toBe('legacy-token');
+    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBeNull();
+  });
+
+  it('prefers the session token and removes a stale persistent copy', () => {
+    window.sessionStorage.setItem('XG2G_API_TOKEN', 'current-token');
+    window.localStorage.setItem('XG2G_API_TOKEN', 'stale-token');
+
+    expect(getStoredToken()).toBe('current-token');
+    expect(window.sessionStorage.getItem('XG2G_API_TOKEN')).toBe('current-token');
+    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBeNull();
   });
 
   it('consumes bootstrap tokens from the URL hash and clears the hash afterwards', () => {
@@ -30,7 +39,8 @@ describe('tokenStorage', () => {
 
     expect(getStoredToken()).toBe('hash-token');
     expect(window.location.hash).toBe('');
-    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBe('hash-token');
+    expect(window.sessionStorage.getItem('XG2G_API_TOKEN')).toBe('hash-token');
+    expect(window.localStorage.getItem('XG2G_API_TOKEN')).toBeNull();
   });
 
   it('clears the token from both storages', () => {

--- a/apps/webui/src/utils/tokenStorage.ts
+++ b/apps/webui/src/utils/tokenStorage.ts
@@ -82,11 +82,14 @@ function persistTokenBestEffort(token: string): void {
   const local = getStorage('local');
 
   if (token) {
-    safeSet(local, TOKEN_KEY, token);
+    safeSet(session, TOKEN_KEY, token);
   } else {
-    safeRemove(local, TOKEN_KEY);
+    safeRemove(session, TOKEN_KEY);
   }
-  safeRemove(session, TOKEN_KEY);
+  // Never leave a bearer token in persistent browser storage. Besides clearing
+  // stale values from this build, this completes the one-time migration from
+  // releases that intentionally kept the token across browser restarts.
+  safeRemove(local, TOKEN_KEY);
 }
 
 export function getStoredToken(): string {
@@ -100,17 +103,19 @@ export function getStoredToken(): string {
   const session = getStorage('session');
   const local = getStorage('local');
 
-  const localToken = safeGet(local, TOKEN_KEY);
-  if (localToken) {
-    volatileToken = localToken;
-    return localToken;
+  const sessionToken = safeGet(session, TOKEN_KEY);
+  if (sessionToken) {
+    volatileToken = sessionToken;
+    // Also clean up a stale persistent copy when both stores contain a token.
+    safeRemove(local, TOKEN_KEY);
+    return sessionToken;
   }
 
-  const legacySessionToken = safeGet(session, TOKEN_KEY);
-  if (legacySessionToken) {
-    volatileToken = legacySessionToken;
-    persistTokenBestEffort(legacySessionToken);
-    return legacySessionToken;
+  const legacyLocalToken = safeGet(local, TOKEN_KEY);
+  if (legacyLocalToken) {
+    volatileToken = legacyLocalToken;
+    persistTokenBestEffort(legacyLocalToken);
+    return legacyLocalToken;
   }
 
   return volatileToken;


### PR DESCRIPTION
## What changed

- Keep bearer tokens scoped to the current browser session instead of durable local storage.
- Preserve existing token migration and logout behavior.

## Why

A browser bearer token should not survive a full browser restart. Session-scoped storage narrows exposure while keeping the active signed-in experience unchanged.

## Validation

- `npm --prefix apps/webui run type-check`
- `npm --prefix apps/webui test -- src/utils/tokenStorage.test.ts` (5 tests passed)