### PR TITLE
fix(scan): size the probe budget for a cold tune, not a warm read

### DIFF
--- a/backend/internal/pipeline/scan/manager.go
+++ b/backend/internal/pipeline/scan/manager.go
@@ -24,8 +24,19 @@ import (
 const (
 	backgroundScanTimeout = 30 * time.Minute
 	resolveM3UTimeout     = 2 * time.Second
-	defaultProbeTimeout   = 8 * time.Second
-	extendedProbeTimeout  = 20 * time.Second
+	// defaultProbeTimeout must cover a cold tune plus stream lock, not just a
+	// warm read. Measured across 10 encrypted broadcast channels on an otherwise
+	// idle receiver: median 6.1s, max 10.8s -- every one of them returned
+	// complete media truth when allowed to finish. At the previous 8s budget two
+	// of those ten were killed mid-probe and recorded as failures, which then
+	// held them behind the 24h failureRetryWindow.
+	//
+	// Sized for headroom rather than fitted to that sample: a real scan runs
+	// probes back to back with tuner contention, so the slow tail is longer than
+	// an idle-box measurement suggests. It stays clearly below
+	// extendedProbeTimeout so the two budgets remain distinct tiers.
+	defaultProbeTimeout  = 15 * time.Second
+	extendedProbeTimeout = 20 * time.Second
 
 	extendedProbeAnalyzeDuration = 15 * time.Second
 	extendedProbeSizeBytes       = 8 << 20

--- a/backend/internal/pipeline/scan/probe_budget_test.go
+++ b/backend/internal/pipeline/scan/probe_budget_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package scan
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/vod"
+	infra "github.com/ManuGH/xg2g/internal/infra/ffmpeg"
+	"github.com/stretchr/testify/require"
+)
+
+// measuredColdProbeWorstCase is the slowest complete probe observed across 10
+// encrypted broadcast channels on an idle receiver (median 6.1s). The default
+// budget must clear it with room to spare, because a real scan run adds tuner
+// contention on top.
+const measuredColdProbeWorstCase = 11 * time.Second
+
+func TestDefaultProbeBudgetCoversColdTune(t *testing.T) {
+	require.Greater(t, defaultProbeTimeout, measuredColdProbeWorstCase,
+		"defaultProbeTimeout must exceed the measured worst-case cold probe (%s); "+
+			"a tighter budget kills slow-but-healthy channels mid-probe and records them "+
+			"as failures, which then sit behind the %s failureRetryWindow",
+		measuredColdProbeWorstCase, failureRetryWindow)
+
+	require.Less(t, defaultProbeTimeout, extendedProbeTimeout,
+		"the default budget must stay below the extended one so the two remain distinct tiers")
+}
+
+// The budget is only meaningful if it is actually enforced: a probe that
+// outlasts it must be cancelled rather than allowed to run on.
+func TestProbeAttemptIsCancelledAtBudget(t *testing.T) {
+	m := NewManager(NewMemoryStore(), "", nil)
+
+	budget := 60 * time.Millisecond
+	m.probeFn = func(ctx context.Context, _ string, _ infra.ProbeOptions) (*vod.StreamInfo, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Second):
+			return &vod.StreamInfo{Container: "ts"}, nil
+		}
+	}
+
+	start := time.Now()
+	_, err := m.runProbeAttempt(context.Background(), "http://receiver.example:8001/1:0:1:ABC",
+		infra.ProbeOptions{}, budget)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded), "expected deadline error, got %v", err)
+	require.Less(t, elapsed, 2*time.Second, "probe should be cancelled at the budget, not run on")
+}
+
+// A probe that finishes inside the budget must return its result untouched.
+func TestProbeAttemptSucceedsWithinBudget(t *testing.T) {
+	m := NewManager(NewMemoryStore(), "", nil)
+
+	m.probeFn = func(_ context.Context, _ string, _ infra.ProbeOptions) (*vod.StreamInfo, error) {
+		time.Sleep(10 * time.Millisecond)
+		return &vod.StreamInfo{
+			Container: "ts",
+			Video:     vod.VideoStreamInfo{CodecName: "h264", Width: 1920, Height: 1080},
+			Audio:     vod.AudioStreamInfo{CodecName: "ac3"},
+		}, nil
+	}
+
+	res, err := m.runProbeAttempt(context.Background(), "http://receiver.example:8001/1:0:1:ABC",
+		infra.ProbeOptions{}, time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, "h264", res.Video.CodecName)
+	require.Equal(t, "ac3", res.Audio.CodecName)
+}


### PR DESCRIPTION
## Problem

Encrypted broadcast channels were recorded as scan failures even though they probe cleanly.

Measured across 10 such channels on an idle receiver, using the scan's exact probe parameters:

| | |
| --- | --- |
| median | 6.1s |
| max | **10.8s** |
| complete media truth | **10/10** |

All ten returned full media truth (h264 1920x1080 + ac3) when allowed to finish. At the 8s budget, **2 of 10 were killed mid-probe** — and a killed probe is stored as a failure, which then holds the channel behind the 24h `failureRetryWindow`.

## Fix

`defaultProbeTimeout` 8s → 15s.

Sized for headroom rather than fitted to the sample maximum: a real scan run adds tuner contention on top of an idle-box measurement, so the slow tail is longer than 10.8s. It stays below `extendedProbeTimeout` (20s) so the two budgets remain distinct tiers.

## Hypotheses ruled out by measurement

Before landing on the budget, these were tested and are **not** the cause:

- The spoofed `-user_agent VLC/3.0.21` in `buildProbeArgs` — identical success with and without it.
- `analyzeduration` / `probesize` — no effect.
- Longer timeout alone with the extended parameters — same result as the plain probe.

## Rejected alternatives

**Widening `shouldAttemptExtendedRetry`** so a hard failure on a never-probed channel reaches the 20s tier. The extended retry re-probes from scratch, so a dead channel would cost 8s + 20s instead of today's 8s. Channels that deliver no data at all — dark event feeds are the common case here — burn the whole budget every time (verified: killed at 8s, 20s and 45s alike). That path more than triples the worst case to rescue the slow-but-healthy one, and slow-but-healthy channels would still waste the first 8s before starting over.

**Doing both**, which inherits that same failure cost on top of the wider default.

A flat, correctly sized budget is cheaper on every path here, and the 24h `failureRetryWindow` means the dead-channel cost is paid once a day rather than every pass.

## Tests

- `DefaultProbeBudgetCoversColdTune` — pins the budget above the measured worst case and below the extended tier, with the reasoning in the failure message.
- `ProbeAttemptIsCancelledAtBudget` / `SucceedsWithinBudget` — the budget is actually enforced, so the constant is meaningful.

**Negative control:** reverting the constant to 8s makes `DefaultProbeBudgetCoversColdTune` red.

`make ci-pr` — PR gate bundle passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)