### PR TITLE
feat(retro): integrate DVR ringbuffer engine

### DIFF
--- a/backend/internal/hls/ringbuffer/ingest_server.go
+++ b/backend/internal/hls/ringbuffer/ingest_server.go
@@ -134,7 +134,12 @@ func (s *IngestServer) handleIngest(w http.ResponseWriter, r *http.Request) {
 		dvrCb = s.persistToDisk
 	}
 
-	buf := s.registry.GetOrCreate(sessionID, dvrCb)
+	serviceRef := r.Header.Get("X-Service-Ref")
+	if serviceRef == "" {
+		serviceRef = sessionID
+	}
+
+	buf := s.registry.GetOrCreateService(serviceRef, sessionID, dvrCb)
 	buf.Put(filename, data)
 
 	w.WriteHeader(http.StatusOK)

--- a/backend/internal/hls/ringbuffer/recovery.go
+++ b/backend/internal/hls/ringbuffer/recovery.go
@@ -2,6 +2,8 @@ package ringbuffer
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -14,6 +16,7 @@ const (
 	LifecycleRecovering
 	LifecycleReady
 	LifecycleCleanupEnabled
+	LifecycleDegraded
 )
 
 func (s LifecycleState) String() string {
@@ -26,10 +29,14 @@ func (s LifecycleState) String() string {
 		return "READY"
 	case LifecycleCleanupEnabled:
 		return "CLEANUP_ENABLED"
+	case LifecycleDegraded:
+		return "DEGRADED"
 	default:
 		return "UNKNOWN"
 	}
 }
