### PR TITLE
feat(retro): harden DVR recovery and reservation snapshots

### DIFF
--- a/backend/internal/hls/ringbuffer/recovery.go
+++ b/backend/internal/hls/ringbuffer/recovery.go
@@ -2,19 +2,18 @@ package ringbuffer
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"sync"
 	"time"
 )
 
-type LifecycleState uint8
+// LifecycleState tracks startup, recovery, and cleanup states.
+type LifecycleState int
 
 const (
 	LifecycleStarting LifecycleState = iota
 	LifecycleRecovering
-	LifecycleReady
 	LifecycleCleanupEnabled
 	LifecycleDegraded
 )
@@ -25,8 +24,6 @@ func (s LifecycleState) String() string {
 		return "STARTING"
 	case LifecycleRecovering:
 		return "RECOVERING"
-	case LifecycleReady:
-		return "READY"
 	case LifecycleCleanupEnabled:
 		return "CLEANUP_ENABLED"
 	case LifecycleDegraded:
@@ -36,103 +33,126 @@ func (s LifecycleState) String() string {
 	}
 }
 
-var ErrRecoveryFailed = errors.New("ringbuffer recovery failed: state degraded")
-
-// LifecycleManager controls startup recovery before enabling ringbuffer segment cleanup.
+// LifecycleManager controls startup recovery and delays segment cleanup until recovery completes.
 type LifecycleManager struct {
-	mu           sync.Mutex
-	state        LifecycleState
-	store        *ReservationStore
-	index        *SegmentIndex
-	cleanupReady chan struct{}
+	mu        sync.RWMutex
+	state     LifecycleState
+	store     *ReservationStore
+	index     *SegmentIndex
+	readyCond *sync.Cond
 }
 
-// NewLifecycleManager creates a new instance managing ringbuffer startup recovery.
+// NewLifecycleManager initializes a LifecycleManager.
 func NewLifecycleManager(store *ReservationStore, index *SegmentIndex) *LifecycleManager {
-	return &LifecycleManager{
-		state:        LifecycleStarting,
-		store:        store,
-		index:        index,
-		cleanupReady: make(chan struct{}),
+	lm := &LifecycleManager{
+		state: LifecycleStarting,
+		store: store,
+		index: index,
 	}
+	lm.readyCond = sync.NewCond(&lm.mu)
+	return lm
 }
 
+// State returns the current lifecycle state.
 func (lm *LifecycleManager) State() LifecycleState {
-	lm.mu.Lock()
-	defer lm.mu.Unlock()
+	lm.mu.RLock()
+	defer lm.mu.RUnlock()
 	return lm.state
 }
 
-// RunRecovery executes the fail-safe startup recovery sequence.
+// WaitCleanupEnabled blocks until recovery completes successfully and cleanup is enabled.
+func (lm *LifecycleManager) WaitCleanupEnabled() {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	for lm.state != LifecycleCleanupEnabled {
+		lm.readyCond.Wait()
+	}
+}
+
+// RunRecovery performs startup recovery of persistent reservations.
 func (lm *LifecycleManager) RunRecovery() error {
 	lm.mu.Lock()
 	lm.state = LifecycleRecovering
 	lm.mu.Unlock()
 
-	lm.store.mu.Lock()
-	defer lm.store.mu.Unlock()
-
-	if lm.store.storagePath != "" {
-		data, err := os.ReadFile(lm.store.storagePath)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				lm.mu.Lock()
-				lm.state = LifecycleDegraded
-				lm.mu.Unlock()
-				return fmt.Errorf("failed to read reservations state file: %w", err)
-			}
-		} else {
-			var loaded map[string]*Reservation
-			if err := json.Unmarshal(data, &loaded); err != nil {
-				lm.mu.Lock()
-				lm.state = LifecycleDegraded
-				lm.mu.Unlock()
-				return fmt.Errorf("failed to unmarshal corrupted reservations JSON: %w", err)
-			}
-
-			now := time.Now()
-			for id, res := range loaded {
-				if now.After(res.ExpiresAt) {
-					continue // Skip expired reservations
-				}
-				// Verify segments exist and lock them
-				var validSegs []SegmentID
-				for _, segID := range res.SegmentIDs {
-					if seg, ok := lm.index.GetByID(segID); ok {
-						exists := seg.Location.Kind == StorageKindRAM
-						if seg.Location.Kind == StorageKindDisk && seg.Location.Path != "" {
-							_, err := os.Stat(seg.Location.Path)
-							exists = (err == nil)
-						}
-						if exists {
-							if seg.ReservationIDs == nil {
-								seg.ReservationIDs = make(map[string]struct{})
-							}
-							seg.ReservationIDs[id] = struct{}{}
-							seg.State = SegmentReserved
-							validSegs = append(validSegs, segID)
-						} else {
-							seg.State = SegmentMissing
-							res.Status = CompletenessGapped
-						}
-					}
-				}
-				res.SegmentIDs = validSegs
-				lm.store.reservations[id] = res
-			}
-		}
-	}
+	err := lm.performRecovery()
 
 	lm.mu.Lock()
