### PR TITLE
fix(webui): derive Android TV /ui/ link from the deployment root

### DIFF
--- a/apps/webui/src/components/Settings.test.tsx
+++ b/apps/webui/src/components/Settings.test.tsx
@@ -429,4 +429,106 @@ describe('Settings', () => {
     expect(screen.queryByRole('link', { name: 'Open in xg2g App' })).not.toBeInTheDocument();
     expect(screen.getByText('Native clients cannot be handed an externally valid origin because no public_https endpoint allows native access.')).toBeInTheDocument();
   });
+
+  // Published endpoints are origin-only today (the backend rejects any endpoint
+  // URL with a path), so a sub-path endpoint cannot currently reach the WebUI.
+  // These tests pin the derivation model regardless: `/ui/` is a sibling of
+  // `/api/v3` below the deployment root, so it must be derived downward from the
+  // endpoint instead of overwriting its path.
+  it('keeps the deployment sub-path of the contract native endpoint in base_url', async () => {
+    getSystemConfig.mockResolvedValue({
+      data: {
+        openWebIF: { baseUrl: 'http://receiver.local' },
+        streaming: { deliveryPolicy: 'universal' },
+      },
+    });
+    getSystemConnectivity.mockResolvedValue({
+      data: createConnectivityContract({
+        selections: {
+          web: {},
+          webPublic: {},
+          native: {
+            endpoint: {
+              url: 'https://tv.example.net/xg2g',
+              kind: 'local_https',
+              priority: 10,
+              tlsMode: 'required',
+              allowPairing: true,
+              allowStreaming: true,
+              allowWeb: true,
+              allowNative: true,
+              advertiseReason: 'sub-path deployment',
+              source: 'config',
+            },
+            reason: 'highest-priority endpoint with allow_native=true',
+          },
+          nativePublic: {},
+          pairing: {},
+          pairingPublic: {},
+          streaming: {},
+        },
+      }),
+    });
+    getSystemScanStatus.mockResolvedValue({
+      data: {
+        state: 'idle',
+        scannedChannels: 0,
+        totalChannels: 20,
+        updatedCount: 0,
+      },
+    });
+
+    renderWithQueryClient(['/settings?section=android-tv']);
+
+    const link = await screen.findByRole('link', { name: 'Open in xg2g App' });
+    const href = link.getAttribute('href') ?? '';
+    expect(href.startsWith('xg2g://connect?')).toBe(true);
+    const params = new URLSearchParams(href.slice('xg2g://connect?'.length));
+    expect(params.get('base_url')).toBe('https://tv.example.net/xg2g/ui/');
+    expect(screen.getByText('https://tv.example.net/xg2g/ui/')).toBeInTheDocument();
+  });
+
+  it('keeps the deployment sub-path of the configured native endpoint in base_url', async () => {
+    getSystemConfig.mockResolvedValue({
+      data: {
+        openWebIF: { baseUrl: 'http://receiver.local' },
+        connectivity: {
+          profile: 'lan',
+          allowLocalHTTP: false,
+          publishedEndpoints: [
+            {
+              url: 'https://tv.example.net/xg2g/',
+              kind: 'local_https',
+              priority: 10,
+              tlsMode: 'required',
+              allowPairing: true,
+              allowStreaming: true,
+              allowWeb: true,
+              allowNative: true,
+              advertiseReason: 'sub-path deployment',
+              source: 'config',
+            },
+          ],
+        },
+        streaming: { deliveryPolicy: 'universal' },
+      },
+    });
+    getSystemConnectivity.mockResolvedValue({
+      data: createConnectivityContract(),
+    });
+    getSystemScanStatus.mockResolvedValue({
+      data: {
+        state: 'idle',
+        scannedChannels: 0,
+        totalChannels: 20,
+        updatedCount: 0,
+      },
+    });
+
+    renderWithQueryClient(['/settings?section=android-tv']);
+
+    const link = await screen.findByRole('link', { name: 'Open in xg2g App' });
+    const params = new URLSearchParams((link.getAttribute('href') ?? '').slice('xg2g://connect?'.length));
+    expect(params.get('base_url')).toBe('https://tv.example.net/xg2g/ui/');
+  });
 });

--- a/apps/webui/src/components/Settings.tsx
+++ b/apps/webui/src/components/Settings.tsx
@@ -55,7 +55,33 @@ function isSettingsTool(value: string | null): value is SettingsTool {
   return value !== null && SETTINGS_TOOLS.includes(value as SettingsTool);
 }
 
