### PR TITLE
ci: provide FFmpeg to race verification suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,17 @@ jobs:
         env:
           GOTOOLCHAIN: auto
 
+      - name: Install ffmpeg for full verification suite
+        run: |
+          set -euo pipefail
+          if command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg already installed"
+          else
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
+          fi
+          ffmpeg -version | head -n 1
+
       - name: Run scoped race detector
         # Packages where the live transcode/session concurrency lives. These
         # are exactly the packages a fix to the session/ffmpeg/bus hot path


### PR DESCRIPTION
## Summary

- install FFmpeg in the race workflow before its full `go test ./...` verification step
- keep the real three-rendition ABR E2E test active instead of skipping it when the runner lacks the binary
- leave the scoped race detector itself deterministic and unchanged

## Validation

- workflow diff passes `git diff --check`
- make pre-push
- prior GitHub failure confirmed the scoped race detector passed and only the missing `ffmpeg` executable failed the Phase D suite

## Context

Targets fix/android-tv-video-pipeline to repair the Race job on PR #822.