### PR TITLE
fix(android): centralize root-anchored API v3 URLs

### DIFF
--- a/android/app/src/main/java/io/github/manugh/xg2g/android/ApiV3Url.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/ApiV3Url.kt
@@ -1,0 +1,35 @@
+package io.github.manugh.xg2g.android
+
+import okhttp3.HttpUrl
+
+/**
+ * Single source of truth for building `/api/v3` URLs from a configured server base URL.
+ *
+ * The configured base URL carries the SPA base path (`https://host/ui/`), but the REST API is
+ * mounted at the origin root: the backend registers the v3 router under a wildcard below the
+ * compile-time constant `V3BaseURL = "/api/v3"` (backend/internal/control/http/v3/baseurl.go), and
+ * serves the SPA through a hardcoded `http.StripPrefix("/ui", ...)`. Neither is configurable, so
+ * there is no deployment sub-path variant of the API.
+ *
+ * Consequently this is deliberately **origin-rooted**: [HttpUrl.Builder.encodedPath] with a leading
+ * slash replaces the base path rather than appending to it, so any prefix the base URL carries
+ * (`/ui/`, or a `/xg2g/ui/` sub-path) is dropped. Appending instead would produce
+ * `https://host/ui//api/v3/...`, which the SPA handler answers with index.html or a 404.
+ *
+ * If the backend ever gains a configurable deployment prefix, this function is the one place that
+ * has to learn about it — see `ApiV3UrlTest` for the tests that pin the current contract.
+ */
+internal fun apiV3Url(baseUrl: HttpUrl, vararg segments: String): HttpUrl =
+    apiV3UrlBuilder(baseUrl, *segments).build()
+
+/**
+ * Builder variant of [apiV3Url] for call sites that still need to attach query parameters.
+ */
+internal fun apiV3UrlBuilder(baseUrl: HttpUrl, vararg segments: String): HttpUrl.Builder =
+    baseUrl.newBuilder()
+        .encodedPath("/api/v3/")
+        .query(null)
+        .fragment(null)
+        .apply {
+            segments.forEach(::addPathSegment)
+        }

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/DeviceAuthRepository.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/DeviceAuthRepository.kt
@@ -88,7 +88,7 @@ internal class DeviceAuthRepository(
         }
         val normalizedBaseUrl = normalizedBaseUrl(baseUrl) ?: return
         val uiBaseUrl = normalizedBaseUrl.toHttpUrlOrNull() ?: return