-function resolveAndroidTvBaseUrl(
+// Deployment assumption: published endpoints are ORIGIN-ONLY, so xg2g is not
+// supported under a deployment sub-path today. The backend rejects any endpoint
+// URL carrying a path ("only origin URLs are allowed", see
+// backend/internal/domain/connectivity/published_endpoints.go `parseEndpointURL`)
+// and strips the path again during canonicalization, and every reference
+// topology in docs/ops/PUBLIC_DEPLOYMENT_CONTRACT.md proxies the site root.
+//
+// `ui/` is nevertheless derived *relative* to the endpoint rather than by
+// resolving the absolute path `/ui/`, so that assumption stays non-load-bearing:
+// an absolute path silently replaces the deployment root (`https://host/xg2g/`
+// would become `https://host/ui/`), which would hand the native client a URL
+// that does not exist. `/ui` and `/api/v3` are siblings below the same root
+// (backend/internal/api/server_routes_wiring.go, `V3BaseURL`), so both must be
+// derived downward from it — never by overwriting one another's path.
+function deriveUiUrl(endpointUrl: string): string {
+  try {
+    const root = new URL(endpointUrl);
+    if (!root.pathname.endsWith('/')) {
+      root.pathname = `${root.pathname}/`;
+    }
+    return new URL('ui/', root).toString();
+  } catch {
+    return '';
+  }
+}
+
+export function resolveAndroidTvBaseUrl(
   config: AppConfig | null,
   contract: ConnectivityContract | null,
 ): string {
@@ -63,11 +89,7 @@ function resolveAndroidTvBaseUrl(
     ? contract.selections.nativePublic.endpoint?.url
     : contract?.selections.native.endpoint?.url;
   if (contractNativeUrl) {
-    try {
-      return new URL('/ui/', contractNativeUrl).toString();
-    } catch {
-      return '';
-    }
+    return deriveUiUrl(contractNativeUrl);
   }
 
   const profile = config?.connectivity?.profile ?? 'lan';
@@ -75,11 +97,7 @@ function resolveAndroidTvBaseUrl(
     ?.find((endpoint) => endpoint.allowNative && (profile === 'lan' || endpoint.kind === 'public_https'))
     ?.url;
   if (configuredNativeUrl) {
-    try {
-      return new URL('/ui/', configuredNativeUrl).toString();
-    } catch {
-      return '';
-    }
+    return deriveUiUrl(configuredNativeUrl);
   }
 
   if (profile !== 'lan' || contract?.public) {
@@ -89,7 +107,7 @@ function resolveAndroidTvBaseUrl(
   if (typeof window === 'undefined') {
     return '';
   }
-  return new URL('/ui/', window.location.origin).toString();
+  return deriveUiUrl(window.location.origin);
 }
 
 function Settings() {

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -443,6 +443,12 @@ connectivity:
       advertiseReason: "split-dns lan tls"
 ```
 
+Each `url` must be a bare origin (`scheme://host[:port]`, optionally with a
+trailing `/`). Paths, queries, and fragments are rejected at startup, so xg2g
+cannot be published under a deployment sub-path such as
+`https://tv.example.net/xg2g/` — proxy the site root instead. See
+[Public Deployment Contract](../ops/PUBLIC_DEPLOYMENT_CONTRACT.md#published-endpoint-urls-are-origin-only).
+
 Clients receive this ordered list from the backend during pairing/device session
 flows and the WebUI can reuse it for Android launch setup.
 

--- a/docs/ops/PUBLIC_DEPLOYMENT_CONTRACT.md
+++ b/docs/ops/PUBLIC_DEPLOYMENT_CONTRACT.md
@@ -26,6 +26,29 @@ branches or client-side heuristics.
   - xg2g terminates public TLS directly
   - `tls.enabled` is required
 
+## Published Endpoint URLs Are Origin-Only
+
+Every entry in `connectivity.publishedEndpoints` must be a bare origin:
+`scheme://host[:port]`, optionally with a trailing `/`. A URL carrying a path,
+query, fragment, or userinfo is rejected at startup
+(`published endpoint url is invalid: only origin URLs are allowed`), and the
+path is stripped again during canonicalization.
+
+**xg2g therefore does not support being mounted under a deployment sub-path.**
+Proxy the site root (`https://tv.example.net/`), not `https://tv.example.net/xg2g/`.
+All reference topologies below do exactly that.
+
+The reason is that xg2g's routes are siblings below one deployment root — `/api/v3`,
+`/ui`, `/stream`, `/logos`, `/healthz` — and clients derive each of them downward
+from the single published origin. A sub-path root would have to be carried through
+every client's URL derivation; today it is not, so it is rejected at the source
+rather than silently dropped later.
+
+Terminating the proxy at a sub-path *and* stripping the prefix before forwarding
+is likewise unsupported: the browser would then be at `https://host/xg2g/ui/`
+while the published endpoint (and every URL derived from it) claims
+`https://host/ui/`.
+
 ## Failure Model
 
 - `fatal`
@@ -199,6 +222,8 @@ These are contract violations:
 - local endpoints marked as web-capable in a public profile
 - wildcard `allowedOrigins` in a public profile
 - public web endpoint not present in `allowedOrigins`
+- a published endpoint URL with a path, query, fragment, or userinfo
+  (see "Published Endpoint URLs Are Origin-Only")
 
 ## Verification Path
 


### PR DESCRIPTION
## Was das ist — und was es nicht ist

**Kein aktuell erreichbarer Produktionsfehler.** Das Backend erzwingt heute
Origin-only Published Endpoints, damit ist der beschriebene Pfad nicht auslösbar.
Dieser PR entfernt eine fragile Ableitungslogik aus der WebUI und dokumentiert
die bereits bestehende Invariante. Er ist für alle Eingaben, die das Backend
erzeugen kann, **verhaltensneutral**.

## Die fragile Annahme

`resolveAndroidTvBaseUrl` baute den Android-TV-Onboarding-Link an drei Stellen so:

```ts
new URL('/ui/', endpointUrl)
```

`/ui/` ist ein *absoluter* Pfad und ersetzt daher den kompletten Pfad der Basis-URL,
statt relativ dazu aufzulösen. Für einen Deployment-Root `https://host/xg2g/` ergibt
`new URL('/ui/', 'https://host/xg2g/')` das Ergebnis `https://host/ui/` — der Root
fällt still weg, und der erzeugte `xg2g://connect?base_url=…`-Link zeigt auf einen
Ort, den es nicht gibt.

Das ist derselbe Modellierungsfehler, der auch im Android-Native-Auth-Transport die
falsche API-URL erzeugt (separat verfolgt): eine Endpoint-URL wird rekonstruiert,
indem der Pfad einer anderen überschrieben wird. `/api/v3` und `/ui` sind aber
Geschwister unterhalb *eines* Deployment-Roots und müssen beide von dort nach unten
abgeleitet werden. Der iOS-Client speichert deshalb bewusst den Root und leitet
`/api/v3/` und `/ui/` daraus ab.

## Warum es heute nicht auslösbar ist

`parseEndpointURL` weist jede Endpoint-URL mit Pfad ab
(`backend/internal/domain/connectivity/published_endpoints.go`):

```go
if path := parsed.EscapedPath(); path != "" && path != "/" {
    return nil, fmt.Errorf("%w: only origin URLs are allowed", ErrInvalidEndpointURL)
}
```

`canonicalizeEndpointURL` entfernt den Pfad anschließend ohnehin nochmal, und es gibt
bereits einen Test dafür (`reject non-origin path`). Beide WebUI-Quellen laufen durch
denselben Validator (`buildConnectivityConfigResponse` → `BuildConnectivityContract`
→ `Provider.Build`), also können weder `config.connectivity.publishedEndpoints` noch
`contract.selections.*.endpoint.url` je einen Pfad tragen. Sämtliche Referenz-
Topologien proxen den Site-Root, und die Routen sind fest auf `/ui/*` und `/api/v3`
registriert.

Die Invariante hielt also — sie war nur nirgends dokumentiert, und lokal hat sie
nichts abgesichert.

## Änderung

Alle drei Aufrufstellen laufen jetzt über einen Helper, der die Basis auf einen
Trailing Slash normalisiert und `ui/` **relativ** auflöst:

```ts
const root = new URL(endpointUrl);
if (!root.pathname.endsWith('/')) root.pathname = `${root.pathname}/`;
return new URL('ui/', root).toString();
```

Für Origin-only-Eingaben ist das Ergebnis byte-identisch zu vorher. Das
`try/catch → ''`-Fehlerverhalten bleibt erhalten. Der Kommentar am Helper nennt die
Invariante, verweist auf die erzwingende Stelle im Backend und begründet, warum
relativ abgeleitet wird.

Zusätzlich ist die Origin-only-Regel jetzt explizit dokumentiert — inklusive der
Falle, einen Proxy auf einem Sub-Path mit Prefix-Stripping zu terminieren: der
Browser stünde dann auf `https://host/xg2g/ui/`, während der Published Endpoint und
alles daraus Abgeleitete `https://host/ui/` behauptet.

## Tests

Zwei Fälle, je einer pro Endpoint-Quelle (Contract-Selection ohne Trailing Slash,
`config.publishedEndpoints` mit), prüfen den `base_url`-Parameter des erzeugten
`xg2g://connect`-Links auf Erhalt des Sub-Paths. Beide schlagen fehl, wenn der Helper
auf die Absolut-Pfad-Form zurückgedreht wird:

```
AssertionError: expected 'https://tv.example.net/ui/' to be 'https://tv.example.net/xg2g/ui/'
```

| Check | Ergebnis |
|---|---|
| `vitest run` (voll) | 134 Dateien, 685/685 passed |
| `tsc --noEmit` | exit 0 |
| `eslint` (beide geänderten Dateien) | exit 0 |

## Scope

Bewusst eng gehalten: 1 Commit, 4 Dateien. Der Android-`ApiV3Url`-Fix und die
iOS-2A-Arbeit bleiben in eigenen Branches. Das eingecheckte
`backend/internal/control/http/dist/`-Bundle wurde hier **nicht** neu gebaut — der
Fix ist verhaltensneutral, und ein Rebuild würde den Diff mit generierten Assets
aufblähen; er kommt beim nächsten regulären `make ui-build` mit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
