### PR TITLE
feat(ios): add native Phase 2A foundation

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,6 @@
+build/
+DerivedData/
+*.xcuserstate
+*.xcuserdatad/
+xcuserdata/
+.DS_Store

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,498 @@
+# iOS Client
+
+Xcode project for the `xg2g` iOS client. Sibling of `android/`, same server, same
+wire contract — but deliberately not a line-by-line port of it.
+
+## Architecture
+
+Native first. The target shape is:
+
+```
+SwiftUI app -> native screens -> native API/auth layer -> native playback layer -> backend
+```
+
+and explicitly **not** a `WKWebView` wrapper around the existing Web UI. A web
+view may later appear as an isolated `WebContentView` for admin or rarely-used
+configuration pages, but it is not the UI foundation.
+
+This is a deliberate departure from `android/`, which hosts the Web UI and adds
+native pieces around it. The cost is duplicated product logic, which
+`android/README.md` names as something to avoid; it is accepted here to gain
+player control, PiP, background audio, lock-screen/remote integration, native
+gestures, predictable lifecycle handling, and a clean tvOS base.
+
+One boundary is **not** negotiable: playback *decisions* stay server
+authoritative. The client reports honest capabilities and obeys the decision
+token; it never re-decides codec or container locally. Per
+[ADR-026](../docs/ADR/026-native-webkit-hls-hevc-copy.md) the decision token's
+`CapHash` covers `preferredHlsEngine`, and changing the engine after
+`/live/stream-info` is rejected with `CLAIM_MISMATCH`. Native UI, yes; native
+playback policy, no.
+
+## Status
+
+| Phase | Scope | State |
+| --- | --- | --- |
+| 1 | Project skeleton, server target resolution, unit tests, Swift 6 | done |
+| 2A | `ServerOrigin`, `ServerAddress`, `ServerIdentity`, URL consolidation, attack cases | done |
+| 2A | `CredentialStore`, `DeviceKeyStore`, `APIClient` | done — **2A closed** |
+| 2B | Native device auth: pairing, session refresh, DPoP via Secure Enclave | open |
+| 2C | Native app shell: SwiftUI navigation, app state, setup, base layout | open |
+| 2D | First real screen (bouquets / channel list) against a live backend | open |
+| 3 | Playback: `AVPlayer`, intents/sessions/heartbeat, PiP, background audio, now-playing — plus `ios_native` in the backend | open |
+| 4 | EPG, timers, recordings | open |
+| 5 | tvOS | open |
+| 6 | Mac Catalyst | open |
+
+The project builds in **Swift 6 language mode** with full strict concurrency,
+adopted while the source surface was still small enough that the migration cost
+nothing. Keep it that way rather than reverting to Swift 5 to silence an
+isolation error.
+
+## Build And Test
+
+No project generator and no extra toolchain is required. The app target uses an
+Xcode *synchronized folder group*, so new Swift files under `Xg2g/` are picked up
+without touching `Xg2g.xcodeproj`.
+
+```bash
+xcodebuild -project ios/Xg2g.xcodeproj -scheme Xg2g \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
+```
+
+```bash
+xcodebuild -project ios/Xg2g.xcodeproj -scheme Xg2g \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
+```
+
+No signing identity is required: the simulator signs ad-hoc ("Sign to Run
+Locally") on its own. Running on a physical device needs an Apple ID configured
+once in Xcode under *Settings → Accounts*; a free account is enough for 7-day
+builds.
+
+> **Do not add `CODE_SIGNING_ALLOWED=NO`.** It disables signing entirely, and an
+> unsigned app has no Keychain entitlement — every `SecItem` call then fails
+> with `errSecMissingEntitlement` (`-34018`). It looks harmless because pure
+> logic tests still pass; `SecItemKeychainBackendTests` is what catches it.
+
+## Layout
+
+- `Xg2g/` application sources (synchronized group — no project edit to add files)
+- `Xg2gTests/` unit tests (synchronized group)
+- `Support/Info.plist` bundle configuration for **Release**
+- `Support/Info-Debug.plist` bundle configuration for **Debug**
+
+## App Transport Security
+
+A self-hosted xg2g server is usually reached over the LAN, so development needs
+cleartext to a local address. That exemption is confined to Debug by build
+configuration, not by convention: `INFOPLIST_FILE` differs per configuration, so
+a Release build reads a plist that does not contain the key at all and therefore
+cannot ship the exemption. It is `NSAllowsLocalNetworking`, never
+`NSAllowsArbitraryLoads`.
+
+`NSLocalNetworkUsageDescription` stays in both, because reaching a LAN server
+triggers the local-network permission prompt even over HTTPS.
+
+Verify against the built bundles rather than the sources:
+
+```bash
+plutil -extract NSAppTransportSecurity xml1 -o - \
+  "$(ls -d ~/Library/Developer/Xcode/DerivedData/Xg2g-*/Build/Products/Release-iphonesimulator)/Xg2g.app/Info.plist"
+```
+
+A Release bundle must answer `No value at that key path`.
+
+## URL And Identity Layer
+
+Five types, each with exactly one job. There is no second implementation of any
+of them — a duplicated normalizer is how the Android client ended up with two
+disagreeing opinions about one URL.
+
+| Type | Holds | Job |
+| --- | --- | --- |
+| `ServerOrigin` | scheme, host, effective port | Canonical origin. Comparing two values **is** the same-origin check |
+| `ServerAddress` | origin + deployment root path | Derives every endpoint; owns containment |
+| `ServerIdentity` | `.address` or `.instance` | What credentials are bound to |
+| `URLPath` | — | Percent-encoded path canonicalization |
+| `DeepLinkParser` | — | Reads `xg2g://` onboarding links. No URL semantics of its own |
+
+### Invariant: endpoints are derived from the root, downward
+
+**Every endpoint is derived from the stored deployment root. The API is never
+reconstructed from the UI path, and the UI is never reconstructed from the API
+path.** Anything that needs a new endpoint adds a derivation on `ServerAddress`;
+nothing joins onto another endpoint's URL.
+
+### The root is stored, not the Web UI path
+
+The backend mounts `/api/v3` and `/ui` as **siblings** at the deployment root.
+This client therefore persists the *root* and derives `apiBaseURL` and
+`webUIURL` downward from it. Nothing is ever reconstructed sideways out of
+another endpoint's path.
+
+Android persists the UI base (`https://host/ui/`) instead, and its two
+transports disagree about how to get back to the API from there:
+`DeviceAuthRepository.apiUrl` replaces the path with `/api/v3/`, while
+`NativeDeviceAuthTransport.refreshSession` appends segments and therefore
+requests `https://host/ui/api/v3/auth/device/session`, which reaches the SPA
+handler rather than the API router. `NativeAuthContainer` wires the latter.
+Storing the root removes the entire class of mistake.
+
+### Two parsers, one boundary
+
+`parseUserEntered` is for text a human typed and performs exactly **one**
+repair: supplying a missing `https://`. A declared scheme is validated, never
+rewritten — `ftp://host` is rejected rather than turned into something else.
+
+`parseTrusted` is for persisted values and trusted backend responses and repairs
+nothing; a scheme-less string is refused.
+
+They are deliberately two functions rather than one with a flag, so no later
+internal call can take the convenient route and have a machine-supplied string
+reinterpreted instead of validated.
+
+Where the input is genuinely ambiguous — a user pasting `https://host/ui/` out
+of their browser — the parser does not guess. `ServerAddress.rootCandidates`
+hands the alternatives to the setup flow, which resolves it by asking the server
+rather than by assuming.
+
+### Credential binding: never silently weakened
+
+`ServerIdentity` has two cases and they are not interchangeable. `.instance` is
+the **stronger** binding: it distinguishes two deployments sharing an origin and
+survives a hostname change. `.address` is what can be known before pairing, and
+against a backend that does not mint an instance identifier — which is the case
+today, so `.instance` is currently unreachable in practice. See *Backend Notes*.
+
+`ServerIdentity.reconcile(bound:observedInstance:)` is the only way to change a
+binding, and **no outcome returns an identity weaker than the one bound**:
+
+| Bound | Server reports | Outcome |
+| --- | --- | --- |
+| `.address` | nothing | unchanged |
+| `.address` | an ID | **upgraded** — caller must re-key stored credentials |
+| `.instance` | the same ID | unchanged |
+| `.instance` | a *different* ID | **conflict** — different installation, credentials must not be reused |
+| `.instance` | nothing | **binding kept**, explicitly not a downgrade |
+
+The last row is the reason the type exists. A missing value is not evidence of a
+different server, so treating it as one would let a transient failure
+permanently weaken a binding while looking like a successful fallback. An
+exhaustive test asserts that no input to `reconcile` lowers the strength.
+
+`InstanceID` is validated on the way in — length bounds and an
+`[A-Za-z0-9._-]` charset — because a server-supplied string that becomes part of
+a Keychain account key must not be able to carry separators or escape the key
+format.
+
+### URL containment: never decode
+
+`ServerAddress.contains(_:)` is the single containment check, and it **never
+decodes**. `%2e%2e`, `%2f` and `%5c` are not traversal for `URLSession` or for
+the server, so treating them as traversal here would be a second parser opinion
+— exactly the differential this layer exists to prevent. Being "more careful"
+than the network stack is not safer, it is merely different, and different is
+the bug.
+
+`Xg2gTests/URLContainmentAttackTests.swift` asserts twice per case: that
+`URLRequest` carries the URL byte-for-byte unchanged, and what the verdict is.
+The first assertion is what keeps the second honest — if Foundation ever starts
+rewriting one of these, the test fails before the verdict silently becomes a
+lie. Measured today: Foundation rewrites none of them.
+
+Covered: real dot-segment traversal (rejected), harmless `.` and in-root `..`
+(accepted), encoded slash and backslash as non-separators, encoded dots in
+lower, upper and mixed case, double-encoded dots, prefix-confusion siblings
+(`/xg2gX` against root `/xg2g/`), scheme/port/host mismatches, equivalent origin
+spellings, userinfo disguise, and Unicode hosts.
+
+Treat this layer as **closed**. It should not be reopened at each auth step; new
+endpoints are added by derivation on `ServerAddress`, not by new URL handling.
+
+### Deep links configure less than on Android
+
+Only the `xg2g://` scheme can configure a server, and its `base_url` goes
+through the **strict** parser as a deployment root. An `https://` link
+configures nothing at all.
+
+This is a **security invariant**, not a convenience: *only* `xg2g://` may change
+server configuration. It is deliberately narrower than Android, which accepts an
+https deep link as a base URL behind an `isServerSwitch` confirmation — leaving a
+dialog as the only thing between an arbitrary web page and the choice of host
+this client sends credentials to. If universal links are added later they may
+open content within an already-bound server; they must never bind a new one.
+
+#### `base_url` carries a UI URL, not a root
+
+On the wire, `base_url` is the **Web UI URL**. The link is minted by the Web UI,
+not the backend: `apps/webui/src/components/Settings.tsx` builds
+`new URL('/ui/', endpoint)`, yielding `https://host/ui/`.
+
+Rather than let that spread, the legacy transport form is accepted at the edge
+and converted to a deployment root exactly once, inside
+`DeepLinkParser.configuredAddress`. Past that boundary nothing deals in UI URLs.
+A link that already carries a root passes through unchanged, so both forms work
+without callers knowing which they got. Compatibility at the edge, one model in
+the core.
+
+There is a second link shape the backend itself mints —
+`xg2g://pair?pairing_id=…&user_code=…` from
+`backend/internal/control/http/v3/pairing/service.go` — which carries no
+`base_url` and is handled in 2B.
+
+### Credential keys are a storage concern, not a domain concern
+
+`ServerIdentity` deliberately does **not** know how to serialize itself.
+`CredentialKeyEncoding` owns that, so domain logic never depends on an Apple
+storage format and a storage change cannot become a domain change. The format is
+versioned; changing it is a migration with a reader for the old shape, not an
+edit.
+
+All secrets live under one owned Keychain service. That is what makes a
+wipe-on-reinstall possible at all: at first launch after a reinstall the app does
+not yet know which identities were stored, so it can only purge by service rather
+than by enumerating them.
+
+## Credential Storage
+
+`CredentialStore` exposes **only** typed, domain-level operations — "the grant
+for this identity", "this session was refreshed". **No caller ever sees a
+storage key or a namespace string.** Without that rule `CredentialKeyEncoding`
+protects nothing: the representation leaks out through whoever composes a key by
+hand, and the format becomes load-bearing everywhere.
+
+Keychain items are written `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
+and non-synchronizable. *AfterFirstUnlock* rather than *WhenUnlocked* because
+refresh and heartbeat must survive a locked screen once background audio exists;
+*ThisDeviceOnly* because a device-bound grant that rides an iCloud Keychain sync
+or an encrypted backup onto a second device is no longer device-bound. Both
+attributes are **read back from the Keychain** in
+`SecItemKeychainBackendTests` — a security property asserted in a comment is not
+asserted at all.
+
+### Fresh-install purge
+
+The Keychain outlives app deletion; `UserDefaults` does not. `prepareForLaunch()`
+uses that asymmetry: a missing installation marker means a fresh install looking
+at a previous installation's credentials, so everything under this app's
+Keychain service is purged before anything is read. Purging by *service* is not
+laziness — at first launch the app does not know which identities were ever
+stored, so enumerating them is impossible. Reads and writes throw
+`.notPrepared` until this has run.
+
+### Three distinct lifecycle operations
+
+| Operation | Effect |
+| --- | --- |
+| `endSession` — log out | Drops the session, keeps the pairing |
+| `forgetServer` | Drops every credential for that identity, keeps the device key |
+| *revoke device* | **Not offered here** |
+
+Revocation is remote-first: revoke server-side, wait for success or a defined
+terminal failure, and only then destroy local material. A local-first `revoke`
+on the store would be an attractive nuisance — the key needed to authenticate
+the revocation would already be gone, leaving a grant that is still valid on the
+server and no longer revocable from this device. That sequencing belongs to the
+auth coordinator, which owns the network call.
+
+Nothing here touches the DPoP device key; that is `DeviceKeyStore`'s property
+with its own lifecycle, so clearing credentials can never destroy a
+cryptographic identity.
+
+### Migration writes before it deletes
+
+`migrate(from:to:)` re-keys credentials after an identity upgrade. New entries
+are written before old ones are removed, so an interruption leaves a harmless
+duplicate rather than no credentials at all.
+
+## Device Key
+
+`DeviceKeyStore` owns the device's cryptographic identity, kept strictly apart
+from `CredentialStore`: a grant is something the server issued, a key is
+something this device *is*. Clearing credentials never destroys it.
+
+Three invariants:
+
+1. **Provenance is in the API.** `hardwareBacked` and `software` are distinct,
+   and every attestation carries one. A caller is never handed "a key".
+2. **A software key never silently substitutes for a hardware key.** It exists
+   only under an explicit `DeviceKeyPolicy.allowSoftware(reason:)`. That case
+   sits behind `#if targetEnvironment(simulator)`, so a real iOS build cannot
+   construct it — a development convenience cannot become a production
+   weakening later, because the code allowing it is not compiled into the
+   product. Provenance is re-checked on **every** signature, not just at
+   creation, so a key made under a permissive policy stops working when the
+   policy tightens.
+3. **The private key never leaves the type.** The surface is `sign(_:)`. No
+   `SecKey`, no key material, no Security-framework object is handed out.
+
+This is deliberately not a "DPoP provider": only the non-exportable key lives in
+the Secure Enclave. JWT assembly, `jti`, `htm`/`htu`, `ath` and any nonce
+handling are ordinary software concerns in a layer above.
+
+### Signatures are raw R‖S, not DER
+
+`SecKeyCreateSignature` returns ASN.1 DER (68–72 bytes for P-256). JWS ES256
+requires the raw concatenation `R ‖ S`, 32 bytes each, and the server enforces
+exactly that — `verifyES256Signature` in
+`backend/internal/control/http/v3/dpop/dpop.go` rejects any other length
+outright. `ECDSASignature.rawFromDER` converts, including stripping DER's sign
+padding and **left-padding a short R or S**; forgetting the pad yields a 63-byte
+signature that fails for roughly one signature in 256. Tests assert the length
+over many signatures and verify the result against the reported public key.
+
+The JWK thumbprint is pinned against an independently computed oracle rather
+than described, because member order or whitespace drift changes `jkt` and makes
+the server reject every proof.
+
+### Measured: the simulator has a Secure Enclave
+
+On Apple Silicon under Xcode 26, the iOS simulator **does** provide a Secure
+Enclave — `kSecAttrTokenIDSecureEnclave` key creation succeeds. The widely
+repeated "no Secure Enclave on the simulator" is out of date.
+
+That has a testing consequence worth keeping in mind: gating the
+"software key is rejected under a hardware policy" test on real availability
+made it silently no-op here. `SecureEnclaveDeviceKeyStore` therefore takes an
+injectable `secureEnclaveProbe` so a software key can be forced on any host. The
+seam cannot weaken anything — it only decides what kind of key is *created*,
+while the policy remains the sole gate on what may be *used*.
+
+## API Client
+
+`HTTPAPIClient` owns requests, JSON, status codes, timeouts and error mapping —
+and nothing else. It sits on the finished pieces: `ServerAddress` supplies the
+URLs, `CredentialStore` supplies credentials through typed operations,
+`DeviceKeyStore` signs bytes. It never learns a credential key name, a Secure
+Enclave detail, or a playback decision.
+
+Paths are **relative to the API base** (`"services/bouquets"`). Callers never
+build absolute URLs, so the deployment root stays the single source of truth.
+
+### Four distinct failure categories
+
+Collapsing failures into one "network error" is what makes bugs like the Android
+one invisible, so the categories stay separate:
+
+| Category | Meaning |
+| --- | --- |
+| `.transport` | Nothing came back — offline, timeout, TLS, cannot connect, cancelled |
+| `.problem` | The API answered with an RFC 7807 document, `requestId` preserved |
+| `.http` | An error status *without* a problem document — usually a proxy or gateway answered |
+| `.unexpectedPayload` | HTTP succeeded, the body is not the promised shape |
+
+`.unexpectedPayload` exists specifically for the Android failure mode: the
+request reached the SPA and got HTML back **with status 200**. That is neither a
+transport nor an HTTP error, and it is undiagnosable if lumped in with either.
+The category carries the content type, a body preview and the expected type, so
+one log line identifies it.
+
+`isRetryable` follows from the category rather than from a guess: a wrong body
+or a wrong URL will be equally wrong next time, a gateway error may not be.
+
+### The API scope is tighter than the deployment root
+
+Containment for API calls is checked against `ServerAddress.apiScope`, not the
+deployment root. A path like `api/v3/../../admin` resolves back *inside* the
+deployment and passes a root-level check while having left the API entirely.
+Both boundaries are asserted in `ServerAddressTests`.
+
+### Timestamps: RFC 3339 with *optional* fractional seconds
+
+Go's `time.Time` marshals as RFC 3339 **Nano** — fractional seconds appear only
+when non-zero, so the same field is `…T12:00:00Z` one moment and
+`…T12:00:00.529Z` the next. Foundation's `.iso8601` strategy rejects the
+fractional form, which would make token-expiry decoding fail intermittently,
+roughly whenever the server's clock lands on a non-integral second. The decoder
+accepts both. `Date.ISO8601FormatStyle` is used rather than
+`ISO8601DateFormatter` because the former is a value type and therefore
+`Sendable`.
+
+## CI Requirement
+
+At least one simulator test must keep performing **real** `SecItem` operations.
+`SecItemKeychainBackendTests` and `DeviceKeyStoreTests` are that test. Pure logic
+tests stay green with a broken Keychain setup, so without them a build can look
+entirely healthy while the whole auth stack is inoperative — which is exactly
+what `CODE_SIGNING_ALLOWED=NO` caused before it was removed.
+
+There is no iOS workflow in `.github/workflows` yet; adding one needs a macOS
+runner.
+
+### Host encoding: punycode only
+
+**Punycode is the only accepted non-ASCII domain representation.** A Unicode
+host such as `münchen.example` is *rejected*; its punycode form
+`xn--mnchen-3ya.example` is accepted. This is a security decision, not a gap:
+Foundation exposes no UTS-46 mapping to rely on, and an incorrect IDNA mapping
+is a homograph problem rather than a formatting problem. Treat a rejection here
+as intended behaviour.
+
+Also refused by `ServerOrigin` / `ServerAddress`, in both parsers: user info
+(`https://trusted.example@attacker.example/` reads as one host and resolves to
+another), query strings and fragments on a server address, hosts carrying
+`/ ? # @ \` or whitespace, and ports outside 1–65535. IPv6 literals are
+compressed per RFC 5952 via `Network.IPv6Address`, and a zone index is dropped
+because it is device-local and would split one server into two identities.
+
+## Deliberate Divergences From The Android Client
+
+The wire contract is kept identical so one server serves both clients: same
+query keys, same `/ui/` base path derivation, same override precedence, and the
+same two-step expiry parsing (bare number = epoch millis, otherwise RFC 1123).
+
+These behaviours are **not** carried over:
+
+| Android | Why not | iOS instead |
+| --- | --- | --- |
+| `ServerSettingsStore` keeps `auth_token` in plain SharedPreferences while `DeviceAuthStore` next to it uses EncryptedSharedPreferences | Two credential paths, only one hardened | Keychain for anything token-shaped; `UserDefaults` only for the server URL |
+| `isUnderBasePath` compares raw paths | `java.net.URI.rawPath` does not resolve dot segments, so `/ui/../admin` passes a check meant to confine navigation to `/ui/` | Dot segments resolved before any comparison |
+| `isSameOrigin` dereferences a possibly-null host | Throws on a host-less URL instead of answering `false` | Optionals handled; host-less ⇒ `false` |
+| `isSameOrigin` accepts any matching scheme | It is an origin gate | Restricted to `http`/`https` |
+| `NativePlaybackCapabilities.container` is hardcoded `["hls","fmp4","mpegts","ts","mp4"]` | Codecs are probed but containers are asserted. On Apple this is actively wrong: per [ADR-026](../docs/ADR/026-native-webkit-hls-hevc-copy.md) the native HLS path does not play HEVC in MPEG-TS | Capabilities derived from AVFoundation; never claim `mpegts` + `hevc` together |
+| `dev`/`staging`/`prod` flavors with `usesCleartextTraffic` | Gradle idiom with no iOS counterpart | One narrow ATS exemption (`NSAllowsLocalNetworking`), not `NSAllowsArbitraryLoads` |
+| `ExternalBrowserPolicy` | Works around Android TV browser stubs | Dropped |
+
+One hazard is iOS-specific and has no Android equivalent: `URLComponents` is far
+more permissive than `java.net.URI`. Prefixing `https://` onto an input that
+already declares a foreign scheme yields a URL whose *host is the scheme* and
+whose real host has been demoted into the path — `ftp://demo.example/ui/` became
+`https://ftp/demo.example/ui/`. `normalizeServerURL` therefore validates a
+declared scheme instead of overwriting it, keyed on `://` rather than on a bare
+colon so `demo.example:8080` still works. Both cases are covered by tests.
+
+## Verified Against Android
+
+`Xg2gTests/ServerTargetResolverTests.swift` mirrors every case in
+`android/app/src/test/java/io/github/manugh/xg2g/android/ServerTargetResolverTest.kt`
+one-for-one, then adds the hardening cases above. Keep both suites in step when
+the contract changes.
+
+## Backend Notes
+
+- Device auth needs **no** backend change. Despite its name,
+  `backend/internal/control/http/v3/handlers_android_auth.go` is platform
+  neutral: `platform` and `deviceName` are request fields and `"android"` is
+  merely the default for an empty value. iOS sends `platform: "ios"`.
+- The backend issues no DPoP nonces, so the client implements none.
+- **There is no stable instance identifier today.** No `instanceId`,
+  `installationId`, `serverId` or `deploymentId` exists anywhere in
+  `backend/internal`; `/system/info` describes the Enigma2 receiver, not the
+  xg2g installation; there is no JWKS or exposed server key. `ExchangePairing`
+  returns `deviceId` (this device *at* that server), `deviceGrantId`,
+  `accessSessionId`, `endpoints[]`, `policyVersion` — nothing identifying the
+  installation. `endpoints[]` is endpoint aliasing, which answers "where else am
+  I reachable", not "am I the same installation".
+
+  So `ServerIdentity.instance` is currently unreachable. Making it real needs a
+  backend change: an opaque random identifier minted once at first start,
+  persisted, and readable **before** pairing — otherwise the client cannot form
+  the namespace on first contact. That is a separate decision; the client side
+  is already shaped so it becomes a migration rather than a redesign.
+- A native iOS client family (`ios_native`) is **not** yet registered. The
+  backend currently knows only `ios_safari_native`, the browser path. Phase 3
+  needs it added in `playbackprofile/client_matrix.go`,
+  `playbackprofile/client_family.go`, `playbackcompat/policy.go`,
+  `recordings/capability_registry.go` and the alias map in
+  `pipeline/profiles/resolve.go`.

--- a/ios/Support/Info-Debug.plist
+++ b/ios/Support/Info-Debug.plist
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>xg2g</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+
+	<!-- Live TV keeps playing when the app leaves the foreground. Mirrors the
+	     Android PlaybackService behaviour; required before the native AVPlayer
+	     path lands so backgrounding does not tear down an owned tuner lease. -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+
+	<!-- xg2g://connect?base_url=... onboarding link, same contract as the
+	     Android custom scheme handled by ServerTargetResolver. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.github.manugh.xg2g.ios.connect</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>xg2g</string>
+			</array>
+		</dict>
+	</array>
+
+	<!-- A self-hosted xg2g server is normally reached over the LAN. ATS is left
+	     fully enabled for public hosts; only local networking (.local names and
+	     IP literals) is exempted, which is the narrow iOS equivalent of the
+	     Android dev flavor's usesCleartextTraffic. Note this is deliberately
+	     NOT NSAllowsArbitraryLoads. -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>xg2g connects to your receiver and xg2g server on your local network.</string>
+</dict>
+</plist>

--- a/ios/Support/Info.plist
+++ b/ios/Support/Info.plist
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>xg2g</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+
+	<!-- Live TV keeps playing when the app leaves the foreground. Mirrors the
+	     Android PlaybackService behaviour; required before the native AVPlayer
+	     path lands so backgrounding does not tear down an owned tuner lease. -->
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+
+	<!-- xg2g://connect?base_url=... onboarding link, same contract as the
+	     Android custom scheme handled by ServerTargetResolver. -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>io.github.manugh.xg2g.ios.connect</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>xg2g</string>
+			</array>
+		</dict>
+	</array>
+
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>xg2g connects to your receiver and xg2g server on your local network.</string>
+</dict>
+</plist>

--- a/ios/Xg2g.xcodeproj/project.pbxproj
+++ b/ios/Xg2g.xcodeproj/project.pbxproj
@@ -1,0 +1,367 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		AAAA0000000000000000AAAF /* Xg2g.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Xg2g.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAAA0000000000000000AAB0 /* Xg2gTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Xg2gTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		AAAA0000000000000000AAC4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AAAA0000000000000000AAC6 /* Info-Debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Debug.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		AAAA0000000000000000AAB1 /* Xg2g */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Xg2g;
+			sourceTree = "<group>";
+		};
+		AAAA0000000000000000AAB2 /* Xg2gTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Xg2gTests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AAAA0000000000000000AAB4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AAAA0000000000000000AAB7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AAAA0000000000000000AAAB = {
+			isa = PBXGroup;
+			children = (
+				AAAA0000000000000000AAB1 /* Xg2g */,
+				AAAA0000000000000000AAB2 /* Xg2gTests */,
+				AAAA0000000000000000AAC5 /* Support */,
+				AAAA0000000000000000AAAC /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AAAA0000000000000000AAAC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AAAA0000000000000000AAAF /* Xg2g.app */,
+				AAAA0000000000000000AAB0 /* Xg2gTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AAAA0000000000000000AAC5 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				AAAA0000000000000000AAC4 /* Info.plist */,
+				AAAA0000000000000000AAC6 /* Info-Debug.plist */,
+			);
+			path = Support;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AAAA0000000000000000AAAD /* Xg2g */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AAAA0000000000000000AABA /* Build configuration list for PBXNativeTarget "Xg2g" */;
+			buildPhases = (
+				AAAA0000000000000000AAB3 /* Sources */,
+				AAAA0000000000000000AAB4 /* Frameworks */,
+				AAAA0000000000000000AAB5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				AAAA0000000000000000AAB1 /* Xg2g */,
+			);
+			name = Xg2g;
+			productName = Xg2g;
+			productReference = AAAA0000000000000000AAAF /* Xg2g.app */;
+			productType = "com.apple.product-type.application";
+		};
+		AAAA0000000000000000AAAE /* Xg2gTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AAAA0000000000000000AABB /* Build configuration list for PBXNativeTarget "Xg2gTests" */;
+			buildPhases = (
+				AAAA0000000000000000AAB6 /* Sources */,
+				AAAA0000000000000000AAB7 /* Frameworks */,
+				AAAA0000000000000000AAB8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AAAA0000000000000000AAC2 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AAAA0000000000000000AAB2 /* Xg2gTests */,
+			);
+			name = Xg2gTests;
+			productName = Xg2gTests;
+			productReference = AAAA0000000000000000AAB0 /* Xg2gTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AAAA0000000000000000AAAA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
+				TargetAttributes = {
+					AAAA0000000000000000AAAD = {
+						CreatedOnToolsVersion = 26.6;
+					};
+					AAAA0000000000000000AAAE = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = AAAA0000000000000000AAAD;
+					};
+				};
+			};
+			buildConfigurationList = AAAA0000000000000000AAB9 /* Build configuration list for PBXProject "Xg2g" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AAAA0000000000000000AAAB;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = AAAA0000000000000000AAAC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AAAA0000000000000000AAAD /* Xg2g */,
+				AAAA0000000000000000AAAE /* Xg2gTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AAAA0000000000000000AAB5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AAAA0000000000000000AAB8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AAAA0000000000000000AAB3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AAAA0000000000000000AAB6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AAAA0000000000000000AAC2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AAAA0000000000000000AAAD /* Xg2g */;
+			targetProxy = AAAA0000000000000000AAC3 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+		AAAA0000000000000000AAC3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AAAA0000000000000000AAAA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AAAA0000000000000000AAAD;
+			remoteInfo = Xg2g;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin XCBuildConfiguration section */
+		AAAA0000000000000000AABC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		AAAA0000000000000000AABD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AAAA0000000000000000AABE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "Support/Info-Debug.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.manugh.xg2g.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AAAA0000000000000000AABF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Support/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.manugh.xg2g.ios;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		AAAA0000000000000000AAC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.manugh.xg2g.ios.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Xg2g.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Xg2g";
+			};
+			name = Debug;
+		};
+		AAAA0000000000000000AAC1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.manugh.xg2g.ios.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Xg2g.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Xg2g";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AAAA0000000000000000AAB9 /* Build configuration list for PBXProject "Xg2g" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AAAA0000000000000000AABC /* Debug */,
+				AAAA0000000000000000AABD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AAAA0000000000000000AABA /* Build configuration list for PBXNativeTarget "Xg2g" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AAAA0000000000000000AABE /* Debug */,
+				AAAA0000000000000000AABF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AAAA0000000000000000AABB /* Build configuration list for PBXNativeTarget "Xg2gTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AAAA0000000000000000AAC0 /* Debug */,
+				AAAA0000000000000000AAC1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AAAA0000000000000000AAAA /* Project object */;
+}

