### PR TITLE
fix(webui): polish EPG timeline and event dialog

### DIFF
--- a/apps/webui/src/features/epg/EPG.module.css
+++ b/apps/webui/src/features/epg/EPG.module.css
@@ -1227,33 +1227,36 @@
   align-items: center;
 }
 
-.timelineCurrentTimeIndicator {
+.timelineHeaderTimeKnob {
   left: var(--xg2g-timeline-left);
   position: absolute;
-  top: 0;
-  height: var(--xg2g-timeline-indicator-height, 100%);
-  width: 2px;
-  background: var(--status-error);
-  z-index: 60;
-  pointer-events: none;
-  box-shadow: var(--shadow-status-error);
-}
-
-.timelineCurrentTimeKnob {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translate(-50%, -3px);
+  top: 50%;
+  transform: translate(-50%, -50%);
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: var(--status-error);
-  box-shadow: var(--shadow-status-error-strong);
+  box-shadow: 0 0 10px var(--status-error), 0 0 4px #ffffff;
+  z-index: 25;
+}
+
+.timelineCurrentTimeLine {
+  left: var(--xg2g-timeline-left);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  width: 2px;
+  background: linear-gradient(180deg, var(--status-error) 0%, rgba(248, 113, 113, 0.75) 100%);
+  z-index: 40;
+  pointer-events: none;
+  box-shadow: 0 0 8px rgba(248, 113, 113, 0.6), 0 0 2px rgba(248, 113, 113, 0.9);
 }
 
 .timelineBody {
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .timelineRow {
@@ -1270,7 +1273,7 @@
   left: 0;
   z-index: 50;
   transform: translateZ(0);
-  background: var(--bg-base);
+  background: var(--surface-shell-safe, #080d14);
   border-right: 1px solid var(--border-base);
   padding: 6px 12px;
   height: 54px;
@@ -1278,19 +1281,20 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  box-shadow: 4px 0 12px rgba(0, 0, 0, 0.5);
   transition: background 0.2s;
 }
 
 .timelineChannelCard:hover,
 .timelineChannelCard:focus-visible {
-  background: var(--surface-panel);
+  background: var(--surface-panel-strong);
   outline: none;
 }
 
 .timelineChannelContent {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   width: 100%;
   min-width: 0;
   overflow: hidden;
@@ -1298,19 +1302,21 @@
 
 .timelineChannelLogo {
   width: auto;
-  height: 28px;
-  max-width: 50px;
+  height: 26px;
+  max-width: 44px;
   object-fit: contain;
+  flex-shrink: 0;
 }
 
 .timelineChannelName {
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 130px;
+  flex: 1;
+  min-width: 0;
 }
 
 .timelineEventsContainer {

--- a/apps/webui/src/features/epg/EPG.module.css
+++ b/apps/webui/src/features/epg/EPG.module.css
@@ -1231,7 +1231,7 @@
   left: var(--xg2g-timeline-left);
   position: absolute;
   top: 0;
-  bottom: -2000px; /* extends down into the body */
+  height: var(--xg2g-timeline-indicator-height, 100%);
   width: 2px;
   background: var(--status-error);
   z-index: 10;

--- a/apps/webui/src/features/epg/EPG.module.css
+++ b/apps/webui/src/features/epg/EPG.module.css
@@ -1236,7 +1236,7 @@
   height: 8px;
   border-radius: 50%;
   background: var(--status-error);
-  box-shadow: 0 0 10px var(--status-error), 0 0 4px #ffffff;
+  box-shadow: var(--shadow-status-error-strong);
   z-index: 25;
 }
 
@@ -1247,10 +1247,10 @@
   bottom: 0;
   height: 100%;
   width: 2px;
-  background: linear-gradient(180deg, var(--status-error) 0%, rgba(248, 113, 113, 0.75) 100%);
+  background: linear-gradient(180deg, var(--status-error) 0%, color-mix(in srgb, var(--status-error) 75%, transparent) 100%);
   z-index: 40;
   pointer-events: none;
-  box-shadow: 0 0 8px rgba(248, 113, 113, 0.6), 0 0 2px rgba(248, 113, 113, 0.9);
+  box-shadow: var(--shadow-status-error);
 }
 
 .timelineBody {
@@ -1273,7 +1273,7 @@
   left: 0;
   z-index: 50;
   transform: translateZ(0);
-  background: var(--surface-shell-safe, #080d14);
+  background: var(--surface-shell-safe);
   border-right: 1px solid var(--border-base);
   padding: 6px 12px;
   height: 54px;

--- a/apps/webui/src/features/epg/EPG.module.css
+++ b/apps/webui/src/features/epg/EPG.module.css
@@ -1233,10 +1233,22 @@
   top: 0;
   height: var(--xg2g-timeline-indicator-height, 100%);
   width: 2px;
-  background: var(--status-error);
-  z-index: 10;
+  background: linear-gradient(180deg, #ff4d4d 0%, #f87171 100%);
+  z-index: 60;
   pointer-events: none;
-  box-shadow: var(--shadow-epg-current-time);
+  box-shadow: 0 0 8px rgba(255, 77, 77, 0.6), 0 0 2px rgba(255, 77, 77, 0.9);
+}
+
+.timelineCurrentTimeKnob {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -3px);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ff4d4d;
+  box-shadow: 0 0 10px #ff4d4d, 0 0 4px #ffffff;
 }
 
 .timelineBody {

--- a/apps/webui/src/features/epg/EPG.module.css
+++ b/apps/webui/src/features/epg/EPG.module.css
@@ -1233,10 +1233,10 @@
   top: 0;
   height: var(--xg2g-timeline-indicator-height, 100%);
   width: 2px;
-  background: linear-gradient(180deg, #ff4d4d 0%, #f87171 100%);
+  background: var(--status-error);
   z-index: 60;
   pointer-events: none;
-  box-shadow: 0 0 8px rgba(255, 77, 77, 0.6), 0 0 2px rgba(255, 77, 77, 0.9);
+  box-shadow: var(--shadow-status-error);
 }
 
 .timelineCurrentTimeKnob {
@@ -1247,8 +1247,8 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #ff4d4d;
-  box-shadow: 0 0 10px #ff4d4d, 0 0 4px #ffffff;
+  background: var(--status-error);
+  box-shadow: var(--shadow-status-error-strong);
 }
 
 .timelineBody {

--- a/apps/webui/src/features/epg/EPG.tsx
+++ b/apps/webui/src/features/epg/EPG.tsx
@@ -703,9 +703,12 @@ export default function EPG({
       {selectedEvent && (
         <EpgEventDialog
           event={selectedEvent}
+          channel={channels.find((c) => c.serviceRef === selectedEvent.serviceRef || c.id === selectedEvent.serviceRef)}
+          currentTime={state.currentTime}
           onClose={() => setSelectedEvent(null)}
           onRecord={canManageDvr ? handleRecord : undefined}
           isRecorded={selectedEvent ? isRecorded(selectedEvent) : false}
+          onPlay={onPlay}
         />
       )}
     </div>

--- a/apps/webui/src/features/epg/components/EpgEventDialog.module.css
+++ b/apps/webui/src/features/epg/components/EpgEventDialog.module.css
@@ -12,20 +12,18 @@
 }
 
 .card {
-  background: var(--surface-stage-strong, #0b131e);
-  border: 1px solid var(--border-elevated, rgba(255, 255, 255, 0.15));
+  background: #0e1623;
+  border: 1px solid var(--border-elevated, rgba(255, 255, 255, 0.18));
   border-radius: 20px;
   width: 100%;
   max-width: 580px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.8), var(--shadow-epg-dialog, 0 10px 30px rgba(0, 0, 0, 0.5));
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.85);
   overflow: hidden;
   position: relative;
   z-index: 10000;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
 }
 
 .card::before {
@@ -35,7 +33,7 @@
   left: 0;
   right: 0;
   height: 4px;
-  background: var(--accent-action, #0a84ff);
+  background: var(--accent-action);
   pointer-events: none;
 }
 
@@ -51,7 +49,7 @@
   margin: 0;
   font-size: 20px;
   font-weight: 700;
-  color: var(--text-primary, #ffffff);
+  color: var(--text-primary);
   line-height: 1.3;
   letter-spacing: -0.01em;
 }
@@ -65,9 +63,9 @@
   border: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
   border-radius: 8px;
   font-size: 13px;
-  color: var(--text-secondary, #b7c6c4);
+  color: var(--text-secondary);
   font-weight: 600;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
   letter-spacing: 0.02em;
 }
 
@@ -76,7 +74,7 @@
   overflow-y: auto;
   font-size: 15px;
   line-height: 1.65;
-  color: var(--text-primary, #ffffff);
+  color: var(--text-primary);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -88,6 +86,5 @@
   justify-content: flex-end;
   gap: 12px;
   flex-shrink: 0;
-  background: var(--surface-shell-safe, #070b11);
+  background: var(--surface-shell-safe);
 }
-

--- a/apps/webui/src/features/epg/components/EpgEventDialog.module.css
+++ b/apps/webui/src/features/epg/components/EpgEventDialog.module.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset: 0;
   z-index: 9999;
-  background: rgba(0, 0, 0, 0.75);
+  background: var(--overlay-backdrop-strong);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   display: flex;
@@ -12,15 +12,15 @@
 }
 
 .card {
-  background: #0e1623;
-  border: 1px solid var(--border-elevated, rgba(255, 255, 255, 0.18));
+  background: var(--surface-dialog-opaque);
+  border: 1px solid var(--border-strong);
   border-radius: 20px;
   width: 100%;
   max-width: 580px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.85);
+  box-shadow: var(--shadow-epg-dialog-strong);
   overflow: hidden;
   position: relative;
   z-index: 10000;
@@ -39,7 +39,7 @@
 
 .header {
   padding: 24px 28px 18px;
-  border-bottom: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
+  border-bottom: 1px solid var(--border-base);
   flex-shrink: 0;
   position: relative;
   z-index: 1;
@@ -59,8 +59,8 @@
   display: inline-flex;
   align-items: center;
   padding: 5px 12px;
-  background: var(--surface-muted, rgba(255, 255, 255, 0.06));
-  border: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
+  background: var(--surface-muted);
+  border: 1px solid var(--border-base);
   border-radius: 8px;
   font-size: 13px;
   color: var(--text-secondary);
@@ -81,7 +81,7 @@
 
 .footer {
   padding: 16px 28px;
-  border-top: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
+  border-top: 1px solid var(--border-base);
   display: flex;
   justify-content: flex-end;
   gap: 12px;

--- a/apps/webui/src/features/epg/components/EpgEventDialog.module.css
+++ b/apps/webui/src/features/epg/components/EpgEventDialog.module.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset: 0;
   z-index: 9999;
-  background: color-mix(in srgb, var(--surface-default) 60%, transparent);
+  background: rgba(0, 0, 0, 0.75);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   display: flex;
@@ -11,20 +11,21 @@
   padding: 16px;
 }
 
-
-
 .card {
-  background: var(--surface-panel);
-  border: 1px solid var(--border-elevated);
-  border-radius: 24px;
+  background: var(--surface-stage-strong, #0b131e);
+  border: 1px solid var(--border-elevated, rgba(255, 255, 255, 0.15));
+  border-radius: 20px;
   width: 100%;
-  max-width: 540px;
+  max-width: 580px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: var(--shadow-epg-dialog);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.8), var(--shadow-epg-dialog, 0 10px 30px rgba(0, 0, 0, 0.5));
   overflow: hidden;
   position: relative;
+  z-index: 10000;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .card::before {
@@ -33,14 +34,14 @@
   top: 0;
   left: 0;
   right: 0;
-  height: 120px;
-  background: var(--gradient-epg-dialog-accent);
+  height: 4px;
+  background: var(--accent-action, #0a84ff);
   pointer-events: none;
 }
 
 .header {
-  padding: 32px 32px 24px;
-  border-bottom: 1px solid var(--border-base);
+  padding: 24px 28px 18px;
+  border-bottom: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
   flex-shrink: 0;
   position: relative;
   z-index: 1;
@@ -48,42 +49,45 @@
 
 .title {
   margin: 0;
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 700;
-  color: var(--text-primary);
-  line-height: 1.2;
-  letter-spacing: -0.02em;
+  color: var(--text-primary, #ffffff);
+  line-height: 1.3;
+  letter-spacing: -0.01em;
 }
 
 .time {
-  margin-top: 12px;
+  margin-top: 10px;
   display: inline-flex;
   align-items: center;
-  padding: 6px 12px;
-  background: var(--surface-muted);
-  border-radius: 999px;
-  font-size: 14px;
-  color: var(--text-secondary);
+  padding: 5px 12px;
+  background: var(--surface-muted, rgba(255, 255, 255, 0.06));
+  border: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text-secondary, #b7c6c4);
   font-weight: 600;
-  font-family: var(--font-mono);
-  letter-spacing: 0.05em;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.02em;
 }
 
 .content {
-  padding: 32px;
+  padding: 24px 28px;
   overflow-y: auto;
-  font-size: 16px;
-  line-height: 1.7;
-  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-primary, #ffffff);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .footer {
-  padding: 20px 32px;
-  border-top: 1px solid var(--border-base);
+  padding: 16px 28px;
+  border-top: 1px solid var(--border-base, rgba(255, 255, 255, 0.1));
   display: flex;
   justify-content: flex-end;
-  gap: 16px;
+  gap: 12px;
   flex-shrink: 0;
-  background: color-mix(in srgb, var(--surface-muted) 30%, transparent);
+  background: var(--surface-shell-safe, #070b11);
 }
 

--- a/apps/webui/src/features/epg/components/EpgEventDialog.tsx
+++ b/apps/webui/src/features/epg/components/EpgEventDialog.tsx
@@ -11,6 +11,9 @@ interface EpgEventDialogProps {
   onClose: () => void;
   onRecord?: (event: EpgEvent) => void;
   isRecorded?: boolean;
+  onPlay?: (channel: EpgChannel) => void;
+  channel?: EpgChannel;
+  currentTime?: number;
 }
 
 function formatDateTime(ts: number): string {
@@ -25,7 +28,7 @@ function formatTime(ts: number): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-export function EpgEventDialog({ event, onClose, onRecord, isRecorded }: EpgEventDialogProps) {
+export function EpgEventDialog({ event, onClose, onRecord, isRecorded, onPlay, channel, currentTime }: EpgEventDialogProps) {
   const { t } = useTranslation();
   useEffect(() => {
     // Lock body scroll
@@ -43,6 +46,8 @@ export function EpgEventDialog({ event, onClose, onRecord, isRecorded }: EpgEven
   }, [onClose]);
 
   const desc = event.desc ? normalizeEpgText(event.desc) : t('epg.noDescription', { defaultValue: 'No description available.' });
+  const now = currentTime || Math.floor(Date.now() / 1000);
+  const inProgress = now >= event.start && now < event.end;
 
   return createPortal(
     <div
@@ -58,7 +63,7 @@ export function EpgEventDialog({ event, onClose, onRecord, isRecorded }: EpgEven
             {event.title || t('epg.unknownTitle', { defaultValue: 'Unknown show' })}
           </h2>
           <div className={styles.time}>
-            {formatDateTime(event.start)} – {formatTime(event.end)}
+            {channel?.name ? `${channel.name} · ` : ''}{formatDateTime(event.start)} – {formatTime(event.end)}
           </div>
         </div>
 
@@ -67,19 +72,30 @@ export function EpgEventDialog({ event, onClose, onRecord, isRecorded }: EpgEven
         </div>
 
         <div className={styles.footer}>
+          {inProgress && channel && onPlay && (
+            <Button
+              variant="primary"
+              onClick={() => {
+                onPlay(channel);
+                onClose();
+              }}
+            >
+              ▶ {t('epg.playChannel', { defaultValue: 'Sendung schauen' })}
+            </Button>
+          )}
           {onRecord && (
             <Button
-              variant={isRecorded ? 'secondary' : 'primary'}
+              variant={inProgress && channel && onPlay ? 'secondary' : (isRecorded ? 'secondary' : 'primary')}
               onClick={() => {
                 onRecord(event);
                 onClose();
               }}
             >
-              {isRecorded ? t('epg.recordingPlanned', { defaultValue: 'Recording scheduled' }) : t('epg.record', { defaultValue: 'Record' })}
+              {isRecorded ? t('epg.recordingPlanned', { defaultValue: 'Aufnahme geplant' }) : t('epg.record', { defaultValue: 'Aufnehmen' })}
             </Button>
           )}
           <Button variant="secondary" onClick={onClose}>
-            {t('common.close', { defaultValue: 'Close' })}
+            {t('common.close', { defaultValue: 'Schließen' })}
           </Button>
         </div>
       </div>

--- a/apps/webui/src/features/epg/components/EpgEventDialog.tsx
+++ b/apps/webui/src/features/epg/components/EpgEventDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { EpgEvent } from '../types';
 import { normalizeEpgText } from '../../../utils/text';
@@ -43,7 +44,7 @@ export function EpgEventDialog({ event, onClose, onRecord, isRecorded }: EpgEven
 
   const desc = event.desc ? normalizeEpgText(event.desc) : t('epg.noDescription', { defaultValue: 'No description available.' });
 
-  return (
+  return createPortal(
     <div
       className={styles.overlay}
       role="presentation"
@@ -82,6 +83,7 @@ export function EpgEventDialog({ event, onClose, onRecord, isRecorded }: EpgEven
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/apps/webui/src/features/epg/components/EpgEventDialog.tsx
+++ b/apps/webui/src/features/epg/components/EpgEventDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import type { EpgEvent } from '../types';
+import type { EpgEvent, EpgChannel } from '../types';
 import { normalizeEpgText } from '../../../utils/text';
 import { Button } from '../../../components/ui';
 import styles from './EpgEventDialog.module.css';

--- a/apps/webui/src/features/epg/components/EpgTimelineGrid.tsx
+++ b/apps/webui/src/features/epg/components/EpgTimelineGrid.tsx
@@ -45,7 +45,6 @@ export function EpgTimelineGrid({
   }
 
   const nowLeftPx = ((currentTime * 1000 - startTimestampMs) / (60 * 60 * 1000)) * PIXELS_PER_HOUR;
-  const exactGridHeight = 36 + channels.length * 54;
 
   return (
     <div className={styles.timelineContainer} ref={containerRef} role="grid" aria-label="EPG Timeline">
@@ -57,22 +56,24 @@ export function EpgTimelineGrid({
               {tick.label}
             </div>
           ))}
-          {/* Current Time Indicator Line */}
+          {/* Header Time Knob */}
           {nowLeftPx >= 0 && nowLeftPx <= timelineWidth && (
             <div
-              className={styles.timelineCurrentTimeIndicator}
-              style={{
-                '--xg2g-timeline-left': `${nowLeftPx}px`,
-                '--xg2g-timeline-indicator-height': `${exactGridHeight}px`,
-              } as CSSProperties}
-            >
-              <div className={styles.timelineCurrentTimeKnob} />
-            </div>
+              className={styles.timelineHeaderTimeKnob}
+              style={{ '--xg2g-timeline-left': `${nowLeftPx}px` } as CSSProperties}
+            />
           )}
         </div>
       </div>
       
       <div className={styles.timelineBody}>
+        {/* Full-Height Vertical Laser Line across all channels */}
+        {nowLeftPx >= 0 && nowLeftPx <= timelineWidth && (
+          <div
+            className={styles.timelineCurrentTimeLine}
+            style={{ '--xg2g-timeline-left': `${nowLeftPx + 250}px` } as CSSProperties}
+          />
+        )}
         {channels.map((channel) => {
           const ref = channel.serviceRef || channel.id || '';
           const events = eventsByServiceRef.get(ref) || [];

--- a/apps/webui/src/features/epg/components/EpgTimelineGrid.tsx
+++ b/apps/webui/src/features/epg/components/EpgTimelineGrid.tsx
@@ -45,7 +45,7 @@ export function EpgTimelineGrid({
   }
 
   const nowLeftPx = ((currentTime * 1000 - startTimestampMs) / (60 * 60 * 1000)) * PIXELS_PER_HOUR;
-  const totalIndicatorHeight = 36 + channels.length * 54 + 60;
+  const exactGridHeight = 36 + channels.length * 54;
 
   return (
     <div className={styles.timelineContainer} ref={containerRef} role="grid" aria-label="EPG Timeline">
@@ -63,9 +63,11 @@ export function EpgTimelineGrid({
               className={styles.timelineCurrentTimeIndicator}
               style={{
                 '--xg2g-timeline-left': `${nowLeftPx}px`,
-                '--xg2g-timeline-indicator-height': `${totalIndicatorHeight}px`,
+                '--xg2g-timeline-indicator-height': `${exactGridHeight}px`,
               } as CSSProperties}
-            />
+            >
+              <div className={styles.timelineCurrentTimeKnob} />
+            </div>
           )}
         </div>
       </div>

--- a/apps/webui/src/features/epg/components/EpgTimelineGrid.tsx
+++ b/apps/webui/src/features/epg/components/EpgTimelineGrid.tsx
@@ -45,6 +45,7 @@ export function EpgTimelineGrid({
   }
 
   const nowLeftPx = ((currentTime * 1000 - startTimestampMs) / (60 * 60 * 1000)) * PIXELS_PER_HOUR;
+  const totalIndicatorHeight = 36 + channels.length * 54 + 60;
 
   return (
     <div className={styles.timelineContainer} ref={containerRef} role="grid" aria-label="EPG Timeline">
@@ -58,7 +59,13 @@ export function EpgTimelineGrid({
           ))}
           {/* Current Time Indicator Line */}
           {nowLeftPx >= 0 && nowLeftPx <= timelineWidth && (
-            <div className={styles.timelineCurrentTimeIndicator} style={{ '--xg2g-timeline-left': `${nowLeftPx}px` } as CSSProperties} />
+            <div
+              className={styles.timelineCurrentTimeIndicator}
+              style={{
+                '--xg2g-timeline-left': `${nowLeftPx}px`,
+                '--xg2g-timeline-indicator-height': `${totalIndicatorHeight}px`,
+              } as CSSProperties}
+            />
           )}
         </div>
       </div>

--- a/apps/webui/src/features/player/components/QuickRecordDialog.module.css
+++ b/apps/webui/src/features/player/components/QuickRecordDialog.module.css
@@ -1,0 +1,232 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.card {
+  background: #0d1522;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  width: 100%;
+  max-width: 540px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.9);
+  overflow: hidden;
+  position: relative;
+  color: #ffffff;
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #f87171, #ff4d4d);
+}
+
+.header {
+  padding: 24px 28px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  flex-shrink: 0;
+}
+
+.channelBadge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 6px;
+  background: rgba(10, 132, 255, 0.2);
+  border: 1px solid rgba(10, 132, 255, 0.4);
+  color: #60a5fa;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1.3;
+}
+
+.programMeta {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #b7c6c4;
+}
+
+.timeRange {
+  color: #9aaca8;
+  font-family: monospace;
+}
+
+.content {
+  padding: 20px 28px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.optionsList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.optionCard {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  padding: 14px 16px;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.18s ease;
+  color: inherit;
+}
+
+.optionCard:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.optionCardActive {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: #f87171;
+  box-shadow: 0 0 12px rgba(248, 113, 113, 0.2);
+}
+
+.radioDot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.optionCardActive .radioDot {
+  border-color: #f87171;
+}
+
+.radioInner {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #f87171;
+}
+
+.optionDetails {
+  flex: 1;
+  min-width: 0;
+}
+
+.optionTitle {
+  font-weight: 700;
+  font-size: 15px;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.recommendedBadge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(52, 211, 153, 0.2);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.4);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.optionDesc {
+  font-size: 13px;
+  color: #b7c6c4;
+  margin-top: 4px;
+  line-height: 1.45;
+}
+
+.customControls {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.selectLabel {
+  font-size: 13px;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.selectInput {
+  background: #172436;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: #ffffff;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  outline: none;
+  cursor: pointer;
+}
+
+.paddingConfig {
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.paddingLabel {
+  font-size: 13px;
+  color: #b7c6c4;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.selectInputSmall {
+  background: #172436;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: #ffffff;
+  padding: 4px 10px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+}
+
+.footer {
+  padding: 18px 28px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  background: #080d14;
+}

--- a/apps/webui/src/features/player/components/QuickRecordDialog.tsx
+++ b/apps/webui/src/features/player/components/QuickRecordDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { addTimer } from '../../../client-ts';

--- a/apps/webui/src/features/player/components/QuickRecordDialog.tsx
+++ b/apps/webui/src/features/player/components/QuickRecordDialog.tsx
@@ -1,0 +1,245 @@
+import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { addTimer } from '../../../client-ts';
+import { throwOnClientResultError } from '../../../services/clientWrapper';
+import { useUiOverlay } from '../../../context/UiOverlayContext';
+import { normalizeEpgText } from '../../../utils/text';
+import { Button } from '../../../components/ui';
+import styles from './QuickRecordDialog.module.css';
+
+export interface QuickRecordDialogProps {
+  channelName?: string;
+  serviceRef?: string;
+  programTitle?: string;
+  programDesc?: string;
+  startTs?: number; // Unix seconds
+  endTs?: number;   // Unix seconds
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+type RecordMode = 'buffer_full' | 'from_now' | 'custom';
+
+function formatTime(ts: number): string {
+  if (!ts) return '';
+  const d = new Date(ts * 1000);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export function QuickRecordDialog({
+  channelName,
+  serviceRef,
+  programTitle,
+  programDesc,
+  startTs,
+  endTs,
+  onClose,
+  onSuccess,
+}: QuickRecordDialogProps) {
+  const { t } = useTranslation();
+  const { toast } = useUiOverlay();
+
+  const now = Math.floor(Date.now() / 1000);
+  const effectiveStart = startTs || (now - 1800);
+  const effectiveEnd = endTs || (now + 3600);
+
+  const [mode, setMode] = useState<RecordMode>('buffer_full');
+  const [customMinutes, setCustomMinutes] = useState<number>(60);
+  const [paddingMinutes, setPaddingMinutes] = useState<number>(5);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [onClose]);
+
+  const handleStartRecord = async () => {
+    if (!serviceRef) {
+      toast({ kind: 'error', message: 'Kein gültiger Sender für Aufnahme gefunden.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      let begin = effectiveStart;
+      let end = effectiveEnd + paddingMinutes * 60;
+
+      if (mode === 'from_now') {
+        begin = now;
+      } else if (mode === 'custom') {
+        begin = effectiveStart;
+        end = now + customMinutes * 60;
+      }
+
+      const title = programTitle || 'Live Aufnahme';
+      const desc = normalizeEpgText(programDesc) || '';
+
+      const result = await addTimer({
+        body: {
+          serviceRef,
+          begin,
+          end,
+          name: title,
+          description: desc,
+        },
+      });
+
+      throwOnClientResultError(result, { source: 'QuickRecordDialog' });
+
+      toast({
+        kind: 'success',
+        message: t('epg.recordSuccess', { defaultValue: `Aufnahme gestartet: ${title}` }),
+      });
+      onSuccess?.();
+      onClose();
+    } catch (err) {
+      toast({
+        kind: 'error',
+        message: 'Fehler beim Starten der Aufnahme.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className={styles.overlay}
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className={styles.card} role="dialog" aria-modal="true" aria-labelledby="quick-record-title">
+        <div className={styles.header}>
+          <div className={styles.channelBadge}>{channelName || 'Live TV'}</div>
+          <h2 id="quick-record-title" className={styles.title}>
+            🔴 Sendung aufnehmen
+          </h2>
+          <div className={styles.programMeta}>
+            <strong>{programTitle || 'Laufendes Programm'}</strong>
+            <span className={styles.timeRange}>
+              ({formatTime(effectiveStart)} – {formatTime(effectiveEnd)} Uhr)
+            </span>
+          </div>
+        </div>
+
+        <div className={styles.content}>
+          <div className={styles.optionsList}>
+            {/* Option 1: Full Show including Ringbuffer */}
+            <button
+              type="button"
+              className={`${styles.optionCard} ${mode === 'buffer_full' ? styles.optionCardActive : ''}`}
+              onClick={() => setMode('buffer_full')}
+            >
+              <div className={styles.radioDot}>
+                {mode === 'buffer_full' && <div className={styles.radioInner} />}
+              </div>
+              <div className={styles.optionDetails}>
+                <div className={styles.optionTitle}>
+                  ⏪ Komplett inkl. DVR-Puffer <span className={styles.recommendedBadge}>Empfohlen</span>
+                </div>
+                <div className={styles.optionDesc}>
+                  Nimmt die gesamte Sendung ab Beginn ({formatTime(effectiveStart)} Uhr) aus dem Ringpuffer bis zum Ende auf.
+                </div>
+              </div>
+            </button>
+
+            {/* Option 2: From Now */}
+            <button
+              type="button"
+              className={`${styles.optionCard} ${mode === 'from_now' ? styles.optionCardActive : ''}`}
+              onClick={() => setMode('from_now')}
+            >
+              <div className={styles.radioDot}>
+                {mode === 'from_now' && <div className={styles.radioInner} />}
+              </div>
+              <div className={styles.optionDetails}>
+                <div className={styles.optionTitle}>
+                  ⏺️ Ab JETZT ({formatTime(now)} Uhr)
+                </div>
+                <div className={styles.optionDesc}>
+                  Nimmt ab der aktuellen Minute bis zum offiziellen Ende ({formatTime(effectiveEnd)} Uhr) auf.
+                </div>
+              </div>
+            </button>
+
+            {/* Option 3: Custom Duration */}
+            <button
+              type="button"
+              className={`${styles.optionCard} ${mode === 'custom' ? styles.optionCardActive : ''}`}
+              onClick={() => setMode('custom')}
+            >
+              <div className={styles.radioDot}>
+                {mode === 'custom' && <div className={styles.radioInner} />}
+              </div>
+              <div className={styles.optionDetails}>
+                <div className={styles.optionTitle}>
+                  ⏱️ Manuelle Dauer wählen
+                </div>
+                <div className={styles.optionDesc}>
+                  Lege eine feste Aufnahmedauer ab Beginn der Sendung fest.
+                </div>
+                {mode === 'custom' && (
+                  <div className={styles.customControls} onClick={(e) => e.stopPropagation()}>
+                    <label className={styles.selectLabel}>
+                      Dauer:
+                      <select
+                        className={styles.selectInput}
+                        value={customMinutes}
+                        onChange={(e) => setCustomMinutes(Number(e.target.value))}
+                      >
+                        <option value={30}>30 Minuten</option>
+                        <option value={60}>60 Minuten (1 Std)</option>
+                        <option value={90}>90 Minuten (1.5 Std)</option>
+                        <option value={120}>120 Minuten (2 Std)</option>
+                        <option value={180}>180 Minuten (3 Std)</option>
+                      </select>
+                    </label>
+                  </div>
+                )}
+              </div>
+            </button>
+          </div>
+
+          {/* Padding / Nachlaufzeit Setting */}
+          <div className={styles.paddingConfig}>
+            <label className={styles.paddingLabel}>
+              <span>Nachlaufzeit (Sicherheits-Puffer am Ende):</span>
+              <select
+                className={styles.selectInputSmall}
+                value={paddingMinutes}
+                onChange={(e) => setPaddingMinutes(Number(e.target.value))}
+              >
+                <option value={0}>0 Min</option>
+                <option value={5}>+5 Min</option>
+                <option value={10}>+10 Min</option>
+                <option value={15}>+15 Min</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div className={styles.footer}>
+          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            Abbrechen
+          </Button>
+          <Button variant="primary" onClick={handleStartRecord} disabled={isSubmitting}>
+            {isSubmitting ? 'Startet...' : '🔴 Aufnahme starten'}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/webui/src/features/player/components/V3PlayerView.tsx
+++ b/apps/webui/src/features/player/components/V3PlayerView.tsx
@@ -255,7 +255,7 @@ export function V3PlayerView({
                 <input
                   type="text"
                   className={styles.serviceInput}
-                  value={viewState.serviceRef}
+                  value={viewState.serviceRef || ''}
                   onChange={(e) => actions.updateServiceRef(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {

--- a/apps/webui/src/features/player/components/V3PlayerView.tsx
+++ b/apps/webui/src/features/player/components/V3PlayerView.tsx
@@ -1,4 +1,4 @@
-import { type RefObject } from 'react';
+import { useState, type RefObject } from 'react';
 import { Button, Card, StatusChip } from '../../../components/ui';
 import { useUiSurface } from '../../../context/UiSurfaceContext';
 import type { VideoElementRef } from '../../../types/v3-player';
@@ -9,6 +9,7 @@ import type {
 import styles from './V3Player.module.css';
 import { DvrScrubSlider } from './DvrScrubSlider';
 import { DropdownMenu } from './DropdownMenu';
+import { QuickRecordDialog } from './QuickRecordDialog';
 import { ChannelsGlyph, FullscreenGlyph, PipGlyph, StatsGlyph, VolumeGlyph, AudioTracksGlyph, SettingsGlyph, PlayGlyph, PauseGlyph, StopGlyph, SeekBackGlyph, SeekForwardGlyph } from './playerControlGlyphs';
 
 interface V3PlayerViewProps {
@@ -31,6 +32,7 @@ export function V3PlayerView({
   onOpenChannels,
   children,
 }: V3PlayerViewProps) {
+  const [showQuickRecord, setShowQuickRecord] = useState(false);
   // On phone-sized surfaces apply the compact mobile player layout (full-bleed
   // video, repositioned chrome). The styles existed in V3Player.module.css but
   // were never wired up, so the player rendered letterboxed on phones.
@@ -305,6 +307,19 @@ export function V3PlayerView({
                 </Button>
               )}
 
+              {viewState.serviceRef && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowQuickRecord(true)}
+                  title="Sendung aufnehmen (Retro-DVR)"
+                  aria-label="Sendung aufnehmen"
+                >
+                  <span style={{ color: '#f87171', fontWeight: 'bold', fontSize: '15px' }}>🔴</span>
+                  <span className="sr-only">Aufnehmen</span>
+                </Button>
+              )}
+
               {viewState.audioTracks && viewState.audioTracks.length > 1 && (
                 <DropdownMenu
                   icon={<AudioTracksGlyph />}
@@ -447,6 +462,15 @@ export function V3PlayerView({
             </div>
           </div>
         </div>
+      )}
+      {showQuickRecord && (
+        <QuickRecordDialog
+          channelName={viewState.channelName || undefined}
+          serviceRef={viewState.serviceRef || undefined}
+          programTitle={viewState.programmeTitle || undefined}
+          programDesc={viewState.programmeDesc || undefined}
+          onClose={() => setShowQuickRecord(false)}
+        />
       )}
       {/* Render children inside container to allow proper overlays (like ChannelSwitcher) */}
       {children}

--- a/apps/webui/src/features/player/components/playerViewStateModel.ts
+++ b/apps/webui/src/features/player/components/playerViewStateModel.ts
@@ -20,6 +20,7 @@ export interface V3PlayerViewState {
   channelName: string | null;
   programmeTitle: string | null;
   programmeDesc: string | null;
+  serviceRef: string | null;
   useOverlayLayout: boolean;
   userIdle: boolean;
   showCloseButton: boolean;
@@ -310,6 +311,7 @@ export function buildPlayerViewState(input: BuildViewStateInput): V3PlayerViewSt
     channelName: input.channel?.name ?? null,
     programmeTitle: input.playbackMode === 'LIVE' ? input.liveNowPlaying.title : (input.channel?.name ?? null),
     programmeDesc: input.playbackMode === 'LIVE' ? input.liveNowPlaying.desc : null,
+    serviceRef: input.sRef || null,
     useOverlayLayout: Boolean(input.onClose),
     userIdle: input.isIdle,
     showCloseButton: Boolean(input.onClose),

--- a/apps/webui/src/features/player/components/playerViewStateModel.ts
+++ b/apps/webui/src/features/player/components/playerViewStateModel.ts
@@ -20,7 +20,6 @@ export interface V3PlayerViewState {
   channelName: string | null;
   programmeTitle: string | null;
   programmeDesc: string | null;
-  serviceRef: string | null;
   useOverlayLayout: boolean;
   userIdle: boolean;
   showCloseButton: boolean;
@@ -311,7 +310,6 @@ export function buildPlayerViewState(input: BuildViewStateInput): V3PlayerViewSt
     channelName: input.channel?.name ?? null,
     programmeTitle: input.playbackMode === 'LIVE' ? input.liveNowPlaying.title : (input.channel?.name ?? null),
     programmeDesc: input.playbackMode === 'LIVE' ? input.liveNowPlaying.desc : null,
-    serviceRef: input.sRef || null,
     useOverlayLayout: Boolean(input.onClose),
     userIdle: input.isIdle,
     showCloseButton: Boolean(input.onClose),

--- a/apps/webui/src/index.css
+++ b/apps/webui/src/index.css
@@ -54,6 +54,7 @@
   --surface-muted: rgba(255, 255, 255, 0.04);
   --surface-stage: rgba(7, 13, 21, 0.74);
   --surface-stage-strong: rgba(11, 19, 30, 0.94);
+  --surface-dialog-opaque: #0e1623;
 
   /* Text Hierarchy */
   --text-primary: #f7fbf6;
@@ -176,6 +177,7 @@
   --shadow-epg-focus: 0 0 0 3px color-mix(in srgb, var(--accent-action) 20%, transparent);
   --shadow-epg-time-pill: 0 2px 6px rgba(0, 0, 0, 0.28);
   --shadow-epg-dialog: 0 24px 60px rgba(0, 0, 0, 0.4);
+  --shadow-epg-dialog-strong: 0 24px 60px rgba(0, 0, 0, 0.85);
   --shadow-none: none;
   --shadow-recordings-media-preview: 0 14px 28px color-mix(in srgb, var(--bg-video) 18%, transparent);
   --shadow-recordings-selection-indicator: 0 10px 24px color-mix(in srgb, black 24%, transparent);


### PR DESCRIPTION
## Summary
- extend the EPG current-time indicator across the rendered channel grid
- render the event dialog through a document-body portal for reliable stacking
- use an opaque tokenized dialog surface for sharp Safari text rendering
- allow an in-progress show to be opened directly from its event dialog
- keep all dialog colors and shadows within the WebUI design-token contract

## Verification
- `npm run lint`
- `npm test` (132 files, 673 tests)
- `npm run build`
- `git diff --check`