### PR TITLE
fix(player): survive a moving mobile link without repeated transcodes

### DIFF
--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -265,3 +265,47 @@ production.
   anywhere in this repo's git — orphaned artifacts on that host's stale
   checkout, not a repo issue. Needs a decision on the live host, not a
   commit; not actioned here.
+
+---
+
+## P6 — Mobile playback on a moving link (found 2026-08-01)
+
+Context: a train journey produced repeated re-transcodes and then a frozen
+player. The client-side causes were fixed in the same pass (hysteresis and a
+starvation hold on profile selection, a bounded session re-establishment ladder,
+a reachability watchdog, link-aware hls.js tuning, and a bounded wait for the
+dedup lease). The item below is the structural cause and was deliberately not
+attempted alongside them.
+
+### P6.1 Live output carries a single rendition — no ABR ladder
+**Status:** Tracked, not actioned (2026-08-01).
+
+**Finding**
+- `backend/internal/infra/media/ffmpeg/plan_output.go` builds `-var_stream_map`
+  only for multi-**audio** (`sel.IsMultiAudio`). There is no video bitrate
+  ladder, so the master playlist offers exactly one video rendition.
+- Consequence: a client cannot absorb a bandwidth change by switching down.
+  The only available response is to restart the session with a different
+  request profile, and every such restart is a new encoder process.
+- This is why bandwidth jitter on cellular reads as "it re-transcoded several
+  times". The client-side mitigations bound how often that happens; they do not
+  remove the need for it.
+
+**Target**
+- Live HLS output offers at least two video renditions so hls.js can switch
+  down within the same session, leaving profile changes for genuine device or
+  policy changes rather than for bandwidth.
+
+**Why it was not done in the same pass**
+- It is a pipeline change, not a client one: multi-rendition encode multiplies
+  GPU load per session, and it touches the encoder plan, the master playlist,
+  segment layout, the session model and the tuner/capacity accounting. It needs
+  its own branch, its own benchmarks on the actual hardware, and a decision on
+  the capacity trade — none of which belong in a player fix.
+
+**Exit-Criteria**
+- A live master playlist contains more than one `#EXT-X-STREAM-INF`.
+- A client whose downlink drops mid-session switches rendition without a new
+  `/intents` start (assert on session count, not on picture quality).
+- Measured GPU cost per session against the current single-rendition baseline,
+  with the capacity/tuner accounting updated to match.

--- a/apps/webui/src/features/player/orchestrator/playbackMachine.test.ts
+++ b/apps/webui/src/features/player/orchestrator/playbackMachine.test.ts
@@ -156,6 +156,7 @@ describe('playbackMachine', () => {
       epoch: 2,
       delayMs: 250,
       profile: 'repair',
+      holdBandwidth: false,
       failureCode: 'DECODE_EXHAUSTED',
       failureClass: 'media',
     }]);

--- a/apps/webui/src/features/player/orchestrator/playbackMachine.ts
+++ b/apps/webui/src/features/player/orchestrator/playbackMachine.ts
@@ -10,7 +10,7 @@ import type {
   MediaPhase,
 } from './playbackTypes';
 import { classifyPlaybackFailure } from '../semantics/playbackFailureSemantics';
-import { decideRecoveryEscalation } from './recoveryLadder';
+import { createRecoveryLadderState, decideRecoveryEscalation } from './recoveryLadder';
 
 function statusToMediaPhase(status: PlayerStatus): MediaPhase {
   switch (status) {
@@ -97,9 +97,7 @@ export function createInitialPlaybackDomainState(requestedDuration: number | nul
     lastAdvisory: null,
     explicitProfilePinned: false,
     hasSessionIntent: false,
-    recovery: {
-      autoFallbackUsed: false,
-    },
+    recovery: createRecoveryLadderState(),
   };
 }
 
@@ -144,9 +142,13 @@ export function playbackMachine(state: PlaybackDomainState, event: PlaybackMachi
         lastAdvisory: null,
         explicitProfilePinned: event.explicitProfilePinned ?? false,
         hasSessionIntent: event.hasSessionIntent ?? false,
-        recovery: {
-          autoFallbackUsed: false,
-        },
+        // An attempt that continues an automatic recovery inherits the budget;
+        // any other new attempt (user retry, channel change, remount) starts
+        // with a fresh one. See RecoveryLadderState.restartPending for why the
+        // marker is explicit rather than read off the status.
+        recovery: state.recovery.restartPending
+          ? { ...state.recovery, restartPending: false }
+          : createRecoveryLadderState(),
       };
 
     case 'normative.playback.stopped':
@@ -169,9 +171,7 @@ export function playbackMachine(state: PlaybackDomainState, event: PlaybackMachi
         contract: null,
         explicitProfilePinned: false,
         hasSessionIntent: false,
-        recovery: {
-          autoFallbackUsed: false,
-        },
+        recovery: createRecoveryLadderState(),
       };
 
     case 'normative.playback.mode.changed':
@@ -371,28 +371,61 @@ export function runPlaybackMachine(
       failure: event.failure,
       explicitProfilePinned: event.explicitProfilePinned ?? state.explicitProfilePinned,
       hasActiveIntent: state.hasSessionIntent,
+      // Read from the pre-event state: this is about what the session was doing
+      // when it died, not what the failure has just turned it into.
+      hasEstablishedSession: state.sessionPhase === 'ready',
       state: state.recovery,
     });
+
+    // Re-establishing a reaped lease waits longer than a profile fallback: the
+    // server has just torn the session down, and the dedup lease on the service
+    // ref is released as part of that teardown. Starting into it earns a 409.
+    const SESSION_RESTART_DELAY_MS = 1500;
+    const PROFILE_FALLBACK_DELAY_MS = 250;
+
+    const restart = (
+      profile: string | null,
+      delayMs: number,
+      recovery: typeof state.recovery,
+      holdBandwidth = false,
+    ): PlaybackMachineResult => ({
+      state: {
+        ...nextState,
+        status: 'recovering',
+        mediaPhase: 'recovering',
+        failure: null,
+        recovery: { ...recovery, restartPending: true },
+      },
+      commands: [{
+        type: 'command.playback.schedule_auto_fallback',
+        epoch: event.epoch,
+        delayMs,
+        profile,
+        holdBandwidth,
+        failureCode: event.failure.code,
+        failureClass: event.failure.class,
+      }],
+    });
+
+    if (escalation === 'restart_session') {
+      return restart(null, SESSION_RESTART_DELAY_MS, {
+        ...state.recovery,
+        sessionRestarts: state.recovery.sessionRestarts + 1,
+      });
+    }
+
+    if (escalation === 'restart_on_safe_bandwidth') {
+      return restart(null, PROFILE_FALLBACK_DELAY_MS, {
+        ...state.recovery,
+        autoFallbackUsed: true,
+      }, true);
+    }
+
     if (escalation === 'restart_with_fallback_profile') {
-      return {
-        state: {
-          ...nextState,
-          status: 'recovering',
-          mediaPhase: 'recovering',
-          failure: null,
-          recovery: {
-            autoFallbackUsed: true,
-          },
-        },
-        commands: [{
-          type: 'command.playback.schedule_auto_fallback',
-          epoch: event.epoch,
-          delayMs: 250,
-          profile: 'repair',
-          failureCode: event.failure.code,
-          failureClass: event.failure.class,
-        }],
-      };
+      return restart('repair', PROFILE_FALLBACK_DELAY_MS, {
+        ...state.recovery,
+        autoFallbackUsed: true,
+      });
     }
   }
 

--- a/apps/webui/src/features/player/orchestrator/playbackTypes.ts
+++ b/apps/webui/src/features/player/orchestrator/playbackTypes.ts
@@ -253,13 +253,24 @@ export type PlaybackCommand =
     }
   | {
       /**
-       * Schedule an automatic profile fallback retry after a transient media failure.
-       * Executed once per viewing intent via the recovery ladder.
+       * Schedule an automatic recovery restart after a transient failure.
+       * Which restarts are offered, and how often, is the recovery ladder's call.
        */
       type: 'command.playback.schedule_auto_fallback';
       epoch: number;
       delayMs: number;
-      profile: string;
+      /**
+       * Request intent forced onto the retry. `null` keeps whatever the user or
+       * the automatic resolver already selected — used when the encode was fine
+       * and only the session needs re-establishing.
+       */
+      profile: string | null;
+      /**
+       * Pin automatic profile resolution to the safe bandwidth rung for this
+       * retry and a cooldown after it. Set when playback died of link
+       * starvation, where re-measuring would just reproduce the failure.
+       */
+      holdBandwidth?: boolean;
       failureCode: string;
       failureClass: string;
     };

--- a/apps/webui/src/features/player/orchestrator/recoveryLadder.test.ts
+++ b/apps/webui/src/features/player/orchestrator/recoveryLadder.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { createRecoveryLadderState, decideRecoveryEscalation } from './recoveryLadder';
+import {
+  MAX_SESSION_RESTARTS,
+  createRecoveryLadderState,
+  decideRecoveryEscalation,
+} from './recoveryLadder';
 import type { RecoveryEscalationInput } from './recoveryLadder';
 
 function buildInput(overrides: {
   failure?: Partial<RecoveryEscalationInput['failure']>;
   explicitProfilePinned?: boolean;
-  state?: RecoveryEscalationInput['state'];
+  hasActiveIntent?: boolean;
+  hasEstablishedSession?: boolean;
+  state?: Partial<RecoveryEscalationInput['state']>;
 } = {}): RecoveryEscalationInput {
   return {
     failure: {
@@ -17,7 +23,9 @@ function buildInput(overrides: {
       ...overrides.failure,
     },
     explicitProfilePinned: overrides.explicitProfilePinned ?? false,
-    state: overrides.state ?? createRecoveryLadderState(),
+    hasActiveIntent: overrides.hasActiveIntent,
+    hasEstablishedSession: overrides.hasEstablishedSession ?? true,
+    state: { ...createRecoveryLadderState(), ...overrides.state },
   };
 }
 
@@ -32,12 +40,9 @@ describe('decideRecoveryEscalation', () => {
     }))).toBe('give_up');
   });
 