-	lm.state = LifecycleReady
-	lm.state = LifecycleCleanupEnabled
-	close(lm.cleanupReady)
-	lm.mu.Unlock()
+	if err != nil {
+		lm.state = LifecycleDegraded
+		lm.mu.Unlock()
+		return fmt.Errorf("recovery failed, entering degraded state: %w", err)
+	}
 
+	lm.state = LifecycleCleanupEnabled
+	lm.readyCond.Broadcast()
+	lm.mu.Unlock()
 	return nil
 }
 
-// WaitCleanupEnabled blocks until the recovery lifecycle enters CLEANUP_ENABLED.
-func (lm *LifecycleManager) WaitCleanupEnabled() {
-	<-lm.cleanupReady
+func (lm *LifecycleManager) performRecovery() error {
+	lm.store.mu.Lock()
+	defer lm.store.mu.Unlock()
+
+	if lm.store.storagePath == "" {
+		return nil
+	}
+
+	if _, err := os.Stat(lm.store.storagePath); os.IsNotExist(err) {
+		return nil
+	}
+
+	data, err := os.ReadFile(lm.store.storagePath)
+	if err != nil {
+		return fmt.Errorf("failed to read reservations JSON: %w", err)
+	}
+
+	var loaded map[string]*Reservation
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		return fmt.Errorf("failed to unmarshal corrupted reservations JSON: %w", err)
+	}
+
+	now := time.Now()
+	for id, res := range loaded {
+		if now.After(res.ExpiresAt) {
+			continue // Skip expired reservations
+		}
+
+		var validSegs []SegmentID
+		for _, segID := range res.SegmentIDs {
+			seg, ok := lm.index.GetByID(segID)
+			if !ok {
+				continue
+			}
+
+			switch seg.Location.Kind {
+			case StorageKindDisk:
+				// Disk segments survive restart: stat file
+				if seg.Location.Path != "" {
+					if _, err := os.Stat(seg.Location.Path); err == nil {
+						if seg.ReservationIDs == nil {
+							seg.ReservationIDs = make(map[string]struct{})
+						}
+						seg.ReservationIDs[id] = struct{}{}
+						seg.State = SegmentReserved
+						validSegs = append(validSegs, segID)
+					} else {
+						seg.State = SegmentMissing
+					}
+				} else {
+					seg.State = SegmentMissing
+				}
+			case StorageKindRAM:
+				// RAM segments NEVER survive process restart!
+				seg.State = SegmentMissing
+			}
+		}
+
+		res.SegmentIDs = validSegs
+		if len(validSegs) > 0 {
+			lm.store.reservations[id] = res
+		}
+	}
+
+	return nil
 }