-        val sessionUrl = apiUrl(uiBaseUrl, "auth", "session")
+        val sessionUrl = apiV3Url(uiBaseUrl, "auth", "session")
         val deviceState = currentState(normalizedBaseUrl)
         val hasSessionCookie = cookieSession.hasSessionCookie(sessionUrl, SESSION_COOKIE_NAME)
         if (deviceState == null && hasSessionCookie) {
@@ -172,7 +172,7 @@ internal class DeviceAuthRepository(
         val normalizedBaseUrl = normalizedBaseUrl(baseUrl) ?: return targetUrl
         val uiBaseUrl = normalizedBaseUrl.toHttpUrlOrNull() ?: return targetUrl
         val targetPath = resolveTargetPath(uiBaseUrl, targetUrl)
-        val sessionUrl = apiUrl(uiBaseUrl, "auth", "session")
+        val sessionUrl = apiV3Url(uiBaseUrl, "auth", "session")
         val deviceState = currentState(normalizedBaseUrl)
 
         if (deviceState != null) {
@@ -437,7 +437,7 @@ internal class DeviceAuthRepository(
             preparedSessionCookieBaseUrl = null
         }
         cookieSession.clearSessionCookie(
-            url = apiUrl(uiBaseUrl, "auth", "session"),
+            url = apiV3Url(uiBaseUrl, "auth", "session"),
             cookieName = SESSION_COOKIE_NAME,
             cookiePath = SESSION_COOKIE_PATH
         )
@@ -524,16 +524,6 @@ internal class DeviceAuthRepository(
         }
         return uiBaseUrl.resolveAgainst(locationPath)
     }
-
-    private fun apiUrl(baseUrl: HttpUrl, vararg segments: String): HttpUrl =
-        baseUrl.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-            .apply {
-                segments.forEach(::addPathSegment)
-            }
-            .build()
 
     private fun isSameOrigin(candidate: HttpUrl, baseUrl: HttpUrl): Boolean {
         return candidate.scheme == baseUrl.scheme &&
@@ -664,7 +654,7 @@ internal class OkHttpDeviceAuthTransport(
     ): RefreshedDeviceSession = withContext(Dispatchers.IO) {
         Log.i(TAG, "action=refresh_session path=/api/v3/auth/device/session")
         val request = Request.Builder()
-            .url(apiUrl(uiBaseUrl, "auth", "device", "session"))
+            .url(apiV3Url(uiBaseUrl, "auth", "device", "session"))
             .post(
                 JSONObject()
                     .put("deviceGrantId", deviceGrantId)
@@ -697,7 +687,7 @@ internal class OkHttpDeviceAuthTransport(
         withContext(Dispatchers.IO) {
             Log.i(TAG, "action=create_cookie_session path=/api/v3/auth/session")
             val request = Request.Builder()
-                .url(apiUrl(uiBaseUrl, "auth", "session"))
+                .url(apiV3Url(uiBaseUrl, "auth", "session"))
                 .header("Authorization", "Bearer $bearerToken")
                 .post(ByteArray(0).toRequestBody(null))
                 .build()
@@ -719,7 +709,7 @@ internal class OkHttpDeviceAuthTransport(
     ): StartedWebBootstrap = withContext(Dispatchers.IO) {
         Log.i(TAG, "action=start_web_bootstrap path=/api/v3/auth/web-bootstrap targetPath=$targetPath")
         val request = Request.Builder()
-            .url(apiUrl(uiBaseUrl, "auth", "web-bootstrap"))
+            .url(apiV3Url(uiBaseUrl, "auth", "web-bootstrap"))
             .header("Authorization", "Bearer $accessToken")
             .post(
                 JSONObject()
@@ -777,16 +767,6 @@ internal class OkHttpDeviceAuthTransport(
             cookieSession.storeCookies(request.url, response.headers)
         }
     }
-
-    private fun apiUrl(baseUrl: HttpUrl, vararg segments: String): HttpUrl =
-        baseUrl.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-            .apply {
-                segments.forEach(::addPathSegment)
-            }
-            .build()
 
     private fun parseHttpInstant(value: String): Long =
         ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME)

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/MainActivity.kt
@@ -34,8 +34,10 @@ import io.github.manugh.xg2g.android.playback.model.PlaybackJsonCodec
 import io.github.manugh.xg2g.android.playback.model.NativePlaybackRequest
 import io.github.manugh.xg2g.android.playback.net.NativePlaybackCapabilities
 import io.github.manugh.xg2g.android.playback.net.PlaybackApiJsonCodec
+import io.github.manugh.xg2g.android.recordings.recordingThumbnailUrl
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.json.JSONObject
 
 class MainActivity : AppCompatActivity() {
@@ -154,9 +156,9 @@ class MainActivity : AppCompatActivity() {
                         item.resume.posSeconds * 1000L
                     } else 0L
 
-                    val thumbnailUrl = serverSettingsStore.getServerUrl()?.let { base ->
-                        "$base/api/v3/recordings/${item.recordingId}/thumbnail.jpg"
-                    }
+                    val thumbnailUrl = serverSettingsStore.getServerUrl()
+                        ?.toHttpUrlOrNull()
+                        ?.let { base -> recordingThumbnailUrl(base, item.recordingId).toString() }
 
                     nativePlaybackBridge.start(
                         NativePlaybackRequest.Recording(

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransport.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransport.kt
@@ -6,6 +6,7 @@ import io.github.manugh.xg2g.android.DeviceAuthTransport
 import io.github.manugh.xg2g.android.PublishedEndpoint
 import io.github.manugh.xg2g.android.RefreshedDeviceSession
 import io.github.manugh.xg2g.android.StartedWebBootstrap
+import io.github.manugh.xg2g.android.apiV3Url
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
@@ -30,28 +31,7 @@ internal class NativeDeviceAuthTransport(
         deviceGrant: String
     ): RefreshedDeviceSession = withContext(Dispatchers.IO) {
         Log.i(TAG, "action=refresh_session path=/api/v3/auth/device/session")
-        val refreshUrl = uiBaseUrl.newBuilder()
-            .addPathSegment("api")
-            .addPathSegment("v3")
-            .addPathSegment("auth")
-            .addPathSegment("device")
-            .addPathSegment("session")
-            .build()
-
-        val jsonBody = JSONObject()
-            .put("deviceGrantId", deviceGrantId)
-            .put("deviceGrant", deviceGrant)
-            .toString()
-            .toRequestBody("application/json; charset=utf-8".toMediaType())
-
-        val reqBuilder = Request.Builder()
-            .url(refreshUrl)
-            .post(jsonBody)
-
-        val proof = dpopProvider.createProof("POST", refreshUrl.toString())
-        reqBuilder.header("DPoP", proof)
-
-        val request = reqBuilder.build()
+        val request = buildNativeDeviceSessionRequest(uiBaseUrl, deviceGrantId, deviceGrant, dpopProvider)
         okHttpClient.newCall(request).execute().use { response ->
             val body = response.body?.string() ?: ""
             if (!response.isSuccessful) {
@@ -110,4 +90,24 @@ internal class NativeDeviceAuthTransport(
     private companion object {
         const val TAG = "NativeDeviceAuthTransport"
     }
+}
+
+internal fun buildNativeDeviceSessionRequest(
+    uiBaseUrl: HttpUrl,
+    deviceGrantId: String,
+    deviceGrant: String,
+    dpopProvider: DPoPProvider
+): Request {
+    val refreshUrl = apiV3Url(uiBaseUrl, "auth", "device", "session")
+    val jsonBody = JSONObject()
+        .put("deviceGrantId", deviceGrantId)
+        .put("deviceGrant", deviceGrant)
+        .toString()
+        .toRequestBody("application/json; charset=utf-8".toMediaType())
+
+    return Request.Builder()
+        .url(refreshUrl)
+        .post(jsonBody)
+        .header("DPoP", dpopProvider.createProof("POST", refreshUrl.toString()))
+        .build()
 }

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/dashboard/DashboardApiClient.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/dashboard/DashboardApiClient.kt
@@ -2,6 +2,7 @@ package io.github.manugh.xg2g.android.dashboard
 
 import io.github.manugh.xg2g.android.DeviceAuthStore
 import io.github.manugh.xg2g.android.PersistedDeviceAuthStateStore
+import io.github.manugh.xg2g.android.apiV3Url
 import io.github.manugh.xg2g.android.auth.AndroidKeystoreDPoPProvider
 import io.github.manugh.xg2g.android.auth.AuthStateMachine
 import io.github.manugh.xg2g.android.auth.DPoPProvider
@@ -369,18 +370,8 @@ internal class DashboardApiClient(
         }
     }
 
-    private fun apiUrl(vararg segments: String): HttpUrl {
-        val parsed = baseUrl.toHttpUrlOrNull()
-            ?: throw IllegalArgumentException("Invalid server base URL: $baseUrl")
-        val builder = parsed.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-        for (segment in segments) {
-            builder.addPathSegment(segment)
-        }
-        return builder.build()
-    }
+    private fun apiUrl(vararg segments: String): HttpUrl =
+        apiV3Url(requireBaseUrl(), *segments)
 
     private fun requireBaseUrl(): HttpUrl =
         baseUrl.toHttpUrlOrNull()

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/fcm/FcmTokenManager.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/fcm/FcmTokenManager.kt
@@ -1,6 +1,7 @@
 package io.github.manugh.xg2g.android.fcm
 
 import io.github.manugh.xg2g.android.PersistedDeviceAuthStateStore
+import io.github.manugh.xg2g.android.apiV3Url
 import io.github.manugh.xg2g.android.auth.DPoPProvider
 import io.github.manugh.xg2g.android.auth.createNativeAuthenticatedOkHttpClient
 import io.github.manugh.xg2g.android.playback.net.withSameOriginHeaders
@@ -29,9 +30,7 @@ internal class FcmTokenManager(
         bearerToken: String? = null
     ): Boolean = withContext(Dispatchers.IO) {
         val parsed = baseUrl.toHttpUrlOrNull() ?: return@withContext false
-        val url = parsed.newBuilder()
-            .encodedPath("/api/v3/notifications/push-subscriptions")
-            .build()
+        val url = apiV3Url(parsed, "notifications", "push-subscriptions")
 
         val json = JSONObject().apply {
             put("endpoint", fcmToken)

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/guide/GuideApiClient.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/guide/GuideApiClient.kt
@@ -2,6 +2,7 @@ package io.github.manugh.xg2g.android.guide
 
 import io.github.manugh.xg2g.android.DeviceAuthStore
 import io.github.manugh.xg2g.android.PersistedDeviceAuthStateStore
+import io.github.manugh.xg2g.android.apiV3UrlBuilder
 import io.github.manugh.xg2g.android.auth.AndroidKeystoreDPoPProvider
 import io.github.manugh.xg2g.android.auth.AuthStateMachine
 import io.github.manugh.xg2g.android.auth.DPoPProvider
@@ -277,13 +278,7 @@ internal class GuideApiClient(
     private fun apiUrl(vararg segments: String): HttpUrl = apiUrlBuilder(*segments).build()
 
     private fun apiUrlBuilder(vararg segments: String): HttpUrl.Builder =
-        requireBaseUrl().newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-            .apply {
-                segments.forEach(::addPathSegment)
-            }
+        apiV3UrlBuilder(requireBaseUrl(), *segments)
 
     private fun requireBaseUrl(): HttpUrl =
         baseUrl.toHttpUrlOrNull()

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/pairing/PairingApiClient.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/pairing/PairingApiClient.kt
@@ -1,6 +1,7 @@
 package io.github.manugh.xg2g.android.pairing
 
 import io.github.manugh.xg2g.android.PublishedEndpoint
+import io.github.manugh.xg2g.android.apiV3Url
 import io.github.manugh.xg2g.android.playback.net.withSameOriginHeaders
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -186,14 +187,7 @@ internal class PairingApiClient(
     private fun apiUrl(vararg segments: String): HttpUrl {
         val parsed = baseUrl.toHttpUrlOrNull()
             ?: throw IllegalArgumentException("Invalid server base URL: $baseUrl")
-        val builder = parsed.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-        for (segment in segments) {
-            builder.addPathSegment(segment)
-        }
-        return builder.build()
+        return apiV3Url(parsed, *segments)
     }
 
     companion object {

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/playback/net/PlaybackApiClient.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/playback/net/PlaybackApiClient.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import io.github.manugh.xg2g.android.DeviceAuthStore
 import io.github.manugh.xg2g.android.PersistedDeviceAuthStateStore
 import io.github.manugh.xg2g.android.ServerSettingsStore
+import io.github.manugh.xg2g.android.apiV3Url
 import io.github.manugh.xg2g.android.auth.AndroidKeystoreDPoPProvider
 import io.github.manugh.xg2g.android.auth.DPoPProvider
 import io.github.manugh.xg2g.android.auth.createNativeAuthenticatedOkHttpClient
@@ -284,15 +285,7 @@ internal class PlaybackApiClient(
     }
 
     private fun apiUrl(vararg segments: String): HttpUrl {
-        val uiBase = requireUiBaseUrl()
-        return uiBase.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-            .apply {
-                segments.forEach(::addPathSegment)
-            }
-            .build()
+        return apiV3Url(requireUiBaseUrl(), *segments)
     }
 
     private fun extractCapHashFromDecisionToken(token: String?): String? {
@@ -369,14 +362,7 @@ internal fun normalizeRecordingPlaybackUrl(
         return playbackUrl
     }
 
-    val playlistApiUrl = uiBaseUrl.newBuilder()
-        .encodedPath("/api/v3/")
-        .query(null)
-        .fragment(null)
-        .addPathSegment("recordings")
-        .addPathSegment(recordingId)
-        .addPathSegment("playlist.m3u8")
-        .build()
+    val playlistApiUrl = apiV3Url(uiBaseUrl, "recordings", recordingId, "playlist.m3u8")
 
     return recordingPlaylistHttpUrl(
         apiUrl = playlistApiUrl,

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/recordings/RecordingThumbnailUrl.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/recordings/RecordingThumbnailUrl.kt
@@ -1,0 +1,13 @@
+package io.github.manugh.xg2g.android.recordings
+
+import io.github.manugh.xg2g.android.apiV3Url
+import okhttp3.HttpUrl
+
+/**
+ * The single recording-specific source for thumbnail URLs.
+ *
+ * Kept as a top-level function rather than a [RecordingsApiClient] method so the UI can build the
+ * URL without constructing an authenticated HTTP client just to format a path.
+ */
+internal fun recordingThumbnailUrl(baseUrl: HttpUrl, recordingId: String): HttpUrl =
+    apiV3Url(baseUrl, "recordings", recordingId, "thumbnail.jpg")

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/recordings/RecordingsApiClient.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/recordings/RecordingsApiClient.kt
@@ -2,6 +2,7 @@ package io.github.manugh.xg2g.android.recordings
 
 import io.github.manugh.xg2g.android.DeviceAuthStore
 import io.github.manugh.xg2g.android.PersistedDeviceAuthStateStore
+import io.github.manugh.xg2g.android.apiV3Url
 import io.github.manugh.xg2g.android.auth.AndroidKeystoreDPoPProvider
 import io.github.manugh.xg2g.android.auth.AuthStateMachine
 import io.github.manugh.xg2g.android.auth.DPoPProvider
@@ -155,9 +156,8 @@ internal class RecordingsApiClient(
         parseRecordingItems(itemsArr)
     }
 
-    fun buildThumbnailUrl(recordingId: String): String {
-        return apiUrl("recordings", recordingId, "thumbnail.jpg").toString()
-    }
+    fun buildThumbnailUrl(recordingId: String): String =
+        recordingThumbnailUrl(requireBaseUrl(), recordingId).toString()
 
     private fun parseRecordingItems(arr: JSONArray): List<RecordingItem> {
         val list = mutableListOf<RecordingItem>()
@@ -199,18 +199,12 @@ internal class RecordingsApiClient(
         // Native REST API requests manage authentication per request
     }
 
-    private fun apiUrl(vararg segments: String): HttpUrl {
-        val parsed = baseUrl.toHttpUrlOrNull()
+    private fun apiUrl(vararg segments: String): HttpUrl =
+        apiV3Url(requireBaseUrl(), *segments)
+
+    private fun requireBaseUrl(): HttpUrl =
+        baseUrl.toHttpUrlOrNull()
             ?: throw IllegalArgumentException("Invalid server base URL: $baseUrl")
-        val builder = parsed.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-        for (segment in segments) {
-            builder.addPathSegment(segment)
-        }
-        return builder.build()
-    }
 
     companion object {
         private const val SESSION_COOKIE_NAME = "xg2g_session"

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/recordings/RecordingsScreen.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/recordings/RecordingsScreen.kt
@@ -788,12 +788,12 @@ private fun RecordingThumbnailImage(
                 val store = io.github.manugh.xg2g.android.DeviceAuthStore(appContext)
                 val dpopProvider = io.github.manugh.xg2g.android.auth.AndroidKeystoreDPoPProvider()
                 val client = io.github.manugh.xg2g.android.auth.createNativeAuthenticatedOkHttpClient(store, dpopProvider)
-                val urlStr = "$baseUrl/api/v3/recordings/${recordingId}/thumbnail.jpg"
-                val httpUrl = urlStr.toHttpUrlOrNull()
-                if (httpUrl == null) {
+                val parsedBaseUrl = baseUrl.toHttpUrlOrNull()
+                if (parsedBaseUrl == null) {
                     hasError = true
                     return@withContext
                 }
+                val httpUrl = recordingThumbnailUrl(parsedBaseUrl, recordingId)
 
                 val request = Request.Builder()
                     .url(httpUrl)

--- a/android/app/src/main/java/io/github/manugh/xg2g/android/timers/TimersApiClient.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/timers/TimersApiClient.kt
@@ -2,6 +2,7 @@ package io.github.manugh.xg2g.android.timers
 
 import io.github.manugh.xg2g.android.DeviceAuthStore
 import io.github.manugh.xg2g.android.PersistedDeviceAuthStateStore
+import io.github.manugh.xg2g.android.apiV3Url
 import io.github.manugh.xg2g.android.auth.AndroidKeystoreDPoPProvider
 import io.github.manugh.xg2g.android.auth.AuthStateMachine
 import io.github.manugh.xg2g.android.auth.DPoPProvider
@@ -122,14 +123,7 @@ internal class TimersApiClient(
     private fun apiUrl(vararg segments: String): HttpUrl {
         val parsed = baseUrl.toHttpUrlOrNull()
             ?: throw IllegalArgumentException("Invalid server base URL: $baseUrl")
-        val builder = parsed.newBuilder()
-            .encodedPath("/api/v3/")
-            .query(null)
-            .fragment(null)
-        for (segment in segments) {
-            builder.addPathSegment(segment)
-        }
-        return builder.build()
+        return apiV3Url(parsed, *segments)
     }
 
     companion object {

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/ApiV3UrlTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/ApiV3UrlTest.kt
@@ -1,0 +1,90 @@
+package io.github.manugh.xg2g.android
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApiV3UrlTest {
+
+    @Test
+    fun `thumbnail url is root anchored when base url carries the ui path`() {
+        val url = apiV3Url(
+            "https://host/ui/".toHttpUrl(),
+            "recordings",
+            "rec-1",
+            "thumbnail.jpg"
+        )
+
+        assertEquals("https://host/api/v3/recordings/rec-1/thumbnail.jpg", url.toString())
+    }
+
+    @Test
+    fun `ui base path is replaced rather than extended`() {
+        val url = apiV3Url("https://host/ui/".toHttpUrl(), "recordings")
+
+        assertEquals(listOf("api", "v3", "recordings"), url.pathSegments)
+    }
+
+    @Test
+    fun `port and scheme of the configured base url are preserved`() {
+        val url = apiV3Url(
+            "http://host.local:8080/ui/".toHttpUrl(),
+            "recordings",
+            "rec-1",
+            "thumbnail.jpg"
+        )
+
+        assertEquals(
+            "http://host.local:8080/api/v3/recordings/rec-1/thumbnail.jpg",
+            url.toString()
+        )
+    }
+
+    @Test
+    fun `query and fragment of the configured base url are dropped`() {
+        val url = apiV3Url(
+            "https://host/ui/?theme=dark#live".toHttpUrl(),
+            "recordings",
+            "rec-1",
+            "thumbnail.jpg"
+        )
+
+        assertEquals("https://host/api/v3/recordings/rec-1/thumbnail.jpg", url.toString())
+    }
+
+    /**
+     * Regression guard for deployment sub-paths.
+     *
+     * `ServerTargetResolver.extractUiBasePath` preserves a sub-path in the UI base URL
+     * (`https://host/xg2g/ui/` stays intact), so a sub-path base URL can reach this helper. The
+     * backend, however, mounts the v3 router at the origin root via the compile-time constant
+     * `V3BaseURL = "/api/v3"` and serves the SPA through a hardcoded `StripPrefix("/ui")`; there is
+     * no configurable deployment prefix. The API is therefore origin-rooted and the `/xg2g` prefix
+     * is deliberately dropped.
+     *
+     * This test exists to make that decision explicit rather than incidental: if the backend ever
+     * gains a configurable prefix, this test is what should fail and force the discussion.
+     */
+    @Test
+    fun `deployment sub-path in the base url is dropped because the api is origin-rooted`() {
+        val url = apiV3Url(
+            "https://host/xg2g/ui/".toHttpUrl(),
+            "recordings",
+            "rec-1",
+            "thumbnail.jpg"
+        )
+
+        assertEquals("https://host/api/v3/recordings/rec-1/thumbnail.jpg", url.toString())
+    }
+
+    @Test
+    fun `path segments are encoded instead of splitting the path`() {
+        val url = apiV3Url("https://host/ui/".toHttpUrl(), "recordings", "a b/c", "thumbnail.jpg")
+
+        assertEquals(listOf("api", "v3", "recordings", "a b/c", "thumbnail.jpg"), url.pathSegments)
+        assertEquals(
+            "https://host/api/v3/recordings/a%20b%2Fc/thumbnail.jpg",
+            url.toString()
+        )
+    }
+}

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransportTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransportTest.kt
@@ -1,0 +1,42 @@
+package io.github.manugh.xg2g.android.auth
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+
+class NativeDeviceAuthTransportTest {
+    private class CapturingDPoPProvider : DPoPProvider {
+        var proofMethod: String? = null
+        var proofUrl: String? = null
+
+        override fun getOrGenerateKeyPair(): KeyPair =
+            KeyPairGenerator.getInstance("EC").apply { initialize(256) }.generateKeyPair()
+
+        override fun getJWKThumbprint(): String = "test-jkt"
+
+        override fun createProof(htm: String, htu: String, accessToken: String?): String {
+            proofMethod = htm
+            proofUrl = htu
+            return "test-dpop-proof"
+        }
+    }
+
+    @Test
+    fun `refresh roots API URL at origin and signs the transported URL`() {
+        val dpop = CapturingDPoPProvider()
+        val request = buildNativeDeviceSessionRequest(
+            uiBaseUrl = "https://example.com/ui/".toHttpUrl(),
+            deviceGrantId = "grant-id",
+            deviceGrant = "grant-secret",
+            dpopProvider = dpop
+        )
+
+        val expectedUrl = "https://example.com/api/v3/auth/device/session"
+        assertEquals(expectedUrl, request.url.toString())
+        assertEquals("test-dpop-proof", request.header("DPoP"))
+        assertEquals("POST", dpop.proofMethod)
+        assertEquals(expectedUrl, dpop.proofUrl)
+    }
+}


### PR DESCRIPTION
## Summary

- make `ApiV3Url` the single origin-rooted constructor for Android `/api/v3` requests
- migrate auth, dashboard, guide, pairing, playback, recordings, timers, and FCM callers
- unify recording thumbnail construction across both UI call sites and the API client
- fix `NativeDeviceAuthTransport` so refresh requests and their DPoP `htu` target `/api/v3/auth/device/session`, never `/ui/api/v3/...`
- add direct request-level coverage proving the transported URL and signed URL are identical

## Validation

- `:app:testDevDebugUnitTest --tests io.github.manugh.xg2g.android.ApiV3UrlTest --tests io.github.manugh.xg2g.android.auth.NativeDeviceAuthTransportTest`
- make pre-push

## Stack

Targets fix/android-tv-video-pipeline because these native API clients are introduced by PR #822. Retarget to main after #822 merges.