### PR TITLE
ci: SHA-pin Claude workflows, allow dependabot on review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,15 +27,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6bcfb8263aca9b0eab0aba20d96dddd74de2875f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6bcfb8263aca9b0eab0aba20d96dddd74de2875f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- SHA-pin `actions/checkout` and `anthropics/claude-code-action` in `claude.yml` / `claude-code-review.yml` (added by `/install-github-app`), matching the SHA already used repo-wide for `actions/checkout`. These were on tag refs, which `verify-action-pins.sh` rejects — currently failing "Repository Health Checks" on `main`.
- Scope `allowed_bots: 'dependabot[bot]'` on the review workflow so it stops erroring with "Workflow initiated by non-human actor" on every Dependabot PR. Not `'*'` since this repo is public (action's own security note).

## Test plan
- [x] `backend/scripts/verify-action-pins.sh --local-only` passes
- [x] `actionlint` passes on both changed files
- [ ] CI green on this PR