### PR TITLE
feat(retro): add atomic ringbuffer segment reservations

### DIFF
--- a/backend/internal/hls/ringbuffer/recovery.go
+++ b/backend/internal/hls/ringbuffer/recovery.go
@@ -1,0 +1,110 @@
+package ringbuffer
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+)
+
+type LifecycleState uint8
+
+const (
+	LifecycleStarting LifecycleState = iota
+	LifecycleRecovering
+	LifecycleReady
+	LifecycleCleanupEnabled
+)
+
+func (s LifecycleState) String() string {
+	switch s {
+	case LifecycleStarting:
+		return "STARTING"
+	case LifecycleRecovering:
+		return "RECOVERING"
+	case LifecycleReady:
+		return "READY"
+	case LifecycleCleanupEnabled:
+		return "CLEANUP_ENABLED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// LifecycleManager controls startup recovery before enabling ringbuffer segment cleanup.
+type LifecycleManager struct {
+	mu           sync.Mutex
+	state        LifecycleState
+	store        *ReservationStore
+	index        *SegmentIndex
+	cleanupReady chan struct{}
+}
+
+// NewLifecycleManager creates a new instance managing ringbuffer startup recovery.
+func NewLifecycleManager(store *ReservationStore, index *SegmentIndex) *LifecycleManager {
+	return &LifecycleManager{
+		state:        LifecycleStarting,
+		store:        store,
+		index:        index,
+		cleanupReady: make(chan struct{}),
+	}
+}
+
+func (lm *LifecycleManager) State() LifecycleState {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	return lm.state
+}
+
+// RunRecovery executes the startup recovery sequence.
+func (lm *LifecycleManager) RunRecovery() error {
+	lm.mu.Lock()
+	lm.state = LifecycleRecovering
+	lm.mu.Unlock()
+
+	// Load persistent reservations
+	lm.store.mu.Lock()
+	defer lm.store.mu.Unlock()
+
+	if lm.store.storagePath != "" {
+		if data, err := os.ReadFile(lm.store.storagePath); err == nil {
+			var loaded map[string]*Reservation
+			if err := json.Unmarshal(data, &loaded); err == nil {
+				now := time.Now()
+				for id, res := range loaded {
+					if now.After(res.ExpiresAt) {
+						continue // Skip expired reservations
+					}
+					// Verify segments exist and lock them
+					var validSegs []SegmentID
+					for _, segID := range res.SegmentIDs {
+						if seg, ok := lm.index.GetByID(segID); ok {
+							if _, err := os.Stat(seg.Path); err == nil {
+								seg.State = SegmentReserved
+								validSegs = append(validSegs, segID)
+							} else {
+								seg.State = SegmentMissing
+								res.Status = CompletenessGapped
+							}
+						}
+					}
+					res.SegmentIDs = validSegs
+					lm.store.reservations[id] = res
+				}
+			}
+		}
+	}
+
+	lm.mu.Lock()
+	lm.state = LifecycleReady
+	lm.state = LifecycleCleanupEnabled
+	close(lm.cleanupReady)
+	lm.mu.Unlock()
+
+	return nil
+}
+
+// WaitCleanupEnabled blocks until the recovery lifecycle enters CLEANUP_ENABLED.
+func (lm *LifecycleManager) WaitCleanupEnabled() {
+	<-lm.cleanupReady
+}

--- a/backend/internal/hls/ringbuffer/reservation.go
+++ b/backend/internal/hls/ringbuffer/reservation.go
@@ -1,0 +1,51 @@
+package ringbuffer
+
+import (
+	"time"
+)
+
+// ReservationLimits configures strict global and per-service boundaries for reservations.
+type ReservationLimits struct {
+	MaxPinnedBytesGlobal      int64         `json:"max_pinned_bytes_global"`
+	MaxPinnedBytesPerService  int64         `json:"max_pinned_bytes_per_service"`
+	MaxReservationsGlobal     int           `json:"max_reservations_global"`
+	MaxReservationsPerService int           `json:"max_reservations_per_service"`
+	MaxSegmentsPerReservation int           `json:"max_segments_per_reservation"`
+	MaxLeaseDuration          time.Duration `json:"max_lease_duration"`
+}
+
+// DefaultReservationLimits provides sane defaults for Retro-DVR reservations.
+func DefaultReservationLimits() ReservationLimits {
+	return ReservationLimits{
+		MaxPinnedBytesGlobal:      10 * 1024 * 1024 * 1024, // 10 GB
+		MaxPinnedBytesPerService:  4 * 1024 * 1024 * 1024,  // 4 GB
+		MaxReservationsGlobal:     20,
+		MaxReservationsPerService: 5,
+		MaxSegmentsPerReservation: 10000,
+		MaxLeaseDuration:          10 * time.Minute,
+	}
+}
+
+// Reservation represents an atomic, lease-bound hold on a set of ringbuffer segments.
+type Reservation struct {
+	ID         string       `json:"id"`
+	OwnerID    string       `json:"owner_id"`
+	ServiceRef string       `json:"service_ref"`
+	SegmentIDs []SegmentID  `json:"segment_ids"`
+	Start      time.Time    `json:"start"`
+	End        time.Time    `json:"end"`
+	Status     Completeness `json:"status"`
+	CreatedAt  time.Time    `json:"created_at"`
+	ExpiresAt  time.Time    `json:"expires_at"`
+	TotalBytes int64        `json:"total_bytes"`
+}
+
+// ReservationManager defines the authoritative interface for probing, reserving, and renewing segments.
+type ReservationManager interface {
+	ProbeRange(serviceRef string, start, end time.Time) (RangeProbe, error)
+	ReserveRange(serviceRef string, start, end time.Time, ownerID string, leaseDuration time.Duration) (Reservation, error)
+	GetReservation(reservationID string) (Reservation, error)
+	ListReservedSegments(reservationID string) ([]SegmentHandle, error)
+	RenewReservation(reservationID string, leaseDuration time.Duration) error
+	ReleaseReservation(reservationID string) error
+}

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -1,0 +1,343 @@
+package ringbuffer
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+var (
+	ErrReservationNotFound     = errors.New("reservation not found")
+	ErrReservationExpired      = errors.New("reservation expired")
+	ErrLimitExceededGlobal     = errors.New("global reservation byte/count limit exceeded")
+	ErrLimitExceededService    = errors.New("service reservation byte/count limit exceeded")
+	ErrLeaseExceedsMaxDuration = errors.New("lease duration exceeds maximum allowed limit")
+	ErrNoSegmentsAvailable     = errors.New("no valid segments available in requested range")
+)
+
+// ReservationStore provides atomic, thread-safe reservation management backed by SegmentIndex.
+type ReservationStore struct {
+	mu           sync.Mutex
+	index        *SegmentIndex
+	reservations map[string]*Reservation
+	limits       ReservationLimits
+	storagePath  string
+	onExpire     func(res *Reservation)
+}
+
+// NewReservationStore creates a new ReservationStore instance.
+func NewReservationStore(index *SegmentIndex, limits ReservationLimits, storagePath string) *ReservationStore {
+	if limits.MaxPinnedBytesGlobal == 0 {
+		limits = DefaultReservationLimits()
+	}
+	return &ReservationStore{
+		index:        index,
+		reservations: make(map[string]*Reservation),
+		limits:       limits,
+		storagePath:  storagePath,
+	}
+}
+
+// ProbeRange evaluates ringbuffer segment completeness without creating a reservation.
+func (rs *ReservationStore) ProbeRange(serviceRef string, start, end time.Time) (RangeProbe, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	return rs.probeRangeLocked(serviceRef, start, end)
+}
+
+func (rs *ReservationStore) probeRangeLocked(serviceRef string, start, end time.Time) (RangeProbe, error) {
+	segments := rs.index.SelectRange(serviceRef, start, end)
+	probe := RangeProbe{
+		RequestedStart: start,
+		RequestedEnd:   end,
+		SegmentCount:   len(segments),
+	}
+
+	if len(segments) == 0 {
+		probe.Completeness = CompletenessUnavailable
+		return probe, nil
+	}
+
+	availStart := segments[0].StartWallTime
+	availEnd := segments[len(segments)-1].EndWallTime
+	probe.AvailableStart = &availStart
+	probe.AvailableEnd = &availEnd
+
+	var totalBytes int64
+	var codecChanges int
+	var discontinuities int
+	var gaps []Gap
+	lastCodec := ""
+
+	for i, seg := range segments {
+		totalBytes += seg.SizeBytes
+
+		if seg.Discontinuity {
+			discontinuities++
+		}
+		if lastCodec != "" && seg.CodecHash != lastCodec {
+			codecChanges++
+		}
+		lastCodec = seg.CodecHash
+
+		// Check for internal temporal gaps between consecutive segments (>10s)
+		if i > 0 {
+			prevEnd := segments[i-1].EndWallTime
+			if seg.StartWallTime.Sub(prevEnd) > 10*time.Second {
+				gaps = append(gaps, Gap{
+					StartPTS90k:   segments[i-1].EndPTS90k,
+					EndPTS90k:     seg.StartPTS90k,
+					StartWallTime: prevEnd,
+					EndWallTime:   seg.StartWallTime,
+					DurationSec:   seg.StartWallTime.Sub(prevEnd).Seconds(),
+					Reason:        "TEMPORAL_GAP",
+				})
+			}
+		}
+	}
+
+	probe.TotalBytes = totalBytes
+	probe.CodecChanges = codecChanges
+	probe.Discontinuities = discontinuities
+	probe.Gaps = gaps
+
+	hasStart := availStart.Before(start) || availStart.Equal(start)
+	hasEnd := availEnd.After(end) || availEnd.Equal(end)
+
+	if len(gaps) > 0 {
+		probe.Completeness = CompletenessGapped
+	} else if hasStart && hasEnd {
+		probe.Completeness = CompletenessComplete
+	} else if !hasStart && hasEnd {
+		probe.Completeness = CompletenessPartialStart
+	} else if hasStart && !hasEnd {
+		probe.Completeness = CompletenessPartialEnd
+	} else {
+		probe.Completeness = CompletenessPartialBoth
+	}
+
+	return probe, nil
+}
+
+// ReserveRange performs range probing, limit checking, and segment locking in a single atomic transaction.
+func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time, ownerID string, leaseDuration time.Duration) (Reservation, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	// Clean up any expired reservations prior to evaluating limits
+	rs.purgeExpiredLocked()
+
+	if leaseDuration > rs.limits.MaxLeaseDuration {
+		return Reservation{}, ErrLeaseExceedsMaxDuration
+	}
+
+	probe, err := rs.probeRangeLocked(serviceRef, start, end)
+	if err != nil {
+		return Reservation{}, err
+	}
+	if probe.Completeness == CompletenessUnavailable || probe.SegmentCount == 0 {
+		return Reservation{}, ErrNoSegmentsAvailable
+	}
+
+	// Evaluate limits
+	var globalBytes int64
+	var globalCount int
+	var serviceBytes int64
+	var serviceCount int
+
+	for _, res := range rs.reservations {
+		globalBytes += res.TotalBytes
+		globalCount++
+		if res.ServiceRef == serviceRef {
+			serviceBytes += res.TotalBytes
+			serviceCount++
+		}
+	}
+
+	if globalCount+1 > rs.limits.MaxReservationsGlobal || globalBytes+probe.TotalBytes > rs.limits.MaxPinnedBytesGlobal {
+		return Reservation{}, ErrLimitExceededGlobal
+	}
+	if serviceCount+1 > rs.limits.MaxReservationsPerService || serviceBytes+probe.TotalBytes > rs.limits.MaxPinnedBytesPerService {
+		return Reservation{}, ErrLimitExceededService
+	}
+
+	segments := rs.index.SelectRange(serviceRef, start, end)
+	var segIDs []SegmentID
+	for _, seg := range segments {
+		seg.State = SegmentReserved
+		segIDs = append(segIDs, seg.ID)
+	}
+
+	now := time.Now()
+	res := &Reservation{
+		ID:         fmt.Sprintf("res_%d_%s", now.UnixNano(), ownerID),
+		OwnerID:    ownerID,
+		ServiceRef: serviceRef,
+		SegmentIDs: segIDs,
+		Start:      start,
+		End:        end,
+		Status:     probe.Completeness,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(leaseDuration),
+		TotalBytes: probe.TotalBytes,
+	}
+
+	rs.reservations[res.ID] = res
+	_ = rs.saveStateLocked()
+
+	return *res, nil
+}
+
+// GetReservation fetches a reservation by ID.
+func (rs *ReservationStore) GetReservation(reservationID string) (Reservation, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	res, ok := rs.reservations[reservationID]
+	if !ok {
+		return Reservation{}, ErrReservationNotFound
+	}
+	if time.Now().After(res.ExpiresAt) {
+		return Reservation{}, ErrReservationExpired
+	}
+	return *res, nil
+}
+
+// ListReservedSegments returns immutable SegmentHandles for an active reservation.
+func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]SegmentHandle, error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	res, ok := rs.reservations[reservationID]
+	if !ok {
+		return nil, ErrReservationNotFound
+	}
+	if time.Now().After(res.ExpiresAt) {
+		return nil, ErrReservationExpired
+	}
+
+	var handles []SegmentHandle
+	for _, segID := range res.SegmentIDs {
+		seg, ok := rs.index.GetByID(segID)
+		if !ok || seg.State == SegmentDeleting || seg.State == SegmentMissing {
+			continue
+		}
+		handles = append(handles, SegmentHandle{
+			ID:            seg.ID,
+			Path:          seg.Path,
+			Sequence:      seg.Sequence,
+			StartPTS90k:   seg.StartPTS90k,
+			EndPTS90k:     seg.EndPTS90k,
+			PTSEpoch:      seg.PTSEpoch,
+			StartWallTime: seg.StartWallTime,
+			EndWallTime:   seg.EndWallTime,
+			SizeBytes:     seg.SizeBytes,
+			Discontinuity: seg.Discontinuity,
+			CodecHash:     seg.CodecHash,
+		})
+	}
+
+	return handles, nil
+}
+
+// RenewReservation updates the lease expiration timestamp from now, capped by MaxLeaseDuration.
+func (rs *ReservationStore) RenewReservation(reservationID string, leaseDuration time.Duration) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	res, ok := rs.reservations[reservationID]
+	if !ok {
+		return ErrReservationNotFound
+	}
+	if leaseDuration > rs.limits.MaxLeaseDuration {
+		leaseDuration = rs.limits.MaxLeaseDuration
+	}
+
+	res.ExpiresAt = time.Now().Add(leaseDuration)
+	return rs.saveStateLocked()
+}
+
+// ReleaseReservation unlocks segments and removes the reservation.
+func (rs *ReservationStore) ReleaseReservation(reservationID string) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	res, ok := rs.reservations[reservationID]
+	if !ok {
+		return ErrReservationNotFound
+	}
+
+	rs.releaseReservationLocked(res)
+	return rs.saveStateLocked()
+}
+
+func (rs *ReservationStore) releaseReservationLocked(res *Reservation) {
+	for _, segID := range res.SegmentIDs {
+		if seg, ok := rs.index.GetByID(segID); ok && seg.State == SegmentReserved {
+			seg.State = SegmentActive
+		}
+	}
+	delete(rs.reservations, res.ID)
+}
+
+func (rs *ReservationStore) purgeExpiredLocked() {
+	now := time.Now()
+	for id, res := range rs.reservations {
+		if now.After(res.ExpiresAt) {
+			rs.releaseReservationLocked(res)
+			delete(rs.reservations, id)
+		}
+	}
+}
+
+// Atomic file persistence (reservations.json.tmp -> fsync -> rename)
+func (rs *ReservationStore) saveStateLocked() error {
+	if rs.storagePath == "" {
+		return nil
+	}
+
+	dir := filepath.Dir(rs.storagePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	tmpPath := rs.storagePath + ".tmp"
+	data, err := json.MarshalIndent(rs.reservations, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, rs.storagePath); err != nil {
+		return err
+	}
+
+	// Sync parent directory
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
+	}
+
+	return nil
+}

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -26,7 +26,6 @@ type ReservationStore struct {
 	reservations map[string]*Reservation
 	limits       ReservationLimits
 	storagePath  string
-	onExpire     func(res *Reservation)
 }
 
 // NewReservationStore creates a new ReservationStore instance.