--- a/backend/internal/hls/ringbuffer/reservation_store.go
+++ b/backend/internal/hls/ringbuffer/reservation_store.go
@@ -20,6 +20,7 @@ var (
 	ErrLeaseExceedsMaxDuration  = errors.New("lease duration exceeds maximum allowed limit")
 	ErrNoSegmentsAvailable      = errors.New("no valid segments available in requested range")
 	ErrSegmentMissing           = errors.New("one or more reserved segments are missing or deleting")
+	ErrStoreDegraded            = errors.New("reservation store is in a degraded state due to persistence failure")
 )
 
 // ReservationStore provides atomic, thread-safe reservation management backed by SegmentIndex.
@@ -31,6 +32,7 @@ type ReservationStore struct {
 	storagePath  string
 	onExpire     func(res *Reservation)
 	stopCh       chan struct{}
+	degraded     bool
 }
 
 // NewReservationStore creates a new ReservationStore instance.
@@ -68,7 +70,9 @@ func (rs *ReservationStore) reaperLoop() {
 			rs.mu.Lock()
 			purged := rs.purgeExpiredLocked()
 			if purged {
-				_ = rs.saveStateLocked()
+				if err := rs.saveStateLocked(); err != nil {
+					rs.degraded = true // STORE DEGRADED ON PERSISTENCE FAILURE!
+				}
 			}
 			rs.mu.Unlock()
 		}
@@ -137,7 +141,6 @@ func (rs *ReservationStore) probeRangeLocked(serviceRef string, start, end time.
 		}
 		lastCodec = seg.CodecHash
 
-		// Check for sequence or PTS continuity gaps between consecutive segments
 		if i > 0 {
 			prev := segments[i-1]
 			seqGap := seg.Sequence > prev.Sequence+1
@@ -188,6 +191,10 @@ func (rs *ReservationStore) ReserveRange(serviceRef string, start, end time.Time
 
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
+
+	if rs.degraded {
+		return Reservation{}, ErrStoreDegraded
+	}
 
 	rs.purgeExpiredLocked()
 
@@ -285,7 +292,7 @@ func (rs *ReservationStore) GetReservation(reservationID string) (Reservation, e
 	return *res, nil
 }
 
-// ListReservedSegments returns immutable SegmentHandles for an active reservation or error if missing.
+// ListReservedSegments returns immutable SegmentHandles for an active reservation.
 func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]SegmentHandle, error) {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
@@ -317,11 +324,50 @@ func (rs *ReservationStore) ListReservedSegments(reservationID string) ([]Segmen
 			SizeBytes:     seg.SizeBytes,
 			Discontinuity: seg.Discontinuity,
 			CodecHash:     seg.CodecHash,
-			Data:          seg.Data,
 		})
 	}
 
 	return handles, nil
+}
+
+// SnapshotReservation creates a safe, isolated byte snapshot of all reserved segments for Staging.
+func (rs *ReservationStore) SnapshotReservation(reservationID string, registry *Registry) ([]SegmentSnapshot, error) {
+	handles, err := rs.ListReservedSegments(reservationID)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshots []SegmentSnapshot
+	for _, handle := range handles {
+		var payload []byte
+		if handle.Location.Kind == StorageKindRAM {
+			if registry == nil {
+				return nil, fmt.Errorf("registry reference required for RAM snapshot")
+			}
+			buf, ok := registry.Get(handle.ID.SessionID)
+			if !ok {
+				return nil, fmt.Errorf("session buffer %s not found", handle.ID.SessionID)
+			}
+			bytesCopy, ok := buf.ByteSnapshot(handle.Location.Filename)
+			if !ok {
+				return nil, fmt.Errorf("RAM segment payload %s missing", handle.Location.Filename)
+			}
+			payload = bytesCopy
+		} else if handle.Location.Kind == StorageKindDisk && handle.Location.Path != "" {
+			diskBytes, err := os.ReadFile(handle.Location.Path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read disk segment %s: %w", handle.Location.Path, err)
+			}
+			payload = diskBytes
+		}
+
+		snapshots = append(snapshots, SegmentSnapshot{
+			Handle: handle,
+			Data:   payload,
+		})
+	}
+
+	return snapshots, nil
 }
 
 // RenewReservation updates the lease expiration timestamp from now, capped by MaxLeaseDuration.