-  it('never escalates auth or session failures', () => {
+  it('never escalates auth failures', () => {
     expect(decideRecoveryEscalation(buildInput({
       failure: { class: 'auth' },
-    }))).toBe('give_up');
-    expect(decideRecoveryEscalation(buildInput({
-      failure: { class: 'session' },
     }))).toBe('give_up');
   });
 
@@ -66,5 +71,80 @@ describe('decideRecoveryEscalation', () => {
     expect(decideRecoveryEscalation(buildInput({
       failure: { retryable: false, recoverable: false },
     }))).toBe('give_up');
+  });
+
+  // A dead spot long enough to lapse the lease used to end the viewing session:
+  // the reap surfaced as a session-class failure and the ladder gave up, so the
+  // player sat on an error until the user pressed Retry.
+  describe('a reaped lease', () => {
+    const reaped = {
+      class: 'session' as const,
+      source: 'native-host' as const,
+      code: 'SESSION_EXPIRED',
+      terminal: false,
+      retryable: true,
+      recoverable: true,
+    };
+
+    it('is re-established rather than surfaced', () => {
+      expect(decideRecoveryEscalation(buildInput({ failure: reaped }))).toBe('restart_session');
+    });
+
+    it('does not consume the profile-fallback budget', () => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: reaped,
+        state: { autoFallbackUsed: true },
+      }))).toBe('restart_session');
+    });
+
+    it('is bounded, so a server that keeps reaping cannot spin the client', () => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: reaped,
+        state: { sessionRestarts: MAX_SESSION_RESTARTS },
+      }))).toBe('give_up');
+    });
+
+    it('is not re-established without an active intent', () => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: reaped,
+        hasActiveIntent: false,
+      }))).toBe('give_up');
+    });
+
+    it('is not re-established when the session is genuinely gone', () => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: { ...reaped, recoverable: false },
+      }))).toBe('give_up');
+    });
+
+    // A 410 during startup readiness carries the same class and the same
+    // fallback code, but it means the recording was deleted or the packager
+    // failed — retrying spins on a fault that will not clear.
+    it('is not confused with a startup 410, which never reached a live session', () => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: reaped,
+        hasEstablishedSession: false,
+      }))).toBe('give_up');
+    });
+  });
+
+  // Answering a starved link with 'repair' — High + Transcode — asks it for
+  // more bitrate than the stream it just failed to carry.
+  describe('link starvation', () => {
+    it.each([
+      'HLS_NETWORK_RETRIES_EXHAUSTED',
+      'HLSJS_STALL_RECOVERY_FAILED',
+      'NATIVE_STALL_RECOVERY_FAILED',
+    ])('restarts on the safe rung instead of the repair transcode (%s)', (code) => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: { code },
+      }))).toBe('restart_on_safe_bandwidth');
+    });
+
+    it('still uses the repair transcode for decode failures', () => {
+      expect(decideRecoveryEscalation(buildInput({
+        failure: { code: 'MEDIA_DECODE_ERROR' },
+      }))).toBe('restart_with_fallback_profile');
+    });
   });
 });

--- a/apps/webui/src/features/player/orchestrator/recoveryLadder.ts
+++ b/apps/webui/src/features/player/orchestrator/recoveryLadder.ts
@@ -1,9 +1,21 @@
 // Recovery ladder: the orchestrator-level escalation ABOVE the engine's own
 // in-place recoveries (hls.js startLoad/recoverMediaError, native stall
 // recovery, session decode recovery). Those run first; when they exhaust, a
-// failure surfaces here and the ladder decides the last automatic step —
-// one restart with the lightweight 'repair' request profile — before giving
-// the error to the user. Pure decision logic; the orchestrator owns timing.
+// failure surfaces here and the ladder decides the last automatic steps before
+// giving the error to the user. Pure decision logic; the orchestrator owns
+// timing.
+//
+// The ladder distinguishes WHY playback died, because the cheapest correct
+// answer differs per cause and the output carries a single rendition — every
+// restart is a fresh encoder session, so picking the wrong one costs a
+// transcode and usually fails again:
+//
+//   * decode failures  -> restart on the 'repair' intent (High + Transcode)
+//   * network failures -> restart pinned to the safe bandwidth rung; asking a
+//     starved link for MORE bitrate, which 'repair' does, is the one thing
+//     guaranteed not to work
+//   * a reaped lease   -> re-establish the session as-is; the encode was fine,
+//     the client just lost the network long enough for the lease to lapse
 
 import type { PlaybackFailure } from './playbackTypes';
 
@@ -12,24 +24,63 @@ export type RecoveryEscalation =
   | 'none'
   /** Restart the whole attempt once with the forced 'repair' request profile. */
   | 'restart_with_fallback_profile'
+  /** Restart with the automatic profile held down at the safe bandwidth rung. */
+  | 'restart_on_safe_bandwidth'
+  /** Re-establish a reaped session, keeping the profile that was already chosen. */
+  | 'restart_session'
   /** All automatic steps are spent — surface the error. */
   | 'give_up';
+
+/**
+ * A reaped lease is re-established at most this often per viewing intent. The
+ * budget exists so a server that keeps reaping (or a link that never really
+ * comes back) cannot spin the client through endless encoder starts.
+ */
+export const MAX_SESSION_RESTARTS = 2;
 
 export interface RecoveryLadderState {
   /** The one-shot profile fallback has been consumed for this viewing intent. */
   autoFallbackUsed: boolean;
+  /** How many times a reaped session has been re-established this intent. */
+  sessionRestarts: number;
+  /**
+   * A restart this ladder authorised is scheduled but has not begun yet. The
+   * attempt it starts must inherit this budget rather than reset it — a budget
+   * cleared by the very restart it granted bounds nothing, and a link that
+   * stays bad would loop through encoder starts forever. Explicit rather than
+   * inferred from status, because a failure handler pausing the video moves the
+   * status on its own.
+   */
+  restartPending: boolean;
 }
 
 export function createRecoveryLadderState(): RecoveryLadderState {
-  return { autoFallbackUsed: false };
+  return { autoFallbackUsed: false, sessionRestarts: 0, restartPending: false };
 }
 
+/**
+ * Failure codes that mean "the link could not carry this stream", as opposed to
+ * "this device could not decode it". They are answered with less bitrate, never
+ * with the 'repair' transcode.
+ */
+export const NETWORK_STARVATION_CODES: ReadonlySet<string> = new Set([
+  'HLS_NETWORK_RETRIES_EXHAUSTED',
+  'HLSJS_STALL_RECOVERY_FAILED',
+  'NATIVE_STALL_RECOVERY_FAILED',
+]);
+
 export interface RecoveryEscalationInput {
-  failure: Pick<PlaybackFailure, 'class' | 'source' | 'terminal' | 'retryable' | 'recoverable'>;
+  failure: Pick<PlaybackFailure, 'class' | 'source' | 'terminal' | 'retryable' | 'recoverable'> &
+    Partial<Pick<PlaybackFailure, 'code'>>;
   /** User pinned a profile in the UI — automatic profile changes would override intent. */
   explicitProfilePinned: boolean;
   /** Whether the orchestrator is running an active playback intent (channel or recording) vs static src. */
   hasActiveIntent?: boolean;
+  /**
+   * The session had reached READY before this failure. Distinguishes the two
+   * things a 410 can mean, which share a status and a code but not a remedy.
+   */
+  hasEstablishedSession?: boolean;
   state: RecoveryLadderState;
 }
 
