### PR TITLE
test(ffmpeg): configure ABR watchdog budgets

### DIFF
--- a/backend/internal/infra/media/ffmpeg/e2e_abr_execution_test.go
+++ b/backend/internal/infra/media/ffmpeg/e2e_abr_execution_test.go
@@ -71,8 +71,8 @@ func TestE2E_ProductiveBackendABRExecution(t *testing.T) {
 		false,
 		2*time.Second,
 		2,
-		0,
-		0,
+		30*time.Second, // startup watchdog
+		30*time.Second, // stall watchdog
 		"",
 	)
 


### PR DESCRIPTION
## Summary
- give the productive ABR E2E pipeline explicit 30-second startup and stall watchdog budgets
- remove the race caused by zero-duration watchdogs, which fire on their first one-second tick
- retain the two-minute outer test deadline and all existing ABR/PID/PTS assertions

## Validation
- `GOMAXPROCS=2` targeted E2E with full coverage instrumentation: 10/10 pass
- `GOMAXPROCS=2` targeted E2E with `-race`: 5/5 pass
- `make pre-push`: pass

Fixes the remaining Coverage failure on PR #822 after #835.