### PR TITLE
fix(android): emit JOSE ES256 signatures for DPoP

### DIFF
--- a/android/app/src/androidTest/java/io/github/manugh/xg2g/android/auth/AndroidKeystoreDPoPProviderTest.kt
+++ b/android/app/src/androidTest/java/io/github/manugh/xg2g/android/auth/AndroidKeystoreDPoPProviderTest.kt
@@ -1,0 +1,162 @@
+package io.github.manugh.xg2g.android.auth
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.KeyStore
+import java.security.Signature
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+/**
+ * Covers the production signing path that JVM unit tests cannot reach: a hardware/TEE-backed
+ * AndroidKeyStore key, its provider's `Signature.sign()`, and the DER -> JOSE conversion on top.
+ *
+ * The unit tests in src/test exercise [ES256Signature] and [SoftwareDPoPProvider] on a plain JCA
+ * key. Only this test proves the same holds for [AndroidKeystoreDPoPProvider], whose key never
+ * leaves the keystore and whose signature comes from a different JCA provider entirely.
+ *
+ * `backendAcceptsKeystoreProof` additionally verifies the proof against a real running backend.
+ * It is skipped unless a URL is supplied:
+ *
+ *   ./gradlew :app:connectedDevDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.backendUrl=http://10.0.2.2:8080
+ */
+@RunWith(AndroidJUnit4::class)
+class AndroidKeystoreDPoPProviderTest {
+
+    private val testAlias = "xg2g_dpop_instrumentation_test_key"
+    private val provider = AndroidKeystoreDPoPProvider(keyAlias = testAlias)
+
+    @After
+    fun deleteTestKey() {
+        val ks = KeyStore.getInstance("AndroidKeyStore")
+        ks.load(null)
+        if (ks.containsAlias(testAlias)) {
+            ks.deleteEntry(testAlias)
+        }
+    }
+
+    @Test
+    fun keystoreProofSignatureIsRaw64BytesAndVerifies() {
+        // Repeat: a short R or S occurs in roughly 1 of 256 signatures and must still pad to 32.
+        repeat(64) {
+            val proof = provider.createProof("GET", "https://xg2g.example/api/v3/dashboard", "at_test_token")
+            val segments = proof.split(".")
+            assertEquals("proof must be a three-segment JWT", 3, segments.size)
+
+            val signature = Base64.getUrlDecoder().decode(segments[2])
+            // Length is the discriminator: DER for P-256 is 68-72 bytes and can never be 64.
+            // The leading byte is the top byte of R and may legitimately be anything, 0x30 included.
+            assertEquals(
+                "AndroidKeyStore ES256 signature must be raw R||S (first byte 0x%02x)".format(signature[0]),
+                64,
+                signature.size
+            )
+
+            val verifier = Signature.getInstance("SHA256withECDSA")
+            verifier.initVerify(provider.getOrGenerateKeyPair().public)
+            verifier.update("${segments[0]}.${segments[1]}".toByteArray(Charsets.UTF_8))
+            assertTrue(
+                "signature must verify against the keystore public key",
+                verifier.verify(rawToDer(signature))
+            )
+        }
+    }
+
+    /**
+     * Drives a keystore-signed proof through the backend's real `ValidateProof`.
+     *
+     * DeviceGrantFinish validates the DPoP proof before it parses the request body, so an
+     * intentionally malformed body separates the two outcomes without needing a passkey or any
+     * credential: a rejected proof answers `auth/invalid_dpop`, an accepted one gets far enough
+     * to complain about the body instead. The DER control case proves the probe discriminates.
+     */
+    @Test
+    fun backendAcceptsKeystoreProof() {
+        val baseUrl = InstrumentationRegistry.getArguments().getString("backendUrl")
+        assumeTrue("backendUrl instrumentation argument not supplied", !baseUrl.isNullOrBlank())
+
+        val endpoint = baseUrl!!.trimEnd('/') + "/api/v3/auth/device/grant/finish"
+        val client = OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build()
+
+        val proof = provider.createProof("POST", endpoint)
+        val accepted = postProof(client, endpoint, proof)
+        assertFalse(
+            "endpoint is not routed (HTTP 404). The device grant routes exist in mountPasskeyRoutes, " +
+                "which only v3.NewHandler builds; the daemon wires routes through " +
+                "RegisterPasskeyRoutesWithRegistrar, which does not register them.",
+            accepted.first == 404
+        )
+        assertFalse(
+            "backend rejected a keystore-signed proof: ${accepted.second}",
+            accepted.second.contains("invalid_dpop")
+        )
+
+        // Control: the same proof re-encoded as DER (the pre-fix wire format) must be rejected,
+        // otherwise the assertion above would pass for the wrong reason.
+        val segments = proof.split(".")
+        val derSignature = rawToDer(Base64.getUrlDecoder().decode(segments[2]))
+        val derProof = "${segments[0]}.${segments[1]}." +
+            Base64.getUrlEncoder().withoutPadding().encodeToString(derSignature)
+        val rejected = postProof(client, endpoint, derProof)
+        assertTrue(
+            "backend accepted a DER-encoded proof; the probe does not discriminate: ${rejected.second}",
+            rejected.second.contains("invalid_dpop")
+        )
+    }
+
+    private fun postProof(client: OkHttpClient, endpoint: String, proof: String): Pair<Int, String> {
+        val url = endpoint.toHttpUrl()
+        val origin = "${url.scheme}://${url.host}:${url.port}"
+
+        // Deliberately malformed body: we are probing proof validation, which runs first.
+        // Origin is required by the backend's CSRF middleware on unsafe methods, which rejects
+        // with 403 CSRF_FORBIDDEN before any DPoP validation happens.
+        val request = Request.Builder()
+            .url(endpoint)
+            .header("DPoP", proof)
+            .header("Origin", origin)
+            .post("not-json".toRequestBody("application/json".toMediaType()))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val body = response.body?.string().orEmpty()
+            val problemType = runCatching { JSONObject(body).optString("type") }.getOrDefault("")
+            return response.code to (problemType.ifEmpty { body })
+        }
+    }
+
+    /** JCA's verifier and the DER control case both need the ASN.1 form back. */
+    private fun rawToDer(raw: ByteArray): ByteArray {
+        val r = derInteger(trimLeadingZeros(raw.copyOfRange(0, 32)))
+        val s = derInteger(trimLeadingZeros(raw.copyOfRange(32, 64)))
+        return byteArrayOf(0x30, (r.size + s.size).toByte()) + r + s
+    }
+
+    private fun derInteger(magnitude: ByteArray): ByteArray {
+        val content = if (magnitude[0].toInt() and 0x80 != 0) byteArrayOf(0x00) + magnitude else magnitude
+        return byteArrayOf(0x02, content.size.toByte()) + content
+    }
+
+    private fun trimLeadingZeros(bytes: ByteArray): ByteArray {
+        var start = 0
+        while (start < bytes.size - 1 && bytes[start].toInt() == 0) start++
+        return bytes.copyOfRange(start, bytes.size)
+    }
+}

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/auth/AndroidKeystoreDPoPProvider.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/auth/AndroidKeystoreDPoPProvider.kt
@@ -96,7 +96,8 @@ class AndroidKeystoreDPoPProvider(
         val signature = Signature.getInstance("SHA256withECDSA")
         signature.initSign(keyPair.private)
         signature.update(signingInput.toByteArray(Charsets.UTF_8))
-        val sigBytes = signature.sign()
+        // JCA returns ASN.1 DER; JWS ES256 requires raw R || S (RFC 7518 §3.4).
+        val sigBytes = ES256Signature.derToRaw(signature.sign())
         val sigB64 = base64UrlEncode(sigBytes)
 
         return "$signingInput.$sigB64"

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/auth/ES256Signature.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/auth/ES256Signature.kt
@@ -1,0 +1,102 @@
+package io.github.manugh.xg2g.android.auth
+
+/**
+ * Converts JCA ECDSA signatures into the encoding JWS ES256 requires.
+ *
+ * `Signature.getInstance("SHA256withECDSA")` (both the AndroidKeyStore provider and the
+ * software provider) emits an ASN.1 DER `SEQUENCE { INTEGER r, INTEGER s }`, which for P-256
+ * is 68-72 bytes. JWS ES256 (RFC 7518 §3.4) instead requires the raw concatenation R || S,
+ * each left-padded to exactly 32 bytes. Handing DER to a spec-compliant verifier - such as the
+ * xg2g backend's `verifyES256Signature`, which rejects anything that is not exactly 64 bytes -
+ * fails every time.
+ */
+internal object ES256Signature {
+
+    private const val COORDINATE_LENGTH = 32
+    private const val RAW_LENGTH = COORDINATE_LENGTH * 2
+
+    private const val TAG_SEQUENCE = 0x30
+    private const val TAG_INTEGER = 0x02
+
+    /**
+     * Converts a DER-encoded ECDSA P-256 signature into the raw 64-byte R || S form.
+     *
+     * @throws IllegalArgumentException if [der] is not a well-formed P-256 ECDSA signature.
+     */
+    fun derToRaw(der: ByteArray): ByteArray {
+        var offset = 0
+
+        require(der.size >= 8) { "DER signature too short: ${der.size} bytes" }
+        require(der[offset].toInt() and 0xFF == TAG_SEQUENCE) {
+            "DER signature must start with SEQUENCE tag, got 0x%02x".format(der[offset])
+        }
+        offset++
+
+        val sequenceLength = readLength(der, offset).also { offset = it.nextOffset }.value
+        require(offset + sequenceLength == der.size) {
+            "DER SEQUENCE length $sequenceLength does not match payload size ${der.size - offset}"
+        }
+
+        val r = readInteger(der, offset).also { offset = it.nextOffset }.magnitude
+        val s = readInteger(der, offset).also { offset = it.nextOffset }.magnitude
+        require(offset == der.size) { "unexpected trailing bytes in DER signature" }
+
+        val raw = ByteArray(RAW_LENGTH)
+        System.arraycopy(r, 0, raw, COORDINATE_LENGTH - r.size, r.size)
+        System.arraycopy(s, 0, raw, RAW_LENGTH - s.size, s.size)
+        return raw
+    }
+
+    private class Length(val value: Int, val nextOffset: Int)
+
+    private class Integer(val magnitude: ByteArray, val nextOffset: Int)
+
+    private fun readLength(der: ByteArray, start: Int): Length {
+        var offset = start
+        require(offset < der.size) { "truncated DER signature" }
+
+        val first = der[offset++].toInt() and 0xFF
+        if (first and 0x80 == 0) {
+            return Length(first, offset)
+        }
+
+        val byteCount = first and 0x7F
+        require(byteCount in 1..2) { "unsupported DER length encoding: $byteCount bytes" }
+        require(offset + byteCount <= der.size) { "truncated DER length field" }
+
+        var value = 0
+        repeat(byteCount) {
+            value = (value shl 8) or (der[offset++].toInt() and 0xFF)
+        }
+        return Length(value, offset)
+    }
+
+    private fun readInteger(der: ByteArray, start: Int): Integer {
+        var offset = start
+        require(offset < der.size) { "truncated DER signature: missing INTEGER" }
+        require(der[offset].toInt() and 0xFF == TAG_INTEGER) {
+            "expected DER INTEGER tag, got 0x%02x".format(der[offset])
+        }
+        offset++
+
+        val length = readLength(der, offset).also { offset = it.nextOffset }.value
+        require(length > 0 && offset + length <= der.size) { "invalid DER INTEGER length: $length" }
+        require(der[offset].toInt() and 0x80 == 0) { "negative DER INTEGER in ECDSA signature" }
+
+        // DER encodes minimal two's-complement integers, so a leading 0x00 is present only to
+        // keep a 32-byte value positive. Strip it before left-padding to the fixed width.
+        var contentStart = offset
+        var contentLength = length
+        while (contentLength > 1 && der[contentStart].toInt() == 0) {
+            contentStart++
+            contentLength--
+        }
+        require(contentLength <= COORDINATE_LENGTH) {
+            "ECDSA component exceeds P-256 field size: $contentLength bytes"
+        }
+
+        val magnitude = ByteArray(contentLength)
+        System.arraycopy(der, contentStart, magnitude, 0, contentLength)
+        return Integer(magnitude, offset + length)
+    }
+}

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/auth/SoftwareDPoPProvider.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/auth/SoftwareDPoPProvider.kt
@@ -71,7 +71,8 @@ class SoftwareDPoPProvider : DPoPProvider {
         val signature = Signature.getInstance("SHA256withECDSA")
         signature.initSign(keyPair.private)
         signature.update(signingInput.toByteArray(Charsets.UTF_8))
-        val sigBytes = signature.sign()
+        // JCA returns ASN.1 DER; JWS ES256 requires raw R || S (RFC 7518 §3.4).
+        val sigBytes = ES256Signature.derToRaw(signature.sign())
         val sigB64 = base64UrlEncode(sigBytes)
 
         return "$signingInput.$sigB64"

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/auth/DPoPProofSignatureTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/auth/DPoPProofSignatureTest.kt
@@ -1,0 +1,124 @@
+package io.github.manugh.xg2g.android.auth
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+import java.util.Base64
+
+/**
+ * The backend (`verifyES256Signature` in backend/internal/control/http/v3/dpop/dpop.go) rejects
+ * any DPoP proof whose signature is not exactly 64 raw bytes, per JWS ES256 (RFC 7518 §3.4).
+ * JCA hands us ASN.1 DER instead, so every proof must be converted before it goes on the wire.
+ */
+class DPoPProofSignatureTest {
+
+    @Test
+    fun `proof signature segment is exactly 64 bytes and verifies against the public key`() {
+        val provider = SoftwareDPoPProvider()
+        val signingInputsSeen = mutableSetOf<String>()
+
+        // ~1 in 256 signatures has a short R or S; repeat so the padding path is actually exercised.
+        repeat(256) {
+            val proof = provider.createProof(
+                htm = "GET",
+                htu = "https://xg2g.example/api/v3/dashboard",
+                accessToken = "at_test_token"
+            )
+
+            val segments = proof.split(".")
+            assertEquals("proof must be a three-segment JWT", 3, segments.size)
+            signingInputsSeen += "${segments[0]}.${segments[1]}"
+
+            val rawSignature = Base64.getUrlDecoder().decode(segments[2])
+            assertEquals(
+                "ES256 signature must be raw R||S, not DER (first byte 0x%02x)".format(rawSignature[0]),
+                64,
+                rawSignature.size
+            )
+
+            val verifier = Signature.getInstance("SHA256withECDSA")
+            verifier.initVerify(provider.getOrGenerateKeyPair().public)
+            verifier.update("${segments[0]}.${segments[1]}".toByteArray(Charsets.UTF_8))
+            assertTrue("signature must verify against the proof's own public key", verifier.verify(rawToDer(rawSignature)))
+        }
+
+        assertEquals("each proof must carry a unique jti", 256, signingInputsSeen.size)
+    }
+
+    @Test
+    fun `proof public key matches the advertised jwk thumbprint`() {
+        val provider = SoftwareDPoPProvider()
+        val proof = provider.createProof("POST", "https://xg2g.example/api/v3/streams", null)
+        val header = String(Base64.getUrlDecoder().decode(proof.split(".")[0]), Charsets.UTF_8)
+
+        val ecPubKey = provider.getOrGenerateKeyPair().public as ECPublicKey
+        val expectedX = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(fixedWidth(ecPubKey.w.affineX.toByteArray()))
+
+        assertTrue("header jwk must carry the signing key's x coordinate", header.contains("\"x\":\"$expectedX\""))
+    }
+
+    @Test
+    fun `derToRaw left-pads short components`() {
+        // R = 0x01 (1 byte), S = 32 bytes of 0xAA -> needs a leading 0x00 in DER to stay positive.
+        val s = ByteArray(32) { 0xAA.toByte() }
+        val der = byteArrayOf(0x30, 0x26, 0x02, 0x01, 0x01, 0x02, 0x21, 0x00) + s
+
+        val raw = ES256Signature.derToRaw(der)
+
+        assertEquals(64, raw.size)
+        assertArrayEquals(ByteArray(31) + byteArrayOf(0x01), raw.copyOfRange(0, 32))
+        assertArrayEquals(s, raw.copyOfRange(32, 64))
+    }
+
+    @Test
+    fun `derToRaw rejects malformed input`() {
+        val notASequence = ByteArray(70) { 0x31 }
+        val truncated = byteArrayOf(0x30, 0x44, 0x02, 0x20)
+        val rawPassedTwice = ByteArray(64) { 0x07 }
+
+        for (bad in listOf(notASequence, truncated, rawPassedTwice)) {
+            try {
+                ES256Signature.derToRaw(bad)
+                throw AssertionError("expected rejection of malformed DER signature")
+            } catch (_: IllegalArgumentException) {
+                // Expected: a malformed signature must fail loudly, never silently ship a bad proof.
+            }
+        }
+    }
+
+    private fun fixedWidth(bytes: ByteArray): ByteArray {
+        if (bytes.size == 32) return bytes
+        val out = ByteArray(32)
+        if (bytes.size > 32) {
+            System.arraycopy(bytes, bytes.size - 32, out, 0, 32)
+        } else {
+            System.arraycopy(bytes, 0, out, 32 - bytes.size, bytes.size)
+        }
+        return out
+    }
+
+    /** JCA's verifier expects DER, so convert the wire format back for verification. */
+    private fun rawToDer(raw: ByteArray): ByteArray {
+        val r = trimLeadingZeros(raw.copyOfRange(0, 32))
+        val s = trimLeadingZeros(raw.copyOfRange(32, 64))
+        val rDer = derInteger(r)
+        val sDer = derInteger(s)
+        val body = rDer + sDer
+        return byteArrayOf(0x30, body.size.toByte()) + body
+    }
+
+    private fun derInteger(magnitude: ByteArray): ByteArray {
+        val content = if (magnitude[0].toInt() and 0x80 != 0) byteArrayOf(0x00) + magnitude else magnitude
+        return byteArrayOf(0x02, content.size.toByte()) + content
+    }
+
+    private fun trimLeadingZeros(bytes: ByteArray): ByteArray {
+        var start = 0
+        while (start < bytes.size - 1 && bytes[start].toInt() == 0) start++
+        return bytes.copyOfRange(start, bytes.size)
+    }
+}

--- a/backend/internal/control/http/v3/dpop/dpop_test.go
+++ b/backend/internal/control/http/v3/dpop/dpop_test.go
@@ -215,3 +215,57 @@ func TestDPoP_RejectsPointsNotOnP256Curve(t *testing.T) {
 	_, err = validator.ValidateProof(req, proof, "", time.Now())
 	assert.ErrorIs(t, err, dpop.ErrInvalidJWKCurve, "Points not on P-256 curve must be rejected with ErrInvalidJWKCurve")
 }
+
+// TestDPoPValidator_RejectsDEREncodedSignature pins the wire contract that native clients must
+// meet. JCA (Android) and SecKeyCreateSignature (Apple) both emit ASN.1 DER by default; JWS
+// ES256 (RFC 7518 §3.4) requires the raw 64-byte R||S concatenation. A client shipping DER
+// authenticates against nothing, so the two encodings must be verifiably distinguishable here.
+func TestDPoPValidator_RejectsDEREncodedSignature(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	jwk := dpop.JWKECPublicKey{
+		Kty: "EC",
+		Crv: "P-256",
+		X:   base64.RawURLEncoding.EncodeToString(privKey.PublicKey.X.Bytes()),
+		Y:   base64.RawURLEncoding.EncodeToString(privKey.PublicKey.Y.Bytes()),
+	}
+
+	now := time.Now().UTC()
+	targetURL := "https://xg2g.home.matrixcentral.de/api/v3/services"
+
+	headerJSON, _ := json.Marshal(dpop.ProofHeader{Typ: "dpop+jwt", Alg: "ES256", JWK: jwk})
+	payloadJSON, _ := json.Marshal(dpop.ProofPayload{
+		JTI: "jti_der_encoding_001",
+		HTM: "GET",
+		HTU: targetURL,
+		IAT: now.Unix(),
+	})
+	signedData := base64.RawURLEncoding.EncodeToString(headerJSON) + "." + base64.RawURLEncoding.EncodeToString(payloadJSON)
+	hash := sha256.Sum256([]byte(signedData))
+
+	// DER (what an unconverted JCA / SecKey client sends) must be rejected.
+	derSig, err := ecdsa.SignASN1(rand.Reader, privKey, hash[:])
+	require.NoError(t, err)
+	require.NotEqual(t, 64, len(derSig), "DER signature is never exactly 64 bytes for P-256")
+	require.Equal(t, byte(0x30), derSig[0], "DER signature starts with a SEQUENCE tag")
+
+	derProof := signedData + "." + base64.RawURLEncoding.EncodeToString(derSig)
+	req := httptest.NewRequest(http.MethodGet, targetURL, nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+
+	_, err = dpop.NewDefaultValidator().ValidateProof(req, derProof, "", now)
+	assert.ErrorIs(t, err, dpop.ErrInvalidSignature, "DER-encoded ES256 signatures must be rejected")
+
+	// The same signature converted to raw R||S must be accepted.
+	rBig, sBig, err := ecdsa.Sign(rand.Reader, privKey, hash[:])
+	require.NoError(t, err)
+	rawSig := make([]byte, 64)
+	rBig.FillBytes(rawSig[:32])
+	sBig.FillBytes(rawSig[32:])
+
+	rawProof := signedData + "." + base64.RawURLEncoding.EncodeToString(rawSig)
+	claims, err := dpop.NewDefaultValidator().ValidateProof(req, rawProof, "", now)
+	require.NoError(t, err, "raw R||S signatures must be accepted")
+	assert.Equal(t, "jti_der_encoding_001", claims.Payload.JTI)
+}


### PR DESCRIPTION
## Summary

- convert Android `SHA256withECDSA` DER signatures to the 64-byte JOSE `R || S` format required by DPoP
- route both AndroidKeyStore and software DPoP providers through the same converter
- verify the wire contract against the backend verifier
- retain the real AndroidKeyStore instrumentation test across 64 signatures

## Validation

- `:app:testDevDebugUnitTest --tests io.github.manugh.xg2g.android.auth.DPoPProofSignatureTest`
- `go test ./internal/control/http/v3/dpop -count=1`
- make pre-push
- existing android-36 emulator instrumentation proof covers real AndroidKeyStore signing and public-key verification

## Stack

Targets fix/android-tv-video-pipeline because the native DPoP implementation is introduced by PR #822. Retarget to main after #822 merges.