### PR TITLE
fix(backend): register handwritten v3 routes from one canonical list

### DIFF
--- a/backend/internal/api/deadline_classification.go
+++ b/backend/internal/api/deadline_classification.go
@@ -177,7 +177,9 @@ func ClassifyRoute(routerID string, variant ConfigVariant, method string, patter
 	// 1. Unbounded Streaming routes (ONLY GET requests for SSE sessions/events and stream.mp4)
 	// NOTE: SSE sessions/events route requires explicit Flush capability (RequiresFlush = true).
 	if method == http.MethodGet {
-		if strings.HasSuffix(pattern, "/events") {
+		// Both are Server-Sent Event endpoints: they hold the connection open and flush
+		// incrementally, so an API-bounded write deadline would cut the stream.
+		if strings.HasSuffix(pattern, "/events") || strings.HasSuffix(pattern, "/notifications/stream") {
 			return RoutePolicy{
 				Class:                RouteDeadlineStreaming,
 				RequiresFlush:        true,

--- a/backend/internal/api/deadline_classification_test.go
+++ b/backend/internal/api/deadline_classification_test.go
@@ -671,13 +671,13 @@ func TestDeadlineClassification_InventoryCountsAndClassificationList(t *testing.
 				assert.Equal(t, 147, len(regs), "total registrable instances must equal 147 under DevProxy")
 				assert.Equal(t, 147, apiBounded+mediaBounded+streaming)
 				assert.Equal(t, 12, mediaBounded, "RouteDeadlineMediaBounded count is 12 under DevProxy")
-				assert.Equal(t, 133, apiBounded, "RouteDeadlineAPIBounded count is 133 under DevProxy")
+				assert.Equal(t, 132, apiBounded, "RouteDeadlineAPIBounded count is 132 under DevProxy")
 				assert.Equal(t, 2, mayUpgradeCount, "DevProxy has 2 MayUpgradePerRequest routes (GET /ui and GET /ui/*)")
 			} else {
 				assert.Equal(t, 147, len(regs), "total registrable instances must equal 147 under ProdStatic/DevDir")
 				assert.Equal(t, 147, apiBounded+mediaBounded+streaming)
 				assert.Equal(t, 13, mediaBounded, "RouteDeadlineMediaBounded count is 13 under ProdStatic/DevDir")
-				assert.Equal(t, 132, apiBounded, "RouteDeadlineAPIBounded count is 132 under ProdStatic/DevDir")
+				assert.Equal(t, 131, apiBounded, "RouteDeadlineAPIBounded count is 131 under ProdStatic/DevDir")
 				assert.Equal(t, 0, mayUpgradeCount)
 			}
 		})

--- a/backend/internal/api/deadline_policy_binding_test.go
+++ b/backend/internal/api/deadline_policy_binding_test.go
@@ -176,6 +176,26 @@ func getPhase1CanonicalBaselineMap() map[RegistrationKey]RoutePolicy {
 		{http.MethodPost, "/profiles"},
 		{http.MethodGet, "/profiles/{id}"},
 		{http.MethodDelete, "/profiles/{id}"},
+		{http.MethodPost, "/auth/device/grant/start"},
+		{http.MethodPost, "/auth/device/grant/finish"},
+		{http.MethodPost, "/auth/device/refresh"},
+		{http.MethodPost, "/sessions/revoke-user-sessions"},
+		{http.MethodGet, "/household/policies/access"},
+		{http.MethodPost, "/household/policies/access"},
+		{http.MethodPost, "/household/policies/access/revoke"},
+		{http.MethodGet, "/household/approvals"},
+		{http.MethodPost, "/household/approvals"},
+		{http.MethodPost, "/household/approvals/{id}/approve"},
+		{http.MethodPost, "/household/approvals/{id}/deny"},
+		{http.MethodGet, "/household/resource-policy"},
+		{http.MethodPut, "/household/resource-policy"},
+		{http.MethodGet, "/notifications"},
+		{http.MethodGet, "/notifications/stream"},
+		{http.MethodPost, "/notifications/mark-read"},
+		{http.MethodPost, "/notifications/mark-all-read"},
+		{http.MethodDelete, "/notifications/{id}"},
+		{http.MethodGet, "/notifications/vapid-key"},
+		{http.MethodPost, "/notifications/push-subscriptions"},
 	}
 	for _, route := range v3Routes {
 		add("v3", route.method, "/api/v3"+route.path, apiPolicy)
@@ -188,6 +208,7 @@ func getPhase1CanonicalBaselineMap() map[RegistrationKey]RoutePolicy {
 		baseline[key] = policy
 	}
 	setV3Policy(http.MethodGet, "/sessions/{sessionID}/events", ssePolicy)
+	setV3Policy(http.MethodGet, "/notifications/stream", ssePolicy)
 	setV3Policy(http.MethodGet, "/sessions/{sessionID}/hls/{filename}", mediaPolicy)
 	setV3Policy(http.MethodHead, "/sessions/{sessionID}/hls/{filename}", mediaPolicy)
 	setV3Policy(http.MethodGet, "/sessions/{sessionID}/hls/{variant}/{filename}", mediaPolicy)
@@ -235,8 +256,8 @@ func TestCanonicalBaselineParity(t *testing.T) {
 
 	expected := getPhase1CanonicalBaselineMap()
 	actual := snapshotAsMap(snapshot)
-	require.Len(t, expected, 126)
-	require.Len(t, actual, 126)
+	require.Len(t, expected, 146)
+	require.Len(t, actual, 146)
 	require.NoError(t, validatePolicyBindingParity(actual, expected))
 
 	counts := map[string]int{}
@@ -244,7 +265,7 @@ func TestCanonicalBaselineParity(t *testing.T) {
 		counts[key.RouterID]++
 	}
 	require.Equal(t, 26, counts["outer"])
-	require.Equal(t, 100, counts["v3"])
+	require.Equal(t, 120, counts["v3"])
 }
 
 func TestPolicyBindingSnapshotTracksBuildSpecificUIVariant(t *testing.T) {
@@ -267,7 +288,7 @@ func TestPolicyBindingSnapshotTracksBuildSpecificUIVariant(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			_, snapshot, err := s.buildRouterWithBindings(test.variant)
 			require.NoError(t, err)
-			require.Equal(t, 126, snapshot.Len())
+			require.Equal(t, 146, snapshot.Len())
 
 			for key, expected := range map[RegistrationKey]RoutePolicy{
 				{RouterID: "outer", Method: http.MethodGet, Pattern: "/ui/*"}:  test.uiGet,
@@ -348,7 +369,7 @@ func TestPolicyBindingGovernanceDetectsSnapshotMutations(t *testing.T) {
 		delete(actual, v3Key)
 		actual[RegistrationKey{RouterID: "v3", Method: known.Method, Pattern: known.Pattern}] = outerPolicy
 		actual[RegistrationKey{RouterID: "outer", Method: v3Key.Method, Pattern: v3Key.Pattern}] = v3Policy
-		require.Len(t, actual, 126)
+		require.Len(t, actual, 146)
 		require.Error(t, validatePolicyBindingParity(actual, expected))
 	})
 }

--- a/backend/internal/api/routes_reachability_test.go
+++ b/backend/internal/api/routes_reachability_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/config"
+	v3 "github.com/ManuGH/xg2g/internal/control/http/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProductionRouterReachesHandwrittenRoutes drives the router the daemon actually builds.
+//
+// The v3 handwritten routes used to live in two hand-maintained lists: one consumed by
+// v3.NewHandler (which the v3 package tests use) and one consumed by this wiring function.
+// They drifted, and 20 routes - the entire Android device grant surface, the household policy
+// and approval endpoints, and the notification endpoints - existed only in the list the tests
+// exercised. Every one of them answered 404 in production while the test suite stayed green.
+//
+// Asserting against v3.NewHandler cannot catch that, because that is the path that was correct.
+// This test therefore goes through buildRouterWithBindings, the same function cmd/daemon uses.
+func TestProductionRouterReachesHandwrittenRoutes(t *testing.T) {
+	s := mustNewServer(t, config.AppConfig{}, config.NewManager(""))
+	router, _, err := s.buildRouterWithBindings(ConfigVariantProdStatic)
+	require.NoError(t, err)
+	require.NotNil(t, router)
+
+	cases := []struct{ method, path string }{
+		// Android / native device grant
+		{http.MethodPost, "/api/v3/auth/device/grant/start"},
+		{http.MethodPost, "/api/v3/auth/device/grant/finish"},
+		{http.MethodPost, "/api/v3/auth/device/refresh"},
+		{http.MethodPost, "/api/v3/auth/device/session"},
+
+		// Passkey / identity
+		{http.MethodGet, "/api/v3/auth/status"},
+		{http.MethodPost, "/api/v3/auth/passkey/login/start"},
+		{http.MethodPost, "/api/v3/auth/passkey/register/start"},
+		{http.MethodPost, "/api/v3/auth/login/password"},
+		{http.MethodPost, "/api/v3/auth/recovery"},
+
+		// Household policies and approvals (consumed by the WebUI admin sections)
+		{http.MethodGet, "/api/v3/household/policies/access"},
+		{http.MethodGet, "/api/v3/household/approvals"},
+		{http.MethodGet, "/api/v3/household/resource-policy"},
+
+		// Notifications (consumed by the WebUI notification centre)
+		{http.MethodGet, "/api/v3/notifications"},
+		{http.MethodGet, "/api/v3/notifications/vapid-key"},
+		{http.MethodPost, "/api/v3/notifications/mark-read"},
+
+		// Profiles
+		{http.MethodGet, "/api/v3/profiles"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "http://localhost"+tc.path, strings.NewReader("{}"))
+			req.Host = "localhost"
+			req.Header.Set("Content-Type", "application/json")
+			// The CSRF middleware rejects unsafe methods without a same-origin Origin header
+			// before routing is even reached; supply one so a 403 cannot mask a 404.
+			req.Header.Set("Origin", "http://localhost")
+
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			require.NotEqual(t, http.StatusNotFound, rec.Code,
+				"%s %s is not routed in the production router (body: %s)", tc.method, tc.path, truncate(rec.Body.String()))
+			require.NotEqual(t, http.StatusMethodNotAllowed, rec.Code,
+				"%s %s is routed but rejects its own method", tc.method, tc.path)
+		})
+	}
+}
+
+// TestProductionRouterMatchesHandlerRouter pins the two construction paths to the same
+// route inventory, so a route added to one can no longer go missing in the other.
+func TestProductionRouterMatchesHandlerRouter(t *testing.T) {
+	s := mustNewServer(t, config.AppConfig{}, config.NewManager(""))
+	_, snapshot, err := s.buildRouterWithBindings(ConfigVariantProdStatic)
+	require.NoError(t, err)
+
+	production := map[string]bool{}
+	for key := range snapshotAsMap(snapshot) {
+		if key.RouterID == "v3" {
+			production[key.Method+" "+key.Pattern] = true
+		}
+	}
+
+	var missing []string
+	for _, route := range v3.HandwrittenRoutePatterns() {
+		key := route[0] + " " + v3.V3BaseURL + route[1]
+		if !production[key] {
+			missing = append(missing, key)
+		}
+	}
+	require.Empty(t, missing,
+		"handwritten v3 routes did not reach the production router; they must be registered "+
+			"through v3.RegisterPasskeyRoutesWithRegistrar in buildRouterWithBindings: %v", missing)
+}
+
+func truncate(s string) string {
+	if len(s) > 200 {
+		return s[:200] + "..."
+	}
+	return s
+}

--- a/backend/internal/control/http/v3/factory.go
+++ b/backend/internal/control/http/v3/factory.go
@@ -96,9 +96,13 @@ func newHandlerWithMiddlewares(svc *Server, _ config.AppConfig, extra []Middlewa
 	// 2. Create Router with RFC 7807 compliant 404/405 handlers
 	r := NewRouteRouter()
 	r.Get("/.well-known/assetlinks.json", svc.AssetLinks)
+	var mountErr error
 	r.Route(V3BaseURL, func(sub chi.Router) {
-		svc.mountPasskeyRoutes(sub)
+		mountErr = svc.mountPasskeyRoutes(sub)
 	})
+	if mountErr != nil {
+		return nil, fmt.Errorf("register handwritten v3 routes: %w", mountErr)
+	}
 
 	// 3. Create Handler
 	// Use handwritten router to inject scope policy and keep generated code transport-only.

--- a/backend/internal/control/http/v3/handlers_household.go
+++ b/backend/internal/control/http/v3/handlers_household.go
@@ -52,40 +52,6 @@ type CreateProfileRequest struct {
 	ExitPIN         string   `json:"exitPin,omitempty"`
 }
 
-func (s *Server) mountHouseholdRoutes(r chi.Router) {
-	r.Post("/auth/login/password", s.PasswordLogin)
-	r.Post("/auth/invitations/redeem", s.RedeemInvitation)
-
-	r.Group(func(pr chi.Router) {
-		pr.Use(s.authMiddleware)
-		pr.Post("/auth/invitations", s.CreateInvitation)
-		pr.Get("/auth/effective-permissions", s.GetEffectivePermissions)
-		pr.Get("/profiles", s.ListProfiles)
-		pr.Post("/profiles", s.CreateProfile)
-		pr.Get("/profiles/{id}", s.GetProfile)
-		pr.Delete("/profiles/{id}", s.DeleteProfile)
-
-		pr.Get("/household/policies/access", s.GetAccessPolicy)
-		pr.Post("/household/policies/access", s.CreateAccessPolicy)
-		pr.Post("/household/policies/access/revoke", s.RevokeAccessPolicy)
-		pr.Get("/household/approvals", s.ListApprovalRequests)
-		pr.Post("/household/approvals", s.CreateApprovalRequest)
-		pr.Post("/household/approvals/{id}/approve", s.ApproveApprovalRequest)
-		pr.Post("/household/approvals/{id}/deny", s.DenyApprovalRequest)
-		pr.Get("/household/resource-policy", s.GetHouseholdResourcePolicy)
-		pr.Put("/household/resource-policy", s.PutHouseholdResourcePolicy)
-		pr.Post("/sessions/revoke-user-sessions", s.RevokeUserSessions)
-
-		pr.Get("/notifications", s.ListNotifications)
-		pr.Get("/notifications/stream", s.StreamNotifications)
-		pr.Post("/notifications/mark-read", s.MarkNotificationRead)
-		pr.Post("/notifications/mark-all-read", s.MarkAllNotificationsRead)
-		pr.Delete("/notifications/{id}", s.DeleteNotification)
-		pr.Get("/notifications/vapid-key", s.GetVAPIDPublicKey)
-		pr.Post("/notifications/push-subscriptions", s.SavePushSubscription)
-	})
-}
-
 // PasswordLogin handles POST /api/v3/auth/login/password
 func (s *Server) PasswordLogin(w http.ResponseWriter, r *http.Request) {
 	svc := s.getIdentityService()

--- a/backend/internal/control/http/v3/handlers_passkey.go
+++ b/backend/internal/control/http/v3/handlers_passkey.go
@@ -6,7 +6,6 @@ package v3
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -19,90 +18,17 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// RegisterPasskeyRoutesWithRegistrar registers passkey identity routes with policy governance.
+// RegisterPasskeyRoutesWithRegistrar registers the handwritten v3 routes with policy governance.
+// It is the daemon's entry point; the route list itself lives in routes_handwritten.go so that
+// this path and the chi path in NewHandler cannot diverge.
 func RegisterPasskeyRoutesWithRegistrar(registrar RouteRegistrar, svc *Server) error {
-	if registrar == nil || svc == nil {
-		return fmt.Errorf("nil registrar or server")
-	}
-	if err := registrar.Register(http.MethodGet, "/auth/status", http.HandlerFunc(svc.AuthStatus)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/passkey/login/start", http.HandlerFunc(svc.PasskeyLoginStart)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/passkey/login/finish", http.HandlerFunc(svc.PasskeyLoginFinish)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/passkey/register/start", http.HandlerFunc(svc.PasskeyRegisterStart)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/passkey/register/finish", http.HandlerFunc(svc.PasskeyRegisterFinish)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/recovery", http.HandlerFunc(svc.RecoveryLogin)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodGet, "/auth/passkeys", svc.authMiddleware(http.HandlerFunc(svc.ListPasskeys))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodDelete, "/auth/passkeys/{id}", svc.authMiddleware(http.HandlerFunc(svc.DeletePasskey))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/sessions/revoke-others", svc.authMiddleware(http.HandlerFunc(svc.RevokeOtherSessions))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/login/password", http.HandlerFunc(svc.PasswordLogin)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/invitations/redeem", http.HandlerFunc(svc.RedeemInvitation)); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/auth/invitations", svc.authMiddleware(http.HandlerFunc(svc.CreateInvitation))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodGet, "/auth/effective-permissions", svc.authMiddleware(http.HandlerFunc(svc.GetEffectivePermissions))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodGet, "/profiles", svc.authMiddleware(http.HandlerFunc(svc.ListProfiles))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodPost, "/profiles", svc.authMiddleware(http.HandlerFunc(svc.CreateProfile))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodGet, "/profiles/{id}", svc.authMiddleware(http.HandlerFunc(svc.GetProfile))); err != nil {
-		return err
-	}
-	if err := registrar.Register(http.MethodDelete, "/profiles/{id}", svc.authMiddleware(http.HandlerFunc(svc.DeleteProfile))); err != nil {
-		return err
-	}
-	return registrar.Register(http.MethodPost, "/auth/bootstrap/acknowledge-recovery", svc.authMiddleware(http.HandlerFunc(svc.AcknowledgeRecovery)))
+	return registerHandwrittenRoutes(registrar, svc)
 }
 
-func (s *Server) mountPasskeyRoutes(r chi.Router) {
-	r.Get("/auth/status", s.AuthStatus)
-	r.Route("/auth/passkey", func(pr chi.Router) {
-		pr.Post("/login/start", s.PasskeyLoginStart)
-		pr.Post("/login/finish", s.PasskeyLoginFinish)
-		pr.Post("/register/start", s.PasskeyRegisterStart)
-		pr.Post("/register/finish", s.PasskeyRegisterFinish)
-	})
-	r.Route("/auth/device", func(dr chi.Router) {
-		dr.Post("/grant/start", s.DeviceGrantStart)
-		dr.Post("/grant/finish", s.DeviceGrantFinish)
-		dr.Post("/refresh", s.DeviceRefresh)
-	})
-	r.Post("/auth/recovery", s.RecoveryLogin)
-
-	s.mountHouseholdRoutes(r)
-
-	// Protected management endpoints
-	r.Group(func(pr chi.Router) {
-		pr.Use(s.authMiddleware)
-		pr.Get("/auth/passkeys", s.ListPasskeys)
-		pr.Delete("/auth/passkeys/{id}", s.DeletePasskey)
-		pr.Post("/auth/sessions/revoke-others", s.RevokeOtherSessions)
-		pr.Post("/auth/bootstrap/acknowledge-recovery", s.AcknowledgeRecovery)
-	})
+// mountPasskeyRoutes registers the handwritten v3 routes onto a chi router. It is the
+// NewHandler entry point and shares its route list with RegisterPasskeyRoutesWithRegistrar.
+func (s *Server) mountPasskeyRoutes(r chi.Router) error {
+	return registerHandwrittenRoutes(chiRouteRegistrar{router: r}, s)
 }
 
 func (s *Server) getIdentityService() *identity.Service {

--- a/backend/internal/control/http/v3/routes_handwritten.go
+++ b/backend/internal/control/http/v3/routes_handwritten.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2025-2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// handwrittenRoute is one v3 route that is not generated from the OpenAPI contract.
+type handwrittenRoute struct {
+	method  string
+	pattern string
+	handler http.HandlerFunc
+	// authenticated wraps the handler in authMiddleware. The chi construction path used to
+	// express this with a route group; going through the registrar contract requires an
+	// explicit per-route wrap, which behaves identically and survives both paths.
+	authenticated bool
+}
+
+// handwrittenRoutes is the single source of truth for every v3 route that is not generated
+// from the OpenAPI contract.
+//
+// There are two router construction paths: v3.NewHandler builds a chi router directly (used
+// by tests and by anything embedding the v3 handler), while the daemon builds its own router
+// in internal/api and registers routes through a RouteRegistrar. Both used to carry their own
+// hand-maintained copy of this list, and they drifted: 20 routes - the whole Android device
+// grant surface, the household policy and approval endpoints, and the notification endpoints -
+// existed only in the path tests exercise, and answered 404 in production.
+//
+// Adding a route here registers it on both paths. Do not register handwritten v3 routes
+// anywhere else; TestHandwrittenRouteParity enforces that the two paths stay identical.
+func handwrittenRoutes(svc *Server) []handwrittenRoute {
+	return []handwrittenRoute{
+		// Identity and passkey
+		{http.MethodGet, "/auth/status", svc.AuthStatus, false},
+		{http.MethodPost, "/auth/passkey/login/start", svc.PasskeyLoginStart, false},
+		{http.MethodPost, "/auth/passkey/login/finish", svc.PasskeyLoginFinish, false},
+		{http.MethodPost, "/auth/passkey/register/start", svc.PasskeyRegisterStart, false},
+		{http.MethodPost, "/auth/passkey/register/finish", svc.PasskeyRegisterFinish, false},
+		{http.MethodPost, "/auth/recovery", svc.RecoveryLogin, false},
+		{http.MethodPost, "/auth/login/password", svc.PasswordLogin, false},
+
+		// Android / native device grant (RFC 9449 sender-constrained enrollment)
+		{http.MethodPost, "/auth/device/grant/start", svc.DeviceGrantStart, false},
+		{http.MethodPost, "/auth/device/grant/finish", svc.DeviceGrantFinish, false},
+		{http.MethodPost, "/auth/device/refresh", svc.DeviceRefresh, false},
+
+		// Invitations
+		{http.MethodPost, "/auth/invitations/redeem", svc.RedeemInvitation, false},
+		{http.MethodPost, "/auth/invitations", svc.CreateInvitation, true},
+
+		// Session and credential management
+		{http.MethodGet, "/auth/passkeys", svc.ListPasskeys, true},
+		{http.MethodDelete, "/auth/passkeys/{id}", svc.DeletePasskey, true},
+		{http.MethodPost, "/auth/sessions/revoke-others", svc.RevokeOtherSessions, true},
+		{http.MethodPost, "/auth/bootstrap/acknowledge-recovery", svc.AcknowledgeRecovery, true},
+		{http.MethodPost, "/sessions/revoke-user-sessions", svc.RevokeUserSessions, true},
+		{http.MethodGet, "/auth/effective-permissions", svc.GetEffectivePermissions, true},
+
+		// Profiles
+		{http.MethodGet, "/profiles", svc.ListProfiles, true},
+		{http.MethodPost, "/profiles", svc.CreateProfile, true},
+		{http.MethodGet, "/profiles/{id}", svc.GetProfile, true},
+		{http.MethodDelete, "/profiles/{id}", svc.DeleteProfile, true},
+
+		// Household policies and approvals
+		{http.MethodGet, "/household/policies/access", svc.GetAccessPolicy, true},
+		{http.MethodPost, "/household/policies/access", svc.CreateAccessPolicy, true},
+		{http.MethodPost, "/household/policies/access/revoke", svc.RevokeAccessPolicy, true},
+		{http.MethodGet, "/household/approvals", svc.ListApprovalRequests, true},
+		{http.MethodPost, "/household/approvals", svc.CreateApprovalRequest, true},
+		{http.MethodPost, "/household/approvals/{id}/approve", svc.ApproveApprovalRequest, true},
+		{http.MethodPost, "/household/approvals/{id}/deny", svc.DenyApprovalRequest, true},
+		{http.MethodGet, "/household/resource-policy", svc.GetHouseholdResourcePolicy, true},
+		{http.MethodPut, "/household/resource-policy", svc.PutHouseholdResourcePolicy, true},
+
+		// Notifications
+		{http.MethodGet, "/notifications", svc.ListNotifications, true},
+		{http.MethodGet, "/notifications/stream", svc.StreamNotifications, true},
+		{http.MethodPost, "/notifications/mark-read", svc.MarkNotificationRead, true},
+		{http.MethodPost, "/notifications/mark-all-read", svc.MarkAllNotificationsRead, true},
+		{http.MethodDelete, "/notifications/{id}", svc.DeleteNotification, true},
+		{http.MethodGet, "/notifications/vapid-key", svc.GetVAPIDPublicKey, true},
+		{http.MethodPost, "/notifications/push-subscriptions", svc.SavePushSubscription, true},
+	}
+}
+
+// HandwrittenRoutePatterns returns the method and local pattern of every handwritten v3 route.
+// It lets the daemon's wiring tests assert that each of these routes actually reached the
+// production router, which is the invariant that broke when the two paths kept separate lists.
+func HandwrittenRoutePatterns() [][2]string {
+	routes := handwrittenRoutes(&Server{})
+	out := make([][2]string, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, [2]string{route.method, route.pattern})
+	}
+	return out
+}
+
+// registerHandwrittenRoutes registers every handwritten v3 route through registrar.
+func registerHandwrittenRoutes(registrar RouteRegistrar, svc *Server) error {
+	if registrar == nil {
+		return fmt.Errorf("RouteRegistrar cannot be nil")
+	}
+	if svc == nil {
+		return fmt.Errorf("v3 Server cannot be nil")
+	}
+
+	for _, route := range handwrittenRoutes(svc) {
+		var handler http.Handler = route.handler
+		if route.authenticated {
+			handler = svc.authMiddleware(handler)
+		}
+		if err := registrar.Register(route.method, route.pattern, handler); err != nil {
+			return fmt.Errorf("register %s %s: %w", route.method, route.pattern, err)
+		}
+	}
+	return nil
+}
+
+// chiRouteRegistrar adapts a chi.Router to the RouteRegistrar contract so that the chi
+// construction path can consume the same route list as the daemon's registrar path.
+type chiRouteRegistrar struct {
+	router chi.Router
+}
+
+func (c chiRouteRegistrar) Register(method, pattern string, handler http.Handler) (err error) {
+	if c.router == nil {
+		return fmt.Errorf("nil chi router")
+	}
+	// chi panics on an invalid pattern or a duplicate registration; surface that as an error
+	// so handler construction fails loudly instead of at request time.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("chi route registration failed for %s %s: %v", method, pattern, recovered)
+		}
+	}()
+	c.router.Method(method, pattern, handler)
+	return nil
+}


### PR DESCRIPTION
## Summary

- define one canonical handwritten v3 route list
- make both `v3.NewHandler` and the daemon production registrar consume it
- restore 20 routes that existed only in the test router
- classify `/notifications/stream` as flush-capable streaming instead of bounded API work
- add guards against the exact production wiring path

## Root cause

The chi test router and daemon production router maintained separate handwritten registrations. They drifted: 20 routes were present only in tests, so Device Grant, Household, Notifications, profile/session-related features returned 404 in the real daemon despite green router tests.

## Validation

- full backend test suite was green when this commit was produced
- production-router reachability and parity guards pass
- negative control was performed by restoring the old drift and confirming both guards fail with the missing routes
- `make pre-push` passes on the PR head

## Stack

This PR intentionally targets `fix/android-tv-video-pipeline` and contains one commit. The integration branch is tracked in #822. The separate Identity-service wiring fix is stacked on top of this PR.