@@ -302,7 +301,7 @@ func (rs *ReservationStore) saveStateLocked() error {
 	}
 
 	dir := filepath.Dir(rs.storagePath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err
 	}
 
@@ -312,7 +311,7 @@ func (rs *ReservationStore) saveStateLocked() error {
 		return err
 	}
 
-	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // G304: tmpPath is derived from operator-configured storagePath
 	if err != nil {
 		return err
 	}
@@ -334,7 +333,7 @@ func (rs *ReservationStore) saveStateLocked() error {
 	}
 
 	// Sync parent directory
-	if dirFile, err := os.Open(dir); err == nil {
+	if dirFile, err := os.Open(dir); err == nil { //nolint:gosec // G304: dir is derived from operator-configured storagePath
 		_ = dirFile.Sync()
 		_ = dirFile.Close()
 	}

--- a/backend/internal/hls/ringbuffer/reservation_test.go
+++ b/backend/internal/hls/ringbuffer/reservation_test.go
@@ -1,0 +1,224 @@
+package ringbuffer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func createTestSegment(serviceRef string, seq uint64, start, end time.Time, size int64, codec string, disc bool) *InternalSegment {
+	return &InternalSegment{
+		ID: SegmentID{
+			ServiceRef: serviceRef,
+			SessionID:  "sess_1",
+			Sequence:   seq,
+		},
+		Path:          fmt.Sprintf("/tmp/test_seg_%d.ts", seq),
+		Sequence:      seq,
+		StartPTS90k:   int64(seq * 90000),
+		EndPTS90k:     int64((seq + 1) * 90000),
+		PTSEpoch:      1,
+		StartWallTime: start,
+		EndWallTime:   end,
+		SizeBytes:     size,
+		Discontinuity: disc,
+		CodecHash:     codec,
+		State:         SegmentActive,
+	}
+}
+
+func TestProbeRange_Complete(t *testing.T) {
+	idx := NewSegmentIndex()
+	now := time.Now()
+	ref := "1:0:1:1:1:1:0:0:0:0:"
+
+	idx.AddSegment(createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false))
+	idx.AddSegment(createTestSegment(ref, 2, now.Add(-20*time.Minute), now.Add(-10*time.Minute), 1000, "h264", false))
+	idx.AddSegment(createTestSegment(ref, 3, now.Add(-10*time.Minute), now, 1000, "h264", false))
+
+	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	probe, err := store.ProbeRange(ref, now.Add(-25*time.Minute), now.Add(-5*time.Minute))
+	if err != nil {
+		t.Fatalf("ProbeRange failed: %v", err)
+	}
+
+	if probe.Completeness != CompletenessComplete {
+		t.Errorf("Expected COMPLETE, got %v", probe.Completeness)
+	}
+	if probe.SegmentCount != 3 {
+		t.Errorf("Expected 3 segments, got %d", probe.SegmentCount)
+	}
+}
+
+func TestProbeRange_PartialStart(t *testing.T) {
+	idx := NewSegmentIndex()
+	now := time.Now()
+	ref := "1:0:1:1:1:1:0:0:0:0:"
+
+	idx.AddSegment(createTestSegment(ref, 1, now.Add(-15*time.Minute), now.Add(-10*time.Minute), 1000, "h264", false))
+	idx.AddSegment(createTestSegment(ref, 2, now.Add(-10*time.Minute), now, 1000, "h264", false))
+
+	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	probe, err := store.ProbeRange(ref, now.Add(-30*time.Minute), now.Add(-5*time.Minute))
+	if err != nil {
+		t.Fatalf("ProbeRange failed: %v", err)
+	}
+
+	if probe.Completeness != CompletenessPartialStart {
+		t.Errorf("Expected PARTIAL_AT_START, got %v", probe.Completeness)
+	}
+}
+
+func TestReserveRange_AtomicAndLease(t *testing.T) {
+	idx := NewSegmentIndex()
+	now := time.Now()
+	ref := "1:0:1:1:1:1:0:0:0:0:"
+
+	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
+	seg2 := createTestSegment(ref, 2, now.Add(-20*time.Minute), now.Add(-10*time.Minute), 1000, "h264", false)
+	idx.AddSegment(seg1)
+	idx.AddSegment(seg2)
+
+	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	res, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-15*time.Minute), "job_1", 2*time.Second)
+	if err != nil {
+		t.Fatalf("ReserveRange failed: %v", err)
+	}
+
+	if seg1.State != SegmentReserved || seg2.State != SegmentReserved {
+		t.Errorf("Segments were not marked as SegmentReserved! seg1 state=%s, seg2 state=%s", seg1.State, seg2.State)
+	}
+
+	// Cleaner attempt on reserved segment must fail
+	if idx.MarkForDeletion(seg1.ID) {
+		t.Errorf("Cleaner marked reserved segment for deletion!")
+	}
+
+	// Release reservation
+	err = store.ReleaseReservation(res.ID)
+	if err != nil {
+		t.Fatalf("ReleaseReservation failed: %v", err)
+	}
+
+	if seg1.State != SegmentActive {
+		t.Errorf("Segment state after release expected SegmentActive, got %s", seg1.State)
+	}
+}
+
+func TestReserveRange_ContextIndependence(t *testing.T) {
+	idx := NewSegmentIndex()
+	now := time.Now()
+	ref := "1:0:1:1:1:1:0:0:0:0:"
+
+	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
+	idx.AddSegment(seg1)
+
+	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+
+	// Simulate an HTTP request context that gets canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	res, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_http", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("ReserveRange failed: %v", err)
+	}
+
+	// Cancel HTTP context
+	cancel()
+	_ = ctx
+
+	// Reservation must STILL be valid and active in store
+	fetched, err := store.GetReservation(res.ID)
+	if err != nil {
+		t.Fatalf("Reservation disappeared after HTTP context cancellation: %v", err)
+	}
+	if fetched.ID != res.ID {
+		t.Errorf("Reservation ID mismatch")
+	}
+}
+
+func TestCleanerDeletingRace(t *testing.T) {
+	idx := NewSegmentIndex()
+	now := time.Now()
+	ref := "1:0:1:1:1:1:0:0:0:0:"
+
+	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
+	idx.AddSegment(seg1)
+
+	// Cleaner marks segment for deletion
+	marked := idx.MarkForDeletion(seg1.ID)
+	if !marked {
+		t.Fatalf("Failed to mark segment for deletion")
+	}
+
+	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	_, err := store.ReserveRange(ref, now.Add(-28*time.Minute), now.Add(-22*time.Minute), "job_late", 5*time.Minute)
+	if err == nil {
+		t.Fatalf("Expected error when reserving DELETING segment, but got success!")
+	}
+}
+
+func TestStartupRecoveryLifecycle(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ringbuffer_test")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	storagePath := filepath.Join(tmpDir, "reservations.json")
+	idx := NewSegmentIndex()
+	now := time.Now()
+	ref := "1:0:1:1:1:1:0:0:0:0:"
+
+	segFile := filepath.Join(tmpDir, "seg1.ts")
+	if err := os.WriteFile(segFile, []byte("fake_ts_data"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
+	seg1.Path = segFile
+	idx.AddSegment(seg1)
+
+	store := NewReservationStore(idx, DefaultReservationLimits(), storagePath)
+	res, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_recover", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("ReserveRange failed: %v", err)
+	}
+
+	// Re-create store simulating a process restart
+	newIdx := NewSegmentIndex()
+	seg1Reloaded := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
+	seg1Reloaded.Path = segFile
+	newIdx.AddSegment(seg1Reloaded)
+
+	newStore := NewReservationStore(newIdx, DefaultReservationLimits(), storagePath)
+	lifecycle := NewLifecycleManager(newStore, newIdx)
+
+	if lifecycle.State() != LifecycleStarting {
+		t.Errorf("Expected STARTING, got %s", lifecycle.State())
+	}
+
+	err = lifecycle.RunRecovery()
+	if err != nil {
+		t.Fatalf("RunRecovery failed: %v", err)
+	}
+
+	if lifecycle.State() != LifecycleCleanupEnabled {
+		t.Errorf("Expected CLEANUP_ENABLED, got %s", lifecycle.State())
+	}
+
+	// Verify reservation was recovered and segment is reserved
+	recoveredRes, err := newStore.GetReservation(res.ID)
+	if err != nil {
+		t.Fatalf("Failed to recover reservation: %v", err)
+	}
+	if recoveredRes.ID != res.ID {
+		t.Errorf("Recovered reservation ID mismatch")
+	}
+
+	if seg1Reloaded.State != SegmentReserved {
+		t.Errorf("Reloaded segment expected SegmentReserved, got %s", seg1Reloaded.State)
+	}
+}

--- a/backend/internal/hls/ringbuffer/segment.go
+++ b/backend/internal/hls/ringbuffer/segment.go
@@ -1,0 +1,109 @@
+package ringbuffer
+
+import (
+	"fmt"
+	"time"
+)
+
+// SegmentState tracks the authoritative lifecycle state of a segment within the ringbuffer.
+type SegmentState uint8
+
+const (
+	SegmentActive SegmentState = iota
+	SegmentReserved
+	SegmentDeleting
+	SegmentMissing
+)
+
+func (s SegmentState) String() string {
+	switch s {
+	case SegmentActive:
+		return "ACTIVE"
+	case SegmentReserved:
+		return "RESERVED"
+	case SegmentDeleting:
+		return "DELETING"
+	case SegmentMissing:
+		return "MISSING"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// SegmentID uniquely identifies a segment across stream restarts and session boundaries.
+type SegmentID struct {
+	ServiceRef string `json:"service_ref"`
+	SessionID  string `json:"session_id"`
+	Sequence   uint64 `json:"sequence"`
+}
+
+func (id SegmentID) String() string {
+	return fmt.Sprintf("%s:%s:%d", id.ServiceRef, id.SessionID, id.Sequence)
+}
+
+// Completeness describes the availability status of requested segments in the ringbuffer.
+type Completeness string
+
+const (
+	CompletenessComplete     Completeness = "COMPLETE"
+	CompletenessPartialStart Completeness = "PARTIAL_AT_START"
+	CompletenessPartialEnd   Completeness = "PARTIAL_AT_END"
+	CompletenessPartialBoth  Completeness = "PARTIAL_AT_BOTH"
+	CompletenessGapped       Completeness = "GAPPED"
+	CompletenessUnavailable  Completeness = "UNAVAILABLE"
+)
+
+// Gap represents a temporal or media-time discontinuity within a segment range.
+type Gap struct {
+	StartPTS90k   int64     `json:"start_pts_90k"`
+	EndPTS90k     int64     `json:"end_pts_90k"`
+	StartWallTime time.Time `json:"start_wall_time"`
+	EndWallTime   time.Time `json:"end_wall_time"`
+	DurationSec   float64   `json:"duration_sec"`
+	Reason        string    `json:"reason"`
+}
+
+// InternalSegment holds complete metadata and mutable lifecycle state for a segment.
+type InternalSegment struct {
+	ID            SegmentID    `json:"id"`
+	Path          string       `json:"path"`
+	Sequence      uint64       `json:"sequence"`
+	StartPTS90k   int64        `json:"start_pts_90k"`
+	EndPTS90k     int64        `json:"end_pts_90k"`
+	PTSEpoch      uint32       `json:"pts_epoch"`
+	StartWallTime time.Time    `json:"start_wall_time"`
+	EndWallTime   time.Time    `json:"end_wall_time"`
+	SizeBytes     int64        `json:"size_bytes"`
+	Discontinuity bool         `json:"discontinuity"`
+	CodecHash     string       `json:"codec_hash"`
+	State         SegmentState `json:"state"`
+}
+
+// SegmentHandle exposes immutable segment metadata to callers (reservations & jobs).
+type SegmentHandle struct {
+	ID            SegmentID `json:"id"`
+	Path          string    `json:"path"`
+	Sequence      uint64    `json:"sequence"`
+	StartPTS90k   int64     `json:"start_pts_90k"`
+	EndPTS90k     int64     `json:"end_pts_90k"`
+	PTSEpoch      uint32    `json:"pts_epoch"`
+	StartWallTime time.Time `json:"start_wall_time"`
+	EndWallTime   time.Time `json:"end_wall_time"`
+	SizeBytes     int64     `json:"size_bytes"`
+	Discontinuity bool      `json:"discontinuity"`
+	CodecHash     string    `json:"codec_hash"`
+}
+
+// RangeProbe represents the result of probing segment availability over a time window.
+type RangeProbe struct {
+	RequestedStart  time.Time    `json:"requested_start"`
+	RequestedEnd    time.Time    `json:"requested_end"`
+	AvailableStart  *time.Time   `json:"available_start,omitempty"`
+	AvailableEnd    *time.Time   `json:"available_end,omitempty"`
+	Completeness    Completeness `json:"completeness"`
+	Gaps            []Gap        `json:"gaps,omitempty"`
+	SegmentCount    int          `json:"segment_count"`
+	TotalBytes      int64        `json:"total_bytes"`
+	CodecChanges    int          `json:"codec_changes"`
+	Discontinuities int          `json:"discontinuities"`
+}

--- a/backend/internal/hls/ringbuffer/segment_index.go
+++ b/backend/internal/hls/ringbuffer/segment_index.go
@@ -1,0 +1,95 @@
+package ringbuffer
+
+import (
+	"sort"
+	"time"
+)
+
+// SegmentIndex manages in-memory segments per service with wall-clock time indexing.
+type SegmentIndex struct {
+	byService map[string][]*InternalSegment
+}
+
+// NewSegmentIndex initializes an empty segment index.
+func NewSegmentIndex() *SegmentIndex {
+	return &SegmentIndex{
+		byService: make(map[string][]*InternalSegment),
+	}
+}
+
+// AddSegment inserts a new segment into the index in sequence order.
+func (idx *SegmentIndex) AddSegment(seg *InternalSegment) {
+	service := seg.ID.ServiceRef
+	segments := idx.byService[service]
+	segments = append(segments, seg)
+	sort.Slice(segments, func(i, j int) bool {
+		return segments[i].Sequence < segments[j].Sequence
+	})
+	idx.byService[service] = segments
+}
+
+// SelectRange filters non-deleting segments falling within [start, end].
+func (idx *SegmentIndex) SelectRange(serviceRef string, start, end time.Time) []*InternalSegment {
+	segments := idx.byService[serviceRef]
+	var matched []*InternalSegment
+
+	for _, seg := range segments {
+		// Ignore segments marked for deletion or missing
+		if seg.State == SegmentDeleting || seg.State == SegmentMissing {
+			continue
+		}
+
+		// Check overlap with requested window
+		if seg.EndWallTime.After(start) && seg.StartWallTime.Before(end) {
+			matched = append(matched, seg)
+		}
+	}
+
+	return matched
+}
+
+// GetByID looks up a segment by its compound ID.
+func (idx *SegmentIndex) GetByID(id SegmentID) (*InternalSegment, bool) {
+	segments, ok := idx.byService[id.ServiceRef]
+	if !ok {
+		return nil, false
+	}
+	for _, seg := range segments {
+		if seg.ID == id {
+			return seg, true
+		}
+	}
+	return nil, false
+}
+
+// MarkForDeletion transitions active, unreserved segments to SegmentDeleting state.
+func (idx *SegmentIndex) MarkForDeletion(id SegmentID) bool {
+	seg, ok := idx.GetByID(id)
+	if !ok {
+		return false
+	}
+	if seg.State == SegmentReserved {
+		return false // Cannot delete a reserved segment
+	}
+	seg.State = SegmentDeleting
+	return true
+}
+
+// RemoveSegment deletes a segment entry from the index after disk deletion.
+func (idx *SegmentIndex) RemoveSegment(id SegmentID) {
+	segments, ok := idx.byService[id.ServiceRef]
+	if !ok {
+		return
+	}
+	var filtered []*InternalSegment
+	for _, seg := range segments {
+		if seg.ID != id {
+			filtered = append(filtered, seg)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(idx.byService, id.ServiceRef)
+	} else {
+		idx.byService[id.ServiceRef] = filtered
+	}
+}


### PR DESCRIPTION
## Summary
- add immutable ringbuffer segment metadata and indexed range probing
- add atomic segment reservations with lease renewal and release handling
- add startup recovery for reservation state
- cover reservation behavior with focused unit tests

## Verification
- `gofmt -d` (clean)
- `go test ./internal/hls/ringbuffer`
- `go test -race ./internal/hls/ringbuffer`
- `go vet ./internal/hls/ringbuffer`
- `git diff --check`

This is the independently testable backend portion extracted from the closed scope-mixed #786. The unfinished Quick-Recording UI is intentionally excluded.