### PR TITLE
fix(android): satisfy CSRF policy on native auth refresh

### DIFF
--- a/android/app/src/main/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransport.kt
+++ b/android/app/src/main/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransport.kt
@@ -7,6 +7,7 @@ import io.github.manugh.xg2g.android.PublishedEndpoint
 import io.github.manugh.xg2g.android.RefreshedDeviceSession
 import io.github.manugh.xg2g.android.StartedWebBootstrap
 import io.github.manugh.xg2g.android.apiV3Url
+import io.github.manugh.xg2g.android.playback.net.withSameOriginHeaders
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
@@ -110,4 +111,5 @@ internal fun buildNativeDeviceSessionRequest(
         .post(jsonBody)
         .header("DPoP", dpopProvider.createProof("POST", refreshUrl.toString()))
         .build()
+        .withSameOriginHeaders(uiBaseUrl)
 }

--- a/android/app/src/test/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransportTest.kt
+++ b/android/app/src/test/java/io/github/manugh/xg2g/android/auth/NativeDeviceAuthTransportTest.kt
@@ -36,6 +36,8 @@ class NativeDeviceAuthTransportTest {
         val expectedUrl = "https://example.com/api/v3/auth/device/session"
         assertEquals(expectedUrl, request.url.toString())
         assertEquals("test-dpop-proof", request.header("DPoP"))
+        assertEquals("https://example.com", request.header("Origin"))
+        assertEquals("https://example.com/ui/", request.header("Referer"))
         assertEquals("POST", dpop.proofMethod)
         assertEquals(expectedUrl, dpop.proofUrl)
     }


### PR DESCRIPTION
Replaces auto-closed stacked PR #832 after its base branch was merged and deleted.

## Summary
- attach same-origin `Origin` and `/ui/` `Referer` headers to native device-auth refresh
- preserve the exact API-v3 request URL and DPoP proof target
- cover URL, method, DPoP, Origin, and Referer together

## Validation
- `NativeDeviceAuthTransportTest`: pass
- `PlaybackApiClientHeadersTest`: pass
- `make pre-push`: pass