+
+var ErrRecoveryFailed = errors.New("ringbuffer recovery failed: state degraded")
 
 // LifecycleManager controls startup recovery before enabling ringbuffer segment cleanup.
 type LifecycleManager struct {
@@ -56,41 +63,57 @@ func (lm *LifecycleManager) State() LifecycleState {
 	return lm.state
 }
 
-// RunRecovery executes the startup recovery sequence.
+// RunRecovery executes the fail-safe startup recovery sequence.
 func (lm *LifecycleManager) RunRecovery() error {
 	lm.mu.Lock()
 	lm.state = LifecycleRecovering
 	lm.mu.Unlock()
 
-	// Load persistent reservations
 	lm.store.mu.Lock()
 	defer lm.store.mu.Unlock()
 
 	if lm.store.storagePath != "" {
-		if data, err := os.ReadFile(lm.store.storagePath); err == nil {
+		data, err := os.ReadFile(lm.store.storagePath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				lm.mu.Lock()
+				lm.state = LifecycleDegraded
+				lm.mu.Unlock()
+				return fmt.Errorf("failed to read reservations state file: %w", err)
+			}
+		} else {
 			var loaded map[string]*Reservation
-			if err := json.Unmarshal(data, &loaded); err == nil {
-				now := time.Now()
-				for id, res := range loaded {
-					if now.After(res.ExpiresAt) {
-						continue // Skip expired reservations
-					}
-					// Verify segments exist and lock them
-					var validSegs []SegmentID
-					for _, segID := range res.SegmentIDs {
-						if seg, ok := lm.index.GetByID(segID); ok {
-							if _, err := os.Stat(seg.Path); err == nil {
-								seg.State = SegmentReserved
-								validSegs = append(validSegs, segID)
-							} else {
-								seg.State = SegmentMissing
-								res.Status = CompletenessGapped
+			if err := json.Unmarshal(data, &loaded); err != nil {
+				lm.mu.Lock()
+				lm.state = LifecycleDegraded
+				lm.mu.Unlock()
+				return fmt.Errorf("failed to unmarshal corrupted reservations JSON: %w", err)
+			}
+
+			now := time.Now()
+			for id, res := range loaded {
+				if now.After(res.ExpiresAt) {
+					continue // Skip expired reservations
+				}
+				// Verify segments exist and lock them
+				var validSegs []SegmentID
+				for _, segID := range res.SegmentIDs {
+					if seg, ok := lm.index.GetByID(segID); ok {
+						if _, err := os.Stat(seg.Path); err == nil {
+							if seg.ReservationIDs == nil {
+								seg.ReservationIDs = make(map[string]struct{})
 							}
+							seg.ReservationIDs[id] = struct{}{}
+							seg.State = SegmentReserved
+							validSegs = append(validSegs, segID)
+						} else {
+							seg.State = SegmentMissing
+							res.Status = CompletenessGapped
 						}
 					}
-					res.SegmentIDs = validSegs
-					lm.store.reservations[id] = res
 				}
+				res.SegmentIDs = validSegs
+				lm.store.reservations[id] = res
 			}
 		}
 	}

--- a/backend/internal/hls/ringbuffer/recovery.go
+++ b/backend/internal/hls/ringbuffer/recovery.go
@@ -99,7 +99,12 @@ func (lm *LifecycleManager) RunRecovery() error {
 				var validSegs []SegmentID
 				for _, segID := range res.SegmentIDs {
 					if seg, ok := lm.index.GetByID(segID); ok {
-						if _, err := os.Stat(seg.Path); err == nil {
+						exists := seg.Location.Kind == StorageKindRAM
+						if seg.Location.Kind == StorageKindDisk && seg.Location.Path != "" {
+							_, err := os.Stat(seg.Location.Path)
+							exists = (err == nil)
+						}
+						if exists {
 							if seg.ReservationIDs == nil {
 								seg.ReservationIDs = make(map[string]struct{})
 							}

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -29,6 +29,8 @@ type ReservationStore struct {
 	reservations map[string]*Reservation
 	limits       ReservationLimits
 	storagePath  string
+	onExpire     func(res *Reservation)
+	stopCh       chan struct{}
 }
 
 // NewReservationStore creates a new ReservationStore instance.
@@ -36,11 +38,37 @@ func NewReservationStore(index *SegmentIndex, limits ReservationLimits, storageP
 	if limits.MaxPinnedBytesGlobal == 0 {
 		limits = DefaultReservationLimits()
 	}
-	return &ReservationStore{
+	rs := &ReservationStore{
 		index:        index,
 		reservations: make(map[string]*Reservation),
 		limits:       limits,
 		storagePath:  storagePath,
+		stopCh:       make(chan struct{}),
+	}
+	go rs.reaperLoop()
+	return rs
+}
+
+func (rs *ReservationStore) Close() {
+	select {
+	case <-rs.stopCh:
+	default:
+		close(rs.stopCh)
+	}
+}
+
+func (rs *ReservationStore) reaperLoop() {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-rs.stopCh:
+			return
+		case <-ticker.C:
+			rs.mu.Lock()
+			rs.purgeExpiredLocked()
+			rs.mu.Unlock()
+		}
 	}
 }
 
@@ -299,8 +327,13 @@ func (rs *ReservationStore) RenewReservation(reservationID string, leaseDuration
 		leaseDuration = rs.limits.MaxLeaseDuration
 	}
 
+	oldExpiry := res.ExpiresAt
 	res.ExpiresAt = time.Now().Add(leaseDuration)
-	return rs.saveStateLocked()
+	if err := rs.saveStateLocked(); err != nil {
+		res.ExpiresAt = oldExpiry // ROLLBACK!
+		return fmt.Errorf("failed to persist renewed reservation state: %w", err)
+	}
+	return nil
 }
 
 // ReleaseReservation unlocks segments and removes the reservation.
@@ -313,8 +346,14 @@ func (rs *ReservationStore) ReleaseReservation(reservationID string) error {
 		return ErrReservationNotFound
 	}
 
+	delete(rs.reservations, reservationID)
+	if err := rs.saveStateLocked(); err != nil {
+		rs.reservations[reservationID] = res // ROLLBACK!
+		return fmt.Errorf("failed to persist released reservation state: %w", err)
+	}
+
 	rs.releaseReservationLocked(res)
-	return rs.saveStateLocked()
+	return nil
 }
 
 func (rs *ReservationStore) releaseReservationLocked(res *Reservation) {

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -13,10 +13,13 @@ import (
 var (
 	ErrReservationNotFound     = errors.New("reservation not found")
 	ErrReservationExpired      = errors.New("reservation expired")
+	ErrInvalidLeaseDuration    = errors.New("invalid lease duration: must be greater than 0")
 	ErrLimitExceededGlobal     = errors.New("global reservation byte/count limit exceeded")
 	ErrLimitExceededService    = errors.New("service reservation byte/count limit exceeded")
+	ErrLimitExceededMaxSegments = errors.New("reservation max segment limit exceeded")
 	ErrLeaseExceedsMaxDuration = errors.New("lease duration exceeds maximum allowed limit")
 	ErrNoSegmentsAvailable     = errors.New("no valid segments available in requested range")
+	ErrSegmentMissing          = errors.New("one or more reserved segments are missing or deleting")
 )
 
 // ReservationStore provides atomic, thread-safe reservation management backed by SegmentIndex.
@@ -84,17 +87,21 @@ func (rs *ReservationStore) probeRangeLocked(serviceRef string, start, end time.
 		}
 		lastCodec = seg.CodecHash
 
-		// Check for internal temporal gaps between consecutive segments (>10s)
+		// Check for sequence or PTS continuity gaps between consecutive segments
 		if i > 0 {
-			prevEnd := segments[i-1].EndWallTime
-			if seg.StartWallTime.Sub(prevEnd) > 10*time.Second {
+			prev := segments[i-1]
+			seqGap := seg.Sequence > prev.Sequence+1
+			ptsGap := seg.StartPTS90k > prev.EndPTS90k+9000 // >100ms PTS jump
+			timeGap := seg.StartWallTime.Sub(prev.EndWallTime) > 3*time.Second
+
+			if seqGap || ptsGap || timeGap {
 				gaps = append(gaps, Gap{
-					StartPTS90k:   segments[i-1].EndPTS90k,
+					StartPTS90k:   prev.EndPTS90k,
 					EndPTS90k:     seg.StartPTS90k,
-					StartWallTime: prevEnd,
+					StartWallTime: prev.EndWallTime,
 					EndWallTime:   seg.StartWallTime,
-					DurationSec:   seg.StartWallTime.Sub(prevEnd).Seconds(),
-					Reason:        "TEMPORAL_GAP",
+					DurationSec:   seg.StartWallTime.Sub(prev.EndWallTime).Seconds(),
+					Reason:        fmt.Sprintf("GAP_SEQ_%d_PTS_%d", seg.Sequence-prev.Sequence, seg.StartPTS90k-prev.EndPTS90k),
 				})
 			}
 		}
@@ -123,8 +130,12 @@ func (rs *ReservationStore) probeRangeLocked(serviceRef string, start, end time.
 	return probe, nil
 }
 
-// ReserveRange performs range probing, limit checking, and segment locking in a single atomic transaction.
+// ReserveRange performs range probing, limit checking, and multi-job segment locking in a single atomic transaction.
 func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time, ownerID string, leaseDuration time.Duration) (Reservation, error) {
+	if leaseDuration <= 0 {
+		return Reservation{}, ErrInvalidLeaseDuration
+	}
+
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
@@ -142,8 +153,11 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 	if probe.Completeness == CompletenessUnavailable || probe.SegmentCount == 0 {
 		return Reservation{}, ErrNoSegmentsAvailable
 	}
+	if probe.SegmentCount > rs.limits.MaxSegmentsPerReservation {
+		return Reservation{}, ErrLimitExceededMaxSegments
+	}
 
-	// Evaluate limits
+	// Evaluate global and per-service limits
 	var globalBytes int64
 	var globalCount int
 	var serviceBytes int64
@@ -166,15 +180,21 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 	}
 
 	segments := rs.index.SelectRange(serviceRef, start, end)
+	now := time.Now()
+	resID := fmt.Sprintf("res_%d_%s", now.UnixNano(), ownerID)
+
 	var segIDs []SegmentID
 	for _, seg := range segments {
+		if seg.ReservationIDs == nil {
+			seg.ReservationIDs = make(map[string]struct{})
+		}
+		seg.ReservationIDs[resID] = struct{}{}
 		seg.State = SegmentReserved
 		segIDs = append(segIDs, seg.ID)
 	}
 
-	now := time.Now()
 	res := &Reservation{
-		ID:         fmt.Sprintf("res_%d_%s", now.UnixNano(), ownerID),
+		ID:         resID,
 		OwnerID:    ownerID,
 		ServiceRef: serviceRef,
 		SegmentIDs: segIDs,
@@ -187,12 +207,24 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 	}
 
 	rs.reservations[res.ID] = res
-	_ = rs.saveStateLocked()
+
+	// Atomic persistence: If persistence fails, ROLL BACK segment locks!
+	if err := rs.saveStateLocked(); err != nil {
+		// Rollback locks
+		for _, seg := range segments {
+			delete(seg.ReservationIDs, resID)
+			if len(seg.ReservationIDs) == 0 {
+				seg.State = SegmentActive
+			}
+		}
+		delete(rs.reservations, resID)
+		return Reservation{}, fmt.Errorf("failed to persist reservation state: %w", err)
+	}
 
 	return *res, nil
 }
 
-// GetReservation fetches a reservation by ID.
+// GetReservation fetches an unexpired reservation by ID.
 func (rs *ReservationStore) GetReservation(reservationID string) (Reservation, error) {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
@@ -207,7 +239,7 @@ func (rs *ReservationStore) GetReservation(reservationID string) (Reservation, e
 	return *res, nil
 }
 
-// ListReservedSegments returns immutable SegmentHandles for an active reservation.
+// ListReservedSegments returns immutable SegmentHandles for an active reservation or error if missing.
 func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]SegmentHandle, error) {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
@@ -224,7 +256,7 @@ func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]Segmen
 	for _, segID := range res.SegmentIDs {
 		seg, ok := rs.index.GetByID(segID)
 		if !ok || seg.State == SegmentDeleting || seg.State == SegmentMissing {
-			continue
+			return nil, ErrSegmentMissing
 		}
 		handles = append(handles, SegmentHandle{
 			ID:            seg.ID,
@@ -246,6 +278,10 @@ func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]Segmen
 
 // RenewReservation updates the lease expiration timestamp from now, capped by MaxLeaseDuration.
 func (rs *ReservationStore) RenewReservation(reservationID string, leaseDuration time.Duration) error {
+	if leaseDuration <= 0 {
+		return ErrInvalidLeaseDuration
+	}
+
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
@@ -253,6 +289,12 @@ func (rs *ReservationStore) RenewReservation(reservationID string, leaseDuration
 	if !ok {
 		return ErrReservationNotFound
 	}
+
+	// Reject renewal if already expired
+	if time.Now().After(res.ExpiresAt) {
+		return ErrReservationExpired
+	}
+
 	if leaseDuration > rs.limits.MaxLeaseDuration {
 		leaseDuration = rs.limits.MaxLeaseDuration
 	}
@@ -277,8 +319,11 @@ func (rs *ReservationStore) ReleaseReservation(reservationID string) error {
 
 func (rs *ReservationStore) releaseReservationLocked(res *Reservation) {
 	for _, segID := range res.SegmentIDs {
-		if seg, ok := rs.index.GetByID(segID); ok && seg.State == SegmentReserved {
-			seg.State = SegmentActive
+		if seg, ok := rs.index.GetByID(segID); ok {
+			delete(seg.ReservationIDs, res.ID)
+			if len(seg.ReservationIDs) == 0 && seg.State == SegmentReserved {
+				seg.State = SegmentActive
+			}
 		}
 	}
 	delete(rs.reservations, res.ID)
@@ -286,10 +331,12 @@ func (rs *ReservationStore) releaseReservationLocked(res *Reservation) {
 
 func (rs *ReservationStore) purgeExpiredLocked() {
 	now := time.Now()
-	for id, res := range rs.reservations {
+	for _, res := range rs.reservations {
 		if now.After(res.ExpiresAt) {
+			if rs.onExpire != nil {
+				rs.onExpire(res)
+			}
 			rs.releaseReservationLocked(res)
-			delete(rs.reservations, id)
 		}
 	}
 }

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -11,15 +11,15 @@ import (
 )
 
 var (
-	ErrReservationNotFound     = errors.New("reservation not found")
-	ErrReservationExpired      = errors.New("reservation expired")
-	ErrInvalidLeaseDuration    = errors.New("invalid lease duration: must be greater than 0")
-	ErrLimitExceededGlobal     = errors.New("global reservation byte/count limit exceeded")
-	ErrLimitExceededService    = errors.New("service reservation byte/count limit exceeded")
+	ErrReservationNotFound      = errors.New("reservation not found")
+	ErrReservationExpired       = errors.New("reservation expired")
+	ErrInvalidLeaseDuration     = errors.New("invalid lease duration: must be greater than 0")
+	ErrLimitExceededGlobal      = errors.New("global reservation byte/count limit exceeded")
+	ErrLimitExceededService     = errors.New("service reservation byte/count limit exceeded")
 	ErrLimitExceededMaxSegments = errors.New("reservation max segment limit exceeded")
-	ErrLeaseExceedsMaxDuration = errors.New("lease duration exceeds maximum allowed limit")
-	ErrNoSegmentsAvailable     = errors.New("no valid segments available in requested range")
-	ErrSegmentMissing          = errors.New("one or more reserved segments are missing or deleting")
+	ErrLeaseExceedsMaxDuration  = errors.New("lease duration exceeds maximum allowed limit")
+	ErrNoSegmentsAvailable      = errors.New("no valid segments available in requested range")
+	ErrSegmentMissing           = errors.New("one or more reserved segments are missing or deleting")
 )
 
 // ReservationStore provides atomic, thread-safe reservation management backed by SegmentIndex.
@@ -66,10 +66,32 @@ func (rs *ReservationStore) reaperLoop() {
 			return
 		case <-ticker.C:
 			rs.mu.Lock()
-			rs.purgeExpiredLocked()
+			purged := rs.purgeExpiredLocked()
+			if purged {
+				_ = rs.saveStateLocked()
+			}
 			rs.mu.Unlock()
 		}
 	}
+}
+
+// HasReservationsForSession checks if any active reservation belongs to sessionID.
+func (rs *ReservationStore) HasReservationsForSession(sessionID string) bool {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	now := time.Now()
+	for _, res := range rs.reservations {
+		if now.After(res.ExpiresAt) {
+			continue
+		}
+		for _, segID := range res.SegmentIDs {
+			if segID.SessionID == sessionID {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ProbeRange evaluates ringbuffer segment completeness without creating a reservation.
@@ -167,7 +189,6 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
-	// Clean up any expired reservations prior to evaluating limits
 	rs.purgeExpiredLocked()
 
 	if leaseDuration > rs.limits.MaxLeaseDuration {
@@ -185,7 +206,6 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 		return Reservation{}, ErrLimitExceededMaxSegments
 	}
 
-	// Evaluate global and per-service limits
 	var globalBytes int64
 	var globalCount int
 	var serviceBytes int64
@@ -236,9 +256,7 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 
 	rs.reservations[res.ID] = res
 
-	// Atomic persistence: If persistence fails, ROLL BACK segment locks!
 	if err := rs.saveStateLocked(); err != nil {
-		// Rollback locks
 		for _, seg := range segments {
 			delete(seg.ReservationIDs, resID)
 			if len(seg.ReservationIDs) == 0 {
@@ -288,7 +306,8 @@ func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]Segmen
 		}
 		handles = append(handles, SegmentHandle{
 			ID:            seg.ID,
-			Path:          seg.Path,
+			Location:      seg.Location,
+			DurationSec:   seg.DurationSec,
 			Sequence:      seg.Sequence,
 			StartPTS90k:   seg.StartPTS90k,
 			EndPTS90k:     seg.EndPTS90k,
@@ -298,6 +317,7 @@ func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]Segmen
 			SizeBytes:     seg.SizeBytes,
 			Discontinuity: seg.Discontinuity,
 			CodecHash:     seg.CodecHash,
+			Data:          seg.Data,
 		})
 	}
 
@@ -318,7 +338,6 @@ func (rs *ReservationStore) RenewReservation(reservationID string, leaseDuration
 		return ErrReservationNotFound
 	}
 
-	// Reject renewal if already expired
 	if time.Now().After(res.ExpiresAt) {
 		return ErrReservationExpired
 	}
@@ -368,16 +387,19 @@ func (rs *ReservationStore) releaseReservationLocked(res *Reservation) {
 	delete(rs.reservations, res.ID)
 }
 
-func (rs *ReservationStore) purgeExpiredLocked() {
+func (rs *ReservationStore) purgeExpiredLocked() bool {
 	now := time.Now()
+	purged := false
 	for _, res := range rs.reservations {
 		if now.After(res.ExpiresAt) {
 			if rs.onExpire != nil {
 				rs.onExpire(res)
 			}
 			rs.releaseReservationLocked(res)
+			purged = true
 		}
 	}
+	return purged
 }
 
 // Atomic file persistence (reservations.json.tmp -> fsync -> rename)
@@ -418,8 +440,7 @@ func (rs *ReservationStore) saveStateLocked() error {
 		return err
 	}
 
-	// Sync parent directory
-	if dirFile, err := os.Open(dir); err == nil { //nolint:gosec // G304: dir is derived from operator-configured storagePath
+	if dirFile, err := os.Open(dir); err == nil {
 		_ = dirFile.Sync()
 		_ = dirFile.Close()
 	}

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -440,7 +440,7 @@ func (rs *ReservationStore) saveStateLocked() error {
 		return err
 	}
 
-	if dirFile, err := os.Open(dir); err == nil {
+	if dirFile, err := os.Open(dir); err == nil { //nolint:gosec // G304: dir is derived from operator-configured storagePath
 		_ = dirFile.Sync()
 		_ = dirFile.Close()
 	}

--- a/backend/internal/hls/ringbuffer/reservation_test.go
+++ b/backend/internal/hls/ringbuffer/reservation_test.go
@@ -18,7 +18,11 @@ func createTestSegment(serviceRef string, seq uint64, start, end time.Time, size
 			Sequence:   seq,
 			PartIndex:  0,
 		},
-		Path:           fmt.Sprintf("/tmp/test_seg_%d.ts", seq),
+		Location: SegmentLocation{
+			Kind:     StorageKindDisk,
+			Filename: fmt.Sprintf("test_seg_%d.ts", seq),
+			Path:     fmt.Sprintf("/tmp/test_seg_%d.ts", seq),
+		},
 		Sequence:       seq,
 		StartPTS90k:    int64(seq * 90000),
 		EndPTS90k:      int64((seq + 1) * 90000),
@@ -238,7 +242,7 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 	}
 
 	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
-	seg1.Path = segFile
+	seg1.Location.Path = segFile
 	idx.AddSegment(seg1)
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), storagePath)
@@ -250,7 +254,7 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 
 	newIdx := NewSegmentIndex()
 	seg1Reloaded := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
-	seg1Reloaded.Path = segFile
+	seg1Reloaded.Location.Path = segFile
 	newIdx.AddSegment(seg1Reloaded)
 
 	newStore := NewReservationStore(newIdx, DefaultReservationLimits(), storagePath)

--- a/backend/internal/hls/ringbuffer/reservation_test.go
+++ b/backend/internal/hls/ringbuffer/reservation_test.go
@@ -251,3 +251,66 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 		t.Errorf("Reloaded segment expected SegmentReserved, got %s", seg1Reloaded.State)
 	}
 }
+
+func TestRealIngestServer_ReservationEvictionProtection(t *testing.T) {
+	reg := NewRegistry(5) // Max 5 RAM segments
+	sessionID := "test_live_session"
+	buf := reg.GetOrCreate(sessionID, nil)
+
+	now := time.Now()
+	// Put 10 segments
+	for i := uint64(1); i <= 10; i++ {
+		filename := fmt.Sprintf("seg_%06d.ts", i)
+		buf.Put(filename, []byte(fmt.Sprintf("ts_data_%d", i)))
+	}
+
+	// Reserve segments 3, 4, 5
+	start := now.Add(-10 * time.Minute)
+	end := now.Add(10 * time.Minute)
+	res, err := reg.Store().ReserveRange(sessionID, start, end, "test_owner", 10*time.Minute)
+	if err != nil {
+		t.Fatalf("ReserveRange failed: %v", err)
+	}
+
+	// Put 20 MORE segments (triggering heavy eviction)
+	for i := uint64(11); i <= 30; i++ {
+		filename := fmt.Sprintf("seg_%06d.ts", i)
+		buf.Put(filename, []byte(fmt.Sprintf("ts_data_%d", i)))
+	}
+
+	// Reserved segments MUST NOT be evicted from RAM artifacts or index!
+	handles, err := reg.Store().ListReservedSegments(res.ID)
+	if err != nil {
+		t.Fatalf("ListReservedSegments failed: %v", err)
+	}
+	if len(handles) == 0 {
+		t.Fatalf("Expected reserved segment handles, got 0!")
+	}
+
+	for _, segID := range res.SegmentIDs {
+		seg, ok := reg.Index().GetByID(segID)
+		if !ok || seg.State != SegmentReserved {
+			t.Errorf("Reserved segment %s was evicted or lost state!", segID)
+		}
+	}
+
+	// Release reservation
+	if err := reg.Store().ReleaseReservation(res.ID); err != nil {
+		t.Fatalf("ReleaseReservation failed: %v", err)
+	}
+
+	// Put 10 more segments to trigger eviction of unreserved segments
+	for i := uint64(31); i <= 40; i++ {
+		filename := fmt.Sprintf("seg_%06d.ts", i)
+		buf.Put(filename, []byte(fmt.Sprintf("ts_data_%d", i)))
+	}
+
+	// Verify buffer size dropped down to maxSegments
+	buf.mu.RLock()
+	artCount := len(buf.artifacts)
+	buf.mu.RUnlock()
+
+	if artCount > 5 {
+		t.Errorf("Expected artifact count <= 5 after release & eviction, got %d", artCount)
+	}
+}

--- a/backend/internal/hls/ringbuffer/reservation_test.go
+++ b/backend/internal/hls/ringbuffer/reservation_test.go
@@ -16,17 +16,18 @@ func createTestSegment(serviceRef string, seq uint64, start, end time.Time, size
 			SessionID:  "sess_1",
 			Sequence:   seq,
 		},
-		Path:          fmt.Sprintf("/tmp/test_seg_%d.ts", seq),
-		Sequence:      seq,
-		StartPTS90k:   int64(seq * 90000),
-		EndPTS90k:     int64((seq + 1) * 90000),
-		PTSEpoch:      1,
-		StartWallTime: start,
-		EndWallTime:   end,
-		SizeBytes:     size,
-		Discontinuity: disc,
-		CodecHash:     codec,
-		State:         SegmentActive,
+		Path:           fmt.Sprintf("/tmp/test_seg_%d.ts", seq),
+		Sequence:       seq,
+		StartPTS90k:    int64(seq * 90000),
+		EndPTS90k:      int64((seq + 1) * 90000),
+		PTSEpoch:       1,
+		StartWallTime:  start,
+		EndWallTime:    end,
+		SizeBytes:      size,
+		Discontinuity:  disc,
+		CodecHash:      codec,
+		State:          SegmentActive,
+		ReservationIDs: make(map[string]struct{}),
 	}
 }
 
@@ -72,39 +73,48 @@ func TestProbeRange_PartialStart(t *testing.T) {
 	}
 }
 
-func TestReserveRange_AtomicAndLease(t *testing.T) {
+func TestMultiJobReservationOwnership(t *testing.T) {
 	idx := NewSegmentIndex()
 	now := time.Now()
 	ref := "1:0:1:1:1:1:0:0:0:0:"
 
 	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
-	seg2 := createTestSegment(ref, 2, now.Add(-20*time.Minute), now.Add(-10*time.Minute), 1000, "h264", false)
 	idx.AddSegment(seg1)
-	idx.AddSegment(seg2)
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
-	res, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-15*time.Minute), "job_1", 2*time.Second)
+
+	res1, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_1", 5*time.Minute)
 	if err != nil {
-		t.Fatalf("ReserveRange failed: %v", err)
+		t.Fatalf("ReserveRange job_1 failed: %v", err)
 	}
 
-	if seg1.State != SegmentReserved || seg2.State != SegmentReserved {
-		t.Errorf("Segments were not marked as SegmentReserved! seg1 state=%s, seg2 state=%s", seg1.State, seg2.State)
-	}
-
-	// Cleaner attempt on reserved segment must fail
-	if idx.MarkForDeletion(seg1.ID) {
-		t.Errorf("Cleaner marked reserved segment for deletion!")
-	}
-
-	// Release reservation
-	err = store.ReleaseReservation(res.ID)
+	res2, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_2", 5*time.Minute)
 	if err != nil {
-		t.Fatalf("ReleaseReservation failed: %v", err)
+		t.Fatalf("ReserveRange job_2 failed: %v", err)
 	}
 
-	if seg1.State != SegmentActive {
-		t.Errorf("Segment state after release expected SegmentActive, got %s", seg1.State)
+	if len(seg1.ReservationIDs) != 2 {
+		t.Errorf("Expected 2 reservation owners on segment, got %d", len(seg1.ReservationIDs))
+	}
+
+	// Release job 1
+	if err := store.ReleaseReservation(res1.ID); err != nil {
+		t.Fatalf("ReleaseReservation job_1 failed: %v", err)
+	}
+
+	// Segment MUST still be reserved by job 2!
+	if seg1.State != SegmentReserved || len(seg1.ReservationIDs) != 1 {
+		t.Errorf("Segment state was reset to active prematurely! State=%s, count=%d", seg1.State, len(seg1.ReservationIDs))
+	}
+
+	// Release job 2
+	if err := store.ReleaseReservation(res2.ID); err != nil {
+		t.Fatalf("ReleaseReservation job_2 failed: %v", err)
+	}
+
+	// Now segment MUST be active
+	if seg1.State != SegmentActive || len(seg1.ReservationIDs) != 0 {
+		t.Errorf("Segment state after all releases expected SegmentActive, got %s", seg1.State)
 	}
 }
 
@@ -118,18 +128,15 @@ func TestReserveRange_ContextIndependence(t *testing.T) {
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
 
-	// Simulate an HTTP request context that gets canceled
 	ctx, cancel := context.WithCancel(context.Background())
 	res, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_http", 5*time.Minute)
 	if err != nil {
 		t.Fatalf("ReserveRange failed: %v", err)
 	}
 
-	// Cancel HTTP context
 	cancel()
 	_ = ctx
 
-	// Reservation must STILL be valid and active in store
 	fetched, err := store.GetReservation(res.ID)
 	if err != nil {
 		t.Fatalf("Reservation disappeared after HTTP context cancellation: %v", err)
@@ -147,7 +154,6 @@ func TestCleanerDeletingRace(t *testing.T) {
 	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
 	idx.AddSegment(seg1)
 
-	// Cleaner marks segment for deletion
 	marked := idx.MarkForDeletion(seg1.ID)
 	if !marked {
 		t.Fatalf("Failed to mark segment for deletion")
@@ -157,6 +163,31 @@ func TestCleanerDeletingRace(t *testing.T) {
 	_, err := store.ReserveRange(ref, now.Add(-28*time.Minute), now.Add(-22*time.Minute), "job_late", 5*time.Minute)
 	if err == nil {
 		t.Fatalf("Expected error when reserving DELETING segment, but got success!")
+	}
+}
+
+func TestRecoveryCorruptedJSON_FailsSafely(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ringbuffer_corrupt_test")
+	if err != nil {
+		t.Fatalf("MkdirTemp failed: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	storagePath := filepath.Join(tmpDir, "reservations.json")
+	if err := os.WriteFile(storagePath, []byte("NOT_VALID_JSON{{{"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	idx := NewSegmentIndex()
+	store := NewReservationStore(idx, DefaultReservationLimits(), storagePath)
+	lifecycle := NewLifecycleManager(store, idx)
+
+	err = lifecycle.RunRecovery()
+	if err == nil {
+		t.Fatalf("Expected recovery error on corrupted JSON, got nil!")
+	}
+	if lifecycle.State() != LifecycleDegraded {
+		t.Errorf("Expected LifecycleDegraded state, got %s", lifecycle.State())
 	}
 }
 
@@ -187,7 +218,6 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 		t.Fatalf("ReserveRange failed: %v", err)
 	}
 
-	// Re-create store simulating a process restart
 	newIdx := NewSegmentIndex()
 	seg1Reloaded := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
 	seg1Reloaded.Path = segFile
@@ -209,7 +239,6 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 		t.Errorf("Expected CLEANUP_ENABLED, got %s", lifecycle.State())
 	}
 
-	// Verify reservation was recovered and segment is reserved
 	recoveredRes, err := newStore.GetReservation(res.ID)
 	if err != nil {
 		t.Fatalf("Failed to recover reservation: %v", err)

--- a/backend/internal/hls/ringbuffer/reservation_test.go
+++ b/backend/internal/hls/ringbuffer/reservation_test.go
@@ -14,7 +14,9 @@ func createTestSegment(serviceRef string, seq uint64, start, end time.Time, size
 		ID: SegmentID{
 			ServiceRef: serviceRef,
 			SessionID:  "sess_1",
+			Kind:       SegmentKindComplete,
 			Sequence:   seq,
+			PartIndex:  0,
 		},
 		Path:           fmt.Sprintf("/tmp/test_seg_%d.ts", seq),
 		Sequence:       seq,
@@ -31,6 +33,23 @@ func createTestSegment(serviceRef string, seq uint64, start, end time.Time, size
 	}
 }
 
+func TestParseSegmentFilename(t *testing.T) {
+	id1, ok1 := ParseSegmentFilename("ref1", "sess1", "seg_000123.ts")
+	if !ok1 || id1.Kind != SegmentKindComplete || id1.Sequence != 123 || id1.PartIndex != 0 {
+		t.Errorf("Failed to parse seg_000123.ts correctly: %+v", id1)
+	}
+
+	id2, ok2 := ParseSegmentFilename("ref1", "sess1", "part_000123_4.m4s")
+	if !ok2 || id2.Kind != SegmentKindPart || id2.Sequence != 123 || id2.PartIndex != 4 {
+		t.Errorf("Failed to parse part_000123_4.m4s correctly: %+v", id2)
+	}
+
+	_, ok3 := ParseSegmentFilename("ref1", "sess1", "invalid_name.ts")
+	if ok3 {
+		t.Errorf("Expected parse failure on invalid filename, got success")
+	}
+}
+
 func TestProbeRange_Complete(t *testing.T) {
 	idx := NewSegmentIndex()
 	now := time.Now()
@@ -41,6 +60,8 @@ func TestProbeRange_Complete(t *testing.T) {
 	idx.AddSegment(createTestSegment(ref, 3, now.Add(-10*time.Minute), now, 1000, "h264", false))
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	defer store.Close()
+
 	probe, err := store.ProbeRange(ref, now.Add(-25*time.Minute), now.Add(-5*time.Minute))
 	if err != nil {
 		t.Fatalf("ProbeRange failed: %v", err)
@@ -63,6 +84,8 @@ func TestProbeRange_PartialStart(t *testing.T) {
 	idx.AddSegment(createTestSegment(ref, 2, now.Add(-10*time.Minute), now, 1000, "h264", false))
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	defer store.Close()
+
 	probe, err := store.ProbeRange(ref, now.Add(-30*time.Minute), now.Add(-5*time.Minute))
 	if err != nil {
 		t.Fatalf("ProbeRange failed: %v", err)
@@ -82,6 +105,7 @@ func TestMultiJobReservationOwnership(t *testing.T) {
 	idx.AddSegment(seg1)
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	defer store.Close()
 
 	res1, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_1", 5*time.Minute)
 	if err != nil {
@@ -127,6 +151,7 @@ func TestReserveRange_ContextIndependence(t *testing.T) {
 	idx.AddSegment(seg1)
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	defer store.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	res, err := store.ReserveRange(ref, now.Add(-25*time.Minute), now.Add(-21*time.Minute), "job_http", 5*time.Minute)
@@ -154,12 +179,14 @@ func TestCleanerDeletingRace(t *testing.T) {
 	seg1 := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
 	idx.AddSegment(seg1)
 
-	marked := idx.MarkForDeletion(seg1.ID)
+	marked := idx.TryMarkDeleting(seg1.ID)
 	if !marked {
 		t.Fatalf("Failed to mark segment for deletion")
 	}
 
 	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	defer store.Close()
+
 	_, err := store.ReserveRange(ref, now.Add(-28*time.Minute), now.Add(-22*time.Minute), "job_late", 5*time.Minute)
 	if err == nil {
 		t.Fatalf("Expected error when reserving DELETING segment, but got success!")
@@ -180,6 +207,8 @@ func TestRecoveryCorruptedJSON_FailsSafely(t *testing.T) {
 
 	idx := NewSegmentIndex()
 	store := NewReservationStore(idx, DefaultReservationLimits(), storagePath)
+	defer store.Close()
+
 	lifecycle := NewLifecycleManager(store, idx)
 
 	err = lifecycle.RunRecovery()
@@ -217,6 +246,7 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReserveRange failed: %v", err)
 	}
+	store.Close()
 
 	newIdx := NewSegmentIndex()
 	seg1Reloaded := createTestSegment(ref, 1, now.Add(-30*time.Minute), now.Add(-20*time.Minute), 1000, "h264", false)
@@ -224,6 +254,8 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 	newIdx.AddSegment(seg1Reloaded)
 
 	newStore := NewReservationStore(newIdx, DefaultReservationLimits(), storagePath)
+	defer newStore.Close()
+
 	lifecycle := NewLifecycleManager(newStore, newIdx)
 
 	if lifecycle.State() != LifecycleStarting {
@@ -253,7 +285,12 @@ func TestStartupRecoveryLifecycle(t *testing.T) {
 }
 
 func TestRealIngestServer_ReservationEvictionProtection(t *testing.T) {
-	reg := NewRegistry(5) // Max 5 RAM segments
+	reg, err := NewRegistryWithStorage(5, "")
+	if err != nil {
+		t.Fatalf("NewRegistryWithStorage failed: %v", err)
+	}
+	defer reg.Stop()
+
 	sessionID := "test_live_session"
 	buf := reg.GetOrCreate(sessionID, nil)
 

--- a/backend/internal/hls/ringbuffer/ringbuffer.go
+++ b/backend/internal/hls/ringbuffer/ringbuffer.go
@@ -27,7 +27,7 @@ type Buffer struct {
 	serviceRef  string
 	maxSegments int
 	mu          sync.RWMutex
-	segments    []string // ordered slice of segment filenames
+	segments    []string // ordered slice of complete segment filenames (seg_*)
 	artifacts   map[string]*Artifact
 	lastUpdated time.Time
 	dvrCb       DVRCallback
@@ -35,7 +35,6 @@ type Buffer struct {
 	closed      bool
 	store       *ReservationStore
 	index       *SegmentIndex
-	lastSeq     uint64
 }
 
 // NewBuffer creates a new ring buffer for a session.
@@ -119,6 +118,11 @@ func ParseSegmentFilename(serviceRef, sessionID, filename string) (SegmentID, bo
 
 // Put adds or replaces an artifact in the ring buffer.
 func (b *Buffer) Put(filename string, data []byte) {
+	b.PutWithMetadata(filename, data, SegmentMetadata{})
+}
+
+// PutWithMetadata adds a segment with extracted media duration, PTS, and discontinuity metadata.
+func (b *Buffer) PutWithMetadata(filename string, data []byte, meta SegmentMetadata) {
 	art := &Artifact{
 		Filename: filename,
 		Data:     data,
@@ -135,20 +139,42 @@ func (b *Buffer) Put(filename string, data []byte) {
 	b.artifacts[filename] = art
 
 	segID, isSegment := ParseSegmentFilename(b.serviceRef, b.sessionID, filename)
-	if isSegment && !exists {
+	// Variant A: Retro-DVR ONLY indexes and counts COMPLETE segments (seg_*)
+	if isSegment && segID.Kind == SegmentKindComplete && !exists {
 		b.segments = append(b.segments, filename)
 
-		// Register segment with authoritative index
+		durSec := meta.Duration.Seconds()
+		if durSec <= 0 {
+			durSec = 2.0 // Fallback
+		}
+
+		startWall := art.ModTime
+		if meta.ProgramTime != nil {
+			startWall = *meta.ProgramTime
+		}
+		endWall := startWall.Add(time.Duration(durSec * float64(time.Second)))
+
+		// Register segment with authoritative store
 		if b.store != nil {
 			b.store.mu.Lock()
 			b.index.AddSegment(&InternalSegment{
-				ID:            segID,
-				Path:          filename,
+				ID: segID,
+				Location: SegmentLocation{
+					Kind:     StorageKindRAM,
+					Filename: filename,
+				},
+				DurationSec:   durSec,
 				Sequence:      segID.Sequence,
-				StartWallTime: art.ModTime,
-				EndWallTime:   art.ModTime.Add(2 * time.Second),
+				StartPTS90k:   meta.StartPTS90k,
+				EndPTS90k:     meta.EndPTS90k,
+				PTSEpoch:      meta.PTSEpoch,
+				StartWallTime: startWall,
+				EndWallTime:   endWall,
 				SizeBytes:     int64(len(data)),
+				Discontinuity: meta.Discontinuity,
+				CodecHash:     meta.CodecHash,
 				State:         SegmentActive,
+				Data:          data,
 			})
 			b.store.mu.Unlock()
 		}
@@ -194,6 +220,19 @@ func (b *Buffer) Get(filename string) (*Artifact, bool) {
 	defer b.mu.RUnlock()
 	art, ok := b.artifacts[filename]
 	return art, ok
+}
+
+// ByteSnapshot returns an immutable byte slice copy of a RAM artifact for staging handover.
+func (b *Buffer) ByteSnapshot(filename string) ([]byte, bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	art, ok := b.artifacts[filename]
+	if !ok || len(art.Data) == 0 {
+		return nil, false
+	}
+	cp := make([]byte, len(art.Data))
+	copy(cp, art.Data)
+	return cp, true
 }
 
 // Close shuts down the buffer and its background DVR worker.
@@ -291,9 +330,13 @@ func (r *Registry) Get(sessionID string) (*Buffer, bool) {
 	return buf, ok
 }
 
-// Delete removes and closes the buffer for sessionID.
+// Delete removes and closes the buffer for sessionID if not reserved.
 func (r *Registry) Delete(sessionID string) {
 	r.mu.Lock()
+	if r.store != nil && r.store.HasReservationsForSession(sessionID) {
+		r.mu.Unlock()
+		return // DO NOT DELETE SESSION BUFFER IF RESERVED!
+	}
 	buf, ok := r.buffers[sessionID]
 	if ok {
 		delete(r.buffers, sessionID)
@@ -331,6 +374,10 @@ func (r *Registry) cleanupLoop() {
 				last := buf.lastUpdated
 				buf.mu.RUnlock()
 				if now.Sub(last) > 10*time.Minute {
+					// DO NOT DELETE SESSION BUFFER IF IT CONTAINS RESERVED SEGMENTS!
+					if r.store != nil && r.store.HasReservationsForSession(id) {
+						continue
+					}
 					delete(r.buffers, id)
 					buf.Close()
 				}

--- a/backend/internal/hls/ringbuffer/ringbuffer.go
+++ b/backend/internal/hls/ringbuffer/ringbuffer.go
@@ -131,6 +131,7 @@ type Registry struct {
 	maxSegments int
 	closeCh     chan struct{}
 	closeOnce   sync.Once
+	lifecycle   *LifecycleManager
 }
 
 // NewRegistry initializes a Registry.
@@ -140,6 +141,10 @@ func NewRegistry(maxSegments int) *Registry {
 		maxSegments: maxSegments,
 		closeCh:     make(chan struct{}),
 	}
+	idx := NewSegmentIndex()
+	store := NewReservationStore(idx, DefaultReservationLimits(), "")
+	r.lifecycle = NewLifecycleManager(store, idx)
+	_ = r.lifecycle.RunRecovery()
 	go r.cleanupLoop()
 	return r
 }
@@ -196,6 +201,9 @@ func (r *Registry) Stop() {
 }
 
 func (r *Registry) cleanupLoop() {
+	// Block cleanup until startup recovery lifecycle reaches CLEANUP_ENABLED
+	r.lifecycle.WaitCleanupEnabled()
+
 	ticker := time.NewTicker(2 * time.Minute)
 	defer ticker.Stop()
 	for {

--- a/backend/internal/hls/ringbuffer/ringbuffer.go
+++ b/backend/internal/hls/ringbuffer/ringbuffer.go
@@ -5,6 +5,8 @@ package ringbuffer
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -16,13 +18,13 @@ type Artifact struct {
 	ModTime  time.Time
 }
 
-// DVRCallback is invoked asynchronously when a new chunk is ingested,
-// allowing disk archiving without blocking the real-time live streaming path.
+// DVRCallback is invoked asynchronously when a new chunk is ingested.
 type DVRCallback func(sessionID, filename string, data []byte)
 
-// Buffer manages an in-memory ring buffer of HLS segments and playlists for a single live session.
+// Buffer manages an in-memory ring buffer of HLS segments and playlists for a live session.
 type Buffer struct {
 	sessionID   string
+	serviceRef  string
 	maxSegments int
 	mu          sync.RWMutex
 	segments    []string // ordered slice of segment filenames
@@ -33,19 +35,21 @@ type Buffer struct {
 	closed      bool
 	store       *ReservationStore
 	index       *SegmentIndex
+	lastSeq     uint64
 }
 
 // NewBuffer creates a new ring buffer for a session.
 func NewBuffer(sessionID string, maxSegments int, dvrCb DVRCallback) *Buffer {
-	return NewBufferWithStore(sessionID, maxSegments, dvrCb, nil, nil)
+	return NewBufferWithStore(sessionID, sessionID, maxSegments, dvrCb, nil, nil)
 }
 
 // NewBufferWithStore creates a new ring buffer bound to an authoritative ReservationStore.
-func NewBufferWithStore(sessionID string, maxSegments int, dvrCb DVRCallback, store *ReservationStore, index *SegmentIndex) *Buffer {
+func NewBufferWithStore(serviceRef, sessionID string, maxSegments int, dvrCb DVRCallback, store *ReservationStore, index *SegmentIndex) *Buffer {
 	if maxSegments <= 0 {
 		maxSegments = 20
 	}
 	b := &Buffer{
+		serviceRef:  serviceRef,
 		sessionID:   sessionID,
 		maxSegments: maxSegments,
 		artifacts:   make(map[string]*Artifact),
@@ -62,8 +66,6 @@ func NewBufferWithStore(sessionID string, maxSegments int, dvrCb DVRCallback, st
 }
 
 func (b *Buffer) dvrWorker() {
-	// Capture dvrCb once under read lock to formally satisfy the race detector,
-	// even though happens-before guarantees make it safe in practice.
 	b.mu.RLock()
 	cb := b.dvrCb
 	b.mu.RUnlock()
@@ -74,8 +76,48 @@ func (b *Buffer) dvrWorker() {
 	}
 }
 
-// Put adds or replaces an artifact in the ring buffer. If the artifact is a segment
-// (e.g. seg_000001.ts or seg_000001.m4s) and the buffer exceeds maxSegments, the oldest segment is evicted unless reserved.
+// ParseSegmentFilename cleanly parses seg_%d.ts or part_%d_%d.ts without falling back to 0.
+func ParseSegmentFilename(serviceRef, sessionID, filename string) (SegmentID, bool) {
+	if strings.HasPrefix(filename, "seg_") {
+		trimmed := strings.TrimPrefix(filename, "seg_")
+		dotIdx := strings.Index(trimmed, ".")
+		if dotIdx > 0 {
+			trimmed = trimmed[:dotIdx]
+		}
+		if s, err := strconv.ParseUint(trimmed, 10, 64); err == nil {
+			return SegmentID{
+				ServiceRef: serviceRef,
+				SessionID:  sessionID,
+				Kind:       SegmentKindComplete,
+				Sequence:   s,
+				PartIndex:  0,
+			}, true
+		}
+	} else if strings.HasPrefix(filename, "part_") {
+		trimmed := strings.TrimPrefix(filename, "part_")
+		dotIdx := strings.Index(trimmed, ".")
+		if dotIdx > 0 {
+			trimmed = trimmed[:dotIdx]
+		}
+		parts := strings.Split(trimmed, "_")
+		if len(parts) == 2 {
+			s, err1 := strconv.ParseUint(parts[0], 10, 64)
+			p, err2 := strconv.ParseUint(parts[1], 10, 32)
+			if err1 == nil && err2 == nil {
+				return SegmentID{
+					ServiceRef: serviceRef,
+					SessionID:  sessionID,
+					Kind:       SegmentKindPart,
+					Sequence:   s,
+					PartIndex:  uint32(p),
+				}, true
+			}
+		}
+	}
+	return SegmentID{}, false
+}
+
+// Put adds or replaces an artifact in the ring buffer.
 func (b *Buffer) Put(filename string, data []byte) {
 	art := &Artifact{
 		Filename: filename,
@@ -92,32 +134,23 @@ func (b *Buffer) Put(filename string, data []byte) {
 	_, exists := b.artifacts[filename]
 	b.artifacts[filename] = art
 
-	isSegment := len(filename) >= 4 && (filename[:4] == "seg_" || filename[:5] == "part_")
+	segID, isSegment := ParseSegmentFilename(b.serviceRef, b.sessionID, filename)
 	if isSegment && !exists {
 		b.segments = append(b.segments, filename)
 
-		// Parse sequence number if possible
-		var seq uint64
-		if len(filename) > 4 && filename[:4] == "seg_" {
-			_, _ = fmt.Sscanf(filename, "seg_%d", &seq)
-		}
-
-		segID := SegmentID{
-			ServiceRef: b.sessionID,
-			SessionID:  b.sessionID,
-			Sequence:   seq,
-		}
-
-		if b.index != nil {
+		// Register segment with authoritative index
+		if b.store != nil {
+			b.store.mu.Lock()
 			b.index.AddSegment(&InternalSegment{
 				ID:            segID,
 				Path:          filename,
-				Sequence:      seq,
+				Sequence:      segID.Sequence,
 				StartWallTime: art.ModTime,
 				EndWallTime:   art.ModTime.Add(2 * time.Second),
 				SizeBytes:     int64(len(data)),
 				State:         SegmentActive,
 			})
+			b.store.mu.Unlock()
 		}
 
 		var keptSegments []string
@@ -127,24 +160,18 @@ func (b *Buffer) Put(filename string, data []byte) {
 				continue
 			}
 
-			// Parse sequence for candidate eviction
-			var candidateSeq uint64
-			if len(s) > 4 && s[:4] == "seg_" {
-				_, _ = fmt.Sscanf(s, "seg_%d", &candidateSeq)
-			}
-			candID := SegmentID{
-				ServiceRef: b.sessionID,
-				SessionID:  b.sessionID,
-				Sequence:   candidateSeq,
-			}
-
-			// If segment is reserved in index, DO NOT EVICT!
-			if b.index != nil {
-				if seg, ok := b.index.GetByID(candID); ok && seg.IsReserved() {
+			candID, candOk := ParseSegmentFilename(b.serviceRef, b.sessionID, s)
+			if candOk && b.store != nil {
+				b.store.mu.Lock()
+				canEvict := b.index.TryMarkDeleting(candID)
+				if !canEvict {
+					// Reserved! Keep in buffer
+					b.store.mu.Unlock()
 					keptSegments = append(keptSegments, s)
 					continue
 				}
-				b.index.MarkForDeletion(candID)
+				b.index.RemoveSegment(candID)
+				b.store.mu.Unlock()
 			}
 
 			delete(b.artifacts, s)
@@ -152,13 +179,10 @@ func (b *Buffer) Put(filename string, data []byte) {
 		b.segments = keptSegments
 	}
 
-	// Send to DVR channel while holding the lock so Close() cannot race
-	// by closing the channel between the check and the send.
 	if b.dvrCh != nil {
 		select {
 		case b.dvrCh <- art:
 		default:
-			// If DVR writer is overwhelmed, we don't block the live stream ingest
 		}
 	}
 	b.mu.Unlock()
@@ -198,11 +222,12 @@ type Registry struct {
 
 // NewRegistry initializes a Registry.
 func NewRegistry(maxSegments int) *Registry {
-	return NewRegistryWithStorage(maxSegments, "")
+	reg, _ := NewRegistryWithStorage(maxSegments, "")
+	return reg
 }
 
-// NewRegistryWithStorage initializes a Registry with a persistent storage location for reservations.
-func NewRegistryWithStorage(maxSegments int, storagePath string) *Registry {
+// NewRegistryWithStorage initializes a Registry with persistent storage for reservations.
+func NewRegistryWithStorage(maxSegments int, storagePath string) (*Registry, error) {
 	r := &Registry{
 		buffers:     make(map[string]*Buffer),
 		maxSegments: maxSegments,
@@ -211,9 +236,13 @@ func NewRegistryWithStorage(maxSegments int, storagePath string) *Registry {
 	r.index = NewSegmentIndex()
 	r.store = NewReservationStore(r.index, DefaultReservationLimits(), storagePath)
 	r.lifecycle = NewLifecycleManager(r.store, r.index)
-	_ = r.lifecycle.RunRecovery()
+
+	if err := r.lifecycle.RunRecovery(); err != nil && storagePath != "" {
+		return nil, fmt.Errorf("failed to recover ringbuffer state: %w", err)
+	}
+
 	go r.cleanupLoop()
-	return r
+	return r, nil
 }
 
 // DefaultRegistry is the global singleton registry for live sessions.
@@ -229,13 +258,18 @@ func (r *Registry) Index() *SegmentIndex {
 	return r.index
 }
 
-// GetOrCreate returns an existing buffer or creates a new one for sessionID.
+// GetOrCreate returns an existing buffer or creates a new one.
 func (r *Registry) GetOrCreate(sessionID string, dvrCb DVRCallback) *Buffer {
+	return r.GetOrCreateService(sessionID, sessionID, dvrCb)
+}
+
+// GetOrCreateService returns an existing buffer or creates a new one bound to serviceRef.
+func (r *Registry) GetOrCreateService(serviceRef, sessionID string, dvrCb DVRCallback) *Buffer {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	buf, ok := r.buffers[sessionID]
 	if !ok {
-		buf = NewBufferWithStore(sessionID, r.maxSegments, dvrCb, r.store, r.index)
+		buf = NewBufferWithStore(serviceRef, sessionID, r.maxSegments, dvrCb, r.store, r.index)
 		r.buffers[sessionID] = buf
 	} else if dvrCb != nil && buf.dvrCb == nil {
 		buf.mu.Lock()
@@ -270,15 +304,17 @@ func (r *Registry) Delete(sessionID string) {
 	}
 }
 
-// Stop shuts down the cleanup loop. Once stopped, the Registry must not be reused.
+// Stop shuts down the cleanup loop and underlying reservation reaper cleanly.
 func (r *Registry) Stop() {
 	r.closeOnce.Do(func() {
 		close(r.closeCh)
+		if r.store != nil {
+			r.store.Close()
+		}
 	})
 }
 
 func (r *Registry) cleanupLoop() {
-	// Block cleanup until startup recovery lifecycle reaches CLEANUP_ENABLED
 	r.lifecycle.WaitCleanupEnabled()
 
 	ticker := time.NewTicker(2 * time.Minute)

--- a/backend/internal/hls/ringbuffer/ringbuffer.go
+++ b/backend/internal/hls/ringbuffer/ringbuffer.go
@@ -4,6 +4,7 @@
 package ringbuffer
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -30,10 +31,17 @@ type Buffer struct {
 	dvrCb       DVRCallback
 	dvrCh       chan *Artifact
 	closed      bool
+	store       *ReservationStore
+	index       *SegmentIndex
 }
 
 // NewBuffer creates a new ring buffer for a session.
 func NewBuffer(sessionID string, maxSegments int, dvrCb DVRCallback) *Buffer {
+	return NewBufferWithStore(sessionID, maxSegments, dvrCb, nil, nil)
+}
+
+// NewBufferWithStore creates a new ring buffer bound to an authoritative ReservationStore.
+func NewBufferWithStore(sessionID string, maxSegments int, dvrCb DVRCallback, store *ReservationStore, index *SegmentIndex) *Buffer {
 	if maxSegments <= 0 {
 		maxSegments = 20
 	}
@@ -43,6 +51,8 @@ func NewBuffer(sessionID string, maxSegments int, dvrCb DVRCallback) *Buffer {
 		artifacts:   make(map[string]*Artifact),
 		lastUpdated: time.Now(),
 		dvrCb:       dvrCb,
+		store:       store,
+		index:       index,
 	}
 	if dvrCb != nil {
 		b.dvrCh = make(chan *Artifact, 100)
@@ -65,7 +75,7 @@ func (b *Buffer) dvrWorker() {
 }
 
 // Put adds or replaces an artifact in the ring buffer. If the artifact is a segment
-// (e.g. seg_000001.ts or seg_000001.m4s) and the buffer exceeds maxSegments, the oldest segment is evicted.
+// (e.g. seg_000001.ts or seg_000001.m4s) and the buffer exceeds maxSegments, the oldest segment is evicted unless reserved.
 func (b *Buffer) Put(filename string, data []byte) {
 	art := &Artifact{
 		Filename: filename,
@@ -85,11 +95,61 @@ func (b *Buffer) Put(filename string, data []byte) {
 	isSegment := len(filename) >= 4 && (filename[:4] == "seg_" || filename[:5] == "part_")
 	if isSegment && !exists {
 		b.segments = append(b.segments, filename)
-		for len(b.segments) > b.maxSegments {
-			oldest := b.segments[0]
-			b.segments = b.segments[1:]
-			delete(b.artifacts, oldest)
+
+		// Parse sequence number if possible
+		var seq uint64
+		if len(filename) > 4 && filename[:4] == "seg_" {
+			_, _ = fmt.Sscanf(filename, "seg_%d", &seq)
 		}
+
+		segID := SegmentID{
+			ServiceRef: b.sessionID,
+			SessionID:  b.sessionID,
+			Sequence:   seq,
+		}
+
+		if b.index != nil {
+			b.index.AddSegment(&InternalSegment{
+				ID:            segID,
+				Path:          filename,
+				Sequence:      seq,
+				StartWallTime: art.ModTime,
+				EndWallTime:   art.ModTime.Add(2 * time.Second),
+				SizeBytes:     int64(len(data)),
+				State:         SegmentActive,
+			})
+		}
+
+		var keptSegments []string
+		for idx, s := range b.segments {
+			if len(b.segments)-idx <= b.maxSegments {
+				keptSegments = append(keptSegments, s)
+				continue
+			}
+
+			// Parse sequence for candidate eviction
+			var candidateSeq uint64
+			if len(s) > 4 && s[:4] == "seg_" {
+				_, _ = fmt.Sscanf(s, "seg_%d", &candidateSeq)
+			}
+			candID := SegmentID{
+				ServiceRef: b.sessionID,
+				SessionID:  b.sessionID,
+				Sequence:   candidateSeq,
+			}
+
+			// If segment is reserved in index, DO NOT EVICT!
+			if b.index != nil {
+				if seg, ok := b.index.GetByID(candID); ok && seg.IsReserved() {
+					keptSegments = append(keptSegments, s)
+					continue
+				}
+				b.index.MarkForDeletion(candID)
+			}
+
+			delete(b.artifacts, s)
+		}
+		b.segments = keptSegments
 	}
 
 	// Send to DVR channel while holding the lock so Close() cannot race
@@ -131,19 +191,26 @@ type Registry struct {
 	maxSegments int
 	closeCh     chan struct{}
 	closeOnce   sync.Once
+	store       *ReservationStore
+	index       *SegmentIndex
 	lifecycle   *LifecycleManager
 }
 
 // NewRegistry initializes a Registry.
 func NewRegistry(maxSegments int) *Registry {
+	return NewRegistryWithStorage(maxSegments, "")
+}
+
+// NewRegistryWithStorage initializes a Registry with a persistent storage location for reservations.
+func NewRegistryWithStorage(maxSegments int, storagePath string) *Registry {
 	r := &Registry{
 		buffers:     make(map[string]*Buffer),
 		maxSegments: maxSegments,
 		closeCh:     make(chan struct{}),
 	}
-	idx := NewSegmentIndex()
-	store := NewReservationStore(idx, DefaultReservationLimits(), "")
-	r.lifecycle = NewLifecycleManager(store, idx)
+	r.index = NewSegmentIndex()
+	r.store = NewReservationStore(r.index, DefaultReservationLimits(), storagePath)
+	r.lifecycle = NewLifecycleManager(r.store, r.index)
 	_ = r.lifecycle.RunRecovery()
 	go r.cleanupLoop()
 	return r
@@ -152,13 +219,23 @@ func NewRegistry(maxSegments int) *Registry {
 // DefaultRegistry is the global singleton registry for live sessions.
 var DefaultRegistry = NewRegistry(20)
 
+// Store returns the underlying ReservationStore.
+func (r *Registry) Store() *ReservationStore {
+	return r.store
+}
+
+// Index returns the underlying SegmentIndex.
+func (r *Registry) Index() *SegmentIndex {
+	return r.index
+}
+
 // GetOrCreate returns an existing buffer or creates a new one for sessionID.
 func (r *Registry) GetOrCreate(sessionID string, dvrCb DVRCallback) *Buffer {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	buf, ok := r.buffers[sessionID]
 	if !ok {
-		buf = NewBuffer(sessionID, r.maxSegments, dvrCb)
+		buf = NewBufferWithStore(sessionID, r.maxSegments, dvrCb, r.store, r.index)
 		r.buffers[sessionID] = buf
 	} else if dvrCb != nil && buf.dvrCb == nil {
 		buf.mu.Lock()

--- a/backend/internal/hls/ringbuffer/segment.go
+++ b/backend/internal/hls/ringbuffer/segment.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+// StorageKind indicates whether a segment payload resides in RAM or on disk.
+type StorageKind string
+
+const (
+	StorageKindRAM  StorageKind = "RAM"
+	StorageKindDisk StorageKind = "DISK"
+)
+
 // SegmentKind distinguishes full segments from LL-HLS partial segments.
 type SegmentKind string
 
@@ -51,6 +59,24 @@ func (id SegmentID) String() string {
 	return fmt.Sprintf("%s:%s:%s:%d:%d", id.ServiceRef, id.SessionID, id.Kind, id.Sequence, id.PartIndex)
 }
 
+// SegmentLocation describes the exact storage location and payload type for a segment.
+type SegmentLocation struct {
+	Kind     StorageKind `json:"kind"`
+	Filename string      `json:"filename"`
+	Path     string      `json:"path,omitempty"`
+}
+
+// SegmentMetadata contains media-derived timing, sequence, and codec info parsed from HLS playlists.
+type SegmentMetadata struct {
+	Duration      time.Duration
+	StartPTS90k   int64
+	EndPTS90k     int64
+	PTSEpoch      uint32
+	ProgramTime   *time.Time
+	Discontinuity bool
+	CodecHash     string
+}
+
 // Completeness describes the availability status of requested segments in the ringbuffer.
 type Completeness string
 
@@ -76,7 +102,7 @@ type Gap struct {
 // InternalSegment holds complete metadata and mutable lifecycle state for a segment.
 type InternalSegment struct {
 	ID             SegmentID           `json:"id"`
-	Path           string              `json:"path"`
+	Location       SegmentLocation     `json:"location"`
 	DurationSec    float64             `json:"duration_sec"`
 	Sequence       uint64              `json:"sequence"`
 	StartPTS90k    int64               `json:"start_pts_90k"`
@@ -89,6 +115,7 @@ type InternalSegment struct {
 	CodecHash      string              `json:"codec_hash"`
 	State          SegmentState        `json:"state"`
 	ReservationIDs map[string]struct{} `json:"reservation_ids"`
+	Data           []byte              `json:"-"` // Non-nil if StorageKindRAM
 }
 
 // IsReserved returns true if one or more active reservations hold this segment.
@@ -98,18 +125,19 @@ func (seg *InternalSegment) IsReserved() bool {
 
 // SegmentHandle exposes immutable segment metadata to callers (reservations & jobs).
 type SegmentHandle struct {
-	ID            SegmentID `json:"id"`
-	Path          string    `json:"path"`
-	DurationSec   float64   `json:"duration_sec"`
-	Sequence      uint64    `json:"sequence"`
-	StartPTS90k   int64     `json:"start_pts_90k"`
-	EndPTS90k     int64     `json:"end_pts_90k"`
-	PTSEpoch      uint32    `json:"pts_epoch"`
-	StartWallTime time.Time `json:"start_wall_time"`
-	EndWallTime   time.Time `json:"end_wall_time"`
-	SizeBytes     int64     `json:"size_bytes"`
-	Discontinuity bool      `json:"discontinuity"`
-	CodecHash     string    `json:"codec_hash"`
+	ID            SegmentID       `json:"id"`
+	Location      SegmentLocation `json:"location"`
+	DurationSec   float64         `json:"duration_sec"`
+	Sequence      uint64          `json:"sequence"`
+	StartPTS90k   int64           `json:"start_pts_90k"`
+	EndPTS90k     int64           `json:"end_pts_90k"`
+	PTSEpoch      uint32          `json:"pts_epoch"`
+	StartWallTime time.Time       `json:"start_wall_time"`
+	EndWallTime   time.Time       `json:"end_wall_time"`
+	SizeBytes     int64           `json:"size_bytes"`
+	Discontinuity bool            `json:"discontinuity"`
+	CodecHash     string          `json:"codec_hash"`
+	Data          []byte          `json:"-"` // Available if StorageKindRAM
 }
 
 // RangeProbe represents the result of probing segment availability over a time window.

--- a/backend/internal/hls/ringbuffer/segment.go
+++ b/backend/internal/hls/ringbuffer/segment.go
@@ -65,18 +65,24 @@ type Gap struct {
 
 // InternalSegment holds complete metadata and mutable lifecycle state for a segment.
 type InternalSegment struct {
-	ID            SegmentID    `json:"id"`
-	Path          string       `json:"path"`
-	Sequence      uint64       `json:"sequence"`
-	StartPTS90k   int64        `json:"start_pts_90k"`
-	EndPTS90k     int64        `json:"end_pts_90k"`
-	PTSEpoch      uint32       `json:"pts_epoch"`
-	StartWallTime time.Time    `json:"start_wall_time"`
-	EndWallTime   time.Time    `json:"end_wall_time"`
-	SizeBytes     int64        `json:"size_bytes"`
-	Discontinuity bool         `json:"discontinuity"`
-	CodecHash     string       `json:"codec_hash"`
-	State         SegmentState `json:"state"`
+	ID             SegmentID           `json:"id"`
+	Path           string              `json:"path"`
+	Sequence       uint64              `json:"sequence"`
+	StartPTS90k    int64               `json:"start_pts_90k"`
+	EndPTS90k      int64               `json:"end_pts_90k"`
+	PTSEpoch       uint32              `json:"pts_epoch"`
+	StartWallTime  time.Time           `json:"start_wall_time"`
+	EndWallTime    time.Time           `json:"end_wall_time"`
+	SizeBytes      int64               `json:"size_bytes"`
+	Discontinuity  bool                `json:"discontinuity"`
+	CodecHash      string              `json:"codec_hash"`
+	State          SegmentState        `json:"state"`
+	ReservationIDs map[string]struct{} `json:"reservation_ids"`
+}
+
+// IsReserved returns true if one or more active reservations hold this segment.
+func (seg *InternalSegment) IsReserved() bool {
+	return len(seg.ReservationIDs) > 0
 }
 
 // SegmentHandle exposes immutable segment metadata to callers (reservations & jobs).

--- a/backend/internal/hls/ringbuffer/segment.go
+++ b/backend/internal/hls/ringbuffer/segment.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+// SegmentKind distinguishes full segments from LL-HLS partial segments.
+type SegmentKind string
+
+const (
+	SegmentKindComplete SegmentKind = "SEG"
+	SegmentKindPart     SegmentKind = "PART"
+)
+
 // SegmentState tracks the authoritative lifecycle state of a segment within the ringbuffer.
 type SegmentState uint8
 
@@ -32,13 +40,15 @@ func (s SegmentState) String() string {
 
 // SegmentID uniquely identifies a segment across stream restarts and session boundaries.
 type SegmentID struct {
-	ServiceRef string `json:"service_ref"`
-	SessionID  string `json:"session_id"`
-	Sequence   uint64 `json:"sequence"`
+	ServiceRef string      `json:"service_ref"`
+	SessionID  string      `json:"session_id"`
+	Kind       SegmentKind `json:"kind"`
+	Sequence   uint64      `json:"sequence"`
+	PartIndex  uint32      `json:"part_index"`
 }
 
 func (id SegmentID) String() string {
-	return fmt.Sprintf("%s:%s:%d", id.ServiceRef, id.SessionID, id.Sequence)
+	return fmt.Sprintf("%s:%s:%s:%d:%d", id.ServiceRef, id.SessionID, id.Kind, id.Sequence, id.PartIndex)
 }
 
 // Completeness describes the availability status of requested segments in the ringbuffer.
@@ -67,6 +77,7 @@ type Gap struct {
 type InternalSegment struct {
 	ID             SegmentID           `json:"id"`
 	Path           string              `json:"path"`
+	DurationSec    float64             `json:"duration_sec"`
 	Sequence       uint64              `json:"sequence"`
 	StartPTS90k    int64               `json:"start_pts_90k"`
 	EndPTS90k      int64               `json:"end_pts_90k"`
@@ -89,6 +100,7 @@ func (seg *InternalSegment) IsReserved() bool {
 type SegmentHandle struct {
 	ID            SegmentID `json:"id"`
 	Path          string    `json:"path"`
+	DurationSec   float64   `json:"duration_sec"`
 	Sequence      uint64    `json:"sequence"`
 	StartPTS90k   int64     `json:"start_pts_90k"`
 	EndPTS90k     int64     `json:"end_pts_90k"`

--- a/backend/internal/hls/ringbuffer/segment_index.go
+++ b/backend/internal/hls/ringbuffer/segment_index.go
@@ -19,6 +19,9 @@ func NewSegmentIndex() *SegmentIndex {
 
 // AddSegment inserts a new segment into the index in sequence order.
 func (idx *SegmentIndex) AddSegment(seg *InternalSegment) {
+	if seg.ReservationIDs == nil {
+		seg.ReservationIDs = make(map[string]struct{})
+	}
 	service := seg.ID.ServiceRef
 	segments := idx.byService[service]
 	segments = append(segments, seg)
@@ -68,7 +71,7 @@ func (idx *SegmentIndex) MarkForDeletion(id SegmentID) bool {
 	if !ok {
 		return false
 	}
-	if seg.State == SegmentReserved {
+	if seg.IsReserved() {
 		return false // Cannot delete a reserved segment
 	}
 	seg.State = SegmentDeleting

--- a/backend/internal/hls/ringbuffer/segment_index.go
+++ b/backend/internal/hls/ringbuffer/segment_index.go
@@ -26,6 +26,9 @@ func (idx *SegmentIndex) AddSegment(seg *InternalSegment) {
 	segments := idx.byService[service]
 	segments = append(segments, seg)
 	sort.Slice(segments, func(i, j int) bool {
+		if segments[i].Sequence == segments[j].Sequence {
+			return segments[i].ID.PartIndex < segments[j].ID.PartIndex
+		}
 		return segments[i].Sequence < segments[j].Sequence
 	})
 	idx.byService[service] = segments
@@ -37,12 +40,9 @@ func (idx *SegmentIndex) SelectRange(serviceRef string, start, end time.Time) []
 	var matched []*InternalSegment
 
 	for _, seg := range segments {
-		// Ignore segments marked for deletion or missing
 		if seg.State == SegmentDeleting || seg.State == SegmentMissing {
 			continue
 		}
-
-		// Check overlap with requested window
 		if seg.EndWallTime.After(start) && seg.StartWallTime.Before(end) {
 			matched = append(matched, seg)
 		}
@@ -65,20 +65,20 @@ func (idx *SegmentIndex) GetByID(id SegmentID) (*InternalSegment, bool) {
 	return nil, false
 }
 
-// MarkForDeletion transitions active, unreserved segments to SegmentDeleting state.
-func (idx *SegmentIndex) MarkForDeletion(id SegmentID) bool {
+// TryMarkDeleting atomically checks reservation status and transitions unreserved segments to SegmentDeleting.
+func (idx *SegmentIndex) TryMarkDeleting(id SegmentID) bool {
 	seg, ok := idx.GetByID(id)
 	if !ok {
-		return false
+		return true // Missing segment is safe to delete
 	}
 	if seg.IsReserved() {
-		return false // Cannot delete a reserved segment
+		return false // Cannot delete reserved segment
 	}
 	seg.State = SegmentDeleting
 	return true
 }
 
-// RemoveSegment deletes a segment entry from the index after disk deletion.
+// RemoveSegment deletes a segment entry from the index after eviction.
 func (idx *SegmentIndex) RemoveSegment(id SegmentID) {
 	segments, ok := idx.byService[id.ServiceRef]
 	if !ok {


### PR DESCRIPTION
## Summary
- harden multi-job segment reservations and fail-safe recovery
- bridge real HLS ingest and eviction into the reservation store
- add RAM/disk segment locations, media metadata snapshots, lease reaping, and session-aware eviction protection
- preserve the security-hardened atomic persistence path from #788

This is the backend-only continuation extracted from the mixed WIP branch. It deliberately excludes the unfinished Quick Recording UI and unrelated player changes.

## Validation
- `make lint`
- `go test ./internal/hls/ringbuffer`
- `go test -race ./internal/hls/ringbuffer`
- `go vet ./internal/hls/ringbuffer`
- `git diff --check`