--- a/backend/internal/hls/ringbuffer/reservation_test.go
+++ b/backend/internal/hls/ringbuffer/reservation_test.go
@@ -54,6 +54,77 @@ func TestParseSegmentFilename(t *testing.T) {
 	}
 }
 
+func TestPartSegmentPurgingOnCompleteArrival(t *testing.T) {
+	reg, err := NewRegistryWithStorage(5, "")
+	if err != nil {
+		t.Fatalf("NewRegistryWithStorage failed: %v", err)
+	}
+	defer reg.Stop()
+
+	sessionID := "test_part_session"
+	buf := reg.GetOrCreate(sessionID, nil)
+
+	// Ingest partial segments for sequence 10
+	buf.Put("part_000010_0.m4s", []byte("part_data_0"))
+	buf.Put("part_000010_1.m4s", []byte("part_data_1"))
+	buf.Put("part_000010_2.m4s", []byte("part_data_2"))
+
+	buf.mu.RLock()
+	artCountBefore := len(buf.artifacts)
+	buf.mu.RUnlock()
+
+	if artCountBefore < 3 {
+		t.Errorf("Expected at least 3 parts in RAM artifacts, got %d", artCountBefore)
+	}
+
+	// Now put full segment seg_000010.ts
+	buf.Put("seg_000010.ts", []byte("complete_segment_data_10"))
+
+	buf.mu.RLock()
+	_, part0Exists := buf.artifacts["part_000010_0.m4s"]
+	_, seg10Exists := buf.artifacts["seg_000010.ts"]
+	buf.mu.RUnlock()
+
+	if part0Exists {
+		t.Errorf("Expected part_000010_0.m4s to be PURGED from artifacts upon full segment arrival!")
+	}
+	if !seg10Exists {
+		t.Errorf("Expected seg_000010.ts to exist in artifacts!")
+	}
+}
+
+func TestSnapshotReservation_RAM(t *testing.T) {
+	reg, err := NewRegistryWithStorage(5, "")
+	if err != nil {
+		t.Fatalf("NewRegistryWithStorage failed: %v", err)
+	}
+	defer reg.Stop()
+
+	sessionID := "test_snap_session"
+	buf := reg.GetOrCreate(sessionID, nil)
+
+	now := time.Now()
+	buf.Put("seg_000001.ts", []byte("ts_payload_1"))
+	buf.Put("seg_000002.ts", []byte("ts_payload_2"))
+
+	res, err := reg.Store().ReserveRange(sessionID, now.Add(-5*time.Minute), now.Add(5*time.Minute), "test_owner", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("ReserveRange failed: %v", err)
+	}
+
+	snapshots, err := reg.Store().SnapshotReservation(res.ID, reg)
+	if err != nil {
+		t.Fatalf("SnapshotReservation failed: %v", err)
+	}
+
+	if len(snapshots) != 2 {
+		t.Fatalf("Expected 2 segment snapshots, got %d", len(snapshots))
+	}
+	if string(snapshots[0].Data) != "ts_payload_1" {
+		t.Errorf("Expected payload 'ts_payload_1', got '%s'", string(snapshots[0].Data))
+	}
+}
+
 func TestProbeRange_Complete(t *testing.T) {
 	idx := NewSegmentIndex()
 	now := time.Now()

--- a/backend/internal/hls/ringbuffer/ringbuffer.go
+++ b/backend/internal/hls/ringbuffer/ringbuffer.go
@@ -27,7 +27,9 @@ type Buffer struct {
 	serviceRef  string
 	maxSegments int
 	mu          sync.RWMutex
-	segments    []string // ordered slice of complete segment filenames (seg_*)
+	segments    []string            // ordered slice of complete segment filenames (seg_*)
+	parts       map[uint64][]string // partial segments grouped by sequence number (part_<seq>_*)
+	partOrder   []string            // ordered slice of all partial segment filenames
 	artifacts   map[string]*Artifact
 	lastUpdated time.Time
 	dvrCb       DVRCallback
@@ -51,6 +53,7 @@ func NewBufferWithStore(serviceRef, sessionID string, maxSegments int, dvrCb DVR
 		serviceRef:  serviceRef,
 		sessionID:   sessionID,
 		maxSegments: maxSegments,
+		parts:       make(map[uint64][]string),
 		artifacts:   make(map[string]*Artifact),
 		lastUpdated: time.Now(),
 		dvrCb:       dvrCb,
@@ -139,70 +142,91 @@ func (b *Buffer) PutWithMetadata(filename string, data []byte, meta SegmentMetad
 	b.artifacts[filename] = art
 
 	segID, isSegment := ParseSegmentFilename(b.serviceRef, b.sessionID, filename)
-	// Variant A: Retro-DVR ONLY indexes and counts COMPLETE segments (seg_*)
-	if isSegment && segID.Kind == SegmentKindComplete && !exists {
-		b.segments = append(b.segments, filename)
 
-		durSec := meta.Duration.Seconds()
-		if durSec <= 0 {
-			durSec = 2.0 // Fallback
-		}
+	if isSegment {
+		if segID.Kind == SegmentKindPart && !exists {
+			// Track partial segments flüchtig in RAM
+			b.parts[segID.Sequence] = append(b.parts[segID.Sequence], filename)
+			b.partOrder = append(b.partOrder, filename)
 
-		startWall := art.ModTime
-		if meta.ProgramTime != nil {
-			startWall = *meta.ProgramTime
-		}
-		endWall := startWall.Add(time.Duration(durSec * float64(time.Second)))
-
-		// Register segment with authoritative store
-		if b.store != nil {
-			b.store.mu.Lock()
-			b.index.AddSegment(&InternalSegment{
-				ID: segID,
-				Location: SegmentLocation{
-					Kind:     StorageKindRAM,
-					Filename: filename,
-				},
-				DurationSec:   durSec,
-				Sequence:      segID.Sequence,
-				StartPTS90k:   meta.StartPTS90k,
-				EndPTS90k:     meta.EndPTS90k,
-				PTSEpoch:      meta.PTSEpoch,
-				StartWallTime: startWall,
-				EndWallTime:   endWall,
-				SizeBytes:     int64(len(data)),
-				Discontinuity: meta.Discontinuity,
-				CodecHash:     meta.CodecHash,
-				State:         SegmentActive,
-				Data:          data,
-			})
-			b.store.mu.Unlock()
-		}
-
-		var keptSegments []string
-		for idx, s := range b.segments {
-			if len(b.segments)-idx <= b.maxSegments {
-				keptSegments = append(keptSegments, s)
-				continue
+			// Enforce max un-assembled parts limit (50 max)
+			const maxPartsPerSession = 50
+			for len(b.partOrder) > maxPartsPerSession {
+				oldestPart := b.partOrder[0]
+				b.partOrder = b.partOrder[1:]
+				delete(b.artifacts, oldestPart)
+			}
+		} else if segID.Kind == SegmentKindComplete && !exists {
+			// Complete segment arrived: IMMEDIATELY PURGE corresponding transient part_* artifacts!
+			if partFiles, ok := b.parts[segID.Sequence]; ok {
+				for _, pf := range partFiles {
+					delete(b.artifacts, pf)
+				}
+				delete(b.parts, segID.Sequence)
 			}
 
-			candID, candOk := ParseSegmentFilename(b.serviceRef, b.sessionID, s)
-			if candOk && b.store != nil {
+			b.segments = append(b.segments, filename)
+
+			durSec := meta.Duration.Seconds()
+			if durSec <= 0 {
+				durSec = 2.0 // Fallback
+			}
+
+			startWall := art.ModTime
+			if meta.ProgramTime != nil {
+				startWall = *meta.ProgramTime
+			}
+			endWall := startWall.Add(time.Duration(durSec * float64(time.Second)))
+
+			// Register segment with authoritative store
+			if b.store != nil {
 				b.store.mu.Lock()
-				canEvict := b.index.TryMarkDeleting(candID)
-				if !canEvict {
-					// Reserved! Keep in buffer
-					b.store.mu.Unlock()
-					keptSegments = append(keptSegments, s)
-					continue
-				}
-				b.index.RemoveSegment(candID)
+				b.index.AddSegment(&InternalSegment{
+					ID: segID,
+					Location: SegmentLocation{
+						Kind:     StorageKindRAM,
+						Filename: filename,
+					},
+					DurationSec:   durSec,
+					Sequence:      segID.Sequence,
+					StartPTS90k:   meta.StartPTS90k,
+					EndPTS90k:     meta.EndPTS90k,
+					PTSEpoch:      meta.PTSEpoch,
+					StartWallTime: startWall,
+					EndWallTime:   endWall,
+					SizeBytes:     int64(len(data)),
+					Discontinuity: meta.Discontinuity,
+					CodecHash:     meta.CodecHash,
+					State:         SegmentActive,
+				})
 				b.store.mu.Unlock()
 			}
 
-			delete(b.artifacts, s)
+			var keptSegments []string
+			for idx, s := range b.segments {
+				if len(b.segments)-idx <= b.maxSegments {
+					keptSegments = append(keptSegments, s)
+					continue
+				}
+
+				candID, candOk := ParseSegmentFilename(b.serviceRef, b.sessionID, s)
+				if candOk && b.store != nil {
+					b.store.mu.Lock()
+					canEvict := b.index.TryMarkDeleting(candID)
+					if !canEvict {
+						// Reserved! Keep in buffer
+						b.store.mu.Unlock()
+						keptSegments = append(keptSegments, s)
+						continue
+					}
+					b.index.RemoveSegment(candID)
+					b.store.mu.Unlock()
+				}
+
+				delete(b.artifacts, s)
+			}
+			b.segments = keptSegments
 		}
-		b.segments = keptSegments
 	}
 
 	if b.dvrCh != nil {
@@ -374,7 +398,6 @@ func (r *Registry) cleanupLoop() {
 				last := buf.lastUpdated
 				buf.mu.RUnlock()
 				if now.Sub(last) > 10*time.Minute {
-					// DO NOT DELETE SESSION BUFFER IF IT CONTAINS RESERVED SEGMENTS!
 					if r.store != nil && r.store.HasReservationsForSession(id) {
 						continue
 					}

--- a/backend/internal/hls/ringbuffer/segment.go
+++ b/backend/internal/hls/ringbuffer/segment.go
@@ -115,7 +115,6 @@ type InternalSegment struct {
 	CodecHash      string              `json:"codec_hash"`
 	State          SegmentState        `json:"state"`
 	ReservationIDs map[string]struct{} `json:"reservation_ids"`
-	Data           []byte              `json:"-"` // Non-nil if StorageKindRAM
 }
 
 // IsReserved returns true if one or more active reservations hold this segment.
@@ -137,7 +136,12 @@ type SegmentHandle struct {
 	SizeBytes     int64           `json:"size_bytes"`
 	Discontinuity bool            `json:"discontinuity"`
 	CodecHash     string          `json:"codec_hash"`
-	Data          []byte          `json:"-"` // Available if StorageKindRAM
+}
+
+// SegmentSnapshot holds an immutable metadata handle along with an isolated byte copy for staging.
+type SegmentSnapshot struct {
+	Handle SegmentHandle `json:"handle"`
+	Data   []byte        `json:"-"`
 }
 
 // RangeProbe represents the result of probing segment availability over a time window.


### PR DESCRIPTION
## Summary
- purge LL-HLS `part_*` artifacts during recovery
- expose consistent reservation snapshots
- treat RAM-backed reservations as unrecoverable across restarts
- preserve degraded reaper operation when persistence fails

Extracted as the last completed backend commit from the WIP branch. The unfinished disk-store prototype is deliberately excluded.

## Validation
- `make lint`
- `go test -timeout 60s ./internal/hls/ringbuffer`
- `go test -timeout 60s -race ./internal/hls/ringbuffer`
- `go vet ./internal/hls/ringbuffer`
- `git diff --check`