--- a/ios/Xg2g.xcodeproj/xcshareddata/xcschemes/Xg2g.xcscheme
+++ b/ios/Xg2g.xcodeproj/xcshareddata/xcschemes/Xg2g.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2660"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAAA0000000000000000AAAD"
+               BuildableName = "Xg2g.app"
+               BlueprintName = "Xg2g"
+               ReferencedContainer = "container:Xg2g.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAAA0000000000000000AAAE"
+               BuildableName = "Xg2gTests.xctest"
+               BlueprintName = "Xg2gTests"
+               ReferencedContainer = "container:Xg2g.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AAAA0000000000000000AAAD"
+            BuildableName = "Xg2g.app"
+            BlueprintName = "Xg2g"
+            ReferencedContainer = "container:Xg2g.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AAAA0000000000000000AAAD"
+            BuildableName = "Xg2g.app"
+            BlueprintName = "Xg2g"
+            ReferencedContainer = "container:Xg2g.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Xg2g/APIClient.swift
+++ b/ios/Xg2g/APIClient.swift
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+enum HTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+}
+
+/// Marker for endpoints that answer with no body (204, or a 200 we ignore).
+struct EmptyResponse: Decodable, Equatable, Sendable {
+    init() {}
+    init(from decoder: Decoder) throws { self.init() }
+}
+
+/// One API call, described in terms of the v3 API rather than of URLs.
+///
+/// `path` is relative to `ServerAddress.apiBaseURL` — for example
+/// `"services/bouquets"`. Callers never build absolute URLs, so the deployment
+/// root stays the single source of truth for where the API lives.
+struct APIRequest<Response: Decodable & Sendable>: Sendable {
+    let method: HTTPMethod
+    let path: String
+    let query: [URLQueryItem]
+    let body: Data?
+    let contentType: String?
+
+    init(
+        method: HTTPMethod = .get,
+        path: String,
+        query: [URLQueryItem] = [],
+        body: Data? = nil,
+        contentType: String? = nil
+    ) {
+        self.method = method
+        self.path = path
+        self.query = query
+        self.body = body
+        self.contentType = contentType
+    }
+}
+
+/// Adds authentication to an outgoing request.
+///
+/// A seam rather than an implementation: 2B supplies the DPoP-bound one. The
+/// client itself never learns what a credential key is called, what a device
+/// key is, or how a proof is built.
+protocol RequestAuthorizer: Sendable {
+    func authorized(_ request: URLRequest) async throws -> URLRequest
+}
+
+/// No authentication. Used for pairing endpoints, which are unauthenticated by
+/// definition, and until 2B lands.
+struct UnauthenticatedRequests: RequestAuthorizer {
+    func authorized(_ request: URLRequest) async throws -> URLRequest { request }
+}
+
+protocol APIClient: Sendable {
+    func send<Response>(_ request: APIRequest<Response>) async throws -> Response
+}
+
+/// `URLSession`-backed client.
+///
+/// Owns requests, JSON, status codes, timeouts and error mapping. It does not
+/// own credential key names, Secure Enclave details, or playback decisions —
+/// those belong to `CredentialStore`, `DeviceKeyStore` and the server
+/// respectively.
+struct HTTPAPIClient: APIClient {
+
+    private let address: ServerAddress
+    private let session: URLSession
+    private let authorizer: RequestAuthorizer
+    private let decoder: JSONDecoder
+
+    init(
+        address: ServerAddress,
+        session: URLSession = .shared,
+        authorizer: RequestAuthorizer = UnauthenticatedRequests()
+    ) {
+        self.address = address
+        self.session = session
+        self.authorizer = authorizer
+        self.decoder = .xg2g
+    }
+
+    func send<Response>(_ request: APIRequest<Response>) async throws -> Response {
+        let urlRequest = try makeURLRequest(for: request)
+        let authorized: URLRequest
+        do {
+            authorized = try await authorizer.authorized(urlRequest)
+        } catch {
+            throw APIError.invalidEndpoint(path: request.path)
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: authorized)
+        } catch let urlError as URLError {
+            throw APIError.transport(TransportFailure(urlError: urlError))
+        } catch {
+            throw APIError.transport(.other(code: (error as NSError).code))
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.transport(.other(code: 0))
+        }
+
+        let contentType = http.value(forHTTPHeaderField: "Content-Type")
+
+        guard (200...299).contains(http.statusCode) else {
+            throw problemOrHTTPError(data: data, status: http.statusCode, contentType: contentType)
+        }
+
+        if Response.self == EmptyResponse.self {
+            // No body promised, so an unparseable one is not a contract breach.
+            return EmptyResponse() as! Response
+        }
+
+        do {
+            return try decoder.decode(Response.self, from: data)
+        } catch {
+            // HTTP said yes and the body says something else. This is the
+            // "an HTML page came back with 200" case, kept distinguishable
+            // from both transport and HTTP failures on purpose.
+            throw APIError.unexpectedPayload(
+                UnexpectedPayload(
+                    url: authorized.url ?? address.apiBaseURL,
+                    status: http.statusCode,
+                    contentType: contentType,
+                    bodyPreview: Self.preview(of: data),
+                    expected: String(describing: Response.self)
+                )
+            )
+        }
+    }
+
+    // MARK: - Internals
+
+    private func makeURLRequest<Response>(for request: APIRequest<Response>) throws -> URLRequest {
+        // Relative to the API base, which is itself derived from the stored
+        // deployment root. A leading slash would escape it, so it is refused
+        // rather than quietly normalized away.
+        guard !request.path.hasPrefix("/") else {
+            throw APIError.invalidEndpoint(path: request.path)
+        }
+        guard var components = URLComponents(
+            url: address.apiBaseURL.appendingPathComponent(request.path),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw APIError.invalidEndpoint(path: request.path)
+        }
+        if !request.query.isEmpty {
+            components.queryItems = request.query
+        }
+        guard let url = components.url else {
+            throw APIError.invalidEndpoint(path: request.path)
+        }
+
+        // The boundary is the API base, not the deployment root: a path such as
+        // `api/v3/../../admin` resolves back inside the deployment and would
+        // pass a root-level check while having left the API entirely. Reuses
+        // the one containment implementation rather than growing a second.
+        guard address.apiScope.contains(url) else {
+            throw APIError.invalidEndpoint(path: request.path)
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = request.method.rawValue
+        urlRequest.httpBody = request.body
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let contentType = request.contentType {
+            urlRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        return urlRequest
+    }
+
+    private func problemOrHTTPError(data: Data, status: Int, contentType: String?) -> APIError {
+        let isProblemDocument = contentType?
+            .lowercased()
+            .contains("application/problem+json") ?? false
+
+        if isProblemDocument, let problem = try? decoder.decode(ProblemDetails.self, from: data) {
+            return .problem(problem)
+        }
+
+        // A non-2xx that is not a problem document usually means something other
+        // than the API answered — a proxy, a gateway, or the SPA.
+        return .http(status: status, contentType: contentType, bodyPreview: Self.preview(of: data))
+    }
+
+    private static func preview(of data: Data, limit: Int = 256) -> String {
+        let text = String(decoding: data.prefix(limit), as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return data.count > limit ? text + "…" : text
+    }
+}
+
+extension JSONDecoder {
+    /// Decoder matching what the Go backend actually emits.
+    ///
+    /// Go's `time.Time` marshals as RFC 3339 **Nano**: fractional seconds appear
+    /// only when non-zero, so the same field is `…T12:00:00Z` one moment and
+    /// `…T12:00:00.529Z` the next. Foundation's `.iso8601` strategy rejects the
+    /// fractional form outright, which would make token expiry decoding fail
+    /// intermittently — roughly whenever the server's clock lands on a
+    /// non-integral second.
+    static var xg2g: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let text = try container.decode(String.self)
+
+            if let date = try? rfc3339WithFraction.parse(text) { return date }
+            if let date = try? rfc3339.parse(text) { return date }
+
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "expected an RFC 3339 timestamp, got \(text)"
+            )
+        }
+        return decoder
+    }
+
+    // `Date.ISO8601FormatStyle` is a value type and therefore `Sendable`,
+    // unlike `ISO8601DateFormatter` — no shared mutable state to reason about.
+    private static let rfc3339WithFraction = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+    private static let rfc3339 = Date.ISO8601FormatStyle(includingFractionalSeconds: false)
+}

--- a/ios/Xg2g/APIError.swift
+++ b/ios/Xg2g/APIError.swift
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// RFC 7807 problem document, as the API actually defines it.
+///
+/// `type`, `title`, `status` and `requestId` are required by the schema; the
+/// rest is optional. `requestId` is carried through every error because it is
+/// the only thing that correlates a client-side failure with a server log line.
+struct ProblemDetails: Equatable, Sendable, Decodable {
+    let type: String
+    let title: String
+    let status: Int
+    let requestId: String
+    let code: String?
+    let detail: String?
+    let instance: String?
+}
+
+/// Why no response came back at all.
+enum TransportFailure: Equatable, Sendable {
+    case offline
+    case timedOut
+    case cannotConnect
+    case tls
+    case cancelled
+    case other(code: Int)
+}
+
+/// A 2xx response whose body is not what the endpoint promised.
+///
+/// This is its own category on purpose. The Android client requested the API
+/// through the Web UI path and got the SPA's HTML back **with status 200** —
+/// neither a transport failure nor an HTTP error, and invisible if everything
+/// collapses into a generic "network error". Naming it makes that class of bug
+/// diagnosable from a single log line.
+struct UnexpectedPayload: Equatable, Sendable {
+    let url: URL
+    let status: Int
+    let contentType: String?
+    /// Truncated; enough to recognise an HTML page or a proxy notice.
+    let bodyPreview: String
+    let expected: String
+}
+
+enum APIError: Error, Equatable, Sendable {
+    /// Nothing came back: DNS, TLS, timeout, offline, cancelled.
+    case transport(TransportFailure)
+
+    /// The API answered with a well-formed problem document.
+    case problem(ProblemDetails)
+
+    /// An HTTP error status without a usable problem document — typically a
+    /// proxy or gateway answering instead of the API.
+    case http(status: Int, contentType: String?, bodyPreview: String)
+
+    /// HTTP succeeded but the payload was not the promised shape.
+    case unexpectedPayload(UnexpectedPayload)
+
+    /// The request could not be built, or resolved outside the configured
+    /// deployment. A programming error, surfaced rather than silently sent.
+    case invalidEndpoint(path: String)
+
+    /// The correlation id, when the server supplied one.
+    var requestID: String? {
+        if case .problem(let problem) = self { return problem.requestId }
+        return nil
+    }
+
+    /// True when retrying the identical request could plausibly succeed.
+    var isRetryable: Bool {
+        switch self {
+        case .transport(let failure):
+            return failure != .cancelled
+        case .problem(let problem):
+            return problem.status == 429 || (500...599).contains(problem.status)
+        case .http(let status, _, _):
+            return status == 429 || (500...599).contains(status)
+        case .unexpectedPayload, .invalidEndpoint:
+            // A wrong body or a wrong URL will be just as wrong next time.
+            return false
+        }
+    }
+}
+
+extension TransportFailure {
+    init(urlError: URLError) {
+        switch urlError.code {
+        case .notConnectedToInternet, .dataNotAllowed, .internationalRoamingOff:
+            self = .offline
+        case .timedOut:
+            self = .timedOut
+        case .cannotConnectToHost, .cannotFindHost, .dnsLookupFailed, .networkConnectionLost:
+            self = .cannotConnect
+        case .secureConnectionFailed,
+             .serverCertificateUntrusted,
+             .serverCertificateHasBadDate,
+             .serverCertificateNotYetValid,
+             .serverCertificateHasUnknownRoot,
+             .clientCertificateRejected,
+             .clientCertificateRequired,
+             .appTransportSecurityRequiresSecureConnection:
+            self = .tls
+        case .cancelled:
+            self = .cancelled
+        default:
+            self = .other(code: urlError.errorCode)
+        }
+    }
+}

--- a/ios/Xg2g/CredentialKeyEncoding.swift
+++ b/ios/Xg2g/CredentialKeyEncoding.swift
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// What a stored secret is.
+///
+/// The kinds are separate so that destroying one class of secret cannot take
+/// another with it — notably, clearing credentials must never destroy the
+/// device key, which is a cryptographic identity with its own lifecycle.
+enum CredentialKind: String, Sendable, CaseIterable {
+    case deviceGrant = "device_grant"
+    case accessToken = "access_token"
+    case accessSession = "access_session"
+}
+
+/// Serializes domain identities into stable Keychain account strings.
+///
+/// Kept out of `ServerIdentity` on purpose. If the domain type carried its own
+/// storage format, every storage change would become a domain change and
+/// business logic would start depending on an Apple persistence detail. This is
+/// the one place that knows what a key looks like.
+///
+/// The format is versioned. Changing how keys are built is a migration, not an
+/// edit: bump `version`, keep the old reader, and move entries deliberately.
+enum CredentialKeyEncoding {
+
+    /// Bump only together with a migration path for previously written keys.
+    static let version = 1
+
+    /// Keychain service under which *all* of this app's secrets live.
+    ///
+    /// A single owned service is what makes a wipe-on-reinstall possible: at
+    /// first launch after reinstall the app does not yet know which identities
+    /// were stored, so it can only purge by service, not by enumerating them.
+    static let service = "io.github.manugh.xg2g.credentials"
+
+    /// Account string for one secret of one identity.
+    ///
+    /// The identity discriminator (`addr` / `inst`) keeps the two namespaces
+    /// disjoint, so an address-bound entry can never collide with an
+    /// instance-bound one even if a server minted an ID that looks like a URL.
+    static func account(for identity: ServerIdentity, kind: CredentialKind) -> String {
+        "v\(version).\(namespace(of: identity)).\(kind.rawValue)"
+    }
+
+    /// Namespace component for an identity. Internal to the encoding.
+    private static func namespace(of identity: ServerIdentity) -> String {
+        switch identity {
+        case .address(let address):
+            // The canonical address string is already collision-free across
+            // spellings; percent-encoding keeps the "." separator unambiguous.
+            return "addr.\(escaped(address.description))"
+        case .instance(let id):
+            // InstanceID is validated to [A-Za-z0-9._-] at construction, so it
+            // cannot introduce a separator here.
+            return "inst.\(id.rawValue)"
+        }
+    }
+
+    private static let separatorSafe: CharacterSet = {
+        CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_~"))
+    }()
+
+    private static func escaped(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: separatorSafe) ?? value
+    }
+}

