### PR TITLE
feat(bootstrap): log ADR-032 unbound device auth census at daemon startup

### DIFF
--- a/backend/internal/app/bootstrap/bootstrap.go
+++ b/backend/internal/app/bootstrap/bootstrap.go
@@ -132,6 +132,7 @@ func WireServices(ctx context.Context, version, commit, buildDate, explicitConfi
 	if err != nil {
 		return nil, fmt.Errorf("initialize device auth store: %w", err)
 	}
+	logUnboundDeviceAuthCensus(context.Background(), deviceAuthStore, logger, time.Now())
 
 	identityStorePath := filepath.Join(cfg.Store.Path, "identity.sqlite")
 	if cfg.Store.Backend == "memory" {

--- a/backend/internal/app/bootstrap/deviceauth_census.go
+++ b/backend/internal/app/bootstrap/deviceauth_census.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package bootstrap
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	deviceauthstore "github.com/ManuGH/xg2g/internal/domain/deviceauth/store"
+)
+
+// logUnboundDeviceAuthCensus reports how many devices a binding cutoff would
+// affect. See ADR-032 Phase 0.
+//
+// Read-only: no schema change, no write path, no behaviour change. It exists so
+// the cutoff window is chosen from measured numbers rather than from a guess,
+// and so the legacy fleet cannot quietly persist by being invisible.
+//
+// A non-empty fleet logs at warn level on purpose. It is an actionable
+// condition with a deadline attached, not background information.
+func logUnboundDeviceAuthCensus(ctx context.Context, store deviceauthstore.StateStore, logger zerolog.Logger, now time.Time) {
+	reader, ok := store.(deviceauthstore.UnboundInventoryReader)
+	if !ok {
+		// A store backend without the census is not a failure; it simply cannot
+		// answer, and saying so beats silence.
+		logger.Debug().
+			Str("adr", "032").
+			Msg("device auth census unavailable for this store backend")
+		return
+	}
+
+	inventory, err := reader.CountUnboundDeviceAuth(ctx, now)
+	if err != nil {
+		logger.Warn().
+			Err(err).
+			Str("adr", "032").
+			Msg("device auth census failed")
+		return
+	}
+
+	event := logger.Info()
+	if !inventory.IsEmpty() {
+		event = logger.Warn()
+	}
+
+	event = event.
+		Str("adr", "032").
+		Str("binding", "legacy_unbound").
+		Int("devices", inventory.Devices).
+		Int("owners", inventory.Owners).
+		Int("active_grants", inventory.ActiveGrants).
+		Int("active_sessions", inventory.ActiveSessions)
+
+	if inventory.OldestGrantIssuedAtMs > 0 {
+		event = event.Time("oldest_grant_issued_at", time.UnixMilli(inventory.OldestGrantIssuedAtMs).UTC())
+	}
+	if inventory.NewestGrantLastUsedAtMs > 0 {
+		event = event.Time("newest_grant_last_used_at", time.UnixMilli(inventory.NewestGrantLastUsedAtMs).UTC())
+	} else if inventory.ActiveGrants > 0 {
+		// "Never used" is a materially different cutoff decision from "used
+		// recently", so it must not read as a missing field.
+		event = event.Bool("any_grant_ever_used", false)
+	}
+
+	if inventory.IsEmpty() {
+		event.Msg("device auth census: no cryptographically unbound devices")
+		return
+	}
+	event.Msg("device auth census: cryptographically unbound devices present; these must re-pair before the ADR-032 cutoff")
+}

--- a/backend/internal/app/bootstrap/deviceauth_census_test.go
+++ b/backend/internal/app/bootstrap/deviceauth_census_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/ManuGH/xg2g/internal/domain/deviceauth/model"
+	deviceauthstore "github.com/ManuGH/xg2g/internal/domain/deviceauth/store"
+)
+
+func captureCensus(t *testing.T, seed func(t *testing.T, store deviceauthstore.StateStore), now time.Time) map[string]any {
+	t.Helper()
+
+	store := deviceauthstore.NewMemoryStateStore()
+	if seed != nil {
+		seed(t, store)
+	}
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+	logUnboundDeviceAuthCensus(context.Background(), store, logger, now)
+
+	if buf.Len() == 0 {
+		t.Fatal("census produced no log line")
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &fields); err != nil {
+		t.Fatalf("census log is not valid JSON: %v (%s)", err, buf.String())
+	}
+	return fields
+}
+
+func TestCensusReportsEmptyFleetAtInfo(t *testing.T) {
+	fields := captureCensus(t, nil, time.UnixMilli(2_000_000))
+
+	if fields["level"] != "info" {
+		t.Errorf("level = %v, want info for an empty fleet", fields["level"])
+	}
+	if fields["devices"] != float64(0) {
+		t.Errorf("devices = %v, want 0", fields["devices"])
+	}
+	if fields["adr"] != "032" {
+		t.Errorf("adr = %v, want 032", fields["adr"])
+	}
+}
+
+// A remaining legacy fleet has a deadline attached, so it must not be filed
+// away as background information.
+func TestCensusReportsRemainingFleetAtWarn(t *testing.T) {
+	now := time.UnixMilli(2_000_000)
+	lastUsed := time.UnixMilli(1_900_000)
+
+	fields := captureCensus(t, func(t *testing.T, store deviceauthstore.StateStore) {
+		ctx := context.Background()
+		if err := store.PutDevice(ctx, &model.DeviceRecord{
+			DeviceID:      "dev-1",
+			OwnerID:       "alice",
+			DeviceName:    "Shield",
+			DeviceType:    model.DeviceTypeAndroidTV,
+			PolicyProfile: "default",
+			CreatedAt:     time.UnixMilli(1_000_000),
+		}); err != nil {
+			t.Fatalf("put device: %v", err)
+		}
+		if err := store.PutDeviceGrant(ctx, &model.DeviceGrantRecord{
+			GrantID:    "g-1",
+			DeviceID:   "dev-1",
+			GrantHash:  "hash",
+			IssuedAt:   time.UnixMilli(1_100_000),
+			ExpiresAt:  time.UnixMilli(9_000_000),
+			LastUsedAt: &lastUsed,
+		}); err != nil {
+			t.Fatalf("put grant: %v", err)
+		}
+	}, now)
+
+	if fields["level"] != "warn" {
+		t.Errorf("level = %v, want warn while unbound devices remain", fields["level"])
+	}
+	if fields["devices"] != float64(1) {
+		t.Errorf("devices = %v, want 1", fields["devices"])
+	}
+	if fields["active_grants"] != float64(1) {
+		t.Errorf("active_grants = %v, want 1", fields["active_grants"])
+	}
+	if fields["binding"] != "legacy_unbound" {
+		t.Errorf("binding = %v, want legacy_unbound", fields["binding"])
+	}
+	if _, ok := fields["newest_grant_last_used_at"]; !ok {
+		t.Error("expected newest_grant_last_used_at to be reported")
+	}
+}
+
+// "Never used" must be visible as such rather than as an absent field, because
+// it argues for a shorter cutoff window.
+func TestCensusMarksNeverUsedGrantsExplicitly(t *testing.T) {
+	now := time.UnixMilli(2_000_000)
+
+	fields := captureCensus(t, func(t *testing.T, store deviceauthstore.StateStore) {
+		ctx := context.Background()
+		if err := store.PutDevice(ctx, &model.DeviceRecord{
+			DeviceID:      "dev-1",
+			OwnerID:       "alice",
+			DeviceName:    "Shield",
+			DeviceType:    model.DeviceTypeAndroidTV,
+			PolicyProfile: "default",
+			CreatedAt:     time.UnixMilli(1_000_000),
+		}); err != nil {
+			t.Fatalf("put device: %v", err)
+		}
+		if err := store.PutDeviceGrant(ctx, &model.DeviceGrantRecord{
+			GrantID:   "g-1",
+			DeviceID:  "dev-1",
+			GrantHash: "hash",
+			IssuedAt:  time.UnixMilli(1_100_000),
+			ExpiresAt: time.UnixMilli(9_000_000),
+		}); err != nil {
+			t.Fatalf("put grant: %v", err)
+		}
+	}, now)
+
+	if used, ok := fields["any_grant_ever_used"]; !ok || used != false {
+		t.Errorf("any_grant_ever_used = %v (present=%v), want explicit false", used, ok)
+	}
+	if _, ok := fields["newest_grant_last_used_at"]; ok {
+		t.Error("newest_grant_last_used_at must be absent when nothing was ever used")
+	}
+}
+
+func TestCensusVerifiesInventoryIsEmptyContract(t *testing.T) {
+	if !(model.UnboundInventory{}).IsEmpty() {
+		t.Error("a zero inventory must report empty")
+	}
+	if (model.UnboundInventory{Devices: 1}).IsEmpty() {
+		t.Error("an inventory with a device must not report empty")
+	}
+}


### PR DESCRIPTION
## Summary

- Wire `logUnboundDeviceAuthCensus` during daemon startup right after initializing `deviceAuthStore`
- Report count of unbound legacy device grants as specified in ADR-032 Phase 0
- Include unit test for `logUnboundDeviceAuthCensus`

## Validation

- `go test ./internal/app/bootstrap -count=1`
- `make pre-push`