@@ -37,11 +88,34 @@ export function decideRecoveryEscalation({
   failure,
   explicitProfilePinned,
   hasActiveIntent = true,
+  hasEstablishedSession = false,
   state,
 }: RecoveryEscalationInput): RecoveryEscalation {
-  // Terminal, auth and session-policy failures are not transcoder problems —
-  // restarting with a lighter profile cannot fix a 401 or an occupied lease.
-  if (failure.terminal || failure.class === 'auth' || failure.class === 'session') {
+  // Auth is never a transcoder or a network problem — restarting cannot fix a
+  // 401, and retrying one just burns the token faster.
+  if (failure.class === 'auth') {
+    return 'give_up';
+  }
+
+  // A reaped lease (heartbeat 410/404) is the normal outcome of a tunnel or a
+  // dead spot: the session is gone server-side but nothing is actually broken.
+  // Re-establishing it is the whole fix, and it must be decided BEFORE the
+  // terminal bail because the failure is reported as terminal-ish state.
+  //
+  // The gate is hasEstablishedSession, not the status or the code: a 410 during
+  // startup readiness carries the same 'session' class and the same
+  // SESSION_EXPIRED fallback code, but it means the session never came up — the
+  // recording was deleted, the packager failed — and retrying spins on a fault
+  // that will not clear. Only a lease that lapsed under a session which had
+  // actually reached READY is worth re-establishing.
+  if (failure.class === 'session') {
+    if (!hasEstablishedSession || !hasActiveIntent || failure.terminal || !failure.recoverable) {
+      return 'give_up';
+    }
+    return state.sessionRestarts >= MAX_SESSION_RESTARTS ? 'give_up' : 'restart_session';
+  }
+
+  if (failure.terminal) {
     return 'give_up';
   }
 
@@ -65,6 +139,10 @@ export function decideRecoveryEscalation({
 
   if (state.autoFallbackUsed) {
     return 'give_up';
+  }
+
+  if (failure.code && NETWORK_STARVATION_CODES.has(failure.code)) {
+    return 'restart_on_safe_bandwidth';
   }
 
   return 'restart_with_fallback_profile';

--- a/apps/webui/src/features/player/orchestrator/useNetworkRecoveryWatchdog.test.ts
+++ b/apps/webui/src/features/player/orchestrator/useNetworkRecoveryWatchdog.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { shouldWatchForNetworkRecovery } from './useNetworkRecoveryWatchdog';
+
+function failure(overrides: Partial<Parameters<typeof shouldWatchForNetworkRecovery>[0] & object> = {}) {
+  return {
+    class: 'media',
+    code: 'PLAYBACK_FAILURE',
+    terminal: false,
+    status: null as number | null,
+    ...overrides,
+  };
+}
+
+describe('shouldWatchForNetworkRecovery', () => {
+  it('watches when the request never reached the server', () => {
+    expect(shouldWatchForNetworkRecovery(failure({ status: null }))).toBe(true);
+  });
+
+  it('watches a stream that starved even though the server answered', () => {
+    expect(shouldWatchForNetworkRecovery(failure({
+      status: 404,
+      code: 'HLS_NETWORK_RETRIES_EXHAUSTED',
+    }))).toBe(true);
+  });
+
+  // If the server answered, connectivity is not the problem. Polling until it
+  // is reachable would retry a fault that is not going to clear — a deleted
+  // recording stays deleted, a failed packager stays failed.
+  it.each([410, 409, 500])('does not watch a failure the server answered with (%i)', (status) => {
+    expect(shouldWatchForNetworkRecovery(failure({ status, class: 'session' }))).toBe(false);
+  });
+
+  it('never watches auth or terminal failures', () => {
+    expect(shouldWatchForNetworkRecovery(failure({ class: 'auth' }))).toBe(false);
+    expect(shouldWatchForNetworkRecovery(failure({ terminal: true }))).toBe(false);
+  });
+
+  it('does nothing without a failure', () => {
+    expect(shouldWatchForNetworkRecovery(null)).toBe(false);
+  });
+});

--- a/apps/webui/src/features/player/orchestrator/useNetworkRecoveryWatchdog.ts
+++ b/apps/webui/src/features/player/orchestrator/useNetworkRecoveryWatchdog.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { debugLog, debugWarn } from '../../../utils/logging';
+import { timeoutSignal } from '../utils/requestTimeout';
+import { NETWORK_STARVATION_CODES } from './recoveryLadder';
+
+// The last net under the two connectivity edges the player already watches.
+//
+// foregroundResume covers hidden->visible, decideOnlineRecovery covers
+// offline->online. Neither fires in the case that actually strands a mobile
+// viewer: the app is in the foreground, the screen is on, and the link is dead
+// without the browser saying so. `navigator.onLine` reports interface state,
+// not reachability, and stays true through a tunnel — so when a start attempt
+// fails mid-outage the player lands in 'error' and nothing ever takes it out
+// again. The user sees a frozen picture and a Retry button.
+//
+// This watchdog closes that hole from the other side: while playback is parked
+// on a non-terminal error, poll a cheap endpoint until the server answers, then
+// hand one recovery attempt back to the orchestrator.
+
+const FIRST_PROBE_DELAY_MS = 5_000;
+const MAX_PROBE_DELAY_MS = 30_000;
+const PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Automatic recoveries granted per viewing intent. Bounded because the probe
+ * only proves the server is reachable, not that playback will now succeed — a
+ * failure with an unrelated cause would otherwise retry forever.
+ */
+export const MAX_AUTOMATIC_NETWORK_RECOVERIES = 3;
+
+/**
+ * Whether waiting for connectivity could plausibly fix this failure.
+ *
+ * The discriminator is whether the server answered at all. If it did — a 410
+ * for a deleted recording, a packager failure, any HTTP status — then
+ * connectivity is not the problem and polling until the server is reachable
+ * would just retry a fault that is not going to clear. Only a request that
+ * never arrived, or a stream that starved, is worth waiting out.
+ */
+export function shouldWatchForNetworkRecovery(failure: {
+  class: string;
+  code: string;
+  terminal: boolean;
+  status: number | null;
+} | null): boolean {
+  if (!failure || failure.terminal || failure.class === 'auth') {
+    return false;
+  }
+  return failure.status == null || NETWORK_STARVATION_CODES.has(failure.code);
+}
+
+export interface UseNetworkRecoveryWatchdogOptions {
+  apiBase: string;
+  /** Playback is parked on a failure that regained connectivity could fix. */
+  active: boolean;
+  /**
+   * Identifies the current viewing intent (channel or recording). Changing it
+   * returns the recovery budget — a new thing to watch is a fresh start.
+   */
+  intentKey: string;
+  /** Playback is healthy; the budget is returned. */
+  healthy: boolean;
+  onReachable: () => void;
+}
+
+export function useNetworkRecoveryWatchdog({
+  apiBase,
+  active,
+  intentKey,
+  healthy,
+  onReachable,
+}: UseNetworkRecoveryWatchdogOptions): void {
+  const recoveriesRef = useRef(0);
+  const onReachableRef = useRef(onReachable);
+  onReachableRef.current = onReachable;
+
+  const probe = useCallback(async (): Promise<boolean> => {
+    try {
+      const response = await fetch(`${apiBase}/system/healthz`, {
+        method: 'HEAD',
+        cache: 'no-store',
+        credentials: 'same-origin',
+        signal: timeoutSignal(PROBE_TIMEOUT_MS),
+      });
+      return response.ok || response.status === 204;
+    } catch {
+      return false;
+    }
+  }, [apiBase]);
+
+  useEffect(() => {
+    recoveriesRef.current = 0;
+  }, [intentKey]);
+
+  useEffect(() => {
+    if (healthy) {
+      recoveriesRef.current = 0;
+    }
+  }, [healthy]);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    if (recoveriesRef.current >= MAX_AUTOMATIC_NETWORK_RECOVERIES) {
+      debugWarn('[V3Player][Watchdog] Automatic network recoveries exhausted');
+      return;
+    }
+
+    let cancelled = false;
+    let timerId: number | null = null;
+    let attempt = 0;
+
+    const tick = async () => {
+      if (cancelled) {
+        return;
+      }
+      const reachable = await probe();
+      if (cancelled) {
+        return;
+      }
+      if (reachable) {
+        recoveriesRef.current += 1;
+        debugLog('[V3Player][Watchdog] Server reachable again, recovering', {
+          attempt: recoveriesRef.current,
+        });
+        onReachableRef.current();
+        return;
+      }
+      attempt += 1;
+      timerId = window.setTimeout(
+        () => {
+          timerId = null;
+          void tick();
+        },
+        Math.min(FIRST_PROBE_DELAY_MS * 2 ** attempt, MAX_PROBE_DELAY_MS),
+      );
+    };
+
+    // The first probe waits: a failure whose cause is not connectivity would
+    // otherwise be retried the instant it surfaces, and the delay is what keeps
+    // the bounded budget from being spent in one burst.
+    timerId = window.setTimeout(() => {
+      timerId = null;
+      void tick();
+    }, FIRST_PROBE_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+      }
+    };
+  }, [active, probe]);
+}

--- a/apps/webui/src/features/player/playbackEnginePolicy.test.ts
+++ b/apps/webui/src/features/player/playbackEnginePolicy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createHlsRuntimeConfig,
   hlsNetworkRetryBackoffMs,
+  hlsNetworkRetryPolicyForLink,
   HLS_NETWORK_RETRY_POLICY,
   HLS_STARTUP_POLICY,
 } from './playbackEnginePolicy';
@@ -30,6 +31,22 @@ describe('playbackEnginePolicy', () => {
 
     expect(first).not.toBe(second);
     expect(first).toEqual(second);
+  });
+
+  it('trades latency for resilience on a constrained link', () => {
+    expect(createHlsRuntimeConfig('constrained')).toMatchObject({
+      lowLatencyMode: false,
+      liveSyncDuration: 30,
+      maxBufferLength: 180,
+    });
+    expect(hlsNetworkRetryPolicyForLink('constrained')).toEqual({
+      maxRetries: 8,
+      initialBackoffMs: 1_000,
+      backoffCapMs: 15_000,
+    });
+    expect([0, 1, 2, 3, 4, 5].map((retryCount) => (
+      hlsNetworkRetryBackoffMs(retryCount, 'constrained')
+    ))).toEqual([1_000, 2_000, 4_000, 8_000, 15_000, 15_000]);
   });
 
   it('preserves live startup buffering policy', () => {

--- a/apps/webui/src/features/player/playbackEnginePolicy.ts
+++ b/apps/webui/src/features/player/playbackEnginePolicy.ts
@@ -1,6 +1,8 @@
 import type { HlsConfig } from 'hls.js';
+import { hlsTuningForLink, type PlaybackLinkProfile } from './utils/playbackLinkProfile';
 
-export function createHlsRuntimeConfig(): Partial<HlsConfig> {
+export function createHlsRuntimeConfig(link: PlaybackLinkProfile = 'stable'): Partial<HlsConfig> {
+  const tuning = hlsTuningForLink(link);
   return {
     debug: false,
     // Own the buffer via ManagedMediaSource on Safari 17.1+. Keeping this
@@ -10,11 +12,11 @@ export function createHlsRuntimeConfig(): Partial<HlsConfig> {
     enableWorker: true,
     // This engages only for playlists advertising EXT-X-PART. It is a no-op
     // for the stable non-low-latency path.
-    lowLatencyMode: true,
+    lowLatencyMode: tuning.lowLatencyMode,
     backBufferLength: 300,
-    maxBufferLength: 60,
+    maxBufferLength: tuning.maxBufferLength,
     capLevelToPlayerSize: true,
-    liveSyncDuration: 12,
+    liveSyncDuration: tuning.liveSyncDuration,
     // Rate-based live catch-up caused visible judder and compressed audio.
     // A multi-hour DVR window makes slow drift safer than playback-rate churn.
     maxLiveSyncPlaybackRate: 1,
@@ -40,9 +42,22 @@ export const HLS_NETWORK_RETRY_POLICY = Object.freeze({
   backoffCapMs: 30_000,
 });
 
-export function hlsNetworkRetryBackoffMs(retryCount: number): number {
+export function hlsNetworkRetryPolicyForLink(link: PlaybackLinkProfile = 'stable') {
+  const tuning = hlsTuningForLink(link);
+  return {
+    maxRetries: tuning.maxNetworkRetries,
+    initialBackoffMs: HLS_NETWORK_RETRY_POLICY.initialBackoffMs,
+    backoffCapMs: tuning.networkBackoffCapMs,
+  };
+}
+
+export function hlsNetworkRetryBackoffMs(
+  retryCount: number,
+  link: PlaybackLinkProfile = 'stable',
+): number {
+  const policy = hlsNetworkRetryPolicyForLink(link);
   return Math.min(
-    HLS_NETWORK_RETRY_POLICY.initialBackoffMs * Math.pow(2, retryCount),
-    HLS_NETWORK_RETRY_POLICY.backoffCapMs,
+    policy.initialBackoffMs * Math.pow(2, retryCount),
+    policy.backoffCapMs,
   );
 }

--- a/apps/webui/src/features/player/useLiveSessionController.ts
+++ b/apps/webui/src/features/player/useLiveSessionController.ts
@@ -29,6 +29,8 @@ const PLAYBACK_INFO_CODE_SESSION_TIMELINE = 230;
 const SESSION_READY_TIMEOUT_MS = 60_000;
 const SESSION_READY_POLL_MS = 250;
 const SESSION_READY_MAX_ATTEMPTS = Math.ceil(SESSION_READY_TIMEOUT_MS / SESSION_READY_POLL_MS);
+const HEARTBEAT_RETRY_INTERVAL_MS = 5_000;
+const CONNECTION_LOST_AFTER_FAILURES = 2;
 
 type PlaybackMode = 'LIVE' | 'VOD' | 'UNKNOWN';
 type ErrorBodyReader = (res: Response) => Promise<{ json: any | null; text: string | null }>;
@@ -52,6 +54,7 @@ interface UseLiveSessionControllerProps {
 interface LiveSessionController {
   sessionId: string | null;
   sessionIdRef: MutableRefObject<string | null>;
+  connectionLost: boolean;
   authHeaders: (contentType?: boolean) => HeadersInit;
   reportError: (event: 'error' | 'warning' | 'info', code: number, msg?: string) => Promise<void>;
   reportSessionTimeline: (reason: string, timeline: string[]) => Promise<void>;
@@ -112,6 +115,7 @@ export function useLiveSessionController({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [heartbeatInterval, setHeartbeatInterval] = useState<number | null>(null);
   const [, setLeaseExpiresAt] = useState<string | null>(null);
+  const [connectionLost, setConnectionLost] = useState(false);
   const sessionIdRef = useRef<string | null>(null);
   const stopSentRef = useRef<string | null>(null);
   const sessionCookieRef = useRef<SessionCookieState>({ token: null, pending: null });
@@ -629,9 +633,42 @@ export function useLiveSessionController({
     // Guard against non-finite intervalMs (e.g. malformed heartbeatInterval)
     // so AbortSignal.timeout never receives NaN → 0 → immediate abort.
     const safeIntervalMs = Number.isFinite(intervalMs) ? intervalMs : HEARTBEAT_REQUEST_TIMEOUT_MS;
-    const heartbeatRequestTimeoutMs = Math.max(1000, Math.min(safeIntervalMs, HEARTBEAT_REQUEST_TIMEOUT_MS));
+    let cancelled = false;
+    let timerId: number | null = null;
+    let consecutiveFailures = 0;
+    let currentDelayMs = safeIntervalMs;
 
-    const timerId = window.setInterval(async () => {
+    const stopLoop = () => {
+      cancelled = true;
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+        timerId = null;
+      }
+    };
+
+    const schedule = (delayMs: number) => {
+      if (cancelled) return;
+      currentDelayMs = delayMs;
+      timerId = window.setTimeout(() => {
+        timerId = null;
+        void beat();
+      }, delayMs);
+    };
+
+    const noteUnreachable = () => {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= CONNECTION_LOST_AFTER_FAILURES) {
+        setConnectionLost(true);
+      }
+      schedule(HEARTBEAT_RETRY_INTERVAL_MS);
+    };
+
+    const beat = async () => {
+      if (cancelled) return;
+      const heartbeatRequestTimeoutMs = Math.max(
+        1000,
+        Math.min(currentDelayMs, safeIntervalMs, HEARTBEAT_REQUEST_TIMEOUT_MS),
+      );
       try {
         const { response: res } = await fetchWithRecoveredSessionCookie(
           'useLiveSessionController.heartbeat',
@@ -642,13 +679,13 @@ export function useLiveSessionController({
           })
         );
 
-        if (sessionIdRef.current !== trackedSessionId) {
+        if (cancelled || sessionIdRef.current !== trackedSessionId) {
           return;
         }
 
         if (res.status === 401) {
           debugWarn('[V3Player][Heartbeat] Session unauthorized (401)');
-          window.clearInterval(timerId);
+          stopLoop();
           clearSessionLeaseState();
           setPlaybackMode('UNKNOWN');
           setStatus('error');
@@ -670,7 +707,7 @@ export function useLiveSessionController({
           }
         } else if (res.status === 403) {
           debugWarn('[V3Player][Heartbeat] Session forbidden (403)');
-          window.clearInterval(timerId);
+          stopLoop();
           clearSessionLeaseState();
           setPlaybackMode('UNKNOWN');
           setStatus('error');
@@ -697,7 +734,7 @@ export function useLiveSessionController({
           }
           if (!data.acknowledged || !data.leaseExpiresAt || data.sessionId !== trackedSessionId) {
             debugError('[V3Player][Heartbeat] Invalid heartbeat contract response', data);
-            window.clearInterval(timerId);
+            stopLoop();
             clearSessionLeaseState();
             setPlaybackMode('UNKNOWN');
             setStatus('error');
@@ -722,9 +759,12 @@ export function useLiveSessionController({
           setLeaseExpiresAt(data.leaseExpiresAt);
           debugLog('[V3Player][Heartbeat] Lease extended:', data.leaseExpiresAt);
           void refreshSessionSnapshot(trackedSessionId);
+          consecutiveFailures = 0;
+          setConnectionLost(false);
+          schedule(safeIntervalMs);
         } else if (res.status === 410) {
           debugError('[V3Player][Heartbeat] Session expired (410)');
-          window.clearInterval(timerId);
+          stopLoop();
           clearSessionLeaseState();
           setPlaybackMode('UNKNOWN');
           setStatus('error');
@@ -746,7 +786,7 @@ export function useLiveSessionController({
           }
         } else if (res.status === 404) {
           debugWarn('[V3Player][Heartbeat] Session not found (404)');
-          window.clearInterval(timerId);
+          stopLoop();
           clearSessionLeaseState();
           setPlaybackMode('UNKNOWN');
           setStatus('error');
@@ -766,15 +806,23 @@ export function useLiveSessionController({
           if (videoRef.current) {
             videoRef.current.pause();
           }
+        } else {
+          debugWarn('[V3Player][Heartbeat] Unexpected status', res.status);
+          noteUnreachable();
         }
       } catch (err) {
+        if (cancelled) return;
         debugError('[V3Player][Heartbeat] Network error:', err);
+        noteUnreachable();
       }
-    }, intervalMs);
+    };
+
+    schedule(safeIntervalMs);
 
     return () => {
       debugLog('[V3Player][Heartbeat] Cleanup: Clearing heartbeat timer');
-      window.clearInterval(timerId);
+      stopLoop();
+      setConnectionLost(false);
     };
   }, [apiBase, authHeaders, clearPlaybackFailure, clearSessionLeaseState, fetchWithRecoveredSessionCookie, heartbeatInterval, refreshSessionSnapshot, reportPlaybackFailure, sessionId, setPlaybackMode, setStatus, t, videoRef]);
 
@@ -787,7 +835,8 @@ export function useLiveSessionController({
   return {
     sessionId,
     sessionIdRef,
-      authHeaders,
+    connectionLost,
+    authHeaders,
     reportError,
     reportSessionTimeline,
     ensureSessionCookie,

--- a/apps/webui/src/features/player/usePlaybackEngine.ts
+++ b/apps/webui/src/features/player/usePlaybackEngine.ts
@@ -29,10 +29,11 @@ import {
 import {
   createHlsRuntimeConfig,
   hlsNetworkRetryBackoffMs,
-  HLS_NETWORK_RETRY_POLICY,
+  hlsNetworkRetryPolicyForLink,
   HLS_STARTUP_POLICY,
 } from './playbackEnginePolicy';
 import { isInMemorySeekTarget } from './orchestrator/nativePlaybackHelpers';
+import type { PlaybackLinkProfile } from './utils/playbackLinkProfile';
 
 type PlaybackEngineName = 'auto' | 'native' | 'hlsjs';
 type ReportErrorFn = (
@@ -84,6 +85,7 @@ interface UsePlaybackEngineProps {
   isTeardownRef: MutableRefObject<boolean>;
   lastDecodedRef: MutableRefObject<number>;
   playbackEpochRef: MutableRefObject<number>;
+  linkProfileRef?: MutableRefObject<PlaybackLinkProfile>;
   t: TFunction;
   reportError: ReportErrorFn;
   waitForSessionReady: WaitForSessionReadyFn;
@@ -114,6 +116,7 @@ export function usePlaybackEngine({
   isTeardownRef,
   lastDecodedRef,
   playbackEpochRef,
+  linkProfileRef,
   t,
   reportError,
   waitForSessionReady,
@@ -842,7 +845,8 @@ export function usePlaybackEngine({
       if (hlsRef.current) {
         hlsRef.current.destroy();
       }
-      const hls = new Hls(createHlsRuntimeConfig());
+      const linkProfile = linkProfileRef?.current ?? 'stable';
+      const hls = new Hls(createHlsRuntimeConfig(linkProfile));
       hlsRef.current = hls;
 
       // Live startup gate: on a fresh live session the encoder edge is only
@@ -1005,7 +1009,7 @@ export function usePlaybackEngine({
 
       let mediaRecoveryAttempted = false;
       let networkRetryCount = 0;
-      const { maxRetries: maxNetworkRetries } = HLS_NETWORK_RETRY_POLICY;
+      const { maxRetries: maxNetworkRetries } = hlsNetworkRetryPolicyForLink(linkProfile);
 
       hls.on(Hls.Events.ERROR, (_event, data: ErrorData) => {
         if (!data.fatal) {
@@ -1112,7 +1116,7 @@ export function usePlaybackEngine({
               return;
             }
             if (networkRetryCount < maxNetworkRetries) {
-              const backoffMs = hlsNetworkRetryBackoffMs(networkRetryCount);
+              const backoffMs = hlsNetworkRetryBackoffMs(networkRetryCount, linkProfile);
               networkRetryCount++;
               reportPlaybackWarning(PLAYBACK_WARNING_CODE_NETWORK_RETRY, 'hlsjs_network_retry', 'network', networkRetryCount);
               debugWarn(`[V3Player] NETWORK_ERROR recovery attempt ${networkRetryCount}/${maxNetworkRetries}, backoff ${backoffMs}ms`);
@@ -1232,7 +1236,7 @@ export function usePlaybackEngine({
     }
 
     throw new Error('HLS playback engine not available');
-  }, [beginSessionDecodeRecovery, clearHlsRenderProbe, clearHlsStallRecovery, clearNativeStallRecovery, clearPendingNativeAutoplay, hlsRef, isTeardownRef, lastDecodedRef, onAudioTrackSwitched, onAudioTracksUpdated, onPlaybackMilestone, playbackEngineContext, reportError, reportMediaFailure, reportPlaybackFailure, reportPlaybackWarning, sessionIdRef, setStats, setStatus, shouldPreferNativeHls, startNativeHlsPlayback, t, updateStats, videoRef]);
+  }, [beginSessionDecodeRecovery, clearHlsRenderProbe, clearHlsStallRecovery, clearNativeStallRecovery, clearPendingNativeAutoplay, hlsRef, isTeardownRef, lastDecodedRef, linkProfileRef, onAudioTrackSwitched, onAudioTracksUpdated, onPlaybackMilestone, playbackEngineContext, reportError, reportMediaFailure, reportPlaybackFailure, reportPlaybackWarning, sessionIdRef, setStats, setStatus, shouldPreferNativeHls, startNativeHlsPlayback, t, updateStats, videoRef]);
 
   replayHlsRef.current = playHls;
 

--- a/apps/webui/src/features/player/usePlaybackOrchestrator.ts
+++ b/apps/webui/src/features/player/usePlaybackOrchestrator.ts
@@ -35,7 +35,10 @@ import {
 import { gatherPlaybackCapabilities, type CapabilitySnapshot } from './utils/playbackCapabilities';
 import {
   buildPlaybackProfileHeaders,
+  clearNetworkStarvationHold,
+  createAutomaticProfileMemory,
   gatherPlaybackClientContext,
+  noteNetworkStarvation,
   normalizePlaybackProfileSelection,
   resolvePlaybackProfileForPreflight,
   resolvePlaybackRequestProfile,
@@ -45,6 +48,10 @@ import {
   applyPlaybackNetworkProbe,
   measurePlaybackNetwork,
 } from './utils/playbackNetworkProbe';
+import {
+  resolvePlaybackLinkProfile,
+  type PlaybackLinkProfile,
+} from './utils/playbackLinkProfile';
 import { normalizePlayerError } from '../../lib/appErrors';
 import { notifyAuthRequiredIfUnauthorizedResponse } from '../../lib/httpProblem';
 import { useTvInitialFocus } from '../../hooks/useTvInitialFocus';
@@ -89,6 +96,10 @@ import { useDocumentVisibility } from './orchestrator/useDocumentVisibility';
 import { useOnlineStatus } from './orchestrator/useOnlineStatus';
 import { decideForegroundResume } from './orchestrator/foregroundResume';
 import { decideOnlineRecovery } from './orchestrator/onlineRecovery';
+import {
+  shouldWatchForNetworkRecovery,
+  useNetworkRecoveryWatchdog,
+} from './orchestrator/useNetworkRecoveryWatchdog';
 import { startResumePlaybackRecovery } from './orchestrator/resumePlaybackRecovery';
 import { useBufferingOverlay } from './orchestrator/useBufferingOverlay';
 
@@ -114,6 +125,10 @@ import {
   resolveLiveEngineFromMode,
   resolveResumeStateFromContract,
 } from './orchestrator/startupHelpers';
+
+const MAX_LEASE_CONFLICT_RETRIES = 3;
+const DEFAULT_LEASE_CONFLICT_WAIT_MS = 1_000;
+const MAX_LEASE_CONFLICT_WAIT_MS = 5_000;
 
 
 export interface PlaybackOrchestratorRefs {
@@ -331,7 +346,6 @@ export function usePlaybackOrchestrator(
   const retryInFlightRef = useRef(false);
   const stopCommandCompletionRef = useRef<Promise<void>>(Promise.resolve());
   const timelineReportCompletionRef = useRef<Promise<void>>(Promise.resolve());
-  // ADR-00X: Profile-related refs removed (universal policy only)
   const isTeardownRef = useRef<boolean>(false);
   const userPauseIntentRef = useRef<boolean>(false);
   const nativeVideoTempMutedRef = useRef(false);
@@ -340,6 +354,8 @@ export function usePlaybackOrchestrator(
   const wasOfflineRef = useRef(false);
   const cleanupPlaybackResourcesRef = useRef<() => void>(() => {});
   const activeLiveSessionIdRef = useRef<string | null>(null);
+  const automaticProfileMemoryRef = useRef(createAutomaticProfileMemory());
+  const linkProfileRef = useRef<PlaybackLinkProfile>('stable');
 
   const isLifecycleActive = useCallback((generation: number): boolean => (
     !disposedRef.current && lifecycleGenerationRef.current === generation
@@ -526,6 +542,7 @@ export function usePlaybackOrchestrator(
 
   const {
     sessionIdRef,
+    connectionLost,
     authHeaders,
     reportError,
     reportSessionTimeline,
@@ -779,6 +796,7 @@ export function usePlaybackOrchestrator(
     isTeardownRef,
     lastDecodedRef,
     playbackEpochRef,
+    linkProfileRef,
     t,
     reportError,
     waitForSessionReady,
@@ -994,12 +1012,18 @@ export function usePlaybackOrchestrator(
         const automaticRequestProfile = resolvePlaybackRequestProfile(
           requestContext,
           requestCaps,
-          'recording'
+          'recording',
+          automaticProfileMemoryRef.current,
         );
         const requestProfile = resolvePlaybackProfileForPreflight(
           profileForAttempt,
           automaticRequestProfile,
         );
+        linkProfileRef.current = resolvePlaybackLinkProfile({
+          requestProfile,
+          probeKind: networkProbe?.kind,
+          network: requestContext.network,
+        });
         setCapabilitySnapshot(requestCaps);
         let rawContract: unknown = null;
 
@@ -1216,6 +1240,8 @@ export function usePlaybackOrchestrator(
     dispatchPlayback,
     ensureSessionCookie,
     explicitProfile,
+    automaticProfileMemoryRef,
+    linkProfileRef,
     gatherPlaybackCapabilitiesForPlayer,
     isLifecycleActive,
     isStalePlaybackEpoch,
@@ -1343,12 +1369,18 @@ export function usePlaybackOrchestrator(
         const automaticRequestProfile = resolvePlaybackRequestProfile(
           requestContext,
           requestCaps,
-          'live'
+          'live',
+          automaticProfileMemoryRef.current,
         );
         const requestProfile = resolvePlaybackProfileForPreflight(
           profileForAttempt,
           automaticRequestProfile,
         );
+        linkProfileRef.current = resolvePlaybackLinkProfile({
+          requestProfile,
+          probeKind: networkProbe?.kind,
+          network: requestContext.network,
+        });
         const preferredHlsEngine = resolvePreferredHlsEngineForCapabilities(requestCaps);
         setCapabilitySnapshot(requestCaps);
         // raw-fetch-justified: live decision request posts dynamic capability payload not covered by generated wrapper flow.
@@ -1484,12 +1516,33 @@ export function usePlaybackOrchestrator(
 
         if (!isLifecycleActive(lifecycleGeneration)) return;
 
-        // raw-fetch-justified: stream.start intent needs explicit payload shaping and immediate RFC7807 handling.
-        const res = await fetch(`${apiBase}/intents`, {
-          method: 'POST',
-          headers: authHeaders(true),
-          body: JSON.stringify(intentBody)
-        });
+        // A recovery restart can race the previous session's dedup-lease
+        // teardown. Treat 409 as that bounded timing conflict, honoring the
+        // server's Retry-After instead of turning it into a user-visible dead end.
+        let res!: Response;
+        for (let attempt = 0; ; attempt++) {
+          // raw-fetch-justified: stream.start intent needs explicit payload shaping and immediate RFC7807 handling.
+          res = await fetch(`${apiBase}/intents`, {
+            method: 'POST',
+            headers: authHeaders(true),
+            body: JSON.stringify(intentBody)
+          });
+          if (res.status !== 409 || attempt >= MAX_LEASE_CONFLICT_RETRIES) {
+            break;
+          }
+          const retryAfterSeconds = parseInt(res.headers.get('Retry-After') ?? '', 10);
+          const waitMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+            ? Math.min(retryAfterSeconds * 1_000, MAX_LEASE_CONFLICT_WAIT_MS)
+            : DEFAULT_LEASE_CONFLICT_WAIT_MS;
+          debugWarn('[V3Player] Intent lease still held, waiting', { attempt, waitMs });
+          await sleep(waitMs);
+          if (
+            !isLifecycleActive(lifecycleGeneration)
+            || isStaleSessionEpoch(playbackEpoch, sessionEpoch)
+          ) {
+            return;
+          }
+        }
         if (!isLifecycleActive(lifecycleGeneration)) {
           // The request may already have created a backend session while React was
           // unmounting us. Consume the accepted response only to reap that session;
@@ -1710,7 +1763,7 @@ export function usePlaybackOrchestrator(
         });
       }
     }
-  }, [src, recordingId, sRef, explicitProfile, apiBase, authHeaders, clearPlayerError, ensureSessionCookie, waitForSessionReady, mergeSessionPlaybackTrace, playHls, sendStopIntent, clearSessionLeaseState, t, startRecordingPlayback, applyAutoplayMute, gatherPlaybackCapabilitiesForPlayer, prepareForNextPlaybackAttempt, resolvePreferredHlsEngine, resolvePreferredHlsEngineForCapabilities, setActiveSessionId, requestedDuration, beginNativePlayback, channel?.logoUrl, channel?.name, nativePlaybackState, allocatePlaybackEpoch, beginPlaybackAttempt, dispatchPlayback, isLifecycleActive, isStalePlaybackEpoch, allocateSessionEpoch, isStaleSessionEpoch, normalizeRuntimePlaybackError, recordContractAdvisories, reportPlaybackFailure, sessionIdRef, setActiveHlsEngine, setStatus, setTraceId, token]);
+  }, [src, recordingId, sRef, explicitProfile, apiBase, authHeaders, clearPlayerError, ensureSessionCookie, waitForSessionReady, mergeSessionPlaybackTrace, playHls, sendStopIntent, clearSessionLeaseState, t, startRecordingPlayback, applyAutoplayMute, automaticProfileMemoryRef, linkProfileRef, gatherPlaybackCapabilitiesForPlayer, prepareForNextPlaybackAttempt, resolvePreferredHlsEngine, resolvePreferredHlsEngineForCapabilities, setActiveSessionId, requestedDuration, beginNativePlayback, channel?.logoUrl, channel?.name, nativePlaybackState, allocatePlaybackEpoch, beginPlaybackAttempt, dispatchPlayback, isLifecycleActive, isStalePlaybackEpoch, allocateSessionEpoch, isStaleSessionEpoch, normalizeRuntimePlaybackError, recordContractAdvisories, reportPlaybackFailure, sessionIdRef, setActiveHlsEngine, setStatus, setTraceId, sleep, token]);
 
   startStreamRef.current = startStream;
 
@@ -1789,6 +1842,9 @@ export function usePlaybackOrchestrator(
         break;
       case 'command.playback.schedule_auto_fallback':
         {
+          if (command.holdBandwidth) {
+            noteNetworkStarvation(automaticProfileMemoryRef.current);
+          }
           const lifecycleGeneration = lifecycleGenerationRef.current;
           const timerId = window.setTimeout(() => {
             autoFallbackTimersRef.current.delete(timerId);
@@ -1800,7 +1856,7 @@ export function usePlaybackOrchestrator(
                 serviceRef: sRef,
                 recordingId: recordingId || undefined,
                 srcUrl: src || undefined,
-                explicitProfile: command.profile,
+                explicitProfile: command.profile ?? undefined,
               });
             }
           }, command.delayMs);
@@ -1827,6 +1883,10 @@ export function usePlaybackOrchestrator(
       if (ref) setSRef(ref);
     }
   }, [channel]);
+
+  useEffect(() => {
+    clearNetworkStarvationHold(automaticProfileMemoryRef.current);
+  }, [sRef, recordingId]);
 
   useEffect(() => {
     if (!autoStart || mounted.current) return;
@@ -2026,7 +2086,7 @@ export function usePlaybackOrchestrator(
       return;
     }
 
-    if (!isOnline) {
+    if (!isOnline || connectionLost) {
       wasOfflineRef.current = true;
       return;
     }
@@ -2087,7 +2147,15 @@ export function usePlaybackOrchestrator(
         void handleRetry();
       },
     });
-  }, [handleRetry, hasTerminalStatus, hlsRef, hostEnvironment.isTv, isNativePlaybackHost, isOnline, nativePlaybackState, sessionIdRef, setStatus, videoRef]);
+  }, [connectionLost, handleRetry, hasTerminalStatus, hlsRef, hostEnvironment.isTv, isNativePlaybackHost, isOnline, nativePlaybackState, sessionIdRef, setStatus, videoRef]);
+
+  useNetworkRecoveryWatchdog({
+    apiBase,
+    active: !hostEnvironment.isTv && status === 'error' && shouldWatchForNetworkRecovery(failure),
+    intentKey: `${sRef}|${recordingId ?? ''}|${src ?? ''}`,
+    healthy: status === 'playing',
+    onReachable: handleRetry,
+  });
 
   const showBufferingOverlay = useBufferingOverlay(status);
 

--- a/apps/webui/src/features/player/utils/playbackLinkProfile.test.ts
+++ b/apps/webui/src/features/player/utils/playbackLinkProfile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { hlsTuningForLink, resolvePlaybackLinkProfile } from './playbackLinkProfile';
+
+describe('resolvePlaybackLinkProfile', () => {
+  it('treats the bandwidth rung as a constrained link', () => {
+    expect(resolvePlaybackLinkProfile({ requestProfile: 'bandwidth' })).toBe('constrained');
+  });
+
+  it('treats a probe that timed out as a constrained link', () => {
+    expect(resolvePlaybackLinkProfile({ probeKind: 'constrained' })).toBe('constrained');
+  });
+
+  it.each([
+    { metered: true },
+    { saveData: true },
+    { kind: 'cellular' },
+  ])('treats declared mobile conditions as constrained (%o)', (network) => {
+    expect(resolvePlaybackLinkProfile({ network })).toBe('constrained');
+  });
+
+  it('leaves a LAN or measured wifi link on the stable policy', () => {
+    expect(resolvePlaybackLinkProfile({
+      requestProfile: 'quality',
+      probeKind: 'lan',
+      network: { kind: 'lan' },
+    })).toBe('stable');
+  });
+});
+
+describe('hlsTuningForLink', () => {
+  // Low-latency mode is deliberately intolerant of buffer gaps, and a 12s sync
+  // target leaves nothing in hand when a mobile link dips — which is what a
+  // train does constantly. Being further behind live costs a viewer nothing and
+  // buys the buffer that carries playback through a dead spot.
+  it('stops chasing the live edge on a constrained link and buffers instead', () => {
+    const stable = hlsTuningForLink('stable');
+    const constrained = hlsTuningForLink('constrained');
+
+    expect(stable.lowLatencyMode).toBe(true);
+    expect(constrained.lowLatencyMode).toBe(false);
+    expect(constrained.liveSyncDuration).toBeGreaterThan(stable.liveSyncDuration);
+    expect(constrained.maxBufferLength).toBeGreaterThan(stable.maxBufferLength);
+  });
+
+  it('covers a longer outage while still noticing a returning link quickly', () => {
+    const stable = hlsTuningForLink('stable');
+    const constrained = hlsTuningForLink('constrained');
+
+    expect(constrained.maxNetworkRetries).toBeGreaterThan(stable.maxNetworkRetries);
+    expect(constrained.networkBackoffCapMs).toBeLessThan(stable.networkBackoffCapMs);
+  });
+});

--- a/apps/webui/src/features/player/utils/playbackLinkProfile.ts
+++ b/apps/webui/src/features/player/utils/playbackLinkProfile.ts
@@ -1,0 +1,83 @@
+import type { PlaybackRequestProfile } from './playbackRequestProfile';
+
+// How the player should behave given the kind of link it is on.
+//
+// This is player runtime tuning — hls.js loader settings — not a playback
+// decision; the codec and mode remain the backend planner's call.
+//
+// The hls.js defaults here were tuned for a stable connection: low-latency mode
+// chases the live edge, and a 12s sync target plus a 60s buffer keeps the
+// picture close to live. On a phone that is the wrong trade in every respect —
+// low-latency mode is deliberately intolerant of buffer gaps, and sitting near
+// the edge means there is nothing in hand when the link dips. A commuter train
+// dips constantly.
+//
+// Being further behind live costs nothing a mobile viewer would notice and buys
+// the one thing that keeps playback alive through a dead spot: buffer.
+
+export type PlaybackLinkProfile = 'stable' | 'constrained';
+
+export interface HlsLinkTuning {
+  lowLatencyMode: boolean;
+  /** Target distance behind the live edge, in seconds. */
+  liveSyncDuration: number;
+  /** Forward buffer the loader tries to keep, in seconds. */
+  maxBufferLength: number;
+  /** Fatal network errors absorbed before the orchestrator ladder is asked. */
+  maxNetworkRetries: number;
+  /** Ceiling for the exponential retry backoff. */
+  networkBackoffCapMs: number;
+}
+
+const STABLE_TUNING: HlsLinkTuning = {
+  lowLatencyMode: true,
+  liveSyncDuration: 12,
+  maxBufferLength: 60,
+  maxNetworkRetries: 6,
+  networkBackoffCapMs: 30_000,
+};
+
+// A tighter backoff cap with more attempts covers a longer outage in total
+// while still noticing a returning link within seconds rather than half a
+// minute — on a train the link comes back abruptly, and a 30s sleep spends most
+// of the tunnel exit doing nothing.
+const CONSTRAINED_TUNING: HlsLinkTuning = {
+  lowLatencyMode: false,
+  liveSyncDuration: 30,
+  maxBufferLength: 180,
+  maxNetworkRetries: 8,
+  networkBackoffCapMs: 15_000,
+};
+
+export function hlsTuningForLink(link: PlaybackLinkProfile): HlsLinkTuning {
+  return link === 'constrained' ? CONSTRAINED_TUNING : STABLE_TUNING;
+}
+
+export interface ResolveLinkProfileInput {
+  /** The profile the request actually went out with. */
+  requestProfile?: PlaybackRequestProfile;
+  /** Verdict of the server-side probe, when one was reached. */
+  probeKind?: 'lan' | 'measured' | 'constrained';
+  network?: {
+    kind?: string;
+    metered?: boolean;
+    saveData?: boolean;
+  };
+}
+
+export function resolvePlaybackLinkProfile({
+  requestProfile,
+  probeKind,
+  network,
+}: ResolveLinkProfileInput): PlaybackLinkProfile {
+  if (requestProfile === 'bandwidth') {
+    return 'constrained';
+  }
+  if (probeKind === 'constrained') {
+    return 'constrained';
+  }
+  if (network?.metered || network?.saveData || network?.kind === 'cellular') {
+    return 'constrained';
+  }
+  return 'stable';
+}

--- a/apps/webui/src/features/player/utils/playbackNetworkProbe.test.ts
+++ b/apps/webui/src/features/player/utils/playbackNetworkProbe.test.ts
@@ -54,7 +54,12 @@ describe('measurePlaybackNetwork', () => {
     }
   });
 
-  it('does not reuse positive bandwidth evidence when the browser exposes no network fingerprint', async () => {
+  // Safari ships no Network Information API, so there is no fingerprint to key
+  // the cache on. Refusing to reuse the verdict at all meant every Apple client
+  // re-measured on every playback start — and since the reading picks the
+  // encoder profile, and the output has no ABR ladder, a noisy re-measure cost
+  // a whole new transcode. Reuse is bounded by a short TTL instead.
+  it('reuses bandwidth evidence when the browser exposes no network fingerprint', async () => {
     const connectionDescriptor = Object.getOwnPropertyDescriptor(navigator, 'connection');
     delete (navigator as Navigator & { connection?: unknown }).connection;
     const fetchMock = vi.fn(async () => new Response(new Uint8Array(512 * 1024), {
@@ -62,16 +67,17 @@ describe('measurePlaybackNetwork', () => {
       headers: { 'X-XG2G-Playback-Probe': 'measured' },
     }));
     vi.stubGlobal('fetch', fetchMock);
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(100)
-      .mockReturnValueOnce(200)
-      .mockReturnValueOnce(300);
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 100;
+      return now;
+    });
 
     try {
-      await measurePlaybackNetwork('/api/test-network-handoff');
-      await measurePlaybackNetwork('/api/test-network-handoff');
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const first = await measurePlaybackNetwork('/api/test-network-handoff');
+      const second = await measurePlaybackNetwork('/api/test-network-handoff');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(second).toEqual(first);
     } finally {
       if (connectionDescriptor) {
         Object.defineProperty(navigator, 'connection', connectionDescriptor);
@@ -98,11 +104,11 @@ describe('measurePlaybackNetwork', () => {
       headers: { 'X-XG2G-Playback-Probe': 'measured' },
     }));
     vi.stubGlobal('fetch', fetchMock);
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(100)
-      .mockReturnValueOnce(200)
-      .mockReturnValueOnce(300);
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 100;
+      return now;
+    });
 
     try {
       await measurePlaybackNetwork('/api/test-connection-identity');
@@ -143,11 +149,11 @@ describe('measurePlaybackNetwork', () => {
       .mockReturnValueOnce(firstResponse)
       .mockReturnValueOnce(secondResponse);
     vi.stubGlobal('fetch', fetchMock);
-    vi.spyOn(performance, 'now')
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(100)
-      .mockReturnValueOnce(200)
-      .mockReturnValueOnce(300);
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      now += 100;
+      return now;
+    });
 
     try {
       const oldProbe = measurePlaybackNetwork('/api/test-inflight-handoff');
@@ -173,7 +179,7 @@ describe('measurePlaybackNetwork', () => {
       }));
       await expect(replacementProbe).resolves.toEqual({
         kind: 'measured',
-        downlinkMbps: 20.97152,
+        downlinkMbps: 41.94304,
       });
     } finally {
       if (connectionDescriptor) {

--- a/apps/webui/src/features/player/utils/playbackNetworkProbe.ts
+++ b/apps/webui/src/features/player/utils/playbackNetworkProbe.ts
@@ -6,6 +6,18 @@ const PROBE_TIMEOUT_MS = 3000;
 const PROBE_HEADER = 'X-XG2G-Playback-Probe';
 const PROBE_CACHE_TTL_MS = 2 * 60 * 1000;
 const CONSTRAINED_CACHE_TTL_MS = 15 * 1000;
+// TTL used when the platform gives us no way to notice a network change.
+// Safari (iOS and macOS) ships no Network Information API, so there is no
+// connection fingerprint and no 'change' event — without this the cache was
+// unreachable on every Apple client and each playback start re-measured. A
+// shorter window bounds how stale a reused verdict can be; the online/offline
+// listeners still invalidate on the transitions the platform does report.
+const UNKEYED_CACHE_TTL_MS = 45 * 1000;
+// Below this the response body was already buffered when the headers resolved,
+// so the transfer window is not a measurement of anything.
+const MIN_TRANSFER_WINDOW_MS = 5;
+// Number of recent samples the reported downlink is a median over.
+const SAMPLE_WINDOW = 3;
 
 type CachedPlaybackNetworkProbe = {
 	expiresAt: number;
@@ -24,6 +36,7 @@ type NetworkInformationLike = {
 
 const probeCache = new Map<string, CachedPlaybackNetworkProbe>();
 const probesInFlight = new Map<string, Promise<PlaybackNetworkProbe | undefined>>();
+const sampleHistory = new Map<string, number[]>();
 let networkGeneration = 0;
 let windowInvalidationInstalled = false;
 let observedConnection: NetworkInformationLike | null = null;
@@ -63,6 +76,32 @@ function invalidatePlaybackNetworkCache(): void {
 	networkGeneration += 1;
 	probeCache.clear();
 	probesInFlight.clear();
+	sampleHistory.clear();
+}
+
+/**
+ * Drop every cached verdict and sample. The cache is module state that now
+ * survives without a connection fingerprint, so tests must be able to start
+ * from a clean one instead of inheriting the previous test's measurement.
+ */
+export function resetPlaybackNetworkProbeCache(): void {
+	invalidatePlaybackNetworkCache();
+}
+
+// A single 512 KB burst on a mobile link is a noisy estimator: TCP is still
+// ramping, and one bad sample is enough to move the profile decision a whole
+// rung — which, with a single-rendition output, means a new encoder session.
+// Reporting the median of the last few samples rejects the outlier without
+// lagging a genuine change the way an average would.
+function smoothedDownlinkMbps(cacheKey: string, sample: number): number {
+	const history = sampleHistory.get(cacheKey) ?? [];
+	history.push(sample);
+	while (history.length > SAMPLE_WINDOW) {
+		history.shift();
+	}
+	sampleHistory.set(cacheKey, history);
+	const sorted = [...history].sort((a, b) => a - b);
+	return sorted[Math.floor(sorted.length / 2)] ?? sample;
 }
 
 function ensureNetworkInvalidationListeners(): void {
@@ -105,8 +144,21 @@ async function runPlaybackNetworkProbe(apiBase: string): Promise<PlaybackNetwork
 			return undefined;
 		}
 
+		// fetch() resolves once the response HEADERS are in, so timing the body
+		// read alone keeps connection setup and time-to-first-byte out of the
+		// throughput figure. That mattered: on a high-RTT mobile link the old
+		// wall-clock measurement divided 512 KB by (RTT + transfer), which
+		// systematically under-reported the link by a factor that grew with
+		// latency — exactly the conditions where the reading is used to pick a
+		// profile. If the body was already buffered by then the window is too
+		// small to mean anything, so fall back to the wall clock.
+		const transferStartedAt = performance.now();
 		const payload = await response.arrayBuffer();
-		const elapsedMs = performance.now() - startedAt;
+		const now = performance.now();
+		const transferElapsedMs = now - transferStartedAt;
+		const elapsedMs = transferElapsedMs >= MIN_TRANSFER_WINDOW_MS
+			? transferElapsedMs
+			: now - startedAt;
 		if (payload.byteLength !== PROBE_BYTES || elapsedMs <= 0) {
 			return undefined;
 		}
@@ -126,13 +178,13 @@ export function measurePlaybackNetwork(apiBase: string): Promise<PlaybackNetwork
 	const now = Date.now();
 	const networkFingerprint = currentNetworkFingerprint();
 	const cacheKey = networkFingerprint ? `${apiBase}|${networkFingerprint}` : apiBase;
-	const canReusePositiveEvidence = networkFingerprint !== null;
+	// A fingerprint lets us notice a network change and drop the entry, so a
+	// verdict can be trusted for longer. Without one (Safari) the entry is still
+	// worth reusing — re-measuring per start was the bigger error — but only for
+	// a short window, since nothing but online/offline will invalidate it.
+	const positiveTtlMs = networkFingerprint ? PROBE_CACHE_TTL_MS : UNKEYED_CACHE_TTL_MS;
 	const cached = probeCache.get(cacheKey);
-	if (
-		cached
-		&& cached.expiresAt > now
-		&& (cached.value.kind === 'constrained' || canReusePositiveEvidence)
-	) {
+	if (cached && cached.expiresAt > now) {
 		return Promise.resolve(cached.value);
 	}
 	if (cached) {
@@ -149,14 +201,15 @@ export function measurePlaybackNetwork(apiBase: string): Promise<PlaybackNetwork
 		if (generation !== networkGeneration) {
 			return undefined;
 		}
-		if (
-			result
-			&& (result.kind === 'constrained' || canReusePositiveEvidence)
-		) {
-			const ttl = result.kind === 'constrained' ? CONSTRAINED_CACHE_TTL_MS : PROBE_CACHE_TTL_MS;
-			probeCache.set(cacheKey, { expiresAt: Date.now() + ttl, value: result });
+		if (!result) {
+			return result;
 		}
-		return result;
+		const value: PlaybackNetworkProbe = result.kind === 'measured'
+			? { kind: 'measured', downlinkMbps: smoothedDownlinkMbps(cacheKey, result.downlinkMbps) }
+			: result;
+		const ttl = value.kind === 'constrained' ? CONSTRAINED_CACHE_TTL_MS : positiveTtlMs;
+		probeCache.set(cacheKey, { expiresAt: Date.now() + ttl, value });
+		return value;
 	});
 	probesInFlight.set(cacheKey, probe);
 	const clearIfCurrent = () => {

--- a/apps/webui/src/features/player/utils/playbackRequestProfile.test.ts
+++ b/apps/webui/src/features/player/utils/playbackRequestProfile.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  NETWORK_DOWNGRADE_HOLD_MS,
   buildPlaybackProfileHeaders,
+  clearNetworkStarvationHold,
+  createAutomaticProfileMemory,
   normalizePlaybackProfileSelection,
+  noteNetworkStarvation,
   resolvePlaybackProfileForPreflight,
   resolvePlaybackRequestProfile,
   type PlaybackClientContext,
@@ -244,5 +248,68 @@ describe('planner-bound profile selection', () => {
     expect(resolvePlaybackProfileForPreflight('repair', 'quality')).toBe('repair');
     expect(resolvePlaybackProfileForPreflight('auto', 'bandwidth')).toBe('bandwidth');
     expect(resolvePlaybackProfileForPreflight('auto')).toBeUndefined();
+  });
+});
+
+// A single-rendition output means every profile change is a new encoder
+// session. On mobile the measured downlink walks across the thresholds
+// continuously, so without memory the resolver turns ordinary cellular jitter
+// into repeated transcode restarts.
+describe('resolvePlaybackRequestProfile memory', () => {
+  const mobile = (downlinkMbps: number) => buildContext({
+    platform: 'ios',
+    isTv: false,
+    isNativePlayback: false,
+    network: { kind: 'measured', downlinkMbps },
+  });
+
+  it('keeps quality through a dip that a bare threshold would have flipped', () => {
+    const memory = createAutomaticProfileMemory();
+    expect(resolvePlaybackRequestProfile(mobile(40), buildCapabilities(), 'live', memory)).toBe('quality');
+    // 30 is below the entry threshold of 35 but above the exit threshold of 28.
+    expect(resolvePlaybackRequestProfile(mobile(30), buildCapabilities(), 'live', memory)).toBe('quality');
+  });
+
+  it('still gives quality up on a genuine drop', () => {
+    const memory = createAutomaticProfileMemory();
+    resolvePlaybackRequestProfile(mobile(40), buildCapabilities(), 'live', memory);
+    expect(resolvePlaybackRequestProfile(mobile(25), buildCapabilities(), 'live', memory)).toBeUndefined();
+  });
+
+  it('does not climb out of bandwidth on a marginal improvement', () => {
+    const memory = createAutomaticProfileMemory();
+    expect(resolvePlaybackRequestProfile(mobile(12), buildCapabilities(), 'live', memory)).toBe('bandwidth');
+    // 18 clears the 15 entry threshold but not the 20 exit threshold.
+    expect(resolvePlaybackRequestProfile(mobile(18), buildCapabilities(), 'live', memory)).toBe('bandwidth');
+    expect(resolvePlaybackRequestProfile(mobile(22), buildCapabilities(), 'live', memory)).toBeUndefined();
+  });
+
+  it('behaves exactly as before when no memory is supplied', () => {
+    expect(resolvePlaybackRequestProfile(mobile(30), buildCapabilities(), 'live')).toBeUndefined();
+    expect(resolvePlaybackRequestProfile(mobile(18), buildCapabilities(), 'live')).toBeUndefined();
+    expect(resolvePlaybackRequestProfile(mobile(12), buildCapabilities(), 'live')).toBe('bandwidth');
+  });
+
+  it('holds the safe rung after playback died of starvation, whatever the probe now claims', () => {
+    const memory = createAutomaticProfileMemory();
+    noteNetworkStarvation(memory, 1_000);
+    expect(resolvePlaybackRequestProfile(mobile(120), buildCapabilities(), 'live', memory, 2_000))
+      .toBe('bandwidth');
+  });
+
+  it('lets the hold lapse', () => {
+    const memory = createAutomaticProfileMemory();
+    noteNetworkStarvation(memory, 1_000);
+    const afterHold = 1_000 + NETWORK_DOWNGRADE_HOLD_MS + 1;
+    expect(resolvePlaybackRequestProfile(mobile(120), buildCapabilities(), 'live', memory, afterHold))
+      .toBe('quality');
+  });
+
+  it('releases the hold when the viewing intent changes', () => {
+    const memory = createAutomaticProfileMemory();
+    noteNetworkStarvation(memory, 1_000);
+    clearNetworkStarvationHold(memory);
+    expect(resolvePlaybackRequestProfile(mobile(120), buildCapabilities(), 'live', memory, 2_000))
+      .toBe('quality');
   });
 });

--- a/apps/webui/src/features/player/utils/playbackRequestProfile.ts
+++ b/apps/webui/src/features/player/utils/playbackRequestProfile.ts
@@ -263,48 +263,148 @@ function supportsHighQualityPlayback(capabilities: CapabilitySnapshot): boolean 
   return width >= 1920 && height >= 1080;
 }
 
+// Profile selection is a step function over measured downlink, and the encoder
+// output carries a single rendition — there is no ABR ladder to absorb a
+// bandwidth change, so every profile change costs a fresh encoder session. On
+// mobile the measurement walks across the step edges continuously (a train
+// swings between ~5 and ~40 Mbit within a minute), which turns ordinary
+// cellular jitter into repeated transcode restarts. Two mechanisms keep that
+// quiet without making the decision less truthful:
+//
+//   * hysteresis — moving to a different rung needs a clearly better (or
+//     clearly worse) measurement than staying on the current one, so a sample
+//     sitting on an edge never flips the decision back and forth;
+//   * a downgrade hold — once playback has actually died of link starvation,
+//     stay on 'bandwidth' for a cooldown no matter what the next probe claims.
+//     The probe is a 512 KB burst; it cannot see the dead spot that just killed
+//     the stream.
+//
+// The declared signals (save-data, 2g/3g, metered) get no hysteresis: they are
+// statements of intent from the client, not noisy measurements.
+
+/** Below this the link cannot carry any rung but the safe one. */
+const MINIMUM_VIABLE_MBPS = 6;
+/** Downlink under this selects 'bandwidth'... */
+const BANDWIDTH_ENTER_MBPS = 15;
+/** ...and it takes this much to climb back out of it. */
+const BANDWIDTH_EXIT_MBPS = 20;
+/** Downlink at or above this selects 'quality'... */
+const QUALITY_ENTER_MBPS = 35;
+/** ...and it takes a drop below this to give it up. */
+const QUALITY_EXIT_MBPS = 28;
+
+/** How long a starvation failure pins the automatic choice to 'bandwidth'. */
+export const NETWORK_DOWNGRADE_HOLD_MS = 10 * 60 * 1000;
+
+/**
+ * Carries the automatic resolver's memory across attempts. Held by the
+ * orchestrator for the lifetime of a player instance; the resolver stays a
+ * function of (context, capabilities, memory) with no hidden module state.
+ */
+export interface AutomaticProfileMemory {
+  /** The rung the previous automatic resolution settled on. */
+  lastProfile: PlaybackRequestProfile | undefined;
+  /** Epoch ms until which 'bandwidth' is forced; 0 when no hold is active. */
+  bandwidthHoldUntilMs: number;
+}
+
+export function createAutomaticProfileMemory(): AutomaticProfileMemory {
+  return { lastProfile: undefined, bandwidthHoldUntilMs: 0 };
+}
+
+/**
+ * Record that playback died because the link could not carry the stream. Pins
+ * the automatic resolution to 'bandwidth' for the cooldown.
+ */
+export function noteNetworkStarvation(
+  memory: AutomaticProfileMemory,
+  nowMs: number = Date.now(),
+): void {
+  memory.bandwidthHoldUntilMs = nowMs + NETWORK_DOWNGRADE_HOLD_MS;
+  memory.lastProfile = 'bandwidth';
+}
+
+/** Drop any active hold — used when a new viewing intent starts. */
+export function clearNetworkStarvationHold(memory: AutomaticProfileMemory): void {
+  memory.bandwidthHoldUntilMs = 0;
+}
+
+// Network kinds that may be promoted to 'quality'. 'lan' and 'measured' are
+// verdicts of the server-side probe and outrank anything the browser guesses;
+// without them a probed client could only ever be demoted to 'bandwidth',
+// never promoted.
+const QUALITY_ELIGIBLE_NETWORK_KINDS: ReadonlySet<string> = new Set([
+  'lan',
+  'measured',
+  'ethernet',
+  'wifi',
+  'browser',
+  'other',
+]);
+
 export function resolvePlaybackRequestProfile(
   context: PlaybackClientContext,
   capabilities: CapabilitySnapshot,
-  _scope: 'live' | 'recording'
+  _scope: 'live' | 'recording',
+  memory?: AutomaticProfileMemory,
+  nowMs: number = Date.now(),
 ): PlaybackRequestProfile | undefined {
   const network = context.network;
   if (network?.kind === 'offline') {
     return undefined;
   }
 
+  const settle = (profile: PlaybackRequestProfile | undefined) => {
+    if (memory) {
+      memory.lastProfile = profile;
+    }
+    return profile;
+  };
+
+  if (memory && memory.bandwidthHoldUntilMs > nowMs) {
+    return settle('bandwidth');
+  }
+
+  const downlinkMbps = typeof network?.downlinkMbps === 'number' ? network.downlinkMbps : undefined;
+
   if (
     network?.saveData
     || network?.effectiveType === 'slow-2g'
     || network?.effectiveType === '2g'
-    || (typeof network?.downlinkMbps === 'number' && network.downlinkMbps < 6)
+    || (downlinkMbps !== undefined && downlinkMbps < MINIMUM_VIABLE_MBPS)
   ) {
-    return 'bandwidth';
+    return settle('bandwidth');
   }
 
   if (
     network?.kind === 'cellular'
     || network?.metered
     || network?.effectiveType === '3g'
-    || (typeof network?.downlinkMbps === 'number' && network.downlinkMbps < 15)
   ) {
-    return 'bandwidth';
+    return settle('bandwidth');
   }
 
+  const previous = memory?.lastProfile;
+
+  if (downlinkMbps !== undefined) {
+    const bandwidthCeiling = previous === 'bandwidth' ? BANDWIDTH_EXIT_MBPS : BANDWIDTH_ENTER_MBPS;
+    if (downlinkMbps < bandwidthCeiling) {
+      return settle('bandwidth');
+    }
+  }
+
+  const qualityFloor = previous === 'quality' ? QUALITY_EXIT_MBPS : QUALITY_ENTER_MBPS;
   if (
     supportsHighQualityPlayback(capabilities)
     && !network?.saveData
     && !network?.metered
-    // 'lan' and 'measured' are verdicts of the server-side probe and outrank
-    // anything the browser guesses; without them a probed client could only ever
-    // be demoted to 'bandwidth', never promoted to 'quality'.
-    && (network == null || network.kind === 'lan' || network.kind === 'measured' || network.kind === 'ethernet' || network.kind === 'wifi' || network.kind === 'browser' || network.kind === 'other')
-    && (network?.downlinkMbps == null || network.downlinkMbps >= 35)
+    && (network == null || QUALITY_ELIGIBLE_NETWORK_KINDS.has(network.kind))
+    && (downlinkMbps === undefined || downlinkMbps >= qualityFloor)
   ) {
-    return 'quality';
+    return settle('quality');
   }
 
-  return undefined;
+  return settle(undefined);
 }
 
 export function buildPlaybackProfileHeaders(profile?: PlaybackRequestProfile): Record<string, string> {

--- a/apps/webui/tests/V3Player.errors.test.tsx
+++ b/apps/webui/tests/V3Player.errors.test.tsx
@@ -4,6 +4,7 @@ import V3Player from '../src/features/player/components/V3Player';
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import * as sdk from '../src/client-ts';
 import { suppressExpectedConsoleNoise } from './helpers/consoleNoise';
+import { MAX_SESSION_RESTARTS } from '../src/features/player/orchestrator/recoveryLadder';
 
 vi.mock('../src/client-ts', async () => {
   const actual = await vi.importActual<any>('../src/client-ts');
@@ -446,7 +447,11 @@ describe('V3Player Error Semantics (UI-ERR-PLAYER-001)', () => {
     }
   });
 
-  it('tears down on 410 GONE (Session Expired) during heartbeat', async () => {
+  // A lease that lapses under a session which was actually playing is what a
+  // tunnel or a dead spot produces. Surfacing it as a terminal error stranded
+  // the viewer on a Retry button; the player re-establishes it instead, and
+  // only tells the user once the bounded restart budget is spent.
+  it('re-establishes a lease reaped during playback, with a bounded restart budget', async () => {
     let heartbeatCount = 0;
 
     (globalThis.fetch as any).mockImplementation((url: string) => {
@@ -517,16 +522,54 @@ describe('V3Player Error Semantics (UI-ERR-PLAYER-001)', () => {
         await flushMicrotasks();
       });
 
-      // Trigger second heartbeat (410) + flush the async interval callback.
+      // Trigger second heartbeat (410) + flush the async callback.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1100);
         await flushMicrotasks();
       });
 
+      // The reap is absorbed, not reported: no error text, and the ladder has
+      // scheduled a restart rather than ending the viewing session.
       // With fake timers enabled, avoid waitFor here (it schedules timeouts).
-      expect(screen.getByText(/player\.sessionExpired|Session expired/i)).toBeInTheDocument();
-      expect(screen.queryByText('sess-123')).not.toBeInTheDocument();
-      expect(screen.getByText('Session').closest('div')).toHaveTextContent('Session-');
+      expect(screen.queryByText(/player\.sessionExpired|Session expired/i)).not.toBeInTheDocument();
+
+      const startIntents = () => (globalThis.fetch as any).mock.calls
+        .filter((c: any[]) => {
+          if (!String(c[0]).endsWith('/intents')) return false;
+          const body = c[1]?.body ? JSON.parse(String(c[1].body)) : {};
+          return body?.type !== 'stream.stop';
+        }).length;
+      const intentsBeforeRestart = startIntents();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+        await flushMicrotasks();
+      });
+
+      // A fresh start intent is the proof the lease was re-established rather
+      // than handed to the user as an error.
+      expect(startIntents()).toBeGreaterThan(intentsBeforeRestart);
+
+      // This fixture reaps every session it hands out, so the ladder must stop
+      // rather than spin the backend through encoder starts forever. (That the
+      // exhausted budget then surfaces the error is pinned deterministically in
+      // recoveryLadder.test.ts, without fake-timer scheduling in the way.)
+      await act(async () => {
+        for (let i = 0; i < 12; i++) {
+          await vi.advanceTimersByTimeAsync(3000);
+          await flushMicrotasks();
+        }
+      });
+      const startsAfterBudget = startIntents();
+      expect(startsAfterBudget).toBe(intentsBeforeRestart + MAX_SESSION_RESTARTS);
+
+      await act(async () => {
+        for (let i = 0; i < 12; i++) {
+          await vi.advanceTimersByTimeAsync(3000);
+          await flushMicrotasks();
+        }
+      });
+      expect(startIntents()).toBe(startsAfterBudget);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/webui/tests/setupTests.ts
+++ b/apps/webui/tests/setupTests.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
+import { resetPlaybackNetworkProbeCache } from '../src/features/player/utils/playbackNetworkProbe';
 
 // Global cleanup: ensure every test unmounts rendered React trees to prevent
 // V8 heap OOM (~4GB) on CI when many test files render <V3Player> without
@@ -8,6 +9,9 @@ import { afterEach, vi } from 'vitest';
 // to call cleanup() locally.
 afterEach(() => {
   cleanup();
+  // The network probe caches its verdict in module state; without this a test
+  // inherits whatever the previous one measured, making results order-dependent.
+  resetPlaybackNetworkProbeCache();
 });
 
 // Node 26 ships native experimental Web Storage globals (localStorage,


### PR DESCRIPTION
## What changed

- Add hysteresis and a starvation hold to automatic playback-profile selection.
- Tune HLS buffering and retry behavior for constrained links.
- Restart reaped sessions safely and retry bounded `/intents` lease conflicts.
- Detect failed heartbeat reachability and recover through a bounded network watchdog.
- Stabilize mobile network probing and preserve the recovery budget across restarts.

## Why

Moving mobile links can briefly disappear without `navigator.onLine` changing. The old flow repeatedly re-probed, selected an aggressive profile, started new transcodes, and could leave playback stranded after the link returned.

## Validation

- `npm --prefix apps/webui run type-check`
- Targeted player and recovery tests (99 tests passed)
- Complete Web UI suite (132 files, 672 tests passed)