--- a/ios/Xg2g/CredentialStore.swift
+++ b/ios/Xg2g/CredentialStore.swift
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// Typed access to stored credentials.
+///
+/// ## Invariant
+///
+/// **No caller ever sees a storage key or a namespace string.** Every operation
+/// is expressed in domain terms — "the grant for this identity", "this session
+/// was refreshed". Without that rule `CredentialKeyEncoding` protects nothing:
+/// the storage representation simply leaks out through whoever composes a key
+/// by hand, and from then on the format is load-bearing everywhere.
+///
+/// ## What this deliberately does not offer
+///
+/// There is no `revoke`. Revoking a device is remote-first — revoke server-side,
+/// wait for success or a defined terminal failure, and only then destroy local
+/// material. A local-first `revoke` here would be an attractive nuisance: the
+/// key needed to authenticate the revocation would already be gone, leaving a
+/// grant that is valid on the server and no longer revocable from this device.
+/// That sequencing belongs to the auth coordinator, which owns the network call.
+///
+/// Nothing here touches the DPoP device key either; that is `DeviceKeyStore`'s
+/// property and has its own lifecycle.
+protocol CredentialStore: Sendable {
+
+    /// Must run before any read. On a fresh install it purges Keychain material
+    /// that survived a previous installation.
+    func prepareForLaunch() async throws
+
+    func deviceGrant(for identity: ServerIdentity) async throws -> DeviceGrant?
+    func store(_ grant: DeviceGrant, for identity: ServerIdentity) async throws
+
+    func accessSession(for identity: ServerIdentity) async throws -> AccessSession?
+    func store(_ session: AccessSession, for identity: ServerIdentity) async throws
+
+    /// Log out: drop the session, keep the pairing.
+    func endSession(for identity: ServerIdentity) async throws
+
+    /// Forget server: drop every credential for this identity. Keeps the device
+    /// key, which is not server-specific.
+    func forgetServer(_ identity: ServerIdentity) async throws
+
+    /// Re-key credentials after an identity upgrade (`.address` → `.instance`).
+    func migrate(from old: ServerIdentity, to new: ServerIdentity) async throws
+
+    /// Drop everything this app owns.
+    func purgeEverything() async throws
+}
+
+enum CredentialStoreError: Error, Equatable, Sendable {
+    /// A read was attempted before ``CredentialStore/prepareForLaunch()``.
+    case notPrepared
+    case keychain(OSStatus)
+    case malformedStoredValue(CredentialKind)
+    case encodingFailed(CredentialKind)
+}
+
+// MARK: - Keychain backend
+
+/// The raw key/value surface `KeychainCredentialStore` needs.
+///
+/// Extracted so the store's lifecycle rules can be tested without a Keychain,
+/// and so the real `SecItem` attributes are testable on their own.
+protocol KeychainBackend: Sendable {
+    func set(_ data: Data, service: String, account: String) throws
+    func data(service: String, account: String) throws -> Data?
+    func remove(service: String, account: String) throws
+    func removeAll(service: String) throws
+}
+
+/// Records whether this *installation* has run before.
+///
+/// Backed by `UserDefaults`, which is erased when the app is deleted — unlike
+/// the Keychain, which is not. That asymmetry is the whole detection mechanism.
+protocol InstallationMarkerStore: Sendable {
+    func isMarked() -> Bool
+    func mark()
+}
+
+struct UserDefaultsInstallationMarker: InstallationMarkerStore {
+    private let key = "io.github.manugh.xg2g.installationMarker"
+
+    // `UserDefaults` is documented as thread-safe but is not annotated
+    // `Sendable`, so the guarantee has to be asserted here rather than derived.
+    nonisolated(unsafe) private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func isMarked() -> Bool { defaults.bool(forKey: key) }
+    func mark() { defaults.set(true, forKey: key) }
+}
+
+// MARK: - Store
+
+actor KeychainCredentialStore: CredentialStore {
+
+    private let backend: KeychainBackend
+    private let marker: InstallationMarkerStore
+    private var isPrepared = false
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    init(backend: KeychainBackend, marker: InstallationMarkerStore = UserDefaultsInstallationMarker()) {
+        self.backend = backend
+        self.marker = marker
+    }
+
+    func prepareForLaunch() throws {
+        if !marker.isMarked() {
+            // A fresh installation that nevertheless finds Keychain entries is
+            // looking at a previous installation's credentials. Purge by
+            // service: at this point we do not know which identities were ever
+            // stored, so enumerating them is not possible.
+            try wrap { try backend.removeAll(service: CredentialKeyEncoding.service) }
+            marker.mark()
+        }
+        isPrepared = true
+    }
+
+    func deviceGrant(for identity: ServerIdentity) throws -> DeviceGrant? {
+        try load(DeviceGrant.self, kind: .deviceGrant, identity: identity)
+    }
+
+    func store(_ grant: DeviceGrant, for identity: ServerIdentity) throws {
+        try save(grant, kind: .deviceGrant, identity: identity)
+    }
+
+    func accessSession(for identity: ServerIdentity) throws -> AccessSession? {
+        try load(AccessSession.self, kind: .accessSession, identity: identity)
+    }
+
+    func store(_ session: AccessSession, for identity: ServerIdentity) throws {
+        try save(session, kind: .accessSession, identity: identity)
+    }
+
+    func endSession(for identity: ServerIdentity) throws {
+        try requirePrepared()
+        try remove(kind: .accessSession, identity: identity)
+        try remove(kind: .accessToken, identity: identity)
+    }
+
+    func forgetServer(_ identity: ServerIdentity) throws {
+        try requirePrepared()
+        for kind in CredentialKind.allCases {
+            try remove(kind: kind, identity: identity)
+        }
+    }
+
+    func migrate(from old: ServerIdentity, to new: ServerIdentity) throws {
+        try requirePrepared()
+        guard old != new else { return }
+
+        // Write the new entries before removing the old ones. An interruption
+        // then leaves a harmless duplicate rather than no credentials at all;
+        // the stale copy is cleaned up by a later forget or reinstall purge.
+        for kind in CredentialKind.allCases {
+            let account = CredentialKeyEncoding.account(for: old, kind: kind)
+            guard let data = try wrap({ try backend.data(service: CredentialKeyEncoding.service, account: account) }) else {
+                continue
+            }
+            try wrap {
+                try backend.set(
+                    data,
+                    service: CredentialKeyEncoding.service,
+                    account: CredentialKeyEncoding.account(for: new, kind: kind)
+                )
+            }
+        }
+
+        for kind in CredentialKind.allCases {
+            try remove(kind: kind, identity: old)
+        }
+    }
+
+    func purgeEverything() throws {
+        try wrap { try backend.removeAll(service: CredentialKeyEncoding.service) }
+    }
+
+    // MARK: - Internals
+
+    private func requirePrepared() throws {
+        guard isPrepared else { throw CredentialStoreError.notPrepared }
+    }
+
+    private func load<T: Decodable>(_ type: T.Type, kind: CredentialKind, identity: ServerIdentity) throws -> T? {
+        try requirePrepared()
+        let account = CredentialKeyEncoding.account(for: identity, kind: kind)
+        guard let data = try wrap({ try backend.data(service: CredentialKeyEncoding.service, account: account) }) else {
+            return nil
+        }
+        guard let value = try? decoder.decode(T.self, from: data) else {
+            throw CredentialStoreError.malformedStoredValue(kind)
+        }
+        return value
+    }
+
+    private func save<T: Encodable>(_ value: T, kind: CredentialKind, identity: ServerIdentity) throws {
+        try requirePrepared()
+        guard let data = try? encoder.encode(value) else {
+            throw CredentialStoreError.encodingFailed(kind)
+        }
+        try wrap {
+            try backend.set(
+                data,
+                service: CredentialKeyEncoding.service,
+                account: CredentialKeyEncoding.account(for: identity, kind: kind)
+            )
+        }
+    }
+
+    private func remove(kind: CredentialKind, identity: ServerIdentity) throws {
+        try wrap {
+            try backend.remove(
+                service: CredentialKeyEncoding.service,
+                account: CredentialKeyEncoding.account(for: identity, kind: kind)
+            )
+        }
+    }
+
+    @discardableResult
+    private func wrap<T>(_ body: () throws -> T) throws -> T {
+        do {
+            return try body()
+        } catch let error as CredentialStoreError {
+            throw error
+        } catch {
+            throw CredentialStoreError.keychain(errSecInternalError)
+        }
+    }
+}

--- a/ios/Xg2g/Credentials.swift
+++ b/ios/Xg2g/Credentials.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// Long-lived proof that this device was paired with a server.
+///
+/// Separate from the DPoP device key on purpose: the grant is a *credential*
+/// the server issued, the key is a cryptographic *identity* this device owns.
+/// Clearing one must never take the other with it.
+struct DeviceGrant: Equatable, Sendable, Codable {
+    let id: String
+    let secret: String
+    let expiresAt: Date?
+
+    /// The server may rotate a grant on refresh; this keeps the call site
+    /// honest about which fields changed.
+    func rotated(id newID: String?, secret newSecret: String?, expiresAt newExpiry: Date?) -> DeviceGrant {
+        DeviceGrant(
+            id: newID ?? id,
+            secret: newSecret ?? secret,
+            expiresAt: newExpiry ?? expiresAt
+        )
+    }
+}
+
+/// A short-lived access session obtained with a `DeviceGrant`.
+struct AccessSession: Equatable, Sendable, Codable {
+    let sessionID: String
+    let token: String
+    let expiresAt: Date
+    let policyVersion: String?
+
+    /// Treat a token as expired this long before it actually is, so a request
+    /// cannot be issued with a token that dies in flight.
+    ///
+    /// Android has this value twice — `ACCESS_TOKEN_EXPIRY_SKEW_MS` in
+    /// `DeviceAuthStore` and an inline `30_000L` in
+    /// `NativeDeviceAuthRepository`. Same number today, two places to change.
+    /// Here it exists once.
+    static let expirySkew: TimeInterval = 30
+
+    func isUsable(at now: Date) -> Bool {
+        guard !token.isEmpty else { return false }
+        return now.addingTimeInterval(Self.expirySkew) < expiresAt
+    }
+}

--- a/ios/Xg2g/DeepLinkParser.swift
+++ b/ios/Xg2g/DeepLinkParser.swift
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// Launch-time device auth material carried by an onboarding link.
+///
+/// Mirrors `DeviceAuthLaunchCredentials` on Android; the query keys are part of
+/// the wire contract and must stay in step with it.
+struct DeviceAuthLaunchCredentials: Equatable, Sendable {
+    let deviceGrantID: String?
+    let deviceGrant: String?
+    let accessToken: String?
+    let accessTokenExpiresAtEpochMs: Int64?
+}
+
+/// Reads onboarding links. Nothing else.
+///
+/// This type deliberately owns **no** URL semantics: no normalization, no
+/// origin comparison, no path containment. `ServerOrigin` owns origin
+/// semantics, `ServerAddress` owns deployment and path semantics, and anything
+/// this parser extracts goes through `ServerAddressParser.parseTrusted`. A
+/// second normalizer living here is what let the Android client end up with two
+/// disagreeing opinions about the same URL.
+enum DeepLinkParser {
+
+    static let customScheme = "xg2g"
+
+    private enum QueryKey {
+        static let baseURL = "base_url"
+        static let authToken = "auth_token"
+        static let deviceGrantID = "device_grant_id"
+        static let deviceGrant = "device_grant"
+        static let launchAccessToken = "launch_access_token"
+        static let launchAccessTokenExpiresAt = "launch_access_token_expires_at"
+        static let legacyAccessToken = "access_token"
+        static let legacyAccessTokenExpiresAt = "access_token_expires_at"
+    }
+
+    /// The server an onboarding link configures, if any.
+    ///
+    /// ## Security invariant
+    ///
+    /// **Only the `xg2g://` scheme may change server configuration.** An
+    /// `https://` link configures nothing, ever. Such a link is a content link
+    /// into a server the user already bound; letting one point the app at a
+    /// *new* server would mean an arbitrary web page could nominate the host
+    /// this client sends credentials to. Android permits it behind an
+    /// `isServerSwitch` confirmation, so a dialog is the only thing standing in
+    /// the way. If universal links are added later they may open content within
+    /// an already-bound server — they must never bind a new one.
+    ///
+    /// ## Transport form of `base_url`
+    ///
+    /// The `base_url` on the wire is the **Web UI URL**, not the deployment
+    /// root: `apps/webui/src/components/Settings.tsx` mints it as
+    /// `new URL('/ui/', endpoint)`, yielding `https://host/ui/`.
+    ///
+    /// That form is accepted here and converted to a deployment root exactly
+    /// once, at this boundary. Past this function nothing in the app deals in
+    /// UI URLs. This is not the guessing that `rootCandidates` exists to avoid:
+    /// it is a documented transport format with a deterministic, total
+    /// conversion, applied at the edge rather than smeared through the core.
+    static func configuredAddress(from url: URL) -> ServerAddress? {
+        guard let components = components(of: url),
+              components.scheme?.lowercased() == customScheme,
+              let rawBaseURL = queryParameter(components.percentEncodedQuery, named: QueryKey.baseURL),
+              let transported = try? ServerAddressParser.parseTrusted(rawBaseURL)
+        else { return nil }
+
+        return deploymentRoot(ofTransported: transported)
+    }
+
+    /// Converts the link's Web-UI-shaped `base_url` into a deployment root.
+    ///
+    /// A trailing `/ui/` is removed exactly once. A link that already carries a
+    /// root — which a future link generator may well mint — passes through
+    /// unchanged, so both forms work without the caller having to know which
+    /// one it got.
+    private static func deploymentRoot(ofTransported address: ServerAddress) -> ServerAddress {
+        address.rootCandidates.last ?? address
+    }
+
+    static func authToken(from url: URL) -> String? {
+        guard let components = customSchemeComponents(of: url) else { return nil }
+        return trimmedNonEmpty(queryParameter(components.percentEncodedQuery, named: QueryKey.authToken))
+    }
+
+    static func accessToken(from url: URL) -> String? {
+        guard let components = customSchemeComponents(of: url) else { return nil }
+        return trimmedNonEmpty(
+            queryParameter(
+                components.percentEncodedQuery,
+                namedAnyOf: [QueryKey.launchAccessToken, QueryKey.legacyAccessToken]
+            )
+        )
+    }
+
+    static func launchCredentials(from url: URL) -> DeviceAuthLaunchCredentials? {
+        guard let components = customSchemeComponents(of: url) else { return nil }
+        let rawQuery = components.percentEncodedQuery
+
+        let deviceGrantID = trimmedNonEmpty(queryParameter(rawQuery, named: QueryKey.deviceGrantID))
+        let deviceGrant = trimmedNonEmpty(queryParameter(rawQuery, named: QueryKey.deviceGrant))
+        let accessToken = accessToken(from: url)
+        let expiresAtEpochMs = expiryEpochMs(
+            queryParameter(
+                rawQuery,
+                namedAnyOf: [QueryKey.launchAccessTokenExpiresAt, QueryKey.legacyAccessTokenExpiresAt]
+            )
+        )
+
+        if deviceGrantID == nil, deviceGrant == nil, accessToken == nil, expiresAtEpochMs == nil {
+            return nil
+        }
+
+        return DeviceAuthLaunchCredentials(
+            deviceGrantID: deviceGrantID,
+            deviceGrant: deviceGrant,
+            accessToken: accessToken,
+            accessTokenExpiresAtEpochMs: expiresAtEpochMs
+        )
+    }
+
+    /// A bare number is epoch milliseconds; anything else is tried as an
+    /// RFC 1123 HTTP date. Same two-step contract as Android's
+    /// `parseDeviceAuthExpiryEpochMs`.
+    static func expiryEpochMs(_ value: String?) -> Int64? {
+        guard let trimmed = trimmedNonEmpty(value) else { return nil }
+
+        if let numeric = Int64(trimmed) {
+            return numeric > 0 ? numeric : nil
+        }
+
+        guard let date = rfc1123Formatter.date(from: trimmed) else { return nil }
+        return Int64((date.timeIntervalSince1970 * 1000).rounded())
+    }
+
+    // MARK: - Internals
+
+    private static func components(of url: URL) -> URLComponents? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)
+    }
+
+    private static func customSchemeComponents(of url: URL) -> URLComponents? {
+        guard let components = components(of: url),
+              components.scheme?.lowercased() == customScheme
+        else { return nil }
+        return components
+    }
+
+    private static func trimmedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func queryParameter(_ rawQuery: String?, named name: String) -> String? {
+        guard let rawQuery, !rawQuery.isEmpty else { return nil }
+
+        for part in rawQuery.split(separator: "&", omittingEmptySubsequences: true) {
+            let piece = String(part)
+            let key: String
+            let value: String
+
+            if let separator = piece.firstIndex(of: "=") {
+                key = String(piece[piece.startIndex..<separator])
+                value = String(piece[piece.index(after: separator)...])
+            } else {
+                key = piece
+                value = ""
+            }
+
+            if percentDecoded(key) == name {
+                return percentDecoded(value)
+            }
+        }
+        return nil
+    }
+
+    private static func queryParameter(_ rawQuery: String?, namedAnyOf names: [String]) -> String? {
+        for name in names {
+            if let value = queryParameter(rawQuery, named: name) { return value }
+        }
+        return nil
+    }
+
+    private static func percentDecoded(_ value: String) -> String {
+        // `+` means space in a query component, matching Android's URLDecoder.
+        let plusDecoded = value.replacingOccurrences(of: "+", with: " ")
+        return plusDecoded.removingPercentEncoding ?? plusDecoded
+    }
+
+    private static let rfc1123Formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter
+    }()
+}

--- a/ios/Xg2g/DeviceKey.swift
+++ b/ios/Xg2g/DeviceKey.swift
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import CryptoKit
+import Foundation
+
+/// Where the device's private key physically lives.
+///
+/// This is part of the API on purpose. A software key and a Secure Enclave key
+/// are not interchangeable: only the latter is non-exportable and therefore
+/// actually device-bound. Callers — and later the backend — must be able to
+/// tell them apart and decide, rather than be handed "a key" and assume.
+enum DeviceKeyProvenance: String, Sendable, Codable {
+    /// Non-exportable, generated in and confined to the Secure Enclave.
+    case hardwareBacked
+    /// An ordinary Keychain key. Extractable in principle; development only.
+    case software
+}
+
+/// Why a software key was permitted. Required so the reason is recorded rather
+/// than inferred later from the absence of hardware.
+enum SoftwareKeyReason: String, Sendable, Codable {
+    case simulator
+    case development
+}
+
+/// Whether a software key may be created at all.
+enum DeviceKeyPolicy: Sendable, Equatable {
+    /// Hardware only. Provisioning fails outright if the Secure Enclave is
+    /// unavailable — no fallback, silent or otherwise.
+    case requireHardware
+    /// A software key is acceptable. Must be chosen explicitly.
+    case allowSoftware(reason: SoftwareKeyReason)
+
+    /// The policy for this build.
+    ///
+    /// The software case is behind `#if targetEnvironment(simulator)`, so a
+    /// real iOS build cannot construct it at all: a development convenience
+    /// cannot turn into a production weakening later, because the code that
+    /// would allow it is not compiled into the product.
+    static var forCurrentEnvironment: DeviceKeyPolicy {
+        #if targetEnvironment(simulator)
+        return .allowSoftware(reason: .simulator)
+        #else
+        return .requireHardware
+        #endif
+    }
+
+    var permitsSoftware: Bool {
+        if case .allowSoftware = self { return true }
+        return false
+    }
+}
+
+/// The public half of the device key, in JWK form.
+struct ECPublicKeyJWK: Equatable, Sendable, Codable {
+    let kty = "EC"
+    let crv = "P-256"
+    /// Base64url, unpadded, 32 bytes.
+    let x: String
+    /// Base64url, unpadded, 32 bytes.
+    let y: String
+
+    private enum CodingKeys: String, CodingKey {
+        case kty, crv, x, y
+    }
+
+    init(x: String, y: String) {
+        self.x = x
+        self.y = y
+    }
+
+    /// RFC 7638 thumbprint.
+    ///
+    /// The canonical form is byte-identical to the server's
+    /// `identity.ComputeJWKThumbprint`:
+    /// `{"crv":"P-256","kty":"EC","x":…,"y":…}`, SHA-256, base64url unpadded.
+    /// Members in lexicographic order, no whitespace — any deviation yields a
+    /// different `jkt` and every proof is rejected.
+    var thumbprint: String {
+        let canonical = #"{"crv":"P-256","kty":"EC","x":"\#(x)","y":"\#(y)"}"#
+        return Base64URL.encode(Data(SHA256.hash(data: Data(canonical.utf8))))
+    }
+}
+
+/// What the app can say about the key it holds.
+struct DeviceKeyAttestation: Equatable, Sendable {
+    let provenance: DeviceKeyProvenance
+    let publicKey: ECPublicKeyJWK
+
+    var thumbprint: String { publicKey.thumbprint }
+}
+
+enum DeviceKeyError: Error, Equatable, Sendable {
+    /// Policy demanded hardware and the Secure Enclave is not available here.
+    case secureEnclaveUnavailable
+    case keyNotProvisioned
+    /// A key exists but its provenance is weaker than the policy allows. Never
+    /// resolved by using it anyway.
+    case provenanceMismatch(found: DeviceKeyProvenance, policy: DeviceKeyProvenance)
+    case keychain(OSStatus)
+    case keyGenerationFailed
+    case signingFailed
+    case malformedSignature
+    case malformedPublicKey
+}
+
+/// Base64url without padding, as every JOSE field requires.
+enum Base64URL {
+    static func encode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/ios/Xg2g/DeviceKeyStore.swift
+++ b/ios/Xg2g/DeviceKeyStore.swift
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Security
+
+/// The device's cryptographic identity.
+///
+/// ## Invariants
+///
+/// 1. **Provenance is part of the API.** Callers always know whether they hold
+///    a Secure Enclave key or a software key.
+/// 2. **A software key never silently substitutes for a hardware key.** It is
+///    created only under an explicit ``DeviceKeyPolicy/allowSoftware(reason:)``,
+///    which a real iOS build cannot even construct. If a key exists whose
+///    provenance is weaker than the policy, every operation fails rather than
+///    proceeding.
+/// 3. **The private key never leaves this type.** The surface is "sign these
+///    bytes"; no `SecKey`, no key data, no Security-framework object is handed
+///    out. DPoP proof construction is built entirely on top of `sign(_:)`.
+///
+/// This is deliberately *not* a "DPoP provider". Only the non-exportable key
+/// lives in the Secure Enclave; JWT assembly, `jti`, `htm`/`htu`, `ath` and any
+/// nonce handling are ordinary software concerns belonging to a layer above.
+protocol DeviceKeyStore: Sendable {
+    /// The existing key's attestation, or `nil` if none has been provisioned.
+    func attestation() async throws -> DeviceKeyAttestation?
+
+    /// Returns the existing key, creating one if absent.
+    func provisionKey() async throws -> DeviceKeyAttestation
+
+    /// ES256 signature over `data`, as raw `R || S`, exactly 64 bytes.
+    func sign(_ data: Data) async throws -> Data
+
+    /// Destroys the device identity.
+    ///
+    /// Separate from credential clearing on purpose: this is not a credential
+    /// the server issued but an identity this device owns, and it must survive
+    /// a logout or a forgotten server. Revocation is remote-first — the server
+    /// grant is revoked while this key still exists to authenticate the
+    /// revocation, and only then is the key destroyed.
+    func destroyKey() async throws
+}
+
+actor SecureEnclaveDeviceKeyStore: DeviceKeyStore {
+
+    private let policy: DeviceKeyPolicy
+    private let tag: Data
+    private let secureEnclaveProbe: @Sendable () -> Bool
+
+    /// - Parameter secureEnclaveProbe: overridable so the "a software key is
+    ///   never accepted under a hardware policy" invariant can be exercised on
+    ///   machines that *do* have a Secure Enclave — which now includes the
+    ///   simulator on Apple Silicon. Without the seam that test silently
+    ///   no-ops, and a security test that quietly skips is worse than none.
+    ///
+    ///   This cannot weaken anything: the probe only decides what kind of key
+    ///   gets *created*, while `policy` remains the sole gate on what may be
+    ///   *used*. Probing `false` under `.requireHardware` still fails.
+    init(
+        policy: DeviceKeyPolicy = .forCurrentEnvironment,
+        tag: String = "io.github.manugh.xg2g.deviceKey",
+        secureEnclaveProbe: @escaping @Sendable () -> Bool = { SecureEnclaveDeviceKeyStore.isSecureEnclaveAvailable() }
+    ) {
+        self.policy = policy
+        self.tag = Data(tag.utf8)
+        self.secureEnclaveProbe = secureEnclaveProbe
+    }
+
+    /// Whether this device can create Secure Enclave keys.
+    ///
+    /// Probed by actually attempting a key creation rather than by inferring it
+    /// from the platform, because the answer differs between simulator
+    /// generations and inference would be a guess.
+    static func isSecureEnclaveAvailable() -> Bool {
+        guard let access = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            .privateKeyUsage,
+            nil
+        ) else { return false }
+
+        let attributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrKeySizeInBits as String: 256,
+            kSecAttrTokenID as String: kSecAttrTokenIDSecureEnclave,
+            kSecPrivateKeyAttrs as String: [
+                kSecAttrIsPermanent as String: false,
+                kSecAttrAccessControl as String: access,
+            ],
+        ]
+
+        return SecKeyCreateRandomKey(attributes as CFDictionary, nil) != nil
+    }
+
+    // MARK: - DeviceKeyStore
+
+    func attestation() throws -> DeviceKeyAttestation? {
+        guard let key = try loadKey() else { return nil }
+        return try attestation(for: key)
+    }
+
+    func provisionKey() throws -> DeviceKeyAttestation {
+        if let existing = try loadKey() {
+            let attestation = try attestation(for: existing)
+            try enforcePolicy(on: attestation.provenance)
+            return attestation
+        }
+        return try createKey()
+    }
+
+    func sign(_ data: Data) throws -> Data {
+        guard let key = try loadKey() else { throw DeviceKeyError.keyNotProvisioned }
+        // The provenance is checked on every signature, not only at creation:
+        // otherwise a key created under a permissive policy would keep signing
+        // after the policy tightened.
+        try enforcePolicy(on: try attestation(for: key).provenance)
+
+        var error: Unmanaged<CFError>?
+        guard let der = SecKeyCreateSignature(
+            key,
+            .ecdsaSignatureMessageX962SHA256,
+            data as CFData,
+            &error
+        ) as Data? else {
+            throw DeviceKeyError.signingFailed
+        }
+
+        return try ECDSASignature.rawFromDER(der)
+    }
+
+    func destroyKey() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: tag,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw DeviceKeyError.keychain(status)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func enforcePolicy(on provenance: DeviceKeyProvenance) throws {
+        guard provenance == .software, !policy.permitsSoftware else { return }
+        throw DeviceKeyError.provenanceMismatch(found: provenance, policy: .hardwareBacked)
+    }
+
+    private func createKey() throws -> DeviceKeyAttestation {
+        let useSecureEnclave = secureEnclaveProbe()
+
+        if !useSecureEnclave, !policy.permitsSoftware {
+            // No fallback. A build that expects hardware fails loudly rather
+            // than quietly downgrading its own security properties.
+            throw DeviceKeyError.secureEnclaveUnavailable
+        }
+
+        guard let access = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            useSecureEnclave ? [.privateKeyUsage] : [],
+            nil
+        ) else {
+            throw DeviceKeyError.keyGenerationFailed
+        }
+
+        var privateAttributes: [String: Any] = [
+            kSecAttrIsPermanent as String: true,
+            kSecAttrApplicationTag as String: tag,
+            kSecAttrAccessControl as String: access,
+        ]
+        // Not biometry-gated: refresh and heartbeat must be able to sign while
+        // the screen is locked once background audio playback exists.
+        privateAttributes[kSecAttrCanSign as String] = true
+
+        var attributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrKeySizeInBits as String: 256,
+            kSecPrivateKeyAttrs as String: privateAttributes,
+        ]
+        if useSecureEnclave {
+            attributes[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
+        }
+
+        guard let key = SecKeyCreateRandomKey(attributes as CFDictionary, nil) else {
+            throw DeviceKeyError.keyGenerationFailed
+        }
+
+        return try attestation(for: key)
+    }
+
+    private func loadKey() throws -> SecKey? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: tag,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecReturnRef as String: true,
+        ]
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            guard let item = result else { return nil }
+            // CFTypeRef -> SecKey without an unchecked bridge.
+            guard CFGetTypeID(item) == SecKeyGetTypeID() else { return nil }
+            return (item as! SecKey)
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw DeviceKeyError.keychain(status)
+        }
+    }
+
+    private func attestation(for key: SecKey) throws -> DeviceKeyAttestation {
+        let attributes = SecKeyCopyAttributes(key) as? [String: Any] ?? [:]
+        let isSecureEnclave = (attributes[kSecAttrTokenID as String] as? String)
+            == (kSecAttrTokenIDSecureEnclave as String)
+
+        guard let publicKey = SecKeyCopyPublicKey(key) else {
+            throw DeviceKeyError.malformedPublicKey
+        }
+        guard let representation = SecKeyCopyExternalRepresentation(publicKey, nil) as Data? else {
+            throw DeviceKeyError.malformedPublicKey
+        }
+
+        // ANSI X9.63 uncompressed point: 0x04 || X(32) || Y(32).
+        guard representation.count == 65, representation.first == 0x04 else {
+            throw DeviceKeyError.malformedPublicKey
+        }
+        let x = representation[representation.index(representation.startIndex, offsetBy: 1)..<representation.index(representation.startIndex, offsetBy: 33)]
+        let y = representation[representation.index(representation.startIndex, offsetBy: 33)...]
+
+        return DeviceKeyAttestation(
+            provenance: isSecureEnclave ? .hardwareBacked : .software,
+            publicKey: ECPublicKeyJWK(x: Base64URL.encode(Data(x)), y: Base64URL.encode(Data(y)))
+        )
+    }
+}
+
+/// DER to raw signature conversion.
+///
+/// `SecKeyCreateSignature` returns an ASN.1 DER `SEQUENCE { INTEGER r, INTEGER s }`,
+/// which for P-256 is 68–72 bytes. JWS ES256 (RFC 7518 §3.4) requires the raw
+/// concatenation `R || S`, 32 bytes each, exactly 64 total — and the server
+/// enforces precisely that (`verifyES256Signature` rejects any other length).
+/// Emitting the DER blob directly is the mistake the Android client currently
+/// makes, and it fails silently because the server's DPoP check sits in a
+/// fallback branch.
+enum ECDSASignature {
+
+    static func rawFromDER(_ der: Data) throws -> Data {
+        var index = der.startIndex
+
+        func byte() throws -> UInt8 {
+            guard index < der.endIndex else { throw DeviceKeyError.malformedSignature }
+            defer { index = der.index(after: index) }
+            return der[index]
+        }
+
+        func length() throws -> Int {
+            let first = try byte()
+            guard first & 0x80 != 0 else { return Int(first) }
+            let count = Int(first & 0x7F)
+            guard count > 0, count <= 2 else { throw DeviceKeyError.malformedSignature }
+            var value = 0
+            for _ in 0..<count {
+                value = value << 8 | Int(try byte())
+            }
+            return value
+        }
+
+        func integer() throws -> Data {
+            guard try byte() == 0x02 else { throw DeviceKeyError.malformedSignature }
+            let count = try length()
+            guard count > 0, der.distance(from: index, to: der.endIndex) >= count else {
+                throw DeviceKeyError.malformedSignature
+            }
+            let end = der.index(index, offsetBy: count)
+            defer { index = end }
+
+            // DER encodes a leading 0x00 when the high bit would make the value
+            // negative; the raw form has no sign, so it is dropped.
+            var value = Data(der[index..<end])
+            while value.first == 0x00, value.count > 1 {
+                value.removeFirst()
+            }
+            guard value.count <= 32 else { throw DeviceKeyError.malformedSignature }
+            return value
+        }
+
+        guard try byte() == 0x30 else { throw DeviceKeyError.malformedSignature }
+        let sequenceLength = try length()
+        guard der.distance(from: index, to: der.endIndex) == sequenceLength else {
+            throw DeviceKeyError.malformedSignature
+        }
+
+        let r = try integer()
+        let s = try integer()
+        guard index == der.endIndex else { throw DeviceKeyError.malformedSignature }
+
+        return padded(r) + padded(s)
+    }
+
+    /// Left-pads to 32 bytes. A short R or S is a legitimate DER encoding, and
+    /// forgetting to pad produces a 63-byte signature the server rejects — a
+    /// bug that only surfaces for roughly one signature in 256.
+    private static func padded(_ value: Data) -> Data {
+        Data(repeating: 0, count: 32 - value.count) + value
+    }
+}

--- a/ios/Xg2g/SecItemKeychainBackend.swift
+++ b/ios/Xg2g/SecItemKeychainBackend.swift
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Security
+
+/// The real Keychain, behind the narrow surface `KeychainCredentialStore` needs.
+///
+/// ## Accessibility
+///
+/// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`, chosen deliberately:
+///
+/// - *AfterFirstUnlock* rather than *WhenUnlocked*, because heartbeat and token
+///   refresh have to keep working while the screen is locked once background
+///   audio playback exists. A `WhenUnlocked` item would fail exactly when live
+///   TV is still playing in the user's pocket.
+/// - *ThisDeviceOnly*, because a device-bound grant that rides an iCloud
+///   Keychain sync or an encrypted backup to a second device is no longer
+///   device-bound. That is the entire point of pairing a device.
+///
+/// Items are written non-synchronizable for the same reason. Reads and deletes
+/// use `kSecAttrSynchronizableAny` so that anything a previous build might have
+/// written as synchronizable is still found — and, more importantly, still
+/// removable.
+struct SecItemKeychainBackend: KeychainBackend {
+
+    func set(_ data: Data, service: String, account: String) throws {
+        // Delete first rather than SecItemUpdate: an existing item may carry
+        // different accessibility attributes, and update would keep them.
+        try remove(service: service, account: account)
+
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecAttrSynchronizable as String: false,
+        ]
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw CredentialStoreError.keychain(status)
+        }
+    }
+
+    func data(service: String, account: String) throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        switch status {
+        case errSecSuccess:
+            return result as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw CredentialStoreError.keychain(status)
+        }
+    }
+
+    func remove(service: String, account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw CredentialStoreError.keychain(status)
+        }
+    }
+
+    func removeAll(service: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw CredentialStoreError.keychain(status)
+        }
+    }
+}

--- a/ios/Xg2g/ServerAddress.swift
+++ b/ios/Xg2g/ServerAddress.swift
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// A configured xg2g server: a canonical origin plus the path the whole
+/// deployment is mounted under.
+///
+/// ## Why the root, and not the Web UI path
+///
+/// The backend mounts `/api/v3` and `/ui` as **siblings** at the deployment
+/// root (`V3BaseURL = "/api/v3"`, and `/ui` behind `http.StripPrefix("/ui", …)`).
+/// The Android client instead persists the *UI* base (`https://host/ui/`) and
+/// has to reconstruct the API from it, which its two transports do differently:
+/// `DeviceAuthRepository.apiUrl` replaces the path with `/api/v3/`, while
+/// `NativeDeviceAuthTransport.refreshSession` appends segments and so requests
+/// `https://host/ui/api/v3/auth/device/session` — the SPA handler, not the API.
+///
+/// Modelling the **root** removes that whole class of mistake: every endpoint
+/// is derived downward from one stored value, never reconstructed sideways out
+/// of another endpoint's path.
+struct ServerAddress: Hashable, Sendable, CustomStringConvertible {
+
+    enum ParseFailure: Error, Equatable, Sendable {
+        case empty
+        /// The strict parser was handed something that is not an absolute URL.
+        case notAbsolute(String)
+        case malformed(String)
+        case origin(ServerOrigin.Failure)
+        /// A server address is not a request; a query or fragment is meaningless
+        /// and would be silently dropped on the first join.
+        case carriesQueryOrFragment(String)
+        /// `https://trusted.example@attacker.example/` reads as one host to a
+        /// human and resolves to another. Never accepted, never repaired.
+        case carriesUserInfo(String)
+    }
+
+    let origin: ServerOrigin
+    /// Deployment root, in canonical directory form (`"/"`, `"/xg2g/"`, …).
+    let rootPath: String
+
+    var rootURL: URL { url(appending: "") }
+
+    /// The v3 API base. Always derived from the root.
+    var apiBaseURL: URL { url(appending: "api/v3/") }
+
+    /// The Web UI, for the day an isolated `WebContentView` needs it.
+    var webUIURL: URL { url(appending: "ui/") }
+
+    var description: String { "\(origin)\(rootPath)" }
+
+    init(origin: ServerOrigin, rootPath: String) {
+        self.origin = origin
+        self.rootPath = URLPath.canonicalDirectory(rootPath)
+    }
+
+    private func url(appending suffix: String) -> URL {
+        // Built from the canonical serialization rather than through
+        // URLComponents: assigning an unbracketed IPv6 literal to
+        // `URLComponents.host` yields a nil `url`, and `origin.description`
+        // already carries the bracketing and the default-port elision.
+        // `rootPath` is percent-encoded and `suffix` is an ASCII literal, so
+        // the result is well-formed by construction.
+        let string = "\(origin)\(rootPath)\(suffix)"
+        guard let url = URL(string: string) else {
+            preconditionFailure("non-representable ServerAddress: \(string)")
+        }
+        return url
+    }
+
+    /// This deployment scoped down to its API base.
+    ///
+    /// Containment against the deployment root is too weak for API calls: a
+    /// path like `api/v3/../../admin` resolves back inside the deployment and
+    /// would pass, while having left the API entirely. Callers that must stay
+    /// within the API check against this instead.
+    var apiScope: ServerAddress {
+        ServerAddress(origin: origin, rootPath: rootPath + "api/v3/")
+    }
+
+    /// Whether `url` is served by this deployment: identical canonical origin,
+    /// and a path lying under the deployment root.
+    ///
+    /// The path is compared in its **percent-encoded** form with only dot
+    /// segments resolved. Decoding first would make this disagree with what
+    /// `URLSession` and the server actually see — the parser differential this
+    /// whole layer exists to avoid.
+    func contains(_ url: URL) -> Bool {
+        guard let urlOrigin = ServerOrigin(url: url), urlOrigin == origin else { return false }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return false }
+
+        let path = URLPath.removingDotSegments(components.percentEncodedPath)
+
+        // rootPath always carries a trailing slash, so dropping it yields the
+        // "/xg2g" exact-match case for a root of "/xg2g/".
+        if path == String(rootPath.dropLast()) { return true }
+        return path.hasPrefix(rootPath)
+    }
+
+    /// The one path segment this client is allowed to interpret as "you pasted
+    /// the Web UI, the deployment root is one level up".
+    private static let webUISegment = "/ui/"
+
+    /// Ordered candidates for a setup-time reachability probe.
+    ///
+    /// A user pasting the address out of their browser will most likely paste
+    /// the Web UI URL (`https://host/ui/`), whose root is one level up. Rather
+    /// than *guessing* that in the parser — which would be exactly the kind of
+    /// reinterpretation the strict/lenient split exists to prevent — the
+    /// candidates are handed to the setup flow, which resolves the ambiguity by
+    /// asking the server instead of by assuming.
+    ///
+    /// - Important: This is a UX affordance, **not** discovery. The guardrails
+    ///   are deliberate and must stay: at most **one** alternative, produced by
+    ///   removing exactly **one** trailing `/ui/` segment. Paths are never
+    ///   walked up generally. Without that bound this quietly turns into a
+    ///   prober that tries more than anyone intended, and every extra candidate
+    ///   is another address the setup flow will send a request to.
+    var rootCandidates: [ServerAddress] {
+        guard rootPath.hasSuffix(Self.webUISegment) else { return [self] }
+
+        let parent = String(rootPath.dropLast(Self.webUISegment.count - 1))
+        return [self, ServerAddress(origin: origin, rootPath: parent)]
+    }
+}
+
+/// The single boundary between "text a human typed" and "a URL we trust".
+///
+/// The two entry points are intentionally not one function with a flag. Once a
+/// repairing parser is reachable from internal code paths, some later call will
+/// take the convenient route and a machine-supplied string will get reinterpreted
+/// rather than validated.
+enum ServerAddressParser {
+
+    /// Lenient — **only** for text a human typed into the setup field.
+    ///
+    /// The sole repair is supplying a missing `https://`. If the input already
+    /// declares a scheme, it is validated and never reinterpreted: `ftp://host`
+    /// is rejected, not rewritten. Nothing else is inferred — no host guessing,
+    /// no path fixing, no protocol downgrade.
+    static func parseUserEntered(_ input: String) throws(ServerAddress.ParseFailure) -> ServerAddress {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw .empty }
+
+        let candidate = declaredScheme(of: trimmed) == nil ? "https://\(trimmed)" : trimmed
+        return try parseAbsolute(candidate)
+    }
+
+    /// Strict — for persisted values and trusted backend responses such as
+    /// published endpoints. Requires an absolute `http(s)` URL and repairs
+    /// nothing at all.
+    static func parseTrusted(_ input: String) throws(ServerAddress.ParseFailure) -> ServerAddress {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw .empty }
+        guard declaredScheme(of: trimmed) != nil else { throw .notAbsolute(input) }
+
+        return try parseAbsolute(trimmed)
+    }
+
+    // MARK: - Internals
+
+    private static func parseAbsolute(_ input: String) throws(ServerAddress.ParseFailure) -> ServerAddress {
+        guard let components = URLComponents(string: input) else {
+            throw .malformed(input)
+        }
+        guard components.user == nil, components.password == nil else {
+            throw .carriesUserInfo(input)
+        }
+        guard components.percentEncodedQuery == nil, components.percentEncodedFragment == nil else {
+            throw .carriesQueryOrFragment(input)
+        }
+        guard let scheme = components.scheme else {
+            throw .notAbsolute(input)
+        }
+
+        // URLComponents.host strips IPv6 brackets; ServerOrigin accepts either.
+        guard let host = components.host else {
+            throw .origin(.emptyHost)
+        }
+
+        let origin: ServerOrigin
+        do {
+            origin = try ServerOrigin(scheme: scheme, host: host, port: components.port)
+        } catch {
+            throw .origin(error)
+        }
+
+        return ServerAddress(origin: origin, rootPath: components.percentEncodedPath)
+    }
+
+    /// Returns the lowercased scheme when `input` actually declares one.
+    ///
+    /// Keyed on `://`, never on a bare colon: `.` and `-` are legal scheme
+    /// characters, so a colon test would read the ordinary `demo.example:8080`
+    /// as scheme `demo.example`.
+    static func declaredScheme(of input: String) -> String? {
+        guard let separator = input.range(of: "://") else { return nil }
+
+        let candidate = String(input[input.startIndex..<separator.lowerBound])
+        guard let first = candidate.unicodeScalars.first,
+              CharacterSet.letters.contains(first)
+        else { return nil }
+
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "+-."))
+        guard candidate.unicodeScalars.allSatisfy(allowed.contains) else { return nil }
+
+        return candidate.lowercased()
+    }
+}

--- a/ios/Xg2g/ServerIdentity.swift
+++ b/ios/Xg2g/ServerIdentity.swift
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// An opaque, server-minted installation identifier.
+///
+/// Validated on the way in because it becomes part of a Keychain account key.
+/// A server-supplied string that ends up in a storage key must not be able to
+/// carry separators, whitespace or control characters that could collide with,
+/// or escape from, the key format.
+struct InstanceID: Hashable, Sendable, CustomStringConvertible {
+
+    enum Failure: Error, Equatable, Sendable {
+        case empty
+        case tooShort(Int)
+        case tooLong(Int)
+        case illegalCharacter(String)
+    }
+
+    /// Lower bound is a sanity check against degenerate values, not a security
+    /// guarantee — the entropy has to come from the server.
+    static let minimumLength = 8
+    static let maximumLength = 128
+
+    let rawValue: String
+
+    var description: String { rawValue }
+
+    init(_ rawValue: String) throws(Failure) {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw .empty }
+        guard trimmed.count >= Self.minimumLength else { throw .tooShort(trimmed.count) }
+        guard trimmed.count <= Self.maximumLength else { throw .tooLong(trimmed.count) }
+
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        guard trimmed.unicodeScalars.allSatisfy(allowed.contains) else {
+            throw .illegalCharacter(rawValue)
+        }
+
+        self.rawValue = trimmed
+    }
+}
+
+/// What a set of credentials is bound to.
+///
+/// The two cases are **not** interchangeable spellings of the same thing.
+/// `.instance` is strictly the stronger binding: it distinguishes two
+/// deployments that happen to share an origin, and it survives a hostname
+/// change. `.address` is what we can know before pairing, or against a backend
+/// that does not yet mint an instance identifier.
+///
+/// - Important: There is deliberately no operation that produces a weaker
+///   identity from a stronger one. See ``reconcile(bound:observedInstance:)``.
+///   An automatic downgrade would let a transient server failure permanently
+///   weaken a binding while looking like a successful fallback.
+enum ServerIdentity: Hashable, Sendable, CustomStringConvertible {
+    case address(ServerAddress)
+    case instance(InstanceID)
+
+    enum Strength: Int, Comparable, Sendable {
+        case address = 0
+        case instance = 1
+
+        static func < (lhs: Strength, rhs: Strength) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    var strength: Strength {
+        switch self {
+        case .address: return .address
+        case .instance: return .instance
+        }
+    }
+
+    /// Human-readable form for logs and diagnostics.
+    ///
+    /// - Note: This is **not** a storage key. Serializing an identity for the
+    ///   Keychain is `CredentialKeyEncoding`'s job, deliberately kept out of
+    ///   this type so domain logic never depends on an Apple storage format —
+    ///   and so a storage-format change cannot become a domain change.
+    var description: String {
+        switch self {
+        case .address(let address): return "address(\(address))"
+        case .instance(let id): return "instance(\(id))"
+        }
+    }
+
+    /// Outcome of reconciling a stored binding with what the server just said.
+    ///
+    /// Every case either keeps the current identity or strengthens it. None
+    /// returns something weaker — that is the point of the type.
+    enum Resolution: Hashable, Sendable {
+        /// Nothing to do.
+        case unchanged(ServerIdentity)
+
+        /// Address binding was upgraded to instance binding. The caller must
+        /// re-key stored credentials from the old namespace to the new one.
+        case upgraded(from: ServerIdentity, to: ServerIdentity)
+
+        /// The server reported a *different* instance than the one we are bound
+        /// to. This is a different installation reachable at a familiar
+        /// address; credentials must not be reused and re-pairing is required.
+        case conflict(bound: ServerIdentity, observed: InstanceID)
+
+        /// We are instance-bound but the server did not report an instance ID
+        /// this time. The binding is kept, explicitly and on purpose: a missing
+        /// value is not evidence of a different server, and treating it as one
+        /// would downgrade the binding on any transient failure.
+        case instanceUnavailable(ServerIdentity)
+
+        /// The identity to use after this reconciliation.
+        var identity: ServerIdentity {
+            switch self {
+            case .unchanged(let identity): return identity
+            case .upgraded(_, let identity): return identity
+            case .conflict(let bound, _): return bound
+            case .instanceUnavailable(let identity): return identity
+            }
+        }
+
+        /// True when stored credentials must be moved to a new namespace.
+        var requiresRekeying: Bool {
+            if case .upgraded = self { return true }
+            return false
+        }
+
+        /// True when the existing credentials must not be used.
+        var blocksCredentialUse: Bool {
+            if case .conflict = self { return true }
+            return false
+        }
+    }
+
+    /// Reconciles a stored binding with an instance identifier the server just
+    /// reported, if any.
+    ///
+    /// This is the only supported way to change a binding, and by construction
+    /// it never returns an identity weaker than `bound`.
+    static func reconcile(bound: ServerIdentity, observedInstance: InstanceID?) -> Resolution {
+        switch (bound, observedInstance) {
+        case (.address, .none):
+            return .unchanged(bound)
+
+        case (.address, .some(let observed)):
+            return .upgraded(from: bound, to: .instance(observed))
+
+        case (.instance, .none):
+            return .instanceUnavailable(bound)
+
+        case (.instance(let boundID), .some(let observed)):
+            return boundID == observed
+                ? .unchanged(bound)
+                : .conflict(bound: bound, observed: observed)
+        }
+    }
+}

--- a/ios/Xg2g/ServerOrigin.swift
+++ b/ios/Xg2g/ServerOrigin.swift
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Network
+
+/// A canonical `http(s)` origin: scheme, host, effective port. Never a path.
+///
+/// Two textually different spellings of the same server must produce one value,
+/// because this feeds credential scoping — `HTTPS://EXAMPLE.COM:443` and
+/// `https://example.com` are the same origin and must not end up owning two
+/// separate sets of credentials.
+///
+/// Canonicalization rules, all enforced in `init`:
+///
+/// - scheme and host are lowercased;
+/// - the port is always the *effective* port, so a default port is not a
+///   distinguishing feature;
+/// - a single trailing root dot (`example.com.`) is removed;
+/// - IPv6 literals are compressed per RFC 5952 by `Network.IPv6Address` rather
+///   than by hand;
+/// - IPv4 literals are canonicalized, so shorthand forms cannot alias;
+/// - a non-ASCII host is **rejected**, not guessed at. See `Host encoding`.
+///
+/// ## Host encoding
+///
+/// Unicode hosts are refused rather than mapped to punycode here. Getting IDNA
+/// wrong is a homograph problem, not a formatting problem, and Foundation does
+/// not expose a UTS-46 mapping we could rely on. A caller that genuinely needs
+/// an internationalized host supplies the punycode (`xn--`) form, which is
+/// plain ASCII and canonicalizes unambiguously.
+struct ServerOrigin: Hashable, Sendable, CustomStringConvertible {
+
+    enum Scheme: String, Sendable, CaseIterable {
+        case http
+        case https
+
+        var defaultPort: Int {
+            switch self {
+            case .http: return 80
+            case .https: return 443
+            }
+        }
+    }
+
+    /// Why a host could not be canonicalized. Surfaced so setup UI can explain
+    /// the refusal instead of silently failing.
+    enum Failure: Error, Equatable, Sendable {
+        case unsupportedScheme(String)
+        case emptyHost
+        case nonASCIIHost(String)
+        case invalidIPv6Literal(String)
+        case invalidPort(Int)
+        case illegalHostCharacter(String)
+    }
+
+    let scheme: Scheme
+    /// Canonical host. IPv6 literals are stored *without* brackets.
+    let host: String
+    /// Effective port, with the scheme default filled in.
+    let port: Int
+
+    var isDefaultPort: Bool { port == scheme.defaultPort }
+
+    /// True when `host` is an IPv6 literal and therefore needs brackets in URLs.
+    var isIPv6Literal: Bool { host.contains(":") }
+
+    /// Host as it must appear inside a URL authority.
+    var bracketedHost: String { isIPv6Literal ? "[\(host)]" : host }
+
+    /// Canonical serialization. A default port is omitted so it cannot become a
+    /// distinguishing character in a credential key.
+    var description: String {
+        isDefaultPort
+            ? "\(scheme.rawValue)://\(bracketedHost)"
+            : "\(scheme.rawValue)://\(bracketedHost):\(port)"
+    }
+
+    init(scheme rawScheme: String, host rawHost: String, port rawPort: Int?) throws(Failure) {
+        guard let scheme = Scheme(rawValue: rawScheme.lowercased()) else {
+            throw .unsupportedScheme(rawScheme)
+        }
+        self.scheme = scheme
+
+        self.host = try Self.canonicalHost(rawHost)
+
+        let effectivePort = rawPort ?? scheme.defaultPort
+        guard (1...65535).contains(effectivePort) else {
+            throw .invalidPort(effectivePort)
+        }
+        self.port = effectivePort
+    }
+
+    // MARK: - Host canonicalization
+
+    private static func canonicalHost(_ rawHost: String) throws(Failure) -> String {
+        var host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !host.isEmpty else { throw .emptyHost }
+
+        // An IPv6 literal may arrive bracketed or bare depending on which
+        // Foundation accessor produced it.
+        let wasBracketed = host.hasPrefix("[") && host.hasSuffix("]")
+        if wasBracketed {
+            host = String(host.dropFirst().dropLast())
+            guard !host.isEmpty else { throw .emptyHost }
+        }
+
+        if wasBracketed || host.contains(":") {
+            guard let canonical = canonicalIPv6(host) else {
+                throw .invalidIPv6Literal(rawHost)
+            }
+            return canonical
+        }
+
+        // A single trailing root dot is legal DNS and means the same name.
+        if host.hasSuffix("."), host.count > 1 {
+            host.removeLast()
+        }
+        guard !host.isEmpty, host != "." else { throw .emptyHost }
+
+        guard host.allSatisfy(\.isASCII) else {
+            throw .nonASCIIHost(rawHost)
+        }
+
+        // Reject anything that could not appear in an authority, so a stray
+        // slash, space, credential marker or port separator cannot be smuggled
+        // into what callers treat as a bare host.
+        let illegal = CharacterSet(charactersIn: "/?#@\\ \t")
+        guard host.rangeOfCharacter(from: illegal) == nil else {
+            throw .illegalHostCharacter(rawHost)
+        }
+
+        if let canonical = canonicalIPv4(host) {
+            return canonical
+        }
+        return host
+    }
+
+    /// Canonical origin of an already-parsed URL, or `nil` when it carries none
+    /// this client accepts.
+    ///
+    /// This is the **only** same-origin implementation in the app. Comparing
+    /// two `ServerOrigin` values is the same-origin check; there is no second
+    /// one to drift out of step with it.
+    init?(url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme,
+              let host = components.host,
+              // `https://trusted.example@attacker.example/` must never compare
+              // equal to the trusted origin.
+              components.user == nil,
+              components.password == nil,
+              let origin = try? ServerOrigin(scheme: scheme, host: host, port: components.port)
+        else { return nil }
+
+        self = origin
+    }
+
+    /// RFC 5952 compression via Network, so `0:0:0:0:0:0:0:1` and `::1` cannot
+    /// become two different credential namespaces.
+    private static func canonicalIPv6(_ literal: String) -> String? {
+        // A scope/zone id is device-local and must not be part of an identity.
+        let withoutZone = literal.split(separator: "%", maxSplits: 1).first.map(String.init) ?? literal
+        guard let address = IPv6Address(withoutZone) else { return nil }
+        return address.debugDescription.lowercased()
+    }
+
+    private static func canonicalIPv4(_ literal: String) -> String? {
+        guard let address = IPv4Address(literal) else { return nil }
+        return address.debugDescription
+    }
+}

--- a/ios/Xg2g/URLPath.swift
+++ b/ios/Xg2g/URLPath.swift
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+
+/// Path canonicalization shared by everything that compares or joins URL paths.
+///
+/// Every function here operates on the **percent-encoded** path and never
+/// decodes it. That is deliberate: `%2e%2e` and `%2f` are not traversal for
+/// WebKit, for `URLSession`, or for the server, so decoding them here would
+/// invent a second parser opinion — the classic parser-differential bug. What
+/// this code sees must stay what the network stack sees.
+enum URLPath {
+
+    /// Resolves `.` and `..` segments so a prefix comparison cannot be walked
+    /// out of. Percent-encoding is preserved byte for byte.
+    static func removingDotSegments(_ path: String) -> String {
+        let hadTrailingSlash = path.hasSuffix("/")
+        var stack: [String] = []
+
+        for segment in path.split(separator: "/", omittingEmptySubsequences: true) {
+            switch segment {
+            case ".":
+                continue
+            case "..":
+                if !stack.isEmpty { stack.removeLast() }
+            default:
+                stack.append(String(segment))
+            }
+        }
+
+        var resolved = "/" + stack.joined(separator: "/")
+        if hadTrailingSlash, resolved != "/" {
+            resolved += "/"
+        }
+        return resolved
+    }
+
+    /// Canonical *directory* path: always one leading and one trailing slash,
+    /// dot segments resolved. An empty or root path becomes `"/"`.
+    ///
+    /// Directory form matters because every derived path is produced by plain
+    /// concatenation; a missing trailing slash would silently drop the last
+    /// segment under RFC 3986 relative resolution.
+    static func canonicalDirectory(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "/" }
+
+        let withLeadingSlash = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        let withTrailingSlash = withLeadingSlash.hasSuffix("/") ? withLeadingSlash : withLeadingSlash + "/"
+        return removingDotSegments(withTrailingSlash)
+    }
+}

--- a/ios/Xg2g/Xg2gApp.swift
+++ b/ios/Xg2g/Xg2gApp.swift
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import SwiftUI
+
+@main
+struct Xg2gApp: App {
+    var body: some Scene {
+        WindowGroup {
+            // Scaffolding only: replaced by the setup / web shell root in the
+            // next step. Kept minimal so the project and toolchain are verified
+            // before any UI is layered on.
+            Text("xg2g")
+                .font(.largeTitle)
+        }
+    }
+}

--- a/ios/Xg2gTests/APIClientTests.swift
+++ b/ios/Xg2gTests/APIClientTests.swift
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Testing
+@testable import Xg2g
+
+// MARK: - Stub transport
+
+final class StubURLProtocol: URLProtocol {
+    struct Stub: @unchecked Sendable {
+        var status: Int = 200
+        var headers: [String: String] = ["Content-Type": "application/json"]
+        var body: Data = Data("{}".utf8)
+        var error: URLError?
+    }
+
+    nonisolated(unsafe) private static var _stub = Stub()
+    nonisolated(unsafe) private static var _lastRequest: URLRequest?
+    private static let lock = NSLock()
+
+    static var stub: Stub {
+        get { lock.lock(); defer { lock.unlock() }; return _stub }
+        set { lock.lock(); defer { lock.unlock() }; _stub = newValue }
+    }
+
+    static var lastRequest: URLRequest? {
+        lock.lock(); defer { lock.unlock() }; return _lastRequest
+    }
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _stub = Stub()
+        _lastRequest = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self._lastRequest = request
+        let stub = Self._stub
+        Self.lock.unlock()
+
+        if let error = stub.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: stub.status,
+            httpVersion: "HTTP/1.1",
+            headerFields: stub.headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+private struct Bouquet: Decodable, Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+private struct Session: Decodable, Equatable, Sendable {
+    let token: String
+    let expiresAt: Date
+}
+
+// MARK: - Tests
+
+@Suite(.serialized)
+struct APIClientTests {
+
+    private func makeClient(root: String = "https://tv.example/") throws -> HTTPAPIClient {
+        StubURLProtocol.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        return HTTPAPIClient(
+            address: try ServerAddressParser.parseTrusted(root),
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    private func respond(status: Int = 200, contentType: String? = "application/json", body: String) {
+        var stub = StubURLProtocol.Stub()
+        stub.status = status
+        stub.headers = contentType.map { ["Content-Type": $0] } ?? [:]
+        stub.body = Data(body.utf8)
+        StubURLProtocol.stub = stub
+    }
+
+    // MARK: URL construction
+
+    @Test func requestsAreBuiltFromTheDeploymentRoot() async throws {
+        let client = try makeClient()
+        respond(body: #"{"id":"1","name":"Favourites"}"#)
+
+        _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+
+        #expect(StubURLProtocol.lastRequest?.url?.absoluteString == "https://tv.example/api/v3/services/bouquets")
+    }
+
+    @Test func requestsRespectADeploymentSubPath() async throws {
+        let client = try makeClient(root: "https://tv.example/xg2g/")
+        respond(body: #"{"id":"1","name":"Favourites"}"#)
+
+        _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+
+        #expect(
+            StubURLProtocol.lastRequest?.url?.absoluteString
+                == "https://tv.example/xg2g/api/v3/services/bouquets"
+        )
+    }
+
+    @Test func queryItemsAreAppended() async throws {
+        let client = try makeClient()
+        respond(body: #"{"id":"1","name":"x"}"#)
+
+        _ = try await client.send(
+            APIRequest<Bouquet>(path: "epg", query: [URLQueryItem(name: "limit", value: "5")])
+        )
+
+        #expect(StubURLProtocol.lastRequest?.url?.query == "limit=5")
+    }
+
+    @Test func methodAndBodyArePassedThrough() async throws {
+        let client = try makeClient()
+        respond(status: 204, contentType: nil, body: "")
+
+        _ = try await client.send(
+            APIRequest<EmptyResponse>(
+                method: .post,
+                path: "system/refresh",
+                body: Data(#"{"a":1}"#.utf8),
+                contentType: "application/json"
+            )
+        )
+
+        #expect(StubURLProtocol.lastRequest?.httpMethod == "POST")
+        #expect(StubURLProtocol.lastRequest?.value(forHTTPHeaderField: "Content-Type") == "application/json")
+    }
+
+    /// A path is relative to the API base by contract; an absolute one would
+    /// escape the deployment root.
+    @Test func absolutePathsAreRefused() async throws {
+        let client = try makeClient()
+
+        await #expect(throws: APIError.invalidEndpoint(path: "/api/v3/services")) {
+            _ = try await client.send(APIRequest<Bouquet>(path: "/api/v3/services"))
+        }
+    }
+
+    /// Reuses the closed containment layer rather than trusting every future
+    /// call site to compose a well-behaved path.
+    @Test func pathsClimbingOutOfTheDeploymentAreRefused() async throws {
+        let client = try makeClient(root: "https://tv.example/xg2g/")
+
+        await #expect(throws: APIError.invalidEndpoint(path: "../../admin")) {
+            _ = try await client.send(APIRequest<Bouquet>(path: "../../admin"))
+        }
+    }
+
+    // MARK: Decoding
+
+    @Test func decodesASuccessfulResponse() async throws {
+        let client = try makeClient()
+        respond(body: #"{"id":"42","name":"Favourites"}"#)
+
+        let bouquet = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+
+        #expect(bouquet == Bouquet(id: "42", name: "Favourites"))
+    }
+
+    /// Go's `time.Time` emits RFC 3339 **Nano**: fractional seconds appear only
+    /// when non-zero, so both spellings occur for the same field.
+    @Test func decodesTimestampsWithAndWithoutFractionalSeconds() async throws {
+        let client = try makeClient()
+
+        respond(body: #"{"token":"t","expiresAt":"2026-04-09T12:00:00Z"}"#)
+        let whole = try await client.send(APIRequest<Session>(path: "auth/session"))
+        #expect(whole.expiresAt == Date(timeIntervalSince1970: 1_775_736_000))
+
+        respond(body: #"{"token":"t","expiresAt":"2026-04-09T12:00:00.500Z"}"#)
+        let fractional = try await client.send(APIRequest<Session>(path: "auth/session"))
+        #expect(fractional.expiresAt == Date(timeIntervalSince1970: 1_775_736_000.5))
+    }
+
+    @Test func emptyResponsesDoNotRequireABody() async throws {
+        let client = try makeClient()
+        respond(status: 204, contentType: nil, body: "")
+
+        let result = try await client.send(APIRequest<EmptyResponse>(method: .post, path: "system/refresh"))
+
+        #expect(result == EmptyResponse())
+    }
+
+    // MARK: The three error categories
+
+    /// The Android failure mode: the request reached the SPA, which answered
+    /// with HTML and status 200. Neither transport nor HTTP error — and
+    /// invisible if everything collapses into "network error".
+    @Test func htmlWithStatus200IsAnUnexpectedPayloadNotANetworkError() async throws {
+        let client = try makeClient()
+        respond(contentType: "text/html; charset=utf-8", body: "<!doctype html><html><body>xg2g</body></html>")
+
+        do {
+            _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+            Issue.record("expected a failure")
+        } catch let error as APIError {
+            guard case .unexpectedPayload(let payload) = error else {
+                Issue.record("expected .unexpectedPayload, got \(error)")
+                return
+            }
+            #expect(payload.status == 200)
+            #expect(payload.contentType == "text/html; charset=utf-8")
+            #expect(payload.bodyPreview.contains("<!doctype html>"))
+            #expect(payload.expected == "Bouquet")
+            #expect(!error.isRetryable, "a wrong body will be just as wrong next time")
+        }
+    }
+
+    @Test func aProblemDocumentBecomesADomainError() async throws {
+        let client = try makeClient()
+        respond(
+            status: 403,
+            contentType: "application/problem+json",
+            body: #"""
+            {"type":"about:blank","title":"Forbidden","status":403,
+             "requestId":"req_abc123","code":"ADMISSION_DENIED","detail":"nope"}
+            """#
+        )
+
+        do {
+            _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+            Issue.record("expected a failure")
+        } catch let error as APIError {
+            guard case .problem(let problem) = error else {
+                Issue.record("expected .problem, got \(error)")
+                return
+            }
+            #expect(problem.status == 403)
+            #expect(problem.code == "ADMISSION_DENIED")
+            #expect(error.requestID == "req_abc123", "the correlation id must survive to the caller")
+            #expect(!error.isRetryable)
+        }
+    }
+
+    /// A non-2xx that is not a problem document usually means a proxy answered
+    /// instead of the API. That is a different diagnosis and stays distinct.
+    @Test func aNonProblemErrorStatusStaysAnHTTPError() async throws {
+        let client = try makeClient()
+        respond(status: 502, contentType: "text/html", body: "<html>bad gateway</html>")
+
+        do {
+            _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+            Issue.record("expected a failure")
+        } catch let error as APIError {
+            guard case .http(let status, let contentType, let preview) = error else {
+                Issue.record("expected .http, got \(error)")
+                return
+            }
+            #expect(status == 502)
+            #expect(contentType == "text/html")
+            #expect(preview.contains("bad gateway"))
+            #expect(error.isRetryable, "a gateway error may well succeed on retry")
+        }
+    }
+
+    @Test func problemDocumentsWithServerErrorStatusAreRetryable() async throws {
+        let client = try makeClient()
+        respond(
+            status: 503,
+            contentType: "application/problem+json",
+            body: #"{"type":"about:blank","title":"Unavailable","status":503,"requestId":"req_x"}"#
+        )
+
+        do {
+            _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+            Issue.record("expected a failure")
+        } catch let error as APIError {
+            #expect(error.isRetryable)
+        }
+    }
+
+    // MARK: Transport failures
+
+    @Test func transportFailuresAreClassified() async throws {
+        let cases: [(URLError.Code, TransportFailure)] = [
+            (.notConnectedToInternet, .offline),
+            (.timedOut, .timedOut),
+            (.cannotConnectToHost, .cannotConnect),
+            (.secureConnectionFailed, .tls),
+            (.cancelled, .cancelled),
+        ]
+
+        for (code, expected) in cases {
+            let client = try makeClient()
+            var stub = StubURLProtocol.Stub()
+            stub.error = URLError(code)
+            StubURLProtocol.stub = stub
+
+            await #expect(throws: APIError.transport(expected)) {
+                _ = try await client.send(APIRequest<Bouquet>(path: "services/bouquets"))
+            }
+        }
+    }
+
+    @Test func cancellationIsNotRetryableButOtherTransportFailuresAre() {
+        #expect(!APIError.transport(.cancelled).isRetryable)
+        #expect(APIError.transport(.timedOut).isRetryable)
+        #expect(APIError.transport(.offline).isRetryable)
+    }
+}

--- a/ios/Xg2gTests/CredentialKeyEncodingTests.swift
+++ b/ios/Xg2gTests/CredentialKeyEncodingTests.swift
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Testing
+@testable import Xg2g
+
+struct CredentialKeyEncodingTests {
+
+    private func address(_ raw: String) throws -> ServerIdentity {
+        .address(try ServerAddressParser.parseTrusted(raw))
+    }
+
+    private func instance(_ raw: String) throws -> ServerIdentity {
+        .instance(try InstanceID(raw))
+    }
+
+    @Test func addressAndInstanceKeyspacesAreDisjoint() throws {
+        let fromAddress = CredentialKeyEncoding.account(
+            for: try address("https://tv.example/"),
+            kind: .deviceGrant
+        )
+        let fromInstance = CredentialKeyEncoding.account(
+            for: try instance("instance-aaaa"),
+            kind: .deviceGrant
+        )
+
+        #expect(fromAddress != fromInstance)
+        #expect(fromAddress.contains(".addr."))
+        #expect(fromInstance.contains(".inst."))
+    }
+
+    /// Two deployments behind one origin must not share a key.
+    @Test func deploymentsUnderOneOriginGetSeparateKeys() throws {
+        let home = CredentialKeyEncoding.account(for: try address("https://example.com/home/"), kind: .accessToken)
+        let lab = CredentialKeyEncoding.account(for: try address("https://example.com/lab/"), kind: .accessToken)
+
+        #expect(home != lab)
+    }
+
+    @Test func equivalentSpellingsProduceOneKey() throws {
+        let loud = CredentialKeyEncoding.account(for: try address("HTTPS://TV.EXAMPLE:443/"), kind: .accessToken)
+        let quiet = CredentialKeyEncoding.account(for: try address("https://tv.example/"), kind: .accessToken)
+
+        #expect(loud == quiet)
+    }
+
+    @Test func credentialKindsDoNotCollide() throws {
+        let identity = try address("https://tv.example/")
+        let keys = Set(CredentialKind.allCases.map { CredentialKeyEncoding.account(for: identity, kind: $0) })
+
+        #expect(keys.count == CredentialKind.allCases.count)
+    }
+
+    /// The separator must not be forgeable out of an address, or one server
+    /// could be made to address another server's entry.
+    @Test func addressSeparatorsAreEscaped() throws {
+        let key = CredentialKeyEncoding.account(for: try address("https://tv.example/a.b/"), kind: .deviceGrant)
+        let namespace = key.replacingOccurrences(of: "v\(CredentialKeyEncoding.version).addr.", with: "")
+
+        // Everything after the fixed prefix is one escaped component plus the
+        // kind suffix; the address' own dots must not survive as separators.
+        #expect(!namespace.dropLast(CredentialKind.deviceGrant.rawValue.count + 1).contains("."))
+    }
+
+    @Test func keysCarryTheFormatVersion() throws {
+        let key = CredentialKeyEncoding.account(for: try address("https://tv.example/"), kind: .accessToken)
+
+        #expect(key.hasPrefix("v\(CredentialKeyEncoding.version)."))
+    }
+
+    @Test func keysAreStableAcrossCalls() throws {
+        let identity = try address("https://tv.example/")
+
+        #expect(
+            CredentialKeyEncoding.account(for: identity, kind: .deviceGrant)
+                == CredentialKeyEncoding.account(for: identity, kind: .deviceGrant)
+        )
+    }
+}

--- a/ios/Xg2gTests/CredentialStoreTests.swift
+++ b/ios/Xg2gTests/CredentialStoreTests.swift
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Testing
+@testable import Xg2g
+
+// MARK: - Doubles
+
+final class InMemoryKeychainBackend: KeychainBackend, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: Data] = [:]
+
+    private func key(_ service: String, _ account: String) -> String {
+        // U+0000 cannot occur in either component, so this cannot alias.
+        "\(service)\u{0}\(account)"
+    }
+
+    func set(_ data: Data, service: String, account: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        storage[key(service, account)] = data
+    }
+
+    func data(service: String, account: String) throws -> Data? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[key(service, account)]
+    }
+
+    func remove(service: String, account: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        storage.removeValue(forKey: key(service, account))
+    }
+
+    func removeAll(service: String) throws {
+        lock.lock(); defer { lock.unlock() }
+        storage = storage.filter { !$0.key.hasPrefix("\(service)\u{0}") }
+    }
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return storage.count
+    }
+
+    func seedRaw(_ data: Data, service: String, account: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[key(service, account)] = data
+    }
+}
+
+final class FakeInstallationMarker: InstallationMarkerStore, @unchecked Sendable {
+    private let lock = NSLock()
+    private var marked: Bool
+
+    init(marked: Bool) { self.marked = marked }
+
+    func isMarked() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return marked
+    }
+
+    func mark() {
+        lock.lock(); defer { lock.unlock() }
+        marked = true
+    }
+}
+
+// MARK: - Tests
+
+struct CredentialStoreTests {
+
+    private func identity(_ raw: String) throws -> ServerIdentity {
+        .address(try ServerAddressParser.parseTrusted(raw))
+    }
+
+    private func grant(id: String = "dgr-1") -> DeviceGrant {
+        DeviceGrant(id: id, secret: "secret", expiresAt: Date(timeIntervalSince1970: 2_000_000_000))
+    }
+
+    private func session(token: String = "token") -> AccessSession {
+        AccessSession(
+            sessionID: "sess-1",
+            token: token,
+            expiresAt: Date(timeIntervalSince1970: 2_000_000_000),
+            policyVersion: "v1"
+        )
+    }
+
+    private func makeStore(
+        backend: InMemoryKeychainBackend = InMemoryKeychainBackend(),
+        marked: Bool = true
+    ) -> (KeychainCredentialStore, InMemoryKeychainBackend) {
+        (KeychainCredentialStore(backend: backend, marker: FakeInstallationMarker(marked: marked)), backend)
+    }
+
+    // MARK: - Reinstall purge
+
+    /// The Keychain outlives app deletion; `UserDefaults` does not. A missing
+    /// marker therefore means a fresh installation looking at a previous
+    /// installation's credentials.
+    @Test func freshInstallPurgesSurvivingKeychainMaterial() async throws {
+        let backend = InMemoryKeychainBackend()
+        backend.seedRaw(Data("stale".utf8), service: CredentialKeyEncoding.service, account: "v1.addr.old.device_grant")
+        let (store, _) = makeStore(backend: backend, marked: false)
+
+        try await store.prepareForLaunch()
+
+        #expect(backend.count == 0)
+    }
+
+    @Test func reopeningAnExistingInstallKeepsCredentials() async throws {
+        let backend = InMemoryKeychainBackend()
+        backend.seedRaw(Data("kept".utf8), service: CredentialKeyEncoding.service, account: "v1.addr.old.device_grant")
+        let (store, _) = makeStore(backend: backend, marked: true)
+
+        try await store.prepareForLaunch()
+
+        #expect(backend.count == 1)
+    }
+
+    @Test func purgeCoversOnlyOurOwnService() async throws {
+        let backend = InMemoryKeychainBackend()
+        backend.seedRaw(Data("ours".utf8), service: CredentialKeyEncoding.service, account: "a")
+        backend.seedRaw(Data("theirs".utf8), service: "com.other.app", account: "a")
+        let (store, _) = makeStore(backend: backend, marked: false)
+
+        try await store.prepareForLaunch()
+
+        #expect(try backend.data(service: "com.other.app", account: "a") != nil)
+    }
+
+    // MARK: - Preparation is mandatory
+
+    @Test func readingBeforePreparationThrows() async throws {
+        let (store, _) = makeStore()
+
+        await #expect(throws: CredentialStoreError.notPrepared) {
+            _ = try await store.deviceGrant(for: try identity("https://tv.example/"))
+        }
+    }
+
+    @Test func writingBeforePreparationThrows() async throws {
+        let (store, _) = makeStore()
+
+        await #expect(throws: CredentialStoreError.notPrepared) {
+            try await store.store(grant(), for: try identity("https://tv.example/"))
+        }
+    }
+
+    // MARK: - Round trips
+
+    @Test func grantAndSessionRoundTrip() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+        let server = try identity("https://tv.example/")
+
+        try await store.store(grant(), for: server)
+        try await store.store(session(), for: server)
+
+        #expect(try await store.deviceGrant(for: server) == grant())
+        #expect(try await store.accessSession(for: server) == session())
+    }
+
+    @Test func unknownIdentityReadsAsNil() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+
+        #expect(try await store.deviceGrant(for: try identity("https://unknown.example/")) == nil)
+    }
+
+    @Test func identitiesAreIsolatedFromEachOther() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+        let home = try identity("https://example.com/home/")
+        let lab = try identity("https://example.com/lab/")
+
+        try await store.store(grant(id: "home-grant"), for: home)
+        try await store.store(grant(id: "lab-grant"), for: lab)
+
+        #expect(try await store.deviceGrant(for: home)?.id == "home-grant")
+        #expect(try await store.deviceGrant(for: lab)?.id == "lab-grant")
+    }
+
+    // MARK: - The three lifecycle operations
+
+    /// Logout drops the session and keeps the pairing.
+    @Test func endSessionKeepsTheDeviceGrant() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+        let server = try identity("https://tv.example/")
+        try await store.store(grant(), for: server)
+        try await store.store(session(), for: server)
+
+        try await store.endSession(for: server)
+
+        #expect(try await store.accessSession(for: server) == nil)
+        #expect(try await store.deviceGrant(for: server) == grant())
+    }
+
+    /// Forget server drops everything for that identity — and nothing else.
+    @Test func forgetServerClearsOnlyThatIdentity() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+        let gone = try identity("https://gone.example/")
+        let kept = try identity("https://kept.example/")
+        try await store.store(grant(), for: gone)
+        try await store.store(session(), for: gone)
+        try await store.store(grant(id: "kept"), for: kept)
+
+        try await store.forgetServer(gone)
+
+        #expect(try await store.deviceGrant(for: gone) == nil)
+        #expect(try await store.accessSession(for: gone) == nil)
+        #expect(try await store.deviceGrant(for: kept)?.id == "kept")
+    }
+
+    @Test func purgeEverythingClearsAllIdentities() async throws {
+        let (store, backend) = makeStore()
+        try await store.prepareForLaunch()
+        try await store.store(grant(), for: try identity("https://a.example/"))
+        try await store.store(grant(), for: try identity("https://b.example/"))
+
+        try await store.purgeEverything()
+
+        #expect(backend.count == 0)
+    }
+
+    // MARK: - Identity migration
+
+    @Test func migrationMovesCredentialsToTheStrongerIdentity() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+        let addressBound = try identity("https://tv.example/")
+        let instanceBound = ServerIdentity.instance(try InstanceID("instance-aaaa"))
+
+        try await store.store(grant(), for: addressBound)
+        try await store.store(session(), for: addressBound)
+
+        try await store.migrate(from: addressBound, to: instanceBound)
+
+        #expect(try await store.deviceGrant(for: instanceBound) == grant())
+        #expect(try await store.accessSession(for: instanceBound) == session())
+        #expect(try await store.deviceGrant(for: addressBound) == nil)
+        #expect(try await store.accessSession(for: addressBound) == nil)
+    }
+
+    @Test func migrationToTheSameIdentityIsANoOp() async throws {
+        let (store, _) = makeStore()
+        try await store.prepareForLaunch()
+        let server = try identity("https://tv.example/")
+        try await store.store(grant(), for: server)
+
+        try await store.migrate(from: server, to: server)
+
+        #expect(try await store.deviceGrant(for: server) == grant())
+    }
+
+    @Test func migrationOfAnEmptyIdentityDoesNothing() async throws {
+        let (store, backend) = makeStore()
+        try await store.prepareForLaunch()
+
+        try await store.migrate(
+            from: try identity("https://tv.example/"),
+            to: .instance(try InstanceID("instance-aaaa"))
+        )
+
+        #expect(backend.count == 0)
+    }
+
+    // MARK: - Corrupted storage
+
+    @Test func malformedStoredValueIsReportedNotIgnored() async throws {
+        let backend = InMemoryKeychainBackend()
+        let (store, _) = makeStore(backend: backend)
+        try await store.prepareForLaunch()
+        let server = try identity("https://tv.example/")
+
+        backend.seedRaw(
+            Data("not json".utf8),
+            service: CredentialKeyEncoding.service,
+            account: CredentialKeyEncoding.account(for: server, kind: .deviceGrant)
+        )
+
+        await #expect(throws: CredentialStoreError.malformedStoredValue(.deviceGrant)) {
+            _ = try await store.deviceGrant(for: server)
+        }
+    }
+}
+
+struct AccessSessionTests {
+
+    private func session(expiresIn seconds: TimeInterval, token: String = "t") -> AccessSession {
+        AccessSession(
+            sessionID: "s",
+            token: token,
+            expiresAt: Date(timeIntervalSince1970: 1_000_000).addingTimeInterval(seconds),
+            policyVersion: nil
+        )
+    }
+
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    @Test func aComfortablyValidSessionIsUsable() {
+        #expect(session(expiresIn: 600).isUsable(at: now))
+    }
+
+    @Test func anExpiredSessionIsNotUsable() {
+        #expect(!session(expiresIn: -1).isUsable(at: now))
+    }
+
+    /// A token that dies mid-flight is worse than one refreshed slightly early.
+    @Test func aSessionInsideTheSkewWindowIsNotUsable() {
+        #expect(!session(expiresIn: AccessSession.expirySkew - 1).isUsable(at: now))
+        #expect(session(expiresIn: AccessSession.expirySkew + 1).isUsable(at: now))
+    }
+
+    @Test func anEmptyTokenIsNeverUsable() {
+        #expect(!session(expiresIn: 600, token: "").isUsable(at: now))
+    }
+}

--- a/ios/Xg2gTests/DeepLinkParserTests.swift
+++ b/ios/Xg2gTests/DeepLinkParserTests.swift
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Testing
+@testable import Xg2g
+
+struct DeepLinkParserTests {
+
+    private func link(_ raw: String) throws -> URL {
+        try #require(URL(string: raw))
+    }
+
+    // MARK: - Configuring a server
+
+    @Test func customSchemeLinkConfiguresTheDeploymentRoot() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2F")
+
+        let address = try #require(DeepLinkParser.configuredAddress(from: url))
+        #expect(address.rootPath == "/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/api/v3/")
+    }
+
+    /// The form the Web UI actually mints today: `new URL('/ui/', endpoint)`.
+    /// It is converted to a deployment root once, here at the edge.
+    @Test func legacyWebUIBaseURLIsConvertedToTheDeploymentRoot() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2Fui%2F")
+
+        let address = try #require(DeepLinkParser.configuredAddress(from: url))
+        #expect(address.rootPath == "/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/api/v3/")
+        #expect(address.webUIURL.absoluteString == "https://tv.example/ui/")
+    }
+
+    @Test func legacyWebUIBaseURLUnderASubPathKeepsTheSubPath() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2Fxg2g%2Fui%2F")
+
+        let address = try #require(DeepLinkParser.configuredAddress(from: url))
+        #expect(address.rootPath == "/xg2g/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/xg2g/api/v3/")
+    }
+
+    /// A future generator emitting a root must keep working unchanged.
+    @Test func rootShapedBaseURLPassesThroughUnchanged() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2Fxg2g%2F")
+
+        let address = try #require(DeepLinkParser.configuredAddress(from: url))
+        #expect(address.rootPath == "/xg2g/")
+    }
+
+    @Test func customSchemeLinkSupportsADeploymentSubPath() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2Fxg2g%2F")
+
+        let address = try #require(DeepLinkParser.configuredAddress(from: url))
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/xg2g/api/v3/")
+    }
+
+    /// An https link is a content link into a server the user already set up.
+    /// Letting one nominate a *new* server would mean an arbitrary web page
+    /// could choose the host this client sends credentials to.
+    @Test func httpsLinkConfiguresNothing() throws {
+        let url = try link("https://demo.example/ui/live/channel-1")
+
+        #expect(DeepLinkParser.configuredAddress(from: url) == nil)
+    }
+
+    @Test func customSchemeLinkWithoutBaseURLConfiguresNothing() throws {
+        let url = try link("xg2g://connect?auth_token=token-123")
+
+        #expect(DeepLinkParser.configuredAddress(from: url) == nil)
+    }
+
+    /// `base_url` goes through the strict parser, so nothing about it is
+    /// repaired — a scheme-less value is refused rather than assumed https.
+    @Test func schemelessBaseURLIsRefused() throws {
+        let url = try link("xg2g://connect?base_url=tv.example")
+
+        #expect(DeepLinkParser.configuredAddress(from: url) == nil)
+    }
+
+    @Test func baseURLCarryingUserInfoIsRefused() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftrusted.example%40attacker.example%2F")
+
+        #expect(DeepLinkParser.configuredAddress(from: url) == nil)
+    }
+
+    @Test func baseURLWithForeignSchemeIsRefused() throws {
+        let url = try link("xg2g://connect?base_url=ftp%3A%2F%2Ftv.example%2F")
+
+        #expect(DeepLinkParser.configuredAddress(from: url) == nil)
+    }
+
+    // MARK: - Tokens
+
+    @Test func readsAuthTokenFromCustomSchemeLink() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2F&auth_token=token-123")
+
+        #expect(DeepLinkParser.authToken(from: url) == "token-123")
+    }
+
+    @Test func readsAccessToken() throws {
+        let url = try link("xg2g://connect?launch_access_token=device-access-token")
+
+        #expect(DeepLinkParser.accessToken(from: url) == "device-access-token")
+    }
+
+    @Test func stillAcceptsTheLegacyAccessTokenKey() throws {
+        let url = try link("xg2g://connect?access_token=device-access-token")
+
+        #expect(DeepLinkParser.accessToken(from: url) == "device-access-token")
+    }
+
+    /// Tokens are only ever read out of our own scheme.
+    @Test func tokensAreIgnoredOnHTTPSLinks() throws {
+        let url = try link("https://demo.example/ui/?auth_token=token-123&launch_access_token=t")
+
+        #expect(DeepLinkParser.authToken(from: url) == nil)
+        #expect(DeepLinkParser.accessToken(from: url) == nil)
+        #expect(DeepLinkParser.launchCredentials(from: url) == nil)
+    }
+
+    // MARK: - Launch credentials
+
+    @Test func readsGrantAndExpiry() throws {
+        let url = try link(
+            "xg2g://connect?device_grant_id=dgr-123&device_grant=grant-secret"
+                + "&launch_access_token=device-access-token"
+                + "&launch_access_token_expires_at=Thu,%2009%20Apr%202026%2012:00:00%20GMT"
+        )
+
+        let credentials = try #require(DeepLinkParser.launchCredentials(from: url))
+        #expect(credentials.deviceGrantID == "dgr-123")
+        #expect(credentials.deviceGrant == "grant-secret")
+        #expect(credentials.accessToken == "device-access-token")
+        #expect(credentials.accessTokenExpiresAtEpochMs == 1_775_736_000_000)
+    }
+
+    @Test func returnsNilWhenNoCredentialParameterIsPresent() throws {
+        let url = try link("xg2g://connect?base_url=https%3A%2F%2Ftv.example%2F")
+
+        #expect(DeepLinkParser.launchCredentials(from: url) == nil)
+    }
+
+    // MARK: - Expiry parsing
+
+    @Test func expiryAcceptsEpochMillis() {
+        #expect(DeepLinkParser.expiryEpochMs("1775736000000") == 1_775_736_000_000)
+    }
+
+    @Test func expiryRejectsNonPositiveEpoch() {
+        #expect(DeepLinkParser.expiryEpochMs("0") == nil)
+        #expect(DeepLinkParser.expiryEpochMs("-1") == nil)
+    }
+
+    @Test func expiryRejectsGarbage() {
+        #expect(DeepLinkParser.expiryEpochMs("not-a-date") == nil)
+        #expect(DeepLinkParser.expiryEpochMs("   ") == nil)
+        #expect(DeepLinkParser.expiryEpochMs(nil) == nil)
+    }
+}

--- a/ios/Xg2gTests/DeviceKeyStoreTests.swift
+++ b/ios/Xg2gTests/DeviceKeyStoreTests.swift
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import CryptoKit
+import Foundation
+import Security
+import Testing
+@testable import Xg2g
+
+// MARK: - Signature encoding
+
+/// The conversion the server's `verifyES256Signature` depends on: it rejects
+/// anything that is not exactly 64 bytes, so a DER blob never validates.
+struct ECDSASignatureTests {
+
+    /// `SEQUENCE { INTEGER r, INTEGER s }` with no high-bit padding.
+    private func der(r: [UInt8], s: [UInt8]) -> Data {
+        var body: [UInt8] = [0x02, UInt8(r.count)] + r + [0x02, UInt8(s.count)] + s
+        body = [0x30, UInt8(body.count)] + body
+        return Data(body)
+    }
+
+    @Test func convertsAFullLengthSignature() throws {
+        let r = [UInt8](repeating: 0x11, count: 32)
+        let s = [UInt8](repeating: 0x22, count: 32)
+
+        let raw = try ECDSASignature.rawFromDER(der(r: r, s: s))
+
+        #expect(raw.count == 64)
+        #expect(Array(raw.prefix(32)) == r)
+        #expect(Array(raw.suffix(32)) == s)
+    }
+
+    /// DER prepends 0x00 when the high bit is set; the raw form is unsigned.
+    @Test func stripsTheSignPaddingByte() throws {
+        let r: [UInt8] = [0x00] + [UInt8](repeating: 0xFF, count: 32)
+        let s = [UInt8](repeating: 0x22, count: 32)
+
+        let raw = try ECDSASignature.rawFromDER(der(r: r, s: s))
+
+        #expect(raw.count == 64)
+        #expect(Array(raw.prefix(32)) == [UInt8](repeating: 0xFF, count: 32))
+    }
+
+    /// A short R is legal DER. Forgetting to left-pad yields a 63-byte
+    /// signature the server rejects — and it only happens for about one
+    /// signature in 256, so it survives casual testing.
+    @Test func leftPadsAShortInteger() throws {
+        let r = [UInt8](repeating: 0x11, count: 31)
+        let s = [UInt8](repeating: 0x22, count: 32)
+
+        let raw = try ECDSASignature.rawFromDER(der(r: r, s: s))
+
+        #expect(raw.count == 64)
+        #expect(raw.first == 0x00)
+        #expect(Array(raw.prefix(32).dropFirst()) == r)
+    }
+
+    @Test func leftPadsAVeryShortInteger() throws {
+        let raw = try ECDSASignature.rawFromDER(der(r: [0x07], s: [UInt8](repeating: 0x22, count: 32)))
+
+        #expect(raw.count == 64)
+        #expect(Array(raw.prefix(32)) == [UInt8](repeating: 0x00, count: 31) + [0x07])
+    }
+
+    @Test func rejectsMalformedInput() {
+        for bad: [UInt8] in [
+            [],
+            [0x31, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x01],   // not a SEQUENCE
+            [0x30, 0x06, 0x03, 0x01, 0x01, 0x02, 0x01, 0x01],   // not an INTEGER
+            [0x30, 0x20, 0x02, 0x01, 0x01],                     // truncated
+        ] {
+            #expect(throws: DeviceKeyError.malformedSignature) {
+                _ = try ECDSASignature.rawFromDER(Data(bad))
+            }
+        }
+    }
+
+    @Test func rejectsAnOversizedInteger() {
+        let r = [UInt8](repeating: 0x11, count: 33)
+        #expect(throws: DeviceKeyError.malformedSignature) {
+            _ = try ECDSASignature.rawFromDER(der(r: r, s: [UInt8](repeating: 0x22, count: 32)))
+        }
+    }
+}
+
+// MARK: - JWK
+
+struct ECPublicKeyJWKTests {
+
+    /// Oracle computed independently of this implementation:
+    /// sha256(`{"crv":"P-256","kty":"EC","x":"dGVzdC14","y":"dGVzdC15"}`),
+    /// base64url, unpadded. Any change to the canonical form — member order,
+    /// whitespace, padding — changes `jkt` and makes the server reject every
+    /// proof, so it is pinned rather than described.
+    @Test func thumbprintMatchesTheServerCanonicalForm() {
+        let jwk = ECPublicKeyJWK(x: "dGVzdC14", y: "dGVzdC15")
+
+        #expect(jwk.thumbprint == "KPkQZ9JAzMQ212Ca4HYCcvg3sX_zN-AldCezxFGLkH4")
+    }
+
+    @Test func thumbprintIsUnpaddedBase64URL() {
+        let jwk = ECPublicKeyJWK(x: "dGVzdC14", y: "dGVzdC15")
+
+        #expect(jwk.thumbprint.count == 43)
+        #expect(!jwk.thumbprint.contains("="))
+        #expect(!jwk.thumbprint.contains("+"))
+        #expect(!jwk.thumbprint.contains("/"))
+    }
+}
+
+// MARK: - Store
+
+struct DeviceKeyStoreTests {
+
+    private func makeStore(policy: DeviceKeyPolicy) -> (SecureEnclaveDeviceKeyStore, String) {
+        let tag = "io.github.manugh.xg2g.tests.key.\(UUID().uuidString)"
+        return (SecureEnclaveDeviceKeyStore(policy: policy, tag: tag), tag)
+    }
+
+    private func permissivePolicy() -> DeviceKeyPolicy {
+        SecureEnclaveDeviceKeyStore.isSecureEnclaveAvailable()
+            ? .requireHardware
+            : .allowSoftware(reason: .simulator)
+    }
+
+    private func base64URLDecode(_ value: String) throws -> Data {
+        var s = value.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while s.count % 4 != 0 { s += "=" }
+        return try #require(Data(base64Encoded: s))
+    }
+
+    // MARK: Environment
+
+    /// Records what this environment can actually do, rather than inferring it
+    /// from the platform. The rest of the suite keys off this answer.
+    @Test func secureEnclaveAvailabilityIsSelfConsistent() async throws {
+        let available = SecureEnclaveDeviceKeyStore.isSecureEnclaveAvailable()
+        let (store, _) = makeStore(policy: .requireHardware)
+
+        if available {
+            let attestation = try await store.provisionKey()
+            #expect(attestation.provenance == .hardwareBacked)
+            try await store.destroyKey()
+        } else {
+            await #expect(throws: DeviceKeyError.secureEnclaveUnavailable) {
+                _ = try await store.provisionKey()
+            }
+        }
+    }
+
+    /// A real device build cannot construct the software case at all.
+    @Test func environmentPolicyPermitsSoftwareOnlyOnSimulator() {
+        #if targetEnvironment(simulator)
+        #expect(DeviceKeyPolicy.forCurrentEnvironment == .allowSoftware(reason: .simulator))
+        #else
+        #expect(DeviceKeyPolicy.forCurrentEnvironment == .requireHardware)
+        #endif
+    }
+
+    // MARK: Provisioning
+
+    @Test func provisioningIsIdempotent() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+        defer { Task { try? await store.destroyKey() } }
+
+        let first = try await store.provisionKey()
+        let second = try await store.provisionKey()
+
+        #expect(first == second, "a second provision must return the same key, not mint a new identity")
+    }
+
+    @Test func attestationIsNilBeforeProvisioning() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+
+        #expect(try await store.attestation() == nil)
+    }
+
+    @Test func destroyingRemovesTheIdentity() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+        _ = try await store.provisionKey()
+
+        try await store.destroyKey()
+
+        #expect(try await store.attestation() == nil)
+    }
+
+    @Test func destroyingIsIdempotent() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+
+        try await store.destroyKey()
+        try await store.destroyKey()
+    }
+
+    // MARK: Signing
+
+    /// End-to-end proof that the DER conversion is right: the raw signature
+    /// verifies against the very public key the store reports.
+    @Test func signatureIsRawAndVerifiesAgainstTheReportedPublicKey() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+        defer { Task { try? await store.destroyKey() } }
+
+        let attestation = try await store.provisionKey()
+        let message = Data("DPoP signing input".utf8)
+
+        let raw = try await store.sign(message)
+
+        #expect(raw.count == 64, "the server rejects any length other than 64")
+
+        let x = try base64URLDecode(attestation.publicKey.x)
+        let y = try base64URLDecode(attestation.publicKey.y)
+        let publicKey = try P256.Signing.PublicKey(rawRepresentation: x + y)
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: raw)
+
+        #expect(publicKey.isValidSignature(signature, for: message))
+    }
+
+    @Test func signaturesAreAlwaysSixtyFourBytes() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+        defer { Task { try? await store.destroyKey() } }
+        _ = try await store.provisionKey()
+
+        // Repeated because a short R or S only occurs occasionally; a missing
+        // left-pad would show up as a 63-byte signature here.
+        for iteration in 0..<32 {
+            let raw = try await store.sign(Data("message-\(iteration)".utf8))
+            #expect(raw.count == 64)
+        }
+    }
+
+    @Test func signingWithoutAKeyFails() async throws {
+        let (store, _) = makeStore(policy: permissivePolicy())
+
+        await #expect(throws: DeviceKeyError.keyNotProvisioned) {
+            _ = try await store.sign(Data("x".utf8))
+        }
+    }
+
+    // MARK: The substitution invariant
+
+    /// A software key must never be usable where hardware is required — not at
+    /// provisioning, and not later at signing time either.
+    ///
+    /// The Secure Enclave probe is forced to `false` so a real software key is
+    /// created regardless of the host. Gating this test on actual hardware
+    /// availability made it silently no-op on the simulator, which now *does*
+    /// have a Secure Enclave — a security test that skips itself is worse than
+    /// no test at all.
+    @Test func aSoftwareKeyIsRejectedUnderAHardwarePolicy() async throws {
+        let tag = "io.github.manugh.xg2g.tests.key.\(UUID().uuidString)"
+        let permissive = SecureEnclaveDeviceKeyStore(
+            policy: .allowSoftware(reason: .simulator),
+            tag: tag,
+            secureEnclaveProbe: { false }
+        )
+        let strict = SecureEnclaveDeviceKeyStore(policy: .requireHardware, tag: tag)
+        defer { Task { try? await permissive.destroyKey() } }
+
+        let attestation = try await permissive.provisionKey()
+        #expect(attestation.provenance == .software, "the seam must really produce a software key")
+
+        await #expect(throws: DeviceKeyError.provenanceMismatch(found: .software, policy: .hardwareBacked)) {
+            _ = try await strict.provisionKey()
+        }
+        await #expect(throws: DeviceKeyError.provenanceMismatch(found: .software, policy: .hardwareBacked)) {
+            _ = try await strict.sign(Data("x".utf8))
+        }
+    }
+
+    /// A build that requires hardware must fail loudly where there is none,
+    /// never quietly downgrade itself.
+    @Test func hardwarePolicyRefusesToCreateASoftwareKey() async throws {
+        let (_, tag) = makeStore(policy: .requireHardware)
+        let store = SecureEnclaveDeviceKeyStore(
+            policy: .requireHardware,
+            tag: tag,
+            secureEnclaveProbe: { false }
+        )
+
+        await #expect(throws: DeviceKeyError.secureEnclaveUnavailable) {
+            _ = try await store.provisionKey()
+        }
+        #expect(try await store.attestation() == nil, "nothing may be left behind by a refused provisioning")
+    }
+
+    /// A software key still has to be a working P-256 key, or the fallback is
+    /// useless for development.
+    @Test func aSoftwareKeySignsVerifiably() async throws {
+        let tag = "io.github.manugh.xg2g.tests.key.\(UUID().uuidString)"
+        let store = SecureEnclaveDeviceKeyStore(
+            policy: .allowSoftware(reason: .development),
+            tag: tag,
+            secureEnclaveProbe: { false }
+        )
+        defer { Task { try? await store.destroyKey() } }
+
+        let attestation = try await store.provisionKey()
+        let message = Data("software signing input".utf8)
+        let raw = try await store.sign(message)
+
+        #expect(attestation.provenance == .software)
+        #expect(raw.count == 64)
+
+        let x = try base64URLDecode(attestation.publicKey.x)
+        let y = try base64URLDecode(attestation.publicKey.y)
+        let publicKey = try P256.Signing.PublicKey(rawRepresentation: x + y)
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: raw)
+        #expect(publicKey.isValidSignature(signature, for: message))
+    }
+}

--- a/ios/Xg2gTests/SecItemKeychainBackendTests.swift
+++ b/ios/Xg2gTests/SecItemKeychainBackendTests.swift
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Security
+import Testing
+@testable import Xg2g
+
+/// Exercises the real Keychain. The fake backend proves the store's lifecycle
+/// rules; only these prove that the actual `SecItem` attributes are what we
+/// claim — in particular the accessibility class, which is a security property
+/// and therefore has to be read back rather than asserted in a comment.
+///
+/// Each test uses its own service name so runs cannot interfere with each other
+/// or with the app's real entries.
+struct SecItemKeychainBackendTests {
+
+    private let backend = SecItemKeychainBackend()
+
+    private func makeService(_ label: String) -> String {
+        "io.github.manugh.xg2g.tests.\(label).\(UUID().uuidString)"
+    }
+
+    @Test func storesAndReadsBack() throws {
+        let service = makeService("roundtrip")
+        defer { try? backend.removeAll(service: service) }
+
+        try backend.set(Data("hello".utf8), service: service, account: "a")
+
+        #expect(try backend.data(service: service, account: "a") == Data("hello".utf8))
+    }
+
+    @Test func missingItemReadsAsNil() throws {
+        let service = makeService("missing")
+
+        #expect(try backend.data(service: service, account: "absent") == nil)
+    }
+
+    @Test func overwritingReplacesTheValue() throws {
+        let service = makeService("overwrite")
+        defer { try? backend.removeAll(service: service) }
+
+        try backend.set(Data("first".utf8), service: service, account: "a")
+        try backend.set(Data("second".utf8), service: service, account: "a")
+
+        #expect(try backend.data(service: service, account: "a") == Data("second".utf8))
+    }
+
+    @Test func removingIsIdempotent() throws {
+        let service = makeService("remove")
+
+        try backend.set(Data("x".utf8), service: service, account: "a")
+        try backend.remove(service: service, account: "a")
+        // A second delete must not surface errSecItemNotFound as a failure.
+        try backend.remove(service: service, account: "a")
+
+        #expect(try backend.data(service: service, account: "a") == nil)
+    }
+
+    @Test func removeAllClearsTheServiceAndNothingElse() throws {
+        let mine = makeService("wipe-mine")
+        let other = makeService("wipe-other")
+        defer { try? backend.removeAll(service: other) }
+
+        try backend.set(Data("1".utf8), service: mine, account: "a")
+        try backend.set(Data("2".utf8), service: mine, account: "b")
+        try backend.set(Data("3".utf8), service: other, account: "a")
+
+        try backend.removeAll(service: mine)
+
+        #expect(try backend.data(service: mine, account: "a") == nil)
+        #expect(try backend.data(service: mine, account: "b") == nil)
+        #expect(try backend.data(service: other, account: "a") == Data("3".utf8))
+    }
+
+    @Test func accountsAreIsolated() throws {
+        let service = makeService("accounts")
+        defer { try? backend.removeAll(service: service) }
+
+        try backend.set(Data("a".utf8), service: service, account: "a")
+        try backend.set(Data("b".utf8), service: service, account: "b")
+
+        #expect(try backend.data(service: service, account: "a") == Data("a".utf8))
+        #expect(try backend.data(service: service, account: "b") == Data("b".utf8))
+    }
+
+    // MARK: - The security properties, read back from the Keychain
+
+    /// `AfterFirstUnlock` so refresh and heartbeat survive a locked screen once
+    /// background audio exists; `ThisDeviceOnly` so a device-bound grant cannot
+    /// ride a sync or a backup onto another device.
+    @Test func itemsAreAccessibleAfterFirstUnlockAndBoundToThisDevice() throws {
+        let service = makeService("accessibility")
+        defer { try? backend.removeAll(service: service) }
+
+        try backend.set(Data("x".utf8), service: service, account: "a")
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: "a",
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        #expect(status == errSecSuccess)
+        let attributes = try #require(result as? [String: Any])
+        #expect(
+            attributes[kSecAttrAccessible as String] as? String
+                == (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
+        )
+    }
+
+    @Test func itemsAreNotSynchronizable() throws {
+        let service = makeService("sync")
+        defer { try? backend.removeAll(service: service) }
+
+        try backend.set(Data("x".utf8), service: service, account: "a")
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: "a",
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        _ = SecItemCopyMatching(query as CFDictionary, &result)
+
+        let attributes = try #require(result as? [String: Any])
+        let synchronizable = attributes[kSecAttrSynchronizable as String] as? Bool ?? false
+        #expect(!synchronizable)
+    }
+}

--- a/ios/Xg2gTests/ServerAddressTests.swift
+++ b/ios/Xg2gTests/ServerAddressTests.swift
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Testing
+@testable import Xg2g
+
+struct ServerAddressTests {
+
+    // MARK: - Endpoint derivation
+
+    @Test func endpointsAreDerivedFromTheRoot() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/")
+
+        #expect(address.rootURL.absoluteString == "https://tv.example/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/api/v3/")
+        #expect(address.webUIURL.absoluteString == "https://tv.example/ui/")
+    }
+
+    @Test func endpointsRespectADeploymentSubPath() throws {
+        let address = try ServerAddressParser.parseTrusted("https://proxy.example/xg2g/")
+
+        #expect(address.apiBaseURL.absoluteString == "https://proxy.example/xg2g/api/v3/")
+        #expect(address.webUIURL.absoluteString == "https://proxy.example/xg2g/ui/")
+    }
+
+    @Test func nonDefaultPortSurvivesIntoEveryEndpoint() throws {
+        let address = try ServerAddressParser.parseTrusted("http://192.168.1.10:8080/")
+
+        #expect(address.apiBaseURL.absoluteString == "http://192.168.1.10:8080/api/v3/")
+    }
+
+    @Test func ipv6AddressProducesABracketedURL() throws {
+        let address = try ServerAddressParser.parseTrusted("http://[::1]:8080/")
+
+        #expect(address.origin.host == "::1")
+        #expect(address.apiBaseURL.absoluteString == "http://[::1]:8080/api/v3/")
+    }
+
+    @Test func missingPathBecomesTheRoot() throws {
+        #expect(try ServerAddressParser.parseTrusted("https://tv.example").rootPath == "/")
+    }
+
+    // MARK: - The Android modelling trap
+
+    /// Pasting the Web UI URL yields a root one level too deep, which is exactly
+    /// how the Android native transport ends up requesting `/ui/api/v3/...`.
+    /// The parser must not silently "fix" this — it reports what it was given,
+    /// and offers the alternative as a probe candidate.
+    @Test func webUIURLIsNotSilentlyReinterpreted() throws {
+        let address = try ServerAddressParser.parseUserEntered("https://tv.example/ui/")
+
+        #expect(address.rootPath == "/ui/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/ui/api/v3/")
+
+        let candidates = address.rootCandidates
+        #expect(candidates.count == 2)
+        #expect(candidates[0].rootPath == "/ui/")
+        #expect(candidates[1].rootPath == "/")
+        #expect(candidates[1].apiBaseURL.absoluteString == "https://tv.example/api/v3/")
+    }
+
+    @Test func rootAddressOffersOnlyItself() throws {
+        #expect(try ServerAddressParser.parseTrusted("https://tv.example/").rootCandidates.count == 1)
+    }
+
+    /// Candidates are a UX affordance, not discovery. Nothing but a trailing
+    /// `/ui/` may generate an alternative, and never more than one.
+    @Test func deepPathsDoNotGenerateACandidateLadder() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/a/b/c/")
+
+        #expect(address.rootCandidates.count == 1)
+        #expect(address.rootCandidates[0] == address)
+    }
+
+    @Test func onlyOneUISegmentIsEverRemoved() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/ui/ui/")
+
+        #expect(address.rootCandidates.count == 2)
+        #expect(address.rootCandidates[1].rootPath == "/ui/")
+    }
+
+    @Test func aPathMerelyContainingUIIsNotACandidateSource() throws {
+        for path in ["/ui-admin/", "/guide/", "/uix/"] {
+            let address = try ServerAddressParser.parseTrusted("https://tv.example\(path)")
+            #expect(address.rootCandidates.count == 1, "unexpected candidate for \(path)")
+        }
+    }
+
+    // MARK: - Deployment containment (the single same-origin check)
+
+    private func url(_ raw: String) throws -> URL {
+        try #require(URL(string: raw))
+    }
+
+    @Test func containsURLsUnderTheDeploymentRoot() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g/")
+
+        #expect(address.contains(try url("https://tv.example/xg2g/api/v3/services")))
+        #expect(address.contains(try url("https://tv.example/xg2g/ui/live")))
+        // Exact root without the trailing slash.
+        #expect(address.contains(try url("https://tv.example/xg2g")))
+    }
+
+    @Test func rejectsSiblingPathsOutsideTheRoot() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g/")
+
+        #expect(!address.contains(try url("https://tv.example/xg2gother/")))
+        #expect(!address.contains(try url("https://tv.example/admin")))
+        #expect(!address.contains(try url("https://tv.example/")))
+    }
+
+    @Test func rejectsOtherOrigins() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/")
+
+        #expect(!address.contains(try url("http://tv.example/api/v3/")))
+        #expect(!address.contains(try url("https://tv.example:8443/api/v3/")))
+        #expect(!address.contains(try url("https://other.example/api/v3/")))
+    }
+
+    @Test func acceptsEquivalentOriginSpellings() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/")
+
+        #expect(address.contains(try url("https://TV.EXAMPLE:443/api/v3/")))
+    }
+
+    /// Deployment-root containment is too weak for API calls: a traversal can
+    /// leave the API and still land inside the deployment.
+    @Test func apiScopeIsTighterThanTheDeploymentRoot() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g/")
+        let escaped = try url("https://tv.example/xg2g/api/v3/../../admin")
+
+        #expect(address.contains(escaped), "it never leaves the deployment")
+        #expect(!address.apiScope.contains(escaped), "but it does leave the API")
+    }
+
+    @Test func apiScopeAcceptsOrdinaryAPIPaths() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g/")
+
+        #expect(address.apiScope.contains(try url("https://tv.example/xg2g/api/v3/services/bouquets")))
+        #expect(!address.apiScope.contains(try url("https://tv.example/xg2g/ui/live")))
+    }
+
+    @Test func rejectsDotSegmentTraversalOutOfTheRoot() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g/")
+
+        #expect(!address.contains(try url("https://tv.example/xg2g/../admin")))
+    }
+
+    /// A userinfo host reads as the trusted one and resolves to another, so it
+    /// must never satisfy a containment check.
+    @Test func rejectsUserInfoDisguisedOrigin() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/")
+
+        #expect(!address.contains(try url("https://tv.example@attacker.example/api/v3/")))
+    }
+
+    // MARK: - Lenient parser: exactly one repair
+
+    @Test func userInputMayOmitTheScheme() throws {
+        let address = try ServerAddressParser.parseUserEntered("tv.example")
+
+        #expect(address.origin.scheme == .https)
+        #expect(address.rootPath == "/")
+    }
+
+    @Test func userInputMayOmitTheSchemeWithAPort() throws {
+        let address = try ServerAddressParser.parseUserEntered("tv-server.local:8080")
+
+        #expect(address.origin.scheme == .https)
+        #expect(address.origin.port == 8080)
+    }
+
+    /// A declared scheme is validated, never rewritten.
+    @Test func userInputWithForeignSchemeIsRejectedNotRepaired() {
+        #expect(throws: ServerAddress.ParseFailure.origin(.unsupportedScheme("ftp"))) {
+            try ServerAddressParser.parseUserEntered("ftp://tv.example/")
+        }
+    }
+
+    @Test func userInputKeepsAnExplicitHTTPScheme() throws {
+        #expect(try ServerAddressParser.parseUserEntered("http://tv.example/").origin.scheme == .http)
+    }
+
+    @Test func emptyUserInputIsRejected() {
+        #expect(throws: ServerAddress.ParseFailure.empty) {
+            try ServerAddressParser.parseUserEntered("   ")
+        }
+    }
+
+    // MARK: - Strict parser: no repair at all
+
+    @Test func trustedParserRefusesASchemelessString() {
+        #expect(throws: ServerAddress.ParseFailure.notAbsolute("tv.example")) {
+            try ServerAddressParser.parseTrusted("tv.example")
+        }
+    }
+
+    @Test func trustedParserRefusesAForeignScheme() {
+        #expect(throws: ServerAddress.ParseFailure.self) {
+            try ServerAddressParser.parseTrusted("xg2g://connect")
+        }
+    }
+
+    // MARK: - Refusals shared by both parsers
+
+    /// Reads as `trusted.example` to a human, resolves to `attacker.example`.
+    @Test func userInfoIsRejected() {
+        #expect(throws: ServerAddress.ParseFailure.carriesUserInfo("https://trusted.example@attacker.example/")) {
+            try ServerAddressParser.parseTrusted("https://trusted.example@attacker.example/")
+        }
+        #expect(throws: ServerAddress.ParseFailure.self) {
+            try ServerAddressParser.parseUserEntered("https://trusted.example@attacker.example/")
+        }
+    }
+
+    @Test func queryOrFragmentIsRejected() {
+        #expect(throws: ServerAddress.ParseFailure.self) {
+            try ServerAddressParser.parseTrusted("https://tv.example/?next=/admin")
+        }
+        #expect(throws: ServerAddress.ParseFailure.self) {
+            try ServerAddressParser.parseTrusted("https://tv.example/#/live")
+        }
+    }
+
+    @Test func nonASCIIHostIsRejected() {
+        #expect(throws: ServerAddress.ParseFailure.origin(.nonASCIIHost("münchen.example"))) {
+            try ServerAddressParser.parseUserEntered("münchen.example")
+        }
+    }
+
+    // MARK: - Canonicalization reaches through the address
+
+    @Test func spellingVariantsCollapseToOneAddress() throws {
+        let loud = try ServerAddressParser.parseTrusted("HTTPS://TV.EXAMPLE:443/")
+        let quiet = try ServerAddressParser.parseTrusted("https://tv.example/")
+
+        #expect(loud == quiet)
+        #expect(Set([loud, quiet]).count == 1)
+    }
+
+    @Test func dotSegmentsInTheRootAreResolved() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g/../other/")
+
+        #expect(address.rootPath == "/other/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/other/api/v3/")
+    }
+
+    /// `%2e%2e` is not traversal for the network stack, so it must stay a
+    /// literal segment here too. Decoding it would be the parser-differential.
+    @Test func percentEncodedDotsStayLiteral() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/a/%2e%2e/b/")
+
+        #expect(address.rootPath == "/a/%2e%2e/b/")
+    }
+
+    @Test func aMissingTrailingSlashIsAddedToTheRoot() throws {
+        let address = try ServerAddressParser.parseTrusted("https://tv.example/xg2g")
+
+        #expect(address.rootPath == "/xg2g/")
+        #expect(address.apiBaseURL.absoluteString == "https://tv.example/xg2g/api/v3/")
+    }
+}

--- a/ios/Xg2gTests/ServerIdentityTests.swift
+++ b/ios/Xg2gTests/ServerIdentityTests.swift
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Testing
+@testable import Xg2g
+
+struct InstanceIDTests {
+
+    @Test func acceptsAPlausibleServerMintedIdentifier() throws {
+        #expect(try InstanceID("xg2g-01H9Z_abc.DEF").rawValue == "xg2g-01H9Z_abc.DEF")
+    }
+
+    @Test func trimsSurroundingWhitespace() throws {
+        #expect(try InstanceID("  abcdefgh  ").rawValue == "abcdefgh")
+    }
+
+    @Test func rejectsEmpty() {
+        #expect(throws: InstanceID.Failure.empty) { try InstanceID("   ") }
+    }
+
+    @Test func rejectsTooShortAndTooLong() {
+        #expect(throws: InstanceID.Failure.tooShort(3)) { try InstanceID("abc") }
+        #expect(throws: InstanceID.Failure.tooLong(129)) { try InstanceID(String(repeating: "a", count: 129)) }
+    }
+
+    /// The value becomes part of a Keychain account key, so anything that could
+    /// act as a separator or escape the key format is refused at the boundary.
+    @Test func rejectsCharactersThatCouldEscapeAStorageKey() {
+        for hostile in ["abcdefgh:ij", "abcdefgh/ij", "abcdefgh ij", "abcdefgh\nij", "abcdefgh@ij", "abcdefgh\u{0}ij"] {
+            #expect(throws: InstanceID.Failure.self) { try InstanceID(hostile) }
+        }
+    }
+}
+
+struct ServerIdentityTests {
+
+    private func address(_ raw: String = "https://tv.example/") throws -> ServerAddress {
+        try ServerAddressParser.parseTrusted(raw)
+    }
+
+    private func instanceID(_ raw: String = "instance-aaaa") throws -> InstanceID {
+        try InstanceID(raw)
+    }
+
+    // MARK: - Identity equality
+
+    /// Base paths distinguish deployments, so two installations behind one
+    /// origin must remain distinct identities.
+    @Test func deploymentsUnderOneOriginAreDistinctIdentities() throws {
+        let home = ServerIdentity.address(try address("https://example.com/home/"))
+        let lab = ServerIdentity.address(try address("https://example.com/lab/"))
+
+        #expect(home != lab)
+    }
+
+    @Test func spellingVariantsAreOneIdentity() throws {
+        let loud = ServerIdentity.address(try address("HTTPS://TV.EXAMPLE:443/"))
+        let quiet = ServerIdentity.address(try address("https://tv.example/"))
+
+        #expect(loud == quiet)
+    }
+
+    // MARK: - Reconciliation
+
+    @Test func addressBindingIsUpgradedWhenTheServerReportsAnInstance() throws {
+        let bound = ServerIdentity.address(try address())
+        let observed = try instanceID()
+
+        let resolution = ServerIdentity.reconcile(bound: bound, observedInstance: observed)
+
+        #expect(resolution == .upgraded(from: bound, to: .instance(observed)))
+        #expect(resolution.identity == .instance(observed))
+        #expect(resolution.requiresRekeying)
+        #expect(!resolution.blocksCredentialUse)
+    }
+
+    @Test func addressBindingStaysWhenNoInstanceIsReported() throws {
+        let bound = ServerIdentity.address(try address())
+
+        let resolution = ServerIdentity.reconcile(bound: bound, observedInstance: nil)
+
+        #expect(resolution == .unchanged(bound))
+        #expect(!resolution.requiresRekeying)
+    }
+
+    @Test func matchingInstanceIsUnchanged() throws {
+        let bound = ServerIdentity.instance(try instanceID())
+
+        let resolution = ServerIdentity.reconcile(bound: bound, observedInstance: try instanceID())
+
+        #expect(resolution == .unchanged(bound))
+        #expect(!resolution.blocksCredentialUse)
+    }
+
+    /// A familiar address now answering with a different installation. The
+    /// credentials belong to the old one and must not be offered to the new.
+    @Test func differentInstanceIsAConflictAndBlocksCredentialUse() throws {
+        let bound = ServerIdentity.instance(try instanceID("instance-aaaa"))
+        let observed = try instanceID("instance-bbbb")
+
+        let resolution = ServerIdentity.reconcile(bound: bound, observedInstance: observed)
+
+        #expect(resolution == .conflict(bound: bound, observed: observed))
+        #expect(resolution.blocksCredentialUse)
+        #expect(resolution.identity == bound, "a conflict must not adopt the observed identity")
+    }
+
+    /// The case the type exists for: the server failed to report an instance
+    /// while we are instance-bound. A missing value is not evidence of a
+    /// different server, so the stronger binding is kept.
+    @Test func missingInstanceDoesNotWeakenAnInstanceBinding() throws {
+        let bound = ServerIdentity.instance(try instanceID())
+
+        let resolution = ServerIdentity.reconcile(bound: bound, observedInstance: nil)
+
+        #expect(resolution == .instanceUnavailable(bound))
+        #expect(resolution.identity == bound)
+        #expect(resolution.identity.strength == .instance)
+        #expect(!resolution.blocksCredentialUse)
+    }
+
+    // MARK: - The invariant itself
+
+    /// Exhaustive over every reconciliation shape: no input can produce an
+    /// identity weaker than the one already bound.
+    @Test func reconciliationNeverWeakensABinding() throws {
+        let bindings: [ServerIdentity] = [
+            .address(try address("https://tv.example/")),
+            .address(try address("https://tv.example/lab/")),
+            .instance(try instanceID("instance-aaaa")),
+        ]
+        let observations: [InstanceID?] = [
+            nil,
+            try instanceID("instance-aaaa"),
+            try instanceID("instance-bbbb"),
+        ]
+
+        for bound in bindings {
+            for observed in observations {
+                let resolution = ServerIdentity.reconcile(bound: bound, observedInstance: observed)
+                #expect(
+                    resolution.identity.strength >= bound.strength,
+                    "reconcile(\(bound), \(String(describing: observed))) weakened the binding"
+                )
+            }
+        }
+    }
+}

--- a/ios/Xg2gTests/ServerOriginTests.swift
+++ b/ios/Xg2gTests/ServerOriginTests.swift
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Testing
+@testable import Xg2g
+
+/// These tests are the contract for credential scoping: any two spellings of the
+/// same server must collapse to one value, or the same installation ends up
+/// owning two separate credential namespaces.
+struct ServerOriginTests {
+
+    private func origin(_ scheme: String, _ host: String, _ port: Int? = nil) throws -> ServerOrigin {
+        try ServerOrigin(scheme: scheme, host: host, port: port)
+    }
+
+    // MARK: - The case that motivated the type
+
+    @Test func uppercaseAndDefaultPortCollapseToTheSameOrigin() throws {
+        let loud = try origin("HTTPS", "EXAMPLE.COM", 443)
+        let quiet = try origin("https", "example.com", nil)
+
+        #expect(loud == quiet)
+        #expect(loud.description == "https://example.com")
+        #expect(Set([loud, quiet]).count == 1)
+    }
+
+    @Test func httpDefaultPortCollapses() throws {
+        #expect(try origin("http", "example.com", 80) == (try origin("http", "example.com", nil)))
+        #expect(try origin("http", "example.com", 80).description == "http://example.com")
+    }
+
+    @Test func nonDefaultPortIsPartOfTheIdentity() throws {
+        let a = try origin("https", "example.com", 8443)
+        let b = try origin("https", "example.com", nil)
+
+        #expect(a != b)
+        #expect(a.description == "https://example.com:8443")
+    }
+
+    @Test func schemeIsPartOfTheIdentity() throws {
+        #expect(try origin("http", "example.com", nil) != (try origin("https", "example.com", nil)))
+    }
+
+    // MARK: - Host canonicalization
+
+    @Test func trailingRootDotIsRemoved() throws {
+        #expect(try origin("https", "example.com.", nil) == (try origin("https", "example.com", nil)))
+    }
+
+    @Test func onlyOneTrailingDotIsStripped() throws {
+        // "example.com.." is not a legal name; it must not silently become
+        // "example.com".
+        #expect(try origin("https", "example.com..", nil).host == "example.com.")
+    }
+
+    @Test func ipv6IsCompressedToItsCanonicalForm() throws {
+        let long = try origin("https", "0:0:0:0:0:0:0:1", nil)
+        let short = try origin("https", "::1", nil)
+        let bracketed = try origin("https", "[::1]", nil)
+
+        #expect(long == short)
+        #expect(bracketed == short)
+        #expect(short.host == "::1")
+        #expect(short.isIPv6Literal)
+    }
+
+    @Test func ipv6IsBracketedInSerialization() throws {
+        #expect(try origin("https", "::1", nil).description == "https://[::1]")
+        #expect(try origin("https", "::1", 8080).description == "https://[::1]:8080")
+    }
+
+    /// A zone index is device-local. Keeping it would make the same server look
+    /// like two different identities depending on which interface was used.
+    @Test func ipv6ZoneIndexIsNotPartOfTheIdentity() throws {
+        #expect(try origin("https", "fe80::1%en0", nil) == (try origin("https", "fe80::1", nil)))
+    }
+
+    @Test func ipv6MixedCaseCollapses() throws {
+        #expect(try origin("https", "FE80::ABCD", nil) == (try origin("https", "fe80::abcd", nil)))
+    }
+
+    @Test func ipv4LiteralIsAccepted() throws {
+        #expect(try origin("http", "192.168.1.10", 8080).host == "192.168.1.10")
+    }
+
+    @Test func hostIsLowercased() throws {
+        #expect(try origin("https", "Tv-Server.Local", nil).host == "tv-server.local")
+    }
+
+    // MARK: - Refusals
+
+    /// IDNA is a homograph problem, not a formatting problem. A caller that
+    /// needs an internationalized host supplies punycode.
+    @Test func nonASCIIHostIsRejected() {
+        #expect(throws: ServerOrigin.Failure.nonASCIIHost("münchen.example")) {
+            try ServerOrigin(scheme: "https", host: "münchen.example", port: nil)
+        }
+    }
+
+    @Test func punycodeHostIsAccepted() throws {
+        #expect(try origin("https", "xn--mnchen-3ya.example", nil).host == "xn--mnchen-3ya.example")
+    }
+
+    @Test func unsupportedSchemeIsRejected() {
+        #expect(throws: ServerOrigin.Failure.unsupportedScheme("ftp")) {
+            try ServerOrigin(scheme: "ftp", host: "example.com", port: nil)
+        }
+    }
+
+    @Test func emptyHostIsRejected() {
+        #expect(throws: ServerOrigin.Failure.emptyHost) {
+            try ServerOrigin(scheme: "https", host: "   ", port: nil)
+        }
+    }
+
+    @Test func hostCarryingAuthorityDelimitersIsRejected() {
+        for bad in ["example.com/ui", "user@example.com", "example.com\\x", "exa mple.com", "example.com#f"] {
+            #expect(throws: ServerOrigin.Failure.self) {
+                try ServerOrigin(scheme: "https", host: bad, port: nil)
+            }
+        }
+    }
+
+    @Test func outOfRangePortIsRejected() {
+        #expect(throws: ServerOrigin.Failure.invalidPort(0)) {
+            try ServerOrigin(scheme: "https", host: "example.com", port: 0)
+        }
+        #expect(throws: ServerOrigin.Failure.invalidPort(70000)) {
+            try ServerOrigin(scheme: "https", host: "example.com", port: 70000)
+        }
+    }
+
+    @Test func malformedIPv6IsRejected() {
+        #expect(throws: ServerOrigin.Failure.self) {
+            try ServerOrigin(scheme: "https", host: "[::zz::1]", port: nil)
+        }
+    }
+}

--- a/ios/Xg2gTests/URLContainmentAttackTests.swift
+++ b/ios/Xg2gTests/URLContainmentAttackTests.swift
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+import Foundation
+import Testing
+@testable import Xg2g
+
+/// Containment is only meaningful if the URL we judge is the URL that gets
+/// sent. Every case here therefore asserts twice: that `URLRequest` carries the
+/// URL unchanged, and what the verdict is. If Foundation ever starts rewriting
+/// one of these, the first assertion fails and we find out before the second
+/// assertion becomes a lie.
+///
+/// The guiding rule is that this layer **never decodes**. `%2e%2e`, `%2f` and
+/// `%5c` are not traversal for `URLSession` or for the server, so treating them
+/// as traversal here would be a second parser opinion — the differential this
+/// layer exists to prevent. Being "more careful" than the network stack is not
+/// safer; it is just different, and different is the bug.
+struct URLContainmentAttackTests {
+
+    private let root = try! ServerAddressParser.parseTrusted("https://tv.example/xg2g/")
+
+    /// Asserts that the judged URL is byte-for-byte the URL that would be sent,
+    /// then asserts the containment verdict.
+    private func check(_ raw: String, contained expected: Bool, _ note: Comment) throws {
+        let url = try #require(URL(string: raw), "URL(string:) rejected \(raw)")
+        let sent = try #require(URLRequest(url: url).url)
+
+        #expect(
+            sent.absoluteString == url.absoluteString,
+            "URLRequest rewrote the URL: \(url.absoluteString) -> \(sent.absoluteString)"
+        )
+        #expect(root.contains(sent) == expected, note)
+    }
+
+    // MARK: - Real traversal is rejected
+
+    @Test func literalDotSegmentsEscapeAndAreRejected() throws {
+        try check("https://tv.example/xg2g/../admin", contained: false, "'..' really does escape the root")
+        try check("https://tv.example/xg2g/../../admin", contained: false, "repeated traversal")
+        try check("https://tv.example/xg2g/a/../../admin", contained: false, "traversal after a real segment")
+    }
+
+    @Test func harmlessDotSegmentsStayInside() throws {
+        try check("https://tv.example/xg2g/./api/v3/", contained: true, "'.' is a no-op")
+        try check("https://tv.example/xg2g/a/../api/", contained: true, "traversal that stays under the root")
+    }
+
+    // MARK: - Percent-encoded separators are NOT separators
+
+    /// `%2f` is a literal slash inside one segment. Decoding it here would
+    /// invent a segment boundary that neither URLSession nor the server sees.
+    @Test func encodedSlashIsNotASegmentBoundary() throws {
+        try check(
+            "https://tv.example/xg2g/a%2F..%2F..%2Fadmin",
+            contained: true,
+            "%2F must not be read as a separator, so this never leaves the root"
+        )
+        try check(
+            "https://tv.example/%2Fxg2g/admin",
+            contained: false,
+            "a leading %2F is part of the first segment, so this is not under /xg2g/"
+        )
+    }
+
+    /// `%5c` is a literal backslash. Browsers normalize `\` to `/`, which is why
+    /// the backend rejects it in `normalizeWebBootstrapTargetPath`; URLSession
+    /// does not, and this layer feeds URLSession.
+    @Test func encodedBackslashIsNotASegmentBoundary() throws {
+        try check(
+            "https://tv.example/xg2g/a%5C..%5Cadmin",
+            contained: true,
+            "%5C stays inside one segment"
+        )
+        try check(
+            "https://tv.example/%5Cxg2g/admin",
+            contained: false,
+            "not under the root"
+        )
+    }
+
+    // MARK: - Encoded dots are literal, in any spelling
+
+    @Test func encodedDotsAreNotTraversal() throws {
+        try check("https://tv.example/xg2g/%2e%2e/admin", contained: true, "lowercase %2e%2e is a literal segment")
+        try check("https://tv.example/xg2g/%2E%2E/admin", contained: true, "uppercase %2E%2E likewise")
+        try check("https://tv.example/xg2g/%2e%2E/admin", contained: true, "mixed case likewise")
+    }
+
+    @Test func doubleEncodedDotsAreNotTraversal() throws {
+        try check(
+            "https://tv.example/xg2g/%252e%252e/admin",
+            contained: true,
+            "%252e%252e decodes once to %2e%2e, which is still not traversal"
+        )
+    }
+
+    /// The canonical example from the review: a UI path with encoded dots must
+    /// not be read as reaching the API root.
+    @Test func encodedDotsDoNotReachTheAPIFromTheUI() throws {
+        let uiRoot = try ServerAddressParser.parseTrusted("https://tv.example/ui/")
+        let url = try #require(URL(string: "https://tv.example/ui/%2e%2e/api/v3/services"))
+
+        #expect(uiRoot.contains(url), "stays a literal segment under /ui/")
+
+        let deploymentRoot = try ServerAddressParser.parseTrusted("https://tv.example/")
+        #expect(
+            deploymentRoot.apiBaseURL.absoluteString == "https://tv.example/api/v3/",
+            "the real API is reached by derivation from the root, never by traversal"
+        )
+    }
+
+    // MARK: - Prefix confusion
+
+    @Test func siblingPathsSharingAPrefixAreRejected() throws {
+        try check("https://tv.example/xg2gX/api", contained: false, "/xg2gX is not under /xg2g/")
+        try check("https://tv.example/xg2g-other/", contained: false, "hyphenated sibling")
+    }
+
+    @Test func theRootItselfIsContainedWithOrWithoutTrailingSlash() throws {
+        try check("https://tv.example/xg2g/", contained: true, "exact root")
+        try check("https://tv.example/xg2g", contained: true, "root without trailing slash")
+    }
+
+    // MARK: - Origin confusion
+
+    @Test func otherOriginsAreRejected() throws {
+        try check("http://tv.example/xg2g/", contained: false, "scheme differs")
+        try check("https://tv.example:8443/xg2g/", contained: false, "port differs")
+        try check("https://attacker.example/xg2g/", contained: false, "host differs")
+    }
+
+    @Test func equivalentOriginSpellingsAreAccepted() throws {
+        try check("https://TV.EXAMPLE/xg2g/", contained: true, "host case is not significant")
+        try check("https://tv.example.:443/xg2g/", contained: true, "trailing root dot and default port")
+    }
+
+    /// Reads as `tv.example` and resolves to `attacker.example`.
+    @Test func userInfoDisguiseIsRejected() throws {
+        try check("https://tv.example@attacker.example/xg2g/", contained: false, "userinfo host disguise")
+        try check("https://tv.example:pass@attacker.example/xg2g/", contained: false, "with a password too")
+    }
+
+    /// A Unicode host cannot be compared safely, so it can never satisfy
+    /// containment against an ASCII-canonical root.
+    @Test func unicodeHostIsRejected() throws {
+        let url = try #require(URL(string: "https://tv.exämple/xg2g/"))
+        #expect(!root.contains(url))
+    }
+}


### PR DESCRIPTION
Replaces auto-closed stacked PR #829 while deliberately excluding later unrelated planner/benchmark commits that appeared on its original branch.

## Summary
- add the native iOS trust, credential, origin, deep-link, API client, keychain, and device-key foundation
- add the Xcode project, schemes, Info.plists, and comprehensive simulator tests

## Validation
- signed iPhone 17 Pro simulator test suite: pass
- Release simulator build: pass
- built Release Info.plist contains local-network usage text and no ATS exception
- `make pre-push`: pass