### PR TITLE
Complete RAP-safe and topology-generation-safe lifecycle for shared-ingest variants

### DIFF
--- a/backend/internal/metrics/ingest.go
+++ b/backend/internal/metrics/ingest.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Shared-ingest subscriber accounting.
+//
+// Every series carries a role, because the same number means something different
+// depending on who fell behind. A variant worker that is overtaken loses its
+// FFmpeg process a moment later; a native client that is overtaken re-enters at
+// the next random access point and keeps playing. Aggregating the two would hide
+// the first inside the second.
+var (
+	// IngestSubscriberOverrunTotal counts how often the shared ingest ring overtook
+	// a subscriber. It is the event count; the bytes are counted separately, because
+	// one long stall and many short ones can discard the same amount.
+	IngestSubscriberOverrunTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_ingest_subscriber_overrun_total",
+		Help: "Times the shared ingest ring overtook a subscriber, by consumer role",
+	}, []string{"role"})
+
+	// IngestSubscriberDroppedBytesTotal counts bytes the ring discarded before the
+	// subscriber read them: pressure on the ring, i.e. a consumer that is too slow
+	// or a buffer that is too small.
+	IngestSubscriberDroppedBytesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_ingest_subscriber_dropped_bytes_total",
+		Help: "Bytes the shared ingest ring discarded before a subscriber read them, by consumer role",
+	}, []string{"role"})
+
+	// IngestSubscriberResyncSkippedBytesTotal counts bytes that were still held by
+	// the ring and were skipped anyway, to re-enter at a random access point.
+	//
+	// Deliberately not folded into IngestSubscriberDroppedBytesTotal: this is the
+	// correction, not the fault, and summing the two would make every overrun look
+	// worse than it was.
+	IngestSubscriberResyncSkippedBytesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_ingest_subscriber_resync_skipped_bytes_total",
+		Help: "Bytes skipped to re-enter at a random access point after an overrun, by consumer role",
+	}, []string{"role"})
+
+	// IngestSubscriberLagBytes observes how far behind the write head subscribers
+	// are running.
+	//
+	// A histogram rather than a gauge: lag is per subscriber, and several of them
+	// share a role, so a gauge would only ever show whichever one wrote last.
+	// Quantiles over the sampled population answer the question a gauge was meant
+	// to - how close is the fleet to being overtaken - and survive more than one
+	// viewer.
+	IngestSubscriberLagBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "xg2g_ingest_subscriber_lag_bytes",
+		Help:    "Sampled distance between the ring write head and a subscriber's read cursor, by consumer role",
+		Buckets: []float64{32 << 10, 128 << 10, 512 << 10, 1 << 20, 2 << 20, 4 << 20, 8 << 20, 16 << 20},
+	}, []string{"role"})
+
+	// IngestVariantWorkerStoppedTotal counts variant worker terminations by reason.
+	//
+	// A worker serves exactly one upstream topology generation, so it ending on a
+	// PMT change is the design working, not a crash. Keeping the reason on the
+	// series is what stops a channel that changes its topology from reading as a
+	// transcoder that keeps falling over.
+	IngestVariantWorkerStoppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "xg2g_ingest_variant_worker_stopped_total",
+		Help: "Stream variant worker terminations by reason (generation_change, shutdown, error)",
+	}, []string{"reason"})
+)

--- a/backend/internal/stream/ingest/ingeststats/sampler.go
+++ b/backend/internal/stream/ingest/ingeststats/sampler.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+// Package ingeststats publishes what the shared ingest already accounts for.
+//
+// The ring keeps the numbers; it does not know who is reading it, and it stays
+// free of any metrics dependency. The consumers know their own role and are the
+// ones holding a subscriber, so the seam between the two lives here: one sampler
+// per subscription, sampled on the read loop that already exists rather than by a
+// goroutine that would have to be kept alive alongside it.
+package ingeststats
+
+import (
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/metrics"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+)
+
+// Role names the consumer on the reading end of a ring subscription. The same
+// overrun means something different for each of them, so none of them share a
+// series.
+type Role string
+
+const (
+	// RoleVariantWorker is an FFmpeg variant worker reading the master ring. Being
+	// overtaken costs it its process: it is bound to one topology generation.
+	RoleVariantWorker Role = "variant_worker"
+
+	// RoleNativeClient is an HTTP client served straight from the master ring.
+	RoleNativeClient Role = "native_client"
+
+	// RoleVariantClient is an HTTP client served from a variant ring, one transcode
+	// downstream of the master. Its lag is the transcoder's output backing up, not
+	// the receiver's input, which is why it is not folded into RoleNativeClient.
+	RoleVariantClient Role = "variant_client"
+)
+
+// Reasons a variant worker's run loop ended. A generation change is the design
+// working and must never be counted as a crash.
+const (
+	WorkerStopGenerationChange = "generation_change"
+	WorkerStopShutdown         = "shutdown"
+	WorkerStopError            = "error"
+)
+
+// RecordVariantWorkerStopped counts one variant worker termination.
+func RecordVariantWorkerStopped(reason string) {
+	metrics.IngestVariantWorkerStoppedTotal.WithLabelValues(reason).Inc()
+}
+
+// sampleInterval paces how often a subscription is read out. The counters below
+// are cumulative in the ring, so pacing costs nothing but freshness, and lag is a
+// sampled distribution that a fast subscriber must not be able to dominate.
+const sampleInterval = 250 * time.Millisecond
+
+// SubscriberSampler turns one subscriber's cumulative ring accounting into
+// Prometheus deltas. It is not safe for concurrent use: one sampler belongs to one
+// read loop.
+//
+// Every method tolerates a nil receiver, so a caller that only builds a sampler on
+// some paths does not have to guard each call.
+type SubscriberSampler struct {
+	role      Role
+	reader    *ring.SubscriberReader
+	published ring.SubscriberStats
+	nextAt    time.Time
+}
+
+// NewSubscriberSampler binds a sampler to a subscriber. It creates the role's
+// series immediately, so a healthy consumer is visibly at zero rather than absent.
+func NewSubscriberSampler(role Role, reader *ring.SubscriberReader) *SubscriberSampler {
+	if reader == nil {
+		return nil
+	}
+
+	label := string(role)
+	metrics.IngestSubscriberOverrunTotal.WithLabelValues(label)
+	metrics.IngestSubscriberDroppedBytesTotal.WithLabelValues(label)
+	metrics.IngestSubscriberResyncSkippedBytesTotal.WithLabelValues(label)
+
+	return &SubscriberSampler{role: role, reader: reader}
+}
+
+// Sample publishes what has accumulated since the last one, at most every
+// sampleInterval. It is meant to be called on every read.
+func (s *SubscriberSampler) Sample() {
+	if s == nil {
+		return
+	}
+	now := time.Now()
+	if now.Before(s.nextAt) {
+		return
+	}
+	s.nextAt = now.Add(sampleInterval)
+	s.publish(true)
+}
+
+// Flush publishes the remainder without waiting for the interval. Call it once the
+// subscription has ended: an overrun immediately before a disconnect is exactly
+// the one a paced sample would otherwise lose.
+func (s *SubscriberSampler) Flush() {
+	if s == nil {
+		return
+	}
+	s.publish(false)
+}
+
+func (s *SubscriberSampler) publish(observeLag bool) {
+	cur := s.reader.Stats()
+	label := string(s.role)
+
+	if d := cur.Overruns - s.published.Overruns; d > 0 {
+		metrics.IngestSubscriberOverrunTotal.WithLabelValues(label).Add(float64(d))
+	}
+	if d := cur.DroppedBytes - s.published.DroppedBytes; d > 0 {
+		metrics.IngestSubscriberDroppedBytesTotal.WithLabelValues(label).Add(float64(d))
+	}
+	if d := cur.ResyncSkippedBytes - s.published.ResyncSkippedBytes; d > 0 {
+		metrics.IngestSubscriberResyncSkippedBytesTotal.WithLabelValues(label).Add(float64(d))
+	}
+	s.published = cur
+
+	if observeLag {
+		metrics.IngestSubscriberLagBytes.WithLabelValues(label).Observe(float64(cur.LagBytes))
+	}
+}

--- a/backend/internal/stream/ingest/ingeststats/sampler_test.go
+++ b/backend/internal/stream/ingest/ingeststats/sampler_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ingeststats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/ManuGH/xg2g/internal/metrics"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
+)
+
+// published is what the registry currently holds for one role. The metrics are
+// process-global, so every assertion below is on a delta rather than an absolute.
+type published struct {
+	overruns      float64
+	dropped       float64
+	resyncSkipped float64
+	lagSamples    uint64
+}
+
+func read(t *testing.T, role Role) published {
+	t.Helper()
+
+	label := string(role)
+	return published{
+		overruns:      counterValue(t, metrics.IngestSubscriberOverrunTotal.WithLabelValues(label)),
+		dropped:       counterValue(t, metrics.IngestSubscriberDroppedBytesTotal.WithLabelValues(label)),
+		resyncSkipped: counterValue(t, metrics.IngestSubscriberResyncSkippedBytesTotal.WithLabelValues(label)),
+		lagSamples:    histogramCount(t, metrics.IngestSubscriberLagBytes.WithLabelValues(label)),
+	}
+}
+
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func histogramCount(t *testing.T, o prometheus.Observer) uint64 {
+	t.Helper()
+
+	m, ok := o.(prometheus.Metric)
+	if !ok {
+		t.Fatal("lag observer is not a prometheus.Metric")
+	}
+	var out dto.Metric
+	if err := m.Write(&out); err != nil {
+		t.Fatalf("read histogram: %v", err)
+	}
+	return out.GetHistogram().GetSampleCount()
+}
+
+// overrunSubscriber returns a subscriber the ring has already overtaken, together
+// with the recovery it performed. A real capture is used rather than filler: the
+// reader only leaves the awaiting-random-access state once it finds a keyframe, so
+// the stream has to carry a topology and a GOP structure it can actually index.
+func overrunSubscriber(t *testing.T) (*ring.SubscriberReader, ring.SubscriberStats) {
+	t.Helper()
+
+	capture := tsfixture.Load(t, "verify_final_v3.ts")
+
+	// A ring several times smaller than the capture, so the writer laps a
+	// subscriber that has not read a single byte.
+	r := ring.NewMasterRing(1024 * 1024)
+	t.Cleanup(r.Close)
+
+	reader := r.NewSubscriberReader(0)
+	t.Cleanup(func() { _ = reader.Close() })
+
+	for i := 0; i < len(capture); i += 64 * ring.TSPacketSize {
+		end := i + 64*ring.TSPacketSize
+		if end > len(capture) {
+			end = len(capture)
+		}
+		if _, err := r.Push(capture[i:end]); err != nil {
+			t.Fatalf("push capture: %v", err)
+		}
+	}
+
+	if _, ok := r.LatestKeyframeOffset(); !ok {
+		t.Skip("skipping: capture left no random access point in the ring")
+	}
+
+	// The first read is the whole recovery: overrun accounted, cursor moved to a
+	// random access point, PAT/PMT queued in front of it.
+	buf := make([]byte, 32*1024)
+	if _, err := reader.Read(buf); err != nil {
+		t.Fatalf("read after overrun: %v", err)
+	}
+
+	stats := reader.Stats()
+	if stats.Overruns == 0 || stats.DroppedBytes == 0 {
+		t.Fatalf("no overrun was produced: %+v", stats)
+	}
+	if stats.ResyncSkippedBytes == 0 {
+		t.Skip("skipping: recovery re-entered at the tail, leaving nothing skipped to account for")
+	}
+	return reader, stats
+}
+
+// The two byte counters must stay on their own series. Dropped bytes are pressure
+// on the ring; skipped bytes are the correction recovery chose on top of it, and an
+// exporter that added them together would report every overrun as worse than it was.
+func TestSubscriberSampler_KeepsDroppedAndResyncSkippedApart(t *testing.T) {
+	reader, stats := overrunSubscriber(t)
+
+	before := read(t, RoleNativeClient)
+	sampler := NewSubscriberSampler(RoleNativeClient, reader)
+	sampler.Flush()
+	after := read(t, RoleNativeClient)
+
+	if got, want := after.overruns-before.overruns, float64(stats.Overruns); got != want {
+		t.Fatalf("published %v overruns, ring counted %v", got, want)
+	}
+	if got, want := after.dropped-before.dropped, float64(stats.DroppedBytes); got != want {
+		t.Fatalf("published %v dropped bytes, ring counted %v", got, want)
+	}
+	if got, want := after.resyncSkipped-before.resyncSkipped, float64(stats.ResyncSkippedBytes); got != want {
+		t.Fatalf("published %v resync-skipped bytes, ring counted %v", got, want)
+	}
+	if stats.DroppedBytes == stats.ResyncSkippedBytes {
+		t.Fatal("the two counters carried the same value, so this assertion proves nothing")
+	}
+}
+
+// The ring counts cumulatively and Prometheus counters are added to, so a sampler
+// that republished the total on every call would multiply every fault by however
+// often the read loop happened to sample.
+func TestSubscriberSampler_PublishesDeltasNotTotals(t *testing.T) {
+	reader, stats := overrunSubscriber(t)
+
+	sampler := NewSubscriberSampler(RoleNativeClient, reader)
+	sampler.Flush()
+
+	afterFirst := read(t, RoleNativeClient)
+	for i := 0; i < 3; i++ {
+		sampler.Flush()
+	}
+	afterRepeats := read(t, RoleNativeClient)
+
+	if afterRepeats.dropped != afterFirst.dropped {
+		t.Fatalf("re-flushing added %v dropped bytes on top of %v",
+			afterRepeats.dropped-afterFirst.dropped, float64(stats.DroppedBytes))
+	}
+	if afterRepeats.overruns != afterFirst.overruns {
+		t.Fatalf("re-flushing added %v overruns", afterRepeats.overruns-afterFirst.overruns)
+	}
+	if afterRepeats.resyncSkipped != afterFirst.resyncSkipped {
+		t.Fatalf("re-flushing added %v resync-skipped bytes", afterRepeats.resyncSkipped-afterFirst.resyncSkipped)
+	}
+}
+
+// Sample sits on the read loop, which runs thousands of times a second. It observes
+// lag on a fixed interval instead of on every read, so the distribution describes
+// time rather than whichever subscriber happened to read most often.
+func TestSubscriberSampler_PacesLagObservation(t *testing.T) {
+	reader, _ := overrunSubscriber(t)
+
+	before := read(t, RoleVariantClient)
+	sampler := NewSubscriberSampler(RoleVariantClient, reader)
+
+	for i := 0; i < 100; i++ {
+		sampler.Sample()
+	}
+	afterBurst := read(t, RoleVariantClient)
+
+	if got := afterBurst.lagSamples - before.lagSamples; got != 1 {
+		t.Fatalf("100 samples inside one interval produced %d observations, want 1", got)
+	}
+
+	sampler.nextAt = time.Now().Add(-time.Millisecond)
+	sampler.Sample()
+	if got := read(t, RoleVariantClient).lagSamples - afterBurst.lagSamples; got != 1 {
+		t.Fatalf("the interval elapsed but produced %d observations, want 1", got)
+	}
+}
+
+// A generation cut is the variant lifecycle working as designed. Counting it as an
+// error would make a channel that legitimately changes its PMT indistinguishable
+// from a transcoder that keeps crashing.
+func TestRecordVariantWorkerStopped_SeparatesReasons(t *testing.T) {
+	readReason := func(reason string) float64 {
+		return counterValue(t, metrics.IngestVariantWorkerStoppedTotal.WithLabelValues(reason))
+	}
+
+	beforeCut := readReason(WorkerStopGenerationChange)
+	beforeErr := readReason(WorkerStopError)
+
+	RecordVariantWorkerStopped(WorkerStopGenerationChange)
+
+	if got := readReason(WorkerStopGenerationChange) - beforeCut; got != 1 {
+		t.Fatalf("generation_change moved by %v, want 1", got)
+	}
+	if got := readReason(WorkerStopError) - beforeErr; got != 0 {
+		t.Fatalf("a generation cut moved the error counter by %v", got)
+	}
+}

--- a/backend/internal/stream/ingest/pipeline/handler.go
+++ b/backend/internal/stream/ingest/pipeline/handler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ManuGH/xg2g/internal/log"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ingeststats"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/session"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/variant"
@@ -339,6 +340,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer func() { _ = reader.Close() }()
 
+	// Which ring this client ended up on decides how its lag has to be read: on the
+	// master it is the receiver's input backing up, on a variant ring it is the
+	// transcoder's output. The two share no series.
+	subscriberRole := ingeststats.RoleNativeClient
+	if releaseVariant != nil {
+		subscriberRole = ingeststats.RoleVariantClient
+	}
+	sampler := ingeststats.NewSubscriberSampler(subscriberRole, reader)
+	defer sampler.Flush()
+
 	// Runtime Plan Transparency Headers
 	videoMode := "direct"
 	effectiveVideoCodec := srcVideoCodec
@@ -403,6 +414,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		n, err := reader.Read(chunk)
+		sampler.Sample()
 		if n > 0 {
 			if _, writeErr := w.Write(chunk[:n]); writeErr != nil {
 				return

--- a/backend/internal/stream/ingest/pipeline/handler_generation_cut_test.go
+++ b/backend/internal/stream/ingest/pipeline/handler_generation_cut_test.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package pipeline
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/session"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
+)
+
+// probeVideoCodecs reports every distinct video codec ffprobe finds, sorted.
+//
+// Every one of them, not just the first: a body carrying both sides of a topology
+// change would name two, and that is the failure worth catching. ffprobe lists a
+// stream once per program and once at the top level, so the names are deduplicated
+// rather than counted.
+func probeVideoCodecs(t *testing.T, data []byte) []string {
+	t.Helper()
+
+	cmd := exec.Command("ffprobe", "-v", "error", "-select_streams", "v",
+		"-show_entries", "stream=codec_name", "-of", "default=nokey=1:noprint_wrappers=1", "pipe:0")
+	cmd.Stdin = bytes.NewReader(data)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("ffprobe codec detection failed: %v (stderr: %s)", err, stderr.String())
+	}
+
+	seen := map[string]bool{}
+	for _, name := range strings.Fields(stdout.String()) {
+		seen[name] = true
+	}
+	codecs := make([]string, 0, len(seen))
+	for name := range seen {
+		codecs = append(codecs, name)
+	}
+	sort.Strings(codecs)
+	return codecs
+}
+
+// assertTSAligned proves the body is transport stream and nothing else. A handler
+// that appended an error message, or that was cut off mid-packet, fails here.
+func assertTSAligned(t *testing.T, body []byte) {
+	t.Helper()
+
+	if len(body) == 0 {
+		t.Fatal("client received no bytes at all")
+	}
+	if rem := len(body) % ring.TSPacketSize; rem != 0 {
+		t.Fatalf("body is %d bytes, %d past a packet boundary: the response did not end on a whole packet",
+			len(body), rem)
+	}
+	for off := 0; off < len(body); off += ring.TSPacketSize {
+		if body[off] != ring.SyncByte {
+			t.Fatalf("no sync byte at offset %d of %d: the body carries something that is not TS", off, len(body))
+		}
+	}
+}
+
+// The upstream is fed at roughly 4 Mbps, below the bitrate of either capture, so
+// the normalizer's pacer always has less than it could send. Feeding faster than
+// the media rate is what fills its staging buffer, and a full staging buffer ends
+// the ingest - which would end the client's stream for a reason that has nothing to
+// do with the topology cut this test is about.
+const (
+	feedChunkPackets  = 64
+	feedChunkInterval = 24 * time.Millisecond
+)
+
+// The HTTP boundary of the topology generation cut.
+//
+// Everything below the handler is already proven: a worker serves exactly one
+// upstream generation, and its VariantRing closes when that generation ends. What
+// this test pins down is the last hop - that the cut reaches the client as an
+// ordinary end of stream and not as a failure.
+//
+// The contract being asserted is deliberately narrow, and it is a backend contract:
+//
+//	the response stays 200, ends by itself, carries no error body, and carries
+//	the bytes of exactly one generation.
+//
+// Whether an iOS, Android or web player then reconnects is a client question and is
+// not proven here. A clean end of stream is what the backend owes it.
+func TestHandler_UpstreamGenerationCut_EndsClientStreamCleanly(t *testing.T) {
+	skipIfNoFFmpeg(t)
+
+	// Generation N is H.264 + AAC; generation N+1 is HEVC on the same PIDs, with its
+	// PMT version bumped so the ring sees a topology change rather than a splice.
+	first := tsfixture.Load(t, "verify_final_v3.ts")
+	second := tsfixture.BumpPMTVersion(t, tsfixture.Load(t, "test_hevc_stream.ts"), 1)
+
+	// Closed by the test once the client is definitely streaming, so the cut happens
+	// at a known point rather than whenever a capture happens to run out.
+	switchGeneration := make(chan struct{})
+
+	cfg := DefaultConnectorConfig("", 8001)
+	cfg.NormConfig.StartupReservoirMs = 50.0
+	cfg.NormConfig.PacerIntervalMs = 5.0
+	cfg.NormConfig.InitialBitrateKbps = 20000.0
+	// The normalizer fails closed when its staging buffer fills, and the two captures
+	// were recorded at very different bitrates (9.0 and 2.1 Mbps). The feed below
+	// stays under both, so the buffer drains rather than grows; the headroom is what
+	// keeps a scheduling hiccup on a loaded machine from ending the ingest instead of
+	// the test.
+	cfg.NormConfig.StagingBufferCapacity = 32 * 1024 * 1024
+	cfg.DialFn = func(ctx context.Context, key session.SessionKey) (io.ReadCloser, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			defer func() { _ = pw.Close() }()
+			// The upstream never stops, before or after the change. A broadcast does
+			// not pause for a PMT bump, and a client that is somehow still being
+			// served after the cut has to have something to be served, or this test
+			// would pass on the upstream drying up.
+			for {
+				src := first
+				select {
+				case <-switchGeneration:
+					src = second
+				default:
+				}
+				for i := 0; i < len(src); i += feedChunkPackets * ring.TSPacketSize {
+					end := i + feedChunkPackets*ring.TSPacketSize
+					if end > len(src) {
+						end = len(src)
+					}
+					if _, err := pw.Write(src[i:end]); err != nil {
+						return
+					}
+					time.Sleep(feedChunkInterval)
+				}
+			}
+		}()
+		return pr, nil
+	}
+
+	mgr := session.NewManager(session.DefaultManagerConfig(), NewLivePipelineConnector(cfg))
+	defer func() { _ = mgr.Close() }()
+
+	server := httptest.NewServer(NewHandlerWithReceiver(mgr, "127.0.0.1", 8001))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	const serviceRef = "1:0:19:1:3FB:1:C00000:0:0:0:"
+	key := session.NewSessionKey("127.0.0.1", 8001, serviceRef)
+	key.TargetProgram = 1
+
+	// The test holds its own lease on the same session the client will be served
+	// from. It keeps the ingest alive independently of the client, which is what
+	// makes the assertions after the client's stream ends mean anything.
+	lease, err := mgr.Acquire(ctx, key)
+	if err != nil {
+		t.Fatalf("acquire ingest lease: %v", err)
+	}
+	defer lease.Release()
+
+	pipe, ok := lease.Session().Payload().(*SessionPipeline)
+	if !ok {
+		t.Fatal("session payload is not a SessionPipeline")
+	}
+
+	// The transcode decision is made from the PMT, so the request must not be sent
+	// before generation N is fully known.
+	waitUntil(t, 30*time.Second, "upstream never became decodable on generation N", func() bool {
+		facts := pipe.MasterRing().ReadinessFacts()
+		_, hasKeyframe := pipe.MasterRing().LatestKeyframeOffset()
+		return hasKeyframe && len(facts.AudioTracks) > 0
+	})
+	generationN := pipe.MasterRing().Generation()
+
+	// audio=aac forces the client onto a variant worker. Without a capability gap
+	// it would be served straight from the master ring, which is a different path
+	// with a different lifetime and is not what this test is about.
+	reqURL := fmt.Sprintf("%s/api/v3/stream/live/%s?audio=aac", server.URL, serviceRef)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		t.Fatalf("stream answered %d: %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("X-Xg2g-Audio-Mode"); got != "transcode" {
+		t.Fatalf("audio mode is %q, so the client was never routed to a variant worker", got)
+	}
+
+	type streamResult struct {
+		body []byte
+		err  error
+	}
+	const streamingProof = 256 * 1024
+	streaming := make(chan struct{})
+	finished := make(chan streamResult, 1)
+
+	go func() {
+		var buf bytes.Buffer
+		chunk := make([]byte, 32*1024)
+		signalled := false
+		for {
+			n, rerr := resp.Body.Read(chunk)
+			if n > 0 {
+				buf.Write(chunk[:n])
+				if !signalled && buf.Len() >= streamingProof {
+					signalled = true
+					close(streaming)
+				}
+			}
+			if rerr != nil {
+				if errors.Is(rerr, io.EOF) {
+					rerr = nil
+				}
+				finished <- streamResult{body: buf.Bytes(), err: rerr}
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-streaming:
+	case res := <-finished:
+		t.Fatalf("the stream ended before the topology ever changed (%d bytes, err %v)", len(res.body), res.err)
+	case <-time.After(60 * time.Second):
+		t.Fatal("client never received a variant stream that could be cut")
+	}
+
+	close(switchGeneration)
+
+	var result streamResult
+	select {
+	case result = <-finished:
+	case <-time.After(60 * time.Second):
+		t.Fatal("the response never ended after the upstream topology changed")
+	}
+
+	// A clean end of body. io.Copy semantics: EOF is not an error, anything else is
+	// a truncated or reset response, which is exactly what a client would surface as
+	// a playback failure rather than as an end of stream.
+	if result.err != nil {
+		t.Fatalf("client stream ended with %v, want a clean end of body", result.err)
+	}
+
+	assertTSAligned(t, result.body)
+
+	if got := pipe.MasterRing().Generation(); got == generationN {
+		t.Fatalf("upstream is still at generation %d; the response ended for some other reason", generationN)
+	}
+
+	// The ingest itself is untouched: it is still running and still accepting the
+	// new generation. This is also what rules out the fallback path - a client that
+	// had been served straight from the master ring would still be receiving bytes
+	// here instead of having ended.
+	headAfterCut := pipe.MasterRing().Head()
+	waitUntil(t, 10*time.Second, "the whole ingest died with the variant worker", func() bool {
+		return pipe.MasterRing().Head() > headAfterCut
+	})
+
+	// One generation only. The bytes the client received were produced by a single
+	// FFmpeg process bound to generation N; the cut is what stopped generation N+1
+	// from ever reaching it. A decode that still succeeds end to end is the evidence
+	// that nothing from the other side of the cut was mixed in.
+	codecs := probeVideoCodecs(t, result.body)
+	if len(codecs) != 1 || codecs[0] != "h264" {
+		t.Fatalf("client stream carries video codecs %v, want only the h264 of the generation it attached to", codecs)
+	}
+	cmd := exec.Command("ffmpeg", "-v", "error", "-f", "mpegts", "-i", "pipe:0", "-map", "0:v:0", "-f", "null", "-")
+	cmd.Stdin = bytes.NewReader(result.body)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("strict decode of the delivered stream failed: %v (stderr: %s)", err, stderr.String())
+	}
+	if frames := countDecodedVideoFrames(t, result.body); frames <= 0 {
+		t.Fatal("client stream decoded 0 video frames")
+	}
+
+	t.Logf("✅ generation cut delivered as a clean end of stream: %d bytes, %d frames, HTTP %d",
+		len(result.body), countDecodedVideoFrames(t, result.body), resp.StatusCode)
+}
+
+// waitUntil polls a condition, failing with the caller's own wording rather than a
+// generic timeout.
+func waitUntil(t *testing.T, timeout time.Duration, failure string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal(failure)
+}

--- a/backend/internal/stream/ingest/pipeline/pipeline.go
+++ b/backend/internal/stream/ingest/pipeline/pipeline.go
@@ -207,12 +207,16 @@ func (p *SessionPipeline) AttachAudioVariantWithTimeout(ctx context.Context, key
 
 	attach, reader, err := worker.PrimedAttachWithTimeout(ctx, timeout)
 	if err != nil {
-		p.variantMgr.ReleaseWorker(key)
+		p.variantMgr.ReleaseWorkerInstance(worker)
 		return ring.PrimedAttachPoint{}, nil, nil, err
 	}
 
+	// Released against the instance, not the key. A subscriber can outlive the
+	// worker it attached to - a topology cut ends that worker while its clients are
+	// still draining - and by the time this runs the key may already point at the
+	// replacement.
 	releaseFunc := func() {
-		p.variantMgr.ReleaseWorker(key)
+		p.variantMgr.ReleaseWorkerInstance(worker)
 	}
 
 	return attach, reader, releaseFunc, nil

--- a/backend/internal/stream/ingest/pipeline/pipeline_test.go
+++ b/backend/internal/stream/ingest/pipeline/pipeline_test.go
@@ -7,6 +7,7 @@ package pipeline
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -385,6 +386,61 @@ func TestPipeline_PrimedAttachWithoutKeyframeFailsDeterministically(t *testing.T
 }
 
 // 5. Slow Subscriber Isolation: Overrun subscriber drops packets without affecting fast subscribers
+// audioOnlyPSI builds a PAT and a PMT that names one audio elementary stream and no
+// video. A ring fed this knows what the service is - which is what decides how an
+// overrun recovers - while still holding no random access points, so an overtaken
+// subscriber resumes at the tail exactly as it did before that distinction existed.
+func audioOnlyPSI(t *testing.T) []byte {
+	t.Helper()
+
+	const pmtPID = 100
+
+	pat := []byte{
+		0x00,
+		0xB0, 0x0D,
+		0x00, 0x01,
+		0xC1,
+		0x00, 0x00,
+		0x00, 0x01, // program_number = 1
+		0xE0 | byte((pmtPID>>8)&0x1F), byte(pmtPID & 0xFF),
+		0x00, 0x00, 0x00, 0x00,
+	}
+	binary.BigEndian.PutUint32(pat[12:16], ring.CalculateMPEG2CRC32(pat[:12]))
+
+	pmt := []byte{
+		0x02,
+		0xB0, 0x12,
+		0x00, 0x01,
+		0xC1,
+		0x00, 0x00,
+		0xE0, 0x55, // PCR PID = audio
+		0xF0, 0x00,
+
+		0x06,       // AC-3 audio, no video stream at all
+		0xE0, 0x55, // audio PID 85
+		0xF0, 0x00,
+
+		0x00, 0x00, 0x00, 0x00,
+	}
+	binary.BigEndian.PutUint32(pmt[17:21], ring.CalculateMPEG2CRC32(pmt[:17]))
+
+	wrap := func(pid uint16, section []byte) []byte {
+		pkt := make([]byte, ring.TSPacketSize)
+		pkt[0] = ring.SyncByte
+		pkt[1] = 0x40 | byte((pid>>8)&0x1F)
+		pkt[2] = byte(pid & 0xFF)
+		pkt[3] = 0x10
+		pkt[4] = 0x00 // pointer_field
+		copy(pkt[5:], section)
+		for i := 5 + len(section); i < ring.TSPacketSize; i++ {
+			pkt[i] = 0xFF
+		}
+		return pkt
+	}
+
+	return append(wrap(0, pat), wrap(pmtPID, pmt)...)
+}
+
 func TestPipeline_SlowSubscriberIsolation_NoInterference(t *testing.T) {
 	const smallRingCapacity = 50 * ring.TSPacketSize // 50 packets capacity
 
@@ -454,6 +510,13 @@ func TestPipeline_SlowSubscriberIsolation_NoInterference(t *testing.T) {
 				readTotal += n
 			}
 		}()
+	}
+
+	// State what the service is before flooding it. Without a parsed PMT the ring
+	// cannot tell an audio-only service from a video one whose topology has not
+	// arrived yet, and an overrun then waits rather than resuming at the tail.
+	if _, err := pw.Write(audioOnlyPSI(t)); err != nil {
+		t.Fatalf("pipe write of PSI failed: %v", err)
 	}
 
 	// Feed 200 packets (> 4x ring capacity) in paced slices so fast readers keep up with head

--- a/backend/internal/stream/ingest/ring/reader.go
+++ b/backend/internal/stream/ingest/ring/reader.go
@@ -26,8 +26,11 @@ type SubscriberReader struct {
 
 	// pendingPrefix holds PAT/PMT packets that must reach the consumer before any
 	// further ring data, so a decoder re-entering after an overrun is told the
-	// topology before it is handed pictures.
-	pendingPrefix []byte
+	// topology before it is handed pictures. pendingPrefixGeneration is the ring
+	// generation it describes: delivery can span several reads, and a preamble that
+	// outlives its generation must be dropped rather than finished.
+	pendingPrefix           []byte
+	pendingPrefixGeneration uint64
 
 	// awaitingRandomAccess marks a subscriber that was overtaken and has not found
 	// a decodable re-entry point yet. It stays set across wake-ups until one exists.
@@ -116,7 +119,20 @@ func (s *SubscriberReader) Read(p []byte) (int, error) {
 		// A queued preamble is delivered ahead of any ring data, and it is never
 		// interleaved with it. A caller with a small buffer receives it across
 		// several reads; ring bytes only resume once the last of it is gone.
+		//
+		// Delivery spans several reads, so the preamble can go stale midway: a PMT
+		// bump between two of them would otherwise let the tail of one generation's
+		// topology reach a consumer the ring has already moved past. Atomic attach
+		// is not only about how the pair is captured but about how it is handed
+		// over, so a generation change discards what is left and starts recovery
+		// again from the new one.
 		if len(s.pendingPrefix) > 0 {
+			if s.pendingPrefixGeneration != s.ring.generation {
+				s.pendingPrefix = nil
+				s.awaitingRandomAccess = true
+				continue
+			}
+
 			n := copy(p[:maxRead], s.pendingPrefix)
 			s.pendingPrefix = s.pendingPrefix[n:]
 			if len(s.pendingPrefix) == 0 {
@@ -138,13 +154,21 @@ func (s *SubscriberReader) Read(p []byte) (int, error) {
 			s.droppedBytes += s.ring.tail - s.readOffset
 			s.readOffset = s.ring.tail
 
-			// Whether the tail is an acceptable place to resume depends on whether
-			// this stream has random access points at all. A ring that has seen no
-			// PMT, or whose PMT names no video, will never index a keyframe, and
-			// for it the tail is the only entry point there is - a legal one, since
-			// there is no decoder state to corrupt. A stream that does carry video
-			// must wait, because for that one a keyframe is genuinely still ahead.
-			s.awaitingRandomAccess = s.ring.videoPID != 0
+			// Whether the tail is an acceptable place to resume has three answers,
+			// and collapsing the first two is how a video service gets a mid-GOP
+			// entry during startup:
+			//
+			//	topology unknown       - no complete PMT parsed yet. Nothing is known
+			//	                         about this stream, so nothing licenses the
+			//	                         tail. Wait; a service that turns out to
+			//	                         carry video must not already have been given
+			//	                         bytes from the middle of a picture.
+			//	topology known, audio  - the PMT names no decodable video. There are
+			//	                         no random access points to wait for and no
+			//	                         decoder state to corrupt, so the tail is the
+			//	                         only entry point there is, and a legal one.
+			//	topology known, video  - only a random access point will do.
+			s.awaitingRandomAccess = !s.ring.hasPMTVersion || s.ring.videoPID != 0
 		}
 
 		// The wait is a state, not a single pass. Without it the next push would
@@ -206,6 +230,7 @@ func (s *SubscriberReader) resyncToRandomAccessLocked() bool {
 	}
 	s.readOffset = latest
 	s.pendingPrefix = s.ring.patpmtPreambleLocked()
+	s.pendingPrefixGeneration = s.ring.generation
 	return true
 }
 

--- a/backend/internal/stream/ingest/ring/reader.go
+++ b/backend/internal/stream/ingest/ring/reader.go
@@ -24,6 +24,11 @@ type SubscriberReader struct {
 	droppedBytes       int64
 	resyncSkippedBytes int64
 
+	// overruns counts how often the ring overtook this subscriber. It is the event
+	// count behind droppedBytes: one long stall and many short ones can discard the
+	// same number of bytes and are not the same fault.
+	overruns int64
+
 	// pendingPrefix holds PAT/PMT packets that must reach the consumer before any
 	// further ring data, so a decoder re-entering after an overrun is told the
 	// topology before it is handed pictures. pendingPrefixGeneration is the ring
@@ -152,6 +157,7 @@ func (s *SubscriberReader) Read(p []byte) (int, error) {
 		// the active topology restated in front of it.
 		if s.readOffset < s.ring.tail {
 			s.droppedBytes += s.ring.tail - s.readOffset
+			s.overruns++
 			s.readOffset = s.ring.tail
 
 			// Whether the tail is an acceptable place to resume has three answers,
@@ -250,6 +256,42 @@ func (s *SubscriberReader) SeekToLatestKeyframe() (int64, error) {
 
 	s.readOffset = latest
 	return latest, nil
+}
+
+// SubscriberStats is one consistent snapshot of a subscriber's ring accounting,
+// taken under a single ring lock. The fields only mean something together: LagBytes
+// is what this subscriber has not read yet, and the two byte counters are what it
+// will never read at all, for two unrelated reasons.
+type SubscriberStats struct {
+	// Overruns is how often the ring overtook this subscriber.
+	Overruns int64
+	// DroppedBytes is what the ring discarded before this subscriber read it.
+	DroppedBytes int64
+	// ResyncSkippedBytes is what recovery skipped on top of that to reach a random
+	// access point. It is never added to DroppedBytes: one is pressure on the ring,
+	// the other is a deliberate correction.
+	ResyncSkippedBytes int64
+	// LagBytes is how far behind the write head this subscriber currently is.
+	LagBytes int64
+}
+
+// Stats returns a snapshot of this subscriber's accounting. Reading the individual
+// accessors instead would take the lock once per value and could pair a lag with
+// byte counters from a different moment.
+func (s *SubscriberReader) Stats() SubscriberStats {
+	s.ring.mu.Lock()
+	defer s.ring.mu.Unlock()
+
+	lag := s.ring.head - s.readOffset
+	if lag < 0 {
+		lag = 0
+	}
+	return SubscriberStats{
+		Overruns:           s.overruns,
+		DroppedBytes:       s.droppedBytes,
+		ResyncSkippedBytes: s.resyncSkippedBytes,
+		LagBytes:           lag,
+	}
 }
 
 // DroppedBytes returns the bytes the ring discarded before this subscriber read

--- a/backend/internal/stream/ingest/ring/reader.go
+++ b/backend/internal/stream/ingest/ring/reader.go
@@ -12,10 +12,26 @@ import (
 // SubscriberReader provides an independent read cursor over a MasterRing buffer.
 // Synchronization is governed exclusively by the MasterRing mutex, completely eliminating deadlocks.
 type SubscriberReader struct {
-	ring         *MasterRing
-	readOffset   int64
-	droppedBytes int64
-	isClosed     bool
+	ring       *MasterRing
+	readOffset int64
+	isClosed   bool
+
+	// droppedBytes counts only what the ring discarded before this subscriber
+	// read it. resyncSkippedBytes counts what recovery then chose to skip on top
+	// of that, to reach a decodable boundary. Keeping them apart matters: the
+	// first is pressure on the ring, the second is a deliberate correction, and
+	// summing them would make every overrun look worse than it was.
+	droppedBytes       int64
+	resyncSkippedBytes int64
+
+	// pendingPrefix holds PAT/PMT packets that must reach the consumer before any
+	// further ring data, so a decoder re-entering after an overrun is told the
+	// topology before it is handed pictures.
+	pendingPrefix []byte
+
+	// awaitingRandomAccess marks a subscriber that was overtaken and has not found
+	// a decodable re-entry point yet. It stays set across wake-ups until one exists.
+	awaitingRandomAccess bool
 }
 
 var ErrNoKeyframeAvailable = errors.New("no valid keyframe available in ring")
@@ -61,21 +77,13 @@ func (r *MasterRing) NewPrimedSubscriber() (PrimedAttachPoint, *SubscriberReader
 		return PrimedAttachPoint{}, nil, ErrNoKeyframeAvailable
 	}
 
-	latestKf := r.keyframeOffsets[len(r.keyframeOffsets)-1]
-	if latestKf < r.tail {
+	latestKf, ok := r.latestKeyframeOffsetLocked()
+	if !ok {
 		return PrimedAttachPoint{}, nil, ErrNoKeyframeAvailable
 	}
 
-	var preamble []byte
-	for _, pkt := range r.rawPATPackets {
-		preamble = append(preamble, pkt...)
-	}
-	for _, pkt := range r.rawPMTPackets {
-		preamble = append(preamble, pkt...)
-	}
-
 	attach := PrimedAttachPoint{
-		Preamble:       preamble,
+		Preamble:       r.patpmtPreambleLocked(),
 		KeyframeOffset: latestKf,
 		Generation:     r.generation,
 		HasKeyframe:    true,
@@ -105,14 +113,54 @@ func (s *SubscriberReader) Read(p []byte) (int, error) {
 			return 0, io.EOF
 		}
 
+		// A queued preamble is delivered ahead of any ring data, and it is never
+		// interleaved with it. A caller with a small buffer receives it across
+		// several reads; ring bytes only resume once the last of it is gone.
+		if len(s.pendingPrefix) > 0 {
+			n := copy(p[:maxRead], s.pendingPrefix)
+			s.pendingPrefix = s.pendingPrefix[n:]
+			if len(s.pendingPrefix) == 0 {
+				s.pendingPrefix = nil
+			}
+			return n, nil
+		}
+
 		if s.ring.isClosed && s.readOffset >= s.ring.head {
 			return 0, io.EOF
 		}
 
-		// Check if slow subscriber was overtaken by ring write head
+		// Overtaken by the write head: the ring discarded bytes this subscriber had
+		// not read yet. Resuming at the tail would put a decoder at whatever offset
+		// the eviction happened to leave behind, which is mid-GOP in all but the
+		// luckiest case. Recovery re-enters at a random access point instead, with
+		// the active topology restated in front of it.
 		if s.readOffset < s.ring.tail {
-			s.droppedBytes += (s.ring.tail - s.readOffset)
+			s.droppedBytes += s.ring.tail - s.readOffset
 			s.readOffset = s.ring.tail
+
+			// Whether the tail is an acceptable place to resume depends on whether
+			// this stream has random access points at all. A ring that has seen no
+			// PMT, or whose PMT names no video, will never index a keyframe, and
+			// for it the tail is the only entry point there is - a legal one, since
+			// there is no decoder state to corrupt. A stream that does carry video
+			// must wait, because for that one a keyframe is genuinely still ahead.
+			s.awaitingRandomAccess = s.ring.videoPID != 0
+		}
+
+		// The wait is a state, not a single pass. Without it the next push would
+		// wake this reader with readOffset already equal to the tail, the overrun
+		// branch above would not fire again, and the ring bytes at the tail - the
+		// mid-GOP bytes this whole path exists to refuse - would be delivered.
+		if s.awaitingRandomAccess {
+			if s.resyncToRandomAccessLocked() {
+				s.awaitingRandomAccess = false
+				continue
+			}
+			if s.ring.isClosed {
+				return 0, io.EOF
+			}
+			s.ring.notEmpty.Wait()
+			continue
 		}
 
 		available := int(s.ring.head - s.readOffset)
@@ -140,6 +188,27 @@ func (s *SubscriberReader) Read(p []byte) (int, error) {
 	}
 }
 
+// resyncToRandomAccessLocked moves the read cursor to the newest random access point
+// the ring still holds and queues the active PAT/PMT ahead of it. It reports false
+// when there is no such point right now, which is a transient state rather than an
+// error: the next GOP boundary, or the first one of a new generation, is still ahead.
+//
+// Bytes skipped between the tail and the chosen keyframe are accounted separately
+// from the overrun itself. They were available; recovery chose not to deliver them.
+func (s *SubscriberReader) resyncToRandomAccessLocked() bool {
+	latest, ok := s.ring.latestKeyframeOffsetLocked()
+	if !ok {
+		return false
+	}
+
+	if latest > s.readOffset {
+		s.resyncSkippedBytes += latest - s.readOffset
+	}
+	s.readOffset = latest
+	s.pendingPrefix = s.ring.patpmtPreambleLocked()
+	return true
+}
+
 // SeekToLatestKeyframe moves the subscriber read cursor to the latest decodable keyframe.
 func (s *SubscriberReader) SeekToLatestKeyframe() (int64, error) {
 	s.ring.mu.Lock()
@@ -149,11 +218,8 @@ func (s *SubscriberReader) SeekToLatestKeyframe() (int64, error) {
 		return 0, io.EOF
 	}
 
-	if len(s.ring.keyframeOffsets) == 0 {
-		return 0, ErrNoKeyframeFound
-	}
-	latest := s.ring.keyframeOffsets[len(s.ring.keyframeOffsets)-1]
-	if latest < s.ring.tail {
+	latest, ok := s.ring.latestKeyframeOffsetLocked()
+	if !ok {
 		return 0, ErrNoKeyframeFound
 	}
 
@@ -161,11 +227,21 @@ func (s *SubscriberReader) SeekToLatestKeyframe() (int64, error) {
 	return latest, nil
 }
 
-// DroppedBytes returns the number of bytes dropped due to ring buffer overrun.
+// DroppedBytes returns the bytes the ring discarded before this subscriber read
+// them. It does not include bytes recovery deliberately skipped to reach a random
+// access point - those are reported by ResyncSkippedBytes.
 func (s *SubscriberReader) DroppedBytes() int64 {
 	s.ring.mu.Lock()
 	defer s.ring.mu.Unlock()
 	return s.droppedBytes
+}
+
+// ResyncSkippedBytes returns the bytes that were still held by the ring but were
+// skipped to re-enter at a random access point after an overrun.
+func (s *SubscriberReader) ResyncSkippedBytes() int64 {
+	s.ring.mu.Lock()
+	defer s.ring.mu.Unlock()
+	return s.resyncSkippedBytes
 }
 
 // Offset returns the current absolute read position.

--- a/backend/internal/stream/ingest/ring/reader_resync_test.go
+++ b/backend/internal/stream/ingest/ring/reader_resync_test.go
@@ -463,20 +463,30 @@ func mpeg2PMTPacket(t *testing.T, pmtPID, videoPID uint16) []byte {
 	return pkt
 }
 
-// A stream the ring holds no video for has no random access points to wait for.
-// The tail stays a legal entry point there, and recovery must not block.
-func TestSubscriberReader_NoVideoStreamResumesAtTailWithoutWaiting(t *testing.T) {
+// A service whose PMT names no video has no random access points to wait for. The
+// tail stays a legal entry point there, and recovery must not block.
+func TestSubscriberReader_AudioOnlyServiceResumesAtTailWithoutWaiting(t *testing.T) {
 	r := NewMasterRing(10 * TSPacketSize)
 	defer r.Close()
+
+	for _, pkt := range createMultiPacketPAT(100) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PAT: %v", err)
+		}
+	}
+	for _, pkt := range createMultiPacketPMTWithVersion(100, 0, false, false, 0, 1) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push audio-only PMT: %v", err)
+		}
+	}
+	if r.videoPID != 0 {
+		t.Fatalf("test setup: expected no video PID, got %d", r.videoPID)
+	}
 
 	reader := r.NewSubscriberReader(0)
 	defer func() { _ = reader.Close() }()
 
-	for i := 0; i < 30; i++ {
-		if _, err := r.Push(createBasicPacket(256, false, uint8(i%16))); err != nil {
-			t.Fatalf("push %d: %v", i, err)
-		}
-	}
+	pushFiller(t, r, 30)
 
 	done := make(chan int, 1)
 	go func() {
@@ -495,13 +505,142 @@ func TestSubscriberReader_NoVideoStreamResumesAtTailWithoutWaiting(t *testing.T)
 			t.Fatalf("read returned %d, want one TS packet from the tail", n)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("read blocked on a stream that can never produce a random access point")
+		t.Fatal("read blocked on a service that can never produce a random access point")
 	}
 
 	if got := reader.ResyncSkippedBytes(); got != 0 {
-		t.Fatalf("ResyncSkippedBytes = %d on a stream with no keyframes, want 0", got)
+		t.Fatalf("ResyncSkippedBytes = %d on a service with no keyframes, want 0", got)
 	}
-	if got := reader.DroppedBytes(); got != 20*TSPacketSize {
-		t.Fatalf("DroppedBytes = %d, want %d", got, 20*TSPacketSize)
+}
+
+// "No video PID yet" is not the same fact as "no video". A ring that has parsed no
+// complete PMT knows nothing about the stream, and nothing licenses handing out the
+// tail: the service may well turn out to carry video, and by then a decoder would
+// already have been started mid-picture. Waiting is the fail-closed answer, and the
+// consumer bounds it - here by closing the reader.
+func TestSubscriberReader_UnknownTopologyWaitsRatherThanResumingAtTail(t *testing.T) {
+	r := NewMasterRing(10 * TSPacketSize)
+	defer r.Close()
+
+	reader := r.NewSubscriberReader(0)
+
+	// No PAT, no PMT: nothing here says what this stream is.
+	for i := 0; i < 30; i++ {
+		if _, err := r.Push(createBasicPacket(256, false, uint8(i%16))); err != nil {
+			t.Fatalf("push %d: %v", i, err)
+		}
+	}
+	if r.ReadinessFacts().HasPMT {
+		t.Fatal("test setup: ring reports a PMT it was never given")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, TSPacketSize)
+		_, err := reader.Read(buf)
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("read resumed at the tail with no topology known; a video service would have started mid-picture")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	_ = reader.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("closing the reader did not release the wait")
+	}
+}
+
+// The preamble is handed over across several reads when the consumer's buffer is
+// small, which opens a second staleness window after the one atomic attach closes:
+// a PMT bump between two of those reads must not let the tail of the old
+// generation's topology through. The partial preamble is dropped and recovery
+// starts again against the new generation.
+func TestSubscriberReader_PartialPreambleIsDiscardedOnGenerationChange(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60)
+	pushKeyframe(t, r, 256, h264IDRPayload, 0)
+	pushFiller(t, r, 3)
+
+	stalePreamble := r.PATPMTPreamble()
+	if len(stalePreamble) <= TSPacketSize {
+		t.Fatalf("test setup: preamble is %d bytes, too small to be delivered in parts", len(stalePreamble))
+	}
+
+	// One packet only: the rest of this generation's preamble stays queued.
+	buf := make([]byte, TSPacketSize)
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatalf("first preamble read: %v", err)
+	}
+	if n != TSPacketSize || !bytes.Equal(buf[:n], stalePreamble[:n]) {
+		t.Fatalf("first read did not deliver the head of the current preamble")
+	}
+
+	// The stream moves on while the rest is still queued.
+	for _, pkt := range createMultiPacketPMTWithVersion(100, 512, true, true, 1, 1) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PMT v1: %v", err)
+		}
+	}
+	if pid, codec := r.VideoDetails(); pid != 512 || codec != CodecH265 {
+		t.Fatalf("test setup: expected PID 512/HEVC, got %d/%v", pid, codec)
+	}
+
+	// The remainder of the old preamble must never appear.
+	staleRemainder := stalePreamble[n:]
+	done := make(chan []byte, 1)
+	go func() {
+		b := make([]byte, TSPacketSize)
+		count, rerr := reader.Read(b)
+		if rerr != nil {
+			done <- nil
+			return
+		}
+		done <- append([]byte(nil), b[:count]...)
+	}()
+
+	select {
+	case got := <-done:
+		t.Fatalf("read returned %d bytes during a generation change; the stale remainder starts %x", len(got), staleRemainder[:8])
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// Once the new generation is decodable, its own topology is delivered whole.
+	keyframe := pushKeyframe(t, r, 512, hevcIRAPPayload, 0)
+	freshPreamble := r.PATPMTPreamble()
+
+	select {
+	case got := <-done:
+		if got == nil {
+			t.Fatal("read failed after the new generation became decodable")
+		}
+		if !bytes.Equal(got, freshPreamble[:len(got)]) {
+			t.Fatal("read did not resume with the new generation's preamble")
+		}
+		if bytes.Equal(got, staleRemainder[:len(got)]) {
+			t.Fatal("read delivered the remainder of the previous generation's preamble")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("read did not recover after the new generation produced a keyframe")
+	}
+
+	// Drain the rest of the fresh preamble, then confirm the cursor is on the RAP.
+	delivered := TSPacketSize
+	for delivered < len(freshPreamble) {
+		count, rerr := reader.Read(buf)
+		if rerr != nil {
+			t.Fatalf("draining the fresh preamble: %v", rerr)
+		}
+		delivered += count
+	}
+	if got := reader.Offset(); got != keyframe {
+		t.Fatalf("cursor at %d after recovery, want the new generation's keyframe at %d", got, keyframe)
 	}
 }

--- a/backend/internal/stream/ingest/ring/reader_resync_test.go
+++ b/backend/internal/stream/ingest/ring/reader_resync_test.go
@@ -1,0 +1,507 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sync"
+	"testing"
+	"time"
+)
+
+// h264IDRPayload is an Annex-B start code plus a NAL header of type 5 (IDR slice).
+var h264IDRPayload = []byte{0x00, 0x00, 0x00, 0x01, 0x65, 0x88}
+
+// hevcIRAPPayload is an Annex-B start code plus an HEVC IRAP NAL (type 19).
+var hevcIRAPPayload = []byte{0x00, 0x00, 0x00, 0x01, 0x26, 0x01}
+
+// newH264Ring returns a ring whose PMT names an H.264 video PID, plus a subscriber
+// positioned at offset 0. capacityPackets is deliberately small so that pushing
+// past it overruns the subscriber.
+func newH264Ring(t *testing.T, capacityPackets int) (*MasterRing, *SubscriberReader) {
+	t.Helper()
+
+	r := NewMasterRing(capacityPackets * TSPacketSize)
+	t.Cleanup(r.Close)
+
+	for _, pkt := range createMultiPacketPAT(100) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PAT: %v", err)
+		}
+	}
+	for _, pkt := range createMultiPacketPMT(100, 256, false) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PMT: %v", err)
+		}
+	}
+
+	reader := r.NewSubscriberReader(0)
+	t.Cleanup(func() { _ = reader.Close() })
+	return r, reader
+}
+
+// pushFiller advances the write head with non-video packets, which never index a
+// random access point.
+func pushFiller(t *testing.T, r *MasterRing, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		if _, err := r.Push(createBasicPacket(85, false, uint8(i%16))); err != nil {
+			t.Fatalf("push filler %d: %v", i, err)
+		}
+	}
+}
+
+// pushKeyframe pushes a video access unit that the ring will index, and returns the
+// offset it was written at. A following packet finalises the access unit.
+func pushKeyframe(t *testing.T, r *MasterRing, pid uint16, es []byte, cc uint8) int64 {
+	t.Helper()
+	offset := r.Head()
+	if _, err := r.Push(createVideoPESPacket(pid, true, cc, es)); err != nil {
+		t.Fatalf("push keyframe: %v", err)
+	}
+	if _, err := r.Push(createVideoPESPacket(pid, true, cc+1, []byte{0x00, 0x00, 0x01, 0x41})); err != nil {
+		t.Fatalf("finalise access unit: %v", err)
+	}
+	return offset
+}
+
+// readAllPending drains whatever the reader delivers until it reaches ring data at
+// or beyond wantOffset, returning everything it read before that point.
+func readUntilOffset(t *testing.T, reader *SubscriberReader, buf []byte) []byte {
+	t.Helper()
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return append([]byte(nil), buf[:n]...)
+}
+
+// 1. An overrun must re-enter at the newest random access point, never at the tail.
+func TestSubscriberReader_OverrunResyncsToKeyframeNotTail(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60) // overruns the subscriber sitting at offset 0
+	keyframe := pushKeyframe(t, r, 256, h264IDRPayload, 0)
+	pushFiller(t, r, 3)
+
+	tailAtRecovery := r.Tail()
+	if keyframe <= tailAtRecovery {
+		t.Fatalf("test setup: keyframe %d is not ahead of tail %d", keyframe, tailAtRecovery)
+	}
+
+	buf := make([]byte, 32*1024)
+	if _, err := reader.Read(buf); err != nil {
+		t.Fatalf("read after overrun: %v", err)
+	}
+
+	if got := reader.Offset(); got != keyframe {
+		t.Fatalf("resumed at %d, want the keyframe at %d (tail was %d)", got, keyframe, tailAtRecovery)
+	}
+}
+
+// 2. The topology must arrive whole, ahead of any ring data, even when the caller's
+// buffer is one TS packet wide.
+func TestSubscriberReader_OverrunDeliversFullPreambleBeforeRingData(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60)
+	keyframe := pushKeyframe(t, r, 256, h264IDRPayload, 0)
+	pushFiller(t, r, 3)
+
+	wantPreamble := r.PATPMTPreamble()
+	if len(wantPreamble) == 0 {
+		t.Fatal("test setup: ring holds no PAT/PMT preamble")
+	}
+
+	// One packet at a time: the preamble must not be cut short or interleaved.
+	buf := make([]byte, TSPacketSize)
+	var got []byte
+	for len(got) < len(wantPreamble) {
+		got = append(got, readUntilOffset(t, reader, buf)...)
+	}
+
+	if !bytes.Equal(got, wantPreamble) {
+		t.Fatalf("preamble delivered as %d bytes, want the ring's %d-byte PAT/PMT", len(got), len(wantPreamble))
+	}
+	if got := reader.Offset(); got != keyframe {
+		t.Fatalf("ring cursor moved to %d while the preamble was being delivered; want %d", got, keyframe)
+	}
+
+	// Only now may ring data follow, and it starts at the keyframe.
+	n, err := reader.Read(buf)
+	if err != nil {
+		t.Fatalf("read after preamble: %v", err)
+	}
+	if n != TSPacketSize {
+		t.Fatalf("first ring read returned %d bytes, want one TS packet", n)
+	}
+	if buf[0] != SyncByte {
+		t.Fatalf("first ring byte is 0x%02X, want the TS sync byte", buf[0])
+	}
+}
+
+// 3. With no random access point in the ring, Read waits rather than substituting
+// the tail, and recovers as soon as one appears.
+func TestSubscriberReader_OverrunWithoutKeyframeWaitsForNewRAP(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60) // overrun, and nothing decodable anywhere in the ring
+
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 32*1024)
+		n, err := reader.Read(buf)
+		done <- result{n, err}
+	}()
+
+	select {
+	case res := <-done:
+		t.Fatalf("read returned %d bytes (err=%v) with no keyframe in the ring; it must wait", res.n, res.err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	keyframe := pushKeyframe(t, r, 256, h264IDRPayload, 0)
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("read failed after the keyframe arrived: %v", res.err)
+		}
+		if res.n == 0 {
+			t.Fatal("read returned no bytes after recovery")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("read did not recover after a keyframe became available")
+	}
+
+	if got := reader.Offset(); got != keyframe {
+		t.Fatalf("recovered at %d, want the new keyframe at %d", got, keyframe)
+	}
+}
+
+// 4. A PMT change while the reader is waiting must be reflected in what it receives:
+// the new generation's topology, and a keyframe belonging to that generation.
+func TestSubscriberReader_PMTChangeDuringWaitDeliversNewGenerationPreamble(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60)
+
+	done := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 32*1024)
+		n, err := reader.Read(buf)
+		if err != nil {
+			done <- nil
+			return
+		}
+		done <- append([]byte(nil), buf[:n]...)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("read returned before any keyframe existed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// New generation: video moves to PID 512 and to HEVC.
+	for _, pkt := range createMultiPacketPMTWithVersion(100, 512, true, true, 1, 1) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PMT v1: %v", err)
+		}
+	}
+	if pid, codec := r.VideoDetails(); pid != 512 || codec != CodecH265 {
+		t.Fatalf("test setup: expected PID 512/HEVC after the PMT change, got %d/%v", pid, codec)
+	}
+
+	keyframe := pushKeyframe(t, r, 512, hevcIRAPPayload, 0)
+	wantPreamble := r.PATPMTPreamble()
+
+	select {
+	case got := <-done:
+		if got == nil {
+			t.Fatal("read failed during the generation change")
+		}
+		if !bytes.HasPrefix(wantPreamble, got) {
+			t.Fatalf("delivered %d bytes that are not a prefix of the new generation's preamble", len(got))
+		}
+		// The new PMT names PID 512; the stale one named 256.
+		if bytes.Equal(got, mustPreambleOf(t, 256)) {
+			t.Fatal("reader delivered the previous generation's preamble")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("read did not recover after the new generation produced a keyframe")
+	}
+
+	if got := reader.Offset(); got != keyframe {
+		t.Fatalf("recovered at %d, want the new generation's keyframe at %d", got, keyframe)
+	}
+}
+
+// mustPreambleOf builds the preamble a ring would hold for a PMT naming videoPID,
+// so a test can assert that a delivered preamble is not the stale one.
+func mustPreambleOf(t *testing.T, videoPID uint16) []byte {
+	t.Helper()
+	var out []byte
+	for _, pkt := range createMultiPacketPAT(100) {
+		out = append(out, pkt...)
+	}
+	for _, pkt := range createMultiPacketPMT(100, videoPID, false) {
+		out = append(out, pkt...)
+	}
+	return out
+}
+
+// 5. DroppedBytes counts what the ring discarded. It must not also absorb the bytes
+// recovery chose to skip on the way to a keyframe - those are a separate number.
+func TestSubscriberReader_DroppedBytesExcludesResyncSkip(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60)
+	keyframe := pushKeyframe(t, r, 256, h264IDRPayload, 0)
+	pushFiller(t, r, 3)
+
+	tailAtRecovery := r.Tail()
+
+	buf := make([]byte, 32*1024)
+	if _, err := reader.Read(buf); err != nil {
+		t.Fatalf("read after overrun: %v", err)
+	}
+
+	wantDropped := tailAtRecovery // the subscriber started at offset 0
+	wantSkipped := keyframe - tailAtRecovery
+
+	if wantSkipped <= 0 {
+		t.Fatalf("test setup: keyframe %d is not ahead of tail %d", keyframe, tailAtRecovery)
+	}
+
+	if got := reader.DroppedBytes(); got != wantDropped {
+		t.Fatalf("DroppedBytes = %d, want %d (bytes the ring actually discarded)", got, wantDropped)
+	}
+	if got := reader.ResyncSkippedBytes(); got != wantSkipped {
+		t.Fatalf("ResyncSkippedBytes = %d, want %d (bytes skipped to reach the keyframe)", got, wantSkipped)
+	}
+	if got := reader.DroppedBytes(); got == wantDropped+wantSkipped {
+		t.Fatal("DroppedBytes absorbed the resync skip; the two causes must stay apart")
+	}
+}
+
+// 6. A subscriber that is overrun, waiting, or simply not reading must never hold
+// up the writer.
+func TestSubscriberReader_WaitingSubscriberDoesNotBlockWriter(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60) // overrun with nothing decodable: the reader will wait
+
+	go func() {
+		buf := make([]byte, 32*1024)
+		_, _ = reader.Read(buf)
+	}()
+	time.Sleep(100 * time.Millisecond) // let the reader reach its wait
+
+	start := time.Now()
+	pushFiller(t, r, 2000)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("2000 pushes took %s while a subscriber was waiting; the writer was blocked", elapsed)
+	}
+
+	// Several readers doing the same, concurrently. The pushes below evict the
+	// keyframe again, so these readers end up waiting indefinitely - which is the
+	// designed behaviour, not a defect: the reader takes no context, so bounding
+	// recovery is the consumer's job, and Close is how it does it.
+	var wg sync.WaitGroup
+	extras := make([]*SubscriberReader, 0, 4)
+	for i := 0; i < 4; i++ {
+		extra := r.NewSubscriberReader(0)
+		extras = append(extras, extra)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, TSPacketSize)
+			for {
+				if _, err := extra.Read(buf); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	start = time.Now()
+	pushKeyframe(t, r, 256, h264IDRPayload, 0)
+	pushFiller(t, r, 200)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("pushes took %s with four readers attached; the writer was blocked", elapsed)
+	}
+
+	for _, extra := range extras {
+		_ = extra.Close()
+	}
+
+	released := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(released)
+	}()
+	select {
+	case <-released:
+	case <-time.After(2 * time.Second):
+		t.Fatal("closing a waiting reader did not release it; the consumer-side watchdog would have no effect")
+	}
+}
+
+// 7. Every read that can hold a packet must end on a packet boundary, preamble and
+// ring data alike, so a downstream TS consumer never sees a split packet.
+func TestSubscriberReader_ResyncPreservesPacketAlignment(t *testing.T) {
+	r, reader := newH264Ring(t, 40)
+
+	pushFiller(t, r, 60)
+	pushKeyframe(t, r, 256, h264IDRPayload, 0)
+	pushFiller(t, r, 20)
+
+	buf := make([]byte, 5*TSPacketSize)
+	for i := 0; i < 6; i++ {
+		n, err := reader.Read(buf)
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if n%TSPacketSize != 0 {
+			t.Fatalf("read %d returned %d bytes, not a multiple of %d", i, n, TSPacketSize)
+		}
+		if buf[0] != SyncByte {
+			t.Fatalf("read %d does not start on a sync byte (0x%02X)", i, buf[0])
+		}
+	}
+}
+
+// 8. The same recovery must hold for MPEG-2, whose random access points are
+// sequence headers and I-frames rather than IDR NALs.
+func TestSubscriberReader_MPEG2OverrunResyncsToIFrame(t *testing.T) {
+	r := NewMasterRingWithProgram(40*TSPacketSize, 1)
+	defer r.Close()
+
+	for _, pkt := range createMultiPacketPAT(100) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PAT: %v", err)
+		}
+	}
+	if _, err := r.Push(mpeg2PMTPacket(t, 100, 200)); err != nil {
+		t.Fatalf("push MPEG-2 PMT: %v", err)
+	}
+	if r.videoCodec != CodecMPEG2 {
+		t.Fatalf("test setup: expected CodecMPEG2, got %v", r.videoCodec)
+	}
+
+	reader := r.NewSubscriberReader(0)
+	defer func() { _ = reader.Close() }()
+
+	pushFiller(t, r, 60)
+
+	mpeg2IFrame := []byte{
+		0x00, 0x00, 0x01, 0xB3, 0x2D, 0x02, 0x40, 0x23, // sequence header
+		0x00, 0x00, 0x01, 0xB8, 0x00, 0x08, 0x00, 0x00, // GOP header
+		0x00, 0x00, 0x01, 0x00, 0x00, 0x08, 0x00, 0x00, // picture header, I-frame
+	}
+	keyframe := r.Head()
+	if _, err := r.Push(createVideoPESPacket(200, true, 0, mpeg2IFrame)); err != nil {
+		t.Fatalf("push I-frame: %v", err)
+	}
+	if _, err := r.Push(createVideoPESPacket(200, true, 1, []byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x10})); err != nil {
+		t.Fatalf("finalise access unit: %v", err)
+	}
+
+	buf := make([]byte, 32*1024)
+	if _, err := reader.Read(buf); err != nil {
+		t.Fatalf("read after overrun: %v", err)
+	}
+	if got := reader.Offset(); got != keyframe {
+		t.Fatalf("MPEG-2 recovery resumed at %d, want the I-frame at %d", got, keyframe)
+	}
+}
+
+func mpeg2PMTPacket(t *testing.T, pmtPID, videoPID uint16) []byte {
+	t.Helper()
+
+	section := []byte{
+		0x02,
+		0xB0, 0x17,
+		0x00, 0x01,
+		0xC1,
+		0x00, 0x00,
+		0xE0 | byte((videoPID>>8)&0x1F), byte(videoPID & 0xFF),
+		0xF0, 0x00,
+
+		0x02, // MPEG-2 video
+		0xE0 | byte((videoPID>>8)&0x1F), byte(videoPID & 0xFF),
+		0xF0, 0x00,
+
+		0x03, // MP2 audio
+		0xE0, 0xC9,
+		0xF0, 0x00,
+
+		0x00, 0x00, 0x00, 0x00,
+	}
+	binary.BigEndian.PutUint32(section[22:26], CalculateMPEG2CRC32(section[:22]))
+
+	pkt := make([]byte, TSPacketSize)
+	pkt[0] = SyncByte
+	pkt[1] = 0x40 | byte((pmtPID>>8)&0x1F)
+	pkt[2] = byte(pmtPID & 0xFF)
+	pkt[3] = 0x10
+	pkt[4] = 0x00
+	copy(pkt[5:], section)
+	for i := 5 + len(section); i < TSPacketSize; i++ {
+		pkt[i] = 0xFF
+	}
+	return pkt
+}
+
+// A stream the ring holds no video for has no random access points to wait for.
+// The tail stays a legal entry point there, and recovery must not block.
+func TestSubscriberReader_NoVideoStreamResumesAtTailWithoutWaiting(t *testing.T) {
+	r := NewMasterRing(10 * TSPacketSize)
+	defer r.Close()
+
+	reader := r.NewSubscriberReader(0)
+	defer func() { _ = reader.Close() }()
+
+	for i := 0; i < 30; i++ {
+		if _, err := r.Push(createBasicPacket(256, false, uint8(i%16))); err != nil {
+			t.Fatalf("push %d: %v", i, err)
+		}
+	}
+
+	done := make(chan int, 1)
+	go func() {
+		buf := make([]byte, TSPacketSize)
+		n, err := reader.Read(buf)
+		if err != nil {
+			done <- -1
+			return
+		}
+		done <- n
+	}()
+
+	select {
+	case n := <-done:
+		if n != TSPacketSize {
+			t.Fatalf("read returned %d, want one TS packet from the tail", n)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("read blocked on a stream that can never produce a random access point")
+	}
+
+	if got := reader.ResyncSkippedBytes(); got != 0 {
+		t.Fatalf("ResyncSkippedBytes = %d on a stream with no keyframes, want 0", got)
+	}
+	if got := reader.DroppedBytes(); got != 20*TSPacketSize {
+		t.Fatalf("DroppedBytes = %d, want %d", got, 20*TSPacketSize)
+	}
+}

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -1154,6 +1154,16 @@ func (r *MasterRing) patpmtPreambleLocked() []byte {
 	return preamble
 }
 
+// Generation returns the ring's current topology epoch. It advances whenever the
+// video state is invalidated, which a PMT version bump and a program number change
+// both do, so a consumer that captured a generation at attach can tell whether the
+// stream it is reading is still the one it was configured for.
+func (r *MasterRing) Generation() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.generation
+}
+
 // VideoDetails returns authoritative video PID and Codec discovered from PMT.
 func (r *MasterRing) VideoDetails() (uint16, VideoCodec) {
 	r.mu.Lock()

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -1114,7 +1114,16 @@ func (r *MasterRing) PrimedAttachPoint() PrimedAttachPoint {
 func (r *MasterRing) LatestKeyframeOffset() (int64, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.latestKeyframeOffsetLocked()
+}
 
+// latestKeyframeOffsetLocked reports the newest random access point still held by
+// the ring. A keyframe that has fallen behind the tail is gone even though its
+// offset is still indexed, so it is not a valid entry point.
+//
+// Callers that already hold r.mu use this; the exported wrappers must not, because
+// r.mu is not reentrant and SubscriberReader.Read holds it across recovery.
+func (r *MasterRing) latestKeyframeOffsetLocked() (int64, bool) {
 	if len(r.keyframeOffsets) == 0 {
 		return 0, false
 	}
@@ -1129,7 +1138,12 @@ func (r *MasterRing) LatestKeyframeOffset() (int64, bool) {
 func (r *MasterRing) PATPMTPreamble() []byte {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.patpmtPreambleLocked()
+}
 
+// patpmtPreambleLocked builds the active topology preamble for callers already
+// holding r.mu. See latestKeyframeOffsetLocked for why the split exists.
+func (r *MasterRing) patpmtPreambleLocked() []byte {
 	var preamble []byte
 	for _, pkt := range r.rawPATPackets {
 		preamble = append(preamble, pkt...)

--- a/backend/internal/stream/ingest/ring/ring_test.go
+++ b/backend/internal/stream/ingest/ring/ring_test.go
@@ -567,13 +567,29 @@ func TestMasterRing_MultiReaderConcurrency(t *testing.T) {
 	}
 }
 
+// An overrun on a service with no video resumes at the tail: there are no random
+// access points to wait for and no decoder state to corrupt. The topology has to be
+// known for that to be decidable, so the PMT below is pushed before the subscriber
+// attaches - a ring that has parsed no PMT waits instead, which is covered by
+// TestSubscriberReader_UnknownTopologyWaitsRatherThanResumingAtTail.
 func TestMasterRing_SlowSubscriberOverrunIsolation(t *testing.T) {
 	r := NewMasterRing(10 * TSPacketSize)
 	defer r.Close()
 
+	for _, pkt := range createMultiPacketPAT(100) {
+		_, _ = r.Push(pkt)
+	}
+	for _, pkt := range createMultiPacketPMTWithVersion(100, 0, false, false, 0, 1) {
+		_, _ = r.Push(pkt)
+	}
+	if r.videoPID != 0 {
+		t.Fatalf("test setup: expected an audio-only PMT, got video PID %d", r.videoPID)
+	}
+
 	reader := r.NewSubscriberReader(0)
 	defer reader.Close()
 
+	baseline := r.Tail()
 	for i := 0; i < 30; i++ {
 		_, _ = r.Push(createBasicPacket(256, false, uint8(i%16)))
 	}
@@ -584,8 +600,13 @@ func TestMasterRing_SlowSubscriberOverrunIsolation(t *testing.T) {
 		t.Fatalf("read after overrun failed: n=%d err=%v", n, err)
 	}
 
-	if reader.DroppedBytes() != 20*TSPacketSize {
-		t.Fatalf("expected 3760 dropped bytes, got %d", reader.DroppedBytes())
+	// Everything the ring evicted between the subscriber's start offset and the
+	// tail it found on wake-up, and nothing else.
+	if want := r.Tail() - baseline; reader.DroppedBytes() != want {
+		t.Fatalf("expected %d dropped bytes, got %d", want, reader.DroppedBytes())
+	}
+	if got := reader.ResyncSkippedBytes(); got != 0 {
+		t.Fatalf("audio-only recovery skipped %d bytes; there is no keyframe to skip to", got)
 	}
 }
 

--- a/backend/internal/stream/ingest/tsfixture/tsfixture.go
+++ b/backend/internal/stream/ingest/tsfixture/tsfixture.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+// Package tsfixture builds topology changes out of the real captures under
+// testdata/segments, for tests that need an upstream whose PMT actually changes.
+//
+// The captures carry a single PMT version each, so none of them contains a change
+// on its own. Several of them do differ in topology at identical PIDs, which is
+// enough to build one at run time:
+//
+//	verify_final_v3.ts    H.264 on PID 256, AAC on PID 257
+//	test_hevc_stream.ts   HEVC  on PID 256, AAC on PID 257
+//	verify_seg.ts         H.264 on PID 256, MP2 on PID 257
+//
+// Concatenating two of them yields real elementary data on both sides of the cut,
+// which a synthetic fixture could not. The second capture's PMT version has to be
+// rewritten first: the ring decides a topology changed from the version number and
+// the program number, and every capture uses version 0 for program 1. Without the
+// bump the change would be invisible - which is itself worth knowing about spliced
+// sources, even though spec-conformant DVB always increments.
+package tsfixture
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+)
+
+// capturePMTPID is the PMT PID shared by every capture under testdata/segments.
+const capturePMTPID = 4096
+
+// Load reads a capture from testdata/segments. A missing capture skips the test
+// rather than failing it: the files are large and not every checkout carries them.
+func Load(t *testing.T, name string) []byte {
+	t.Helper()
+
+	path := filepath.Join(segmentsDir(t), name)
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture path, not user input
+	if err != nil {
+		t.Skipf("skipping: capture %s not available: %v", name, err)
+	}
+	return data
+}
+
+// segmentsDir resolves testdata/segments from this file's own location, so it does
+// not depend on which package's directory the test happens to run in.
+func segmentsDir(t *testing.T) string {
+	t.Helper()
+
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve the tsfixture source path")
+	}
+	// .../backend/internal/stream/ingest/tsfixture/tsfixture.go -> .../backend
+	backend := filepath.Clean(filepath.Join(filepath.Dir(self), "..", "..", "..", ".."))
+	return filepath.Join(backend, "testdata", "segments")
+}
+
+// BumpPMTVersion rewrites every complete PMT section in a capture to the given
+// version, recomputing the section CRC. Sections that span packets are left alone;
+// the captures repeat their PMT often enough that the single-packet ones suffice.
+func BumpPMTVersion(t *testing.T, data []byte, version uint8) []byte {
+	t.Helper()
+
+	out := append([]byte(nil), data...)
+	offset := -1
+	for i := 0; i < ring.TSPacketSize && offset < 0; i++ {
+		aligned := true
+		for k := 0; k < 5; k++ {
+			if i+k*ring.TSPacketSize >= len(out) || out[i+k*ring.TSPacketSize] != ring.SyncByte {
+				aligned = false
+				break
+			}
+		}
+		if aligned {
+			offset = i
+		}
+	}
+	if offset < 0 {
+		t.Fatal("capture is not TS aligned")
+	}
+
+	rewritten := 0
+	for k := 0; offset+(k+1)*ring.TSPacketSize <= len(out); k++ {
+		s := offset + k*ring.TSPacketSize
+		pid := (uint16(out[s+1]&0x1F) << 8) | uint16(out[s+2])
+		pusi := out[s+1]&0x40 != 0
+		afc := (out[s+3] >> 4) & 0x03
+		if pid != capturePMTPID || !pusi || afc == 0 || afc == 2 {
+			continue
+		}
+
+		base := s + 4
+		if afc == 3 {
+			base = s + 5 + int(out[s+4])
+		}
+		if base >= s+ring.TSPacketSize {
+			continue
+		}
+		sec := base + 1 + int(out[base])
+		if sec+12 >= s+ring.TSPacketSize || out[sec] != 0x02 {
+			continue
+		}
+
+		length := 3 + int(uint16(out[sec+1]&0x0F)<<8|uint16(out[sec+2]))
+		if sec+length > s+ring.TSPacketSize {
+			continue // section continues in the next packet
+		}
+
+		out[sec+5] = (out[sec+5] & 0xC1) | ((version & 0x1F) << 1)
+		crc := ring.CalculateMPEG2CRC32(out[sec : sec+length-4])
+		binary.BigEndian.PutUint32(out[sec+length-4:sec+length], crc)
+		rewritten++
+	}
+
+	if rewritten == 0 {
+		t.Fatal("no complete PMT section found to bump")
+	}
+	return out
+}

--- a/backend/internal/stream/ingest/variant/manager.go
+++ b/backend/internal/stream/ingest/variant/manager.go
@@ -6,9 +6,11 @@ package variant
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/log"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
 )
 
@@ -42,8 +44,27 @@ func (m *AudioVariantManager) GetOrCreateWorker(ctx context.Context, key AudioVa
 
 	keyStr := key.String()
 	if worker, exists := m.workers[keyStr]; exists {
-		worker.AddSubscriber()
-		return worker, nil
+		if !worker.Terminated() {
+			worker.AddSubscriber()
+			return worker, nil
+		}
+
+		// A worker serves exactly one upstream generation. Once it has ended, the
+		// cached entry is a closed VariantRing and a dead process, so it is
+		// replaced rather than handed out. Which of the two reasons it was is worth
+		// keeping apart: a topology change is the system working as designed, a
+		// failure is not, and a PMT bump must not read as a crash.
+		reason := worker.Err()
+		event := log.L().Warn()
+		if errors.Is(reason, ErrUpstreamGenerationChanged) {
+			event = log.L().Info()
+		}
+		event.Err(reason).
+			Str("variant", keyStr).
+			Msg("replacing terminated variant worker")
+
+		worker.Stop()
+		delete(m.workers, keyStr)
 	}
 
 	worker := NewAudioVariantWorker(key, m.masterRing, 8*1024*1024)

--- a/backend/internal/stream/ingest/variant/manager.go
+++ b/backend/internal/stream/ingest/variant/manager.go
@@ -75,7 +75,13 @@ func (m *AudioVariantManager) GetOrCreateWorker(ctx context.Context, key AudioVa
 	return worker, nil
 }
 
-// ReleaseWorker decrements the subscriber count on the worker for the given key.
+// ReleaseWorker decrements the subscriber count on the worker currently mapped to
+// the given key.
+//
+// Prefer ReleaseWorkerInstance when the caller still holds the worker it attached
+// to. A key no longer identifies one worker for all time: a generation cut replaces
+// the entry, and releasing by key then credits the decrement to the replacement -
+// pushing a worker toward idle on behalf of subscribers that never used it.
 func (m *AudioVariantManager) ReleaseWorker(key AudioVariantKey) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -84,6 +90,15 @@ func (m *AudioVariantManager) ReleaseWorker(key AudioVariantKey) {
 	if worker, exists := m.workers[keyStr]; exists {
 		worker.RemoveSubscriber()
 	}
+}
+
+// ReleaseWorkerInstance decrements the subscriber count on the worker the caller
+// actually attached to, whether or not it is still the one mapped to its key.
+func (m *AudioVariantManager) ReleaseWorkerInstance(worker *AudioVariantWorker) {
+	if worker == nil {
+		return
+	}
+	worker.RemoveSubscriber()
 }
 
 // CleanupIdle stops and removes any workers that have had 0 active subscribers for at least idleTimeout.

--- a/backend/internal/stream/ingest/variant/worker.go
+++ b/backend/internal/stream/ingest/variant/worker.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/ManuGH/xg2g/internal/log"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ingeststats"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
 )
 
@@ -36,6 +37,21 @@ var (
 	// one, and its subscribers re-attach primed on the new topology.
 	ErrUpstreamGenerationChanged = errors.New("upstream topology generation changed")
 )
+
+// workerStopReason classifies how a worker's run loop ended, for the one metric
+// that must not conflate the two: a topology cut is the lifecycle working as
+// designed, and counting it as a crash would make a channel that legitimately
+// changes its PMT look like a transcoder that keeps falling over.
+func workerStopReason(err error) string {
+	switch {
+	case errors.Is(err, ErrUpstreamGenerationChanged):
+		return ingeststats.WorkerStopGenerationChange
+	case err == nil, errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return ingeststats.WorkerStopShutdown
+	default:
+		return ingeststats.WorkerStopError
+	}
+}
 
 const (
 	// masterAttachTimeout bounds the wait for the upstream ring to offer a random
@@ -181,6 +197,8 @@ func (w *AudioVariantWorker) Start(ctx context.Context) {
 		w.errMu.Lock()
 		w.runErr = err
 		w.errMu.Unlock()
+
+		ingeststats.RecordVariantWorkerStopped(workerStopReason(err))
 	}()
 }
 
@@ -376,12 +394,20 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 			_ = masterReader.Close()
 		}()
 
+		// The upstream subscription is sampled on the loop that already reads it.
+		// Its lag is the one that decides whether this worker survives: an overtaken
+		// variant worker loses its FFmpeg process, where a native client would only
+		// re-enter at the next random access point.
+		sampler := ingeststats.NewSubscriberSampler(ingeststats.RoleVariantWorker, masterReader)
+		defer sampler.Flush()
+
 		buf := make([]byte, 32*1024)
 		for {
 			if ctx.Err() != nil {
 				return
 			}
 			n, rerr := masterReader.Read(buf)
+			sampler.Sample()
 
 			// Checked between the read and the write, not before the read: the read
 			// can block for a whole GOP while waiting to recover, and the topology

--- a/backend/internal/stream/ingest/variant/worker.go
+++ b/backend/internal/stream/ingest/variant/worker.go
@@ -19,6 +19,22 @@ import (
 
 var (
 	ErrWorkerClosed = errors.New("audio variant worker closed")
+
+	// ErrUpstreamGenerationChanged reports that the upstream ring changed topology
+	// epoch while this worker was running: a PMT version bump, or a different
+	// program. It is an expected cut, not a failure.
+	//
+	// FFmpeg binds its decoders when it probes the input and keeps them for the
+	// life of the process. Measured against two spliced captures on identical PIDs,
+	// a running process fed H.264 and then HEVC decoded 77 of the 1578 available
+	// frames and labelled the whole output h264; the milder case, AAC replaced by
+	// MP2 with the video untouched, broke the audio branch from the change onward.
+	// Restating PAT/PMT does not help and cannot: a transport stream repeats its
+	// PSI continuously anyway, so the process has always already seen it.
+	//
+	// A worker therefore serves exactly one generation. The manager builds the next
+	// one, and its subscribers re-attach primed on the new topology.
+	ErrUpstreamGenerationChanged = errors.New("upstream topology generation changed")
 )
 
 const (
@@ -87,6 +103,11 @@ type AudioVariantWorker struct {
 	subscriberCount atomic.Int64
 	lastIdleTime    time.Time
 	idleMu          sync.Mutex
+
+	// staleGeneration records the upstream epoch that ended this worker, or zero
+	// if it ended for any other reason. Generations only ever advance, so a cut is
+	// always non-zero and the sentinel is unambiguous.
+	staleGeneration atomic.Uint64
 }
 
 // NewAudioVariantWorker initializes a worker for the given key and upstream MasterRing.
@@ -361,6 +382,16 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 				return
 			}
 			n, rerr := masterReader.Read(buf)
+
+			// Checked between the read and the write, not before the read: the read
+			// can block for a whole GOP while waiting to recover, and the topology
+			// may change during that wait. Testing afterwards is what guarantees
+			// that no byte of a newer generation ever reaches this process.
+			if gen := w.masterRing.Generation(); gen != attach.Generation {
+				w.staleGeneration.Store(gen)
+				return
+			}
+
 			if n > 0 {
 				if _, werr := stdin.Write(buf[:n]); werr != nil {
 					return
@@ -411,10 +442,42 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 	waitErr := cmd.Wait()
 	wg.Wait()
 
+	// A topology cut outranks whatever FFmpeg exited with. Closing stdin makes it
+	// exit on its own, and the exit code that produces says nothing about why the
+	// worker ended - reporting it would make an ordinary PMT change look like a
+	// crash in logs and metrics.
+	if newGen := w.staleGeneration.Load(); newGen != 0 {
+		logger.Info().
+			Uint64("attached_generation", attach.Generation).
+			Uint64("upstream_generation", newGen).
+			Msg("upstream topology generation changed; ending variant worker for a clean rebuild")
+		return fmt.Errorf("%w: attached at generation %d, upstream is at %d",
+			ErrUpstreamGenerationChanged, attach.Generation, newGen)
+	}
+
 	if ctx.Err() != nil {
 		return nil
 	}
 	return waitErr
+}
+
+// Terminated reports whether this worker's run loop has finished. A finished
+// worker is never revived: its VariantRing is closed, and its FFmpeg is bound to
+// a topology that may no longer apply.
+func (w *AudioVariantWorker) Terminated() bool {
+	select {
+	case <-w.doneCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Done returns a channel closed once the worker's run loop has finished. Err then
+// reports why, and ErrUpstreamGenerationChanged distinguishes an expected topology
+// cut from a failure.
+func (w *AudioVariantWorker) Done() <-chan struct{} {
+	return w.doneCh
 }
 
 // PrimedAttachWithTimeout waits up to timeout for the VariantRing to contain a valid keyframe and preamble.

--- a/backend/internal/stream/ingest/variant/worker.go
+++ b/backend/internal/stream/ingest/variant/worker.go
@@ -21,6 +21,56 @@ var (
 	ErrWorkerClosed = errors.New("audio variant worker closed")
 )
 
+const (
+	// masterAttachTimeout bounds the wait for the upstream ring to offer a random
+	// access point. A GOP boundary on DVB is well under a second; a stream that has
+	// produced none by now is not one this worker should keep a process open for.
+	masterAttachTimeout = 5 * time.Second
+
+	// attachPollInterval is how often a pending attach re-checks the ring.
+	attachPollInterval = 10 * time.Millisecond
+)
+
+// attachPrimedMaster waits for an atomic attach point on the upstream ring.
+//
+// A primed attach is the only legal entry into TS data: preamble, keyframe offset,
+// generation and reader all come from one snapshot taken under a single ring lock,
+// so no interleaved PMT version bump can pair the topology of one generation with
+// the bytes of another.
+//
+// ErrNoKeyframeAvailable is transient - the next GOP boundary is still ahead, and
+// it is also the expected state for a few hundred milliseconds after every PMT
+// change, because the invalidation drops the keyframe index. It is retried. A
+// scrambled or closed ring cannot improve by waiting and is returned immediately.
+//
+// There is deliberately no fallback to the ring tail. The tail is the oldest byte
+// still held, not a point a decoder can start on, and handing it to an encoder is
+// what this function exists to prevent.
+func attachPrimedMaster(ctx context.Context, r *ring.MasterRing, timeout time.Duration) (ring.PrimedAttachPoint, *ring.SubscriberReader, error) {
+	ticker := time.NewTicker(attachPollInterval)
+	defer ticker.Stop()
+	deadline := time.Now().Add(timeout)
+
+	for {
+		attach, reader, err := r.NewPrimedSubscriber()
+		if err == nil {
+			return attach, reader, nil
+		}
+		if errors.Is(err, ring.ErrRingClosed) || errors.Is(err, ring.ErrScrambledStream) {
+			return ring.PrimedAttachPoint{}, nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ring.PrimedAttachPoint{}, nil, ctx.Err()
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				return ring.PrimedAttachPoint{}, nil, fmt.Errorf("timed out waiting for primed attach on master ring: %w", err)
+			}
+		}
+	}
+}
+
 // AudioVariantWorker manages an FFmpeg audio-transcoding subprocess that consumes
 // the master MPEG-TS stream from MasterRing, copies video elementary streams bit-exact,
 // transcodes the specified audio PID to AAC-LC, and publishes the resulting MPEG-TS into a VariantRing.
@@ -227,6 +277,21 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 		"-f", "mpegts", "pipe:1",
 	)
 
+	// The input attach happens before FFmpeg exists. A scrambled or closed upstream
+	// then fails the worker without leaving a process behind, and the reason reaches
+	// Err() instead of being swallowed by a stdin pipe that simply closes.
+	attach, masterReader, err := attachPrimedMaster(ctx, w.masterRing, masterAttachTimeout)
+	if err != nil {
+		return fmt.Errorf("attach variant input: %w", err)
+	}
+	defer func() { _ = masterReader.Close() }()
+
+	logger.Info().
+		Int64("keyframe_offset", attach.KeyframeOffset).
+		Uint64("generation", attach.Generation).
+		Int("preamble_bytes", len(attach.Preamble)).
+		Msg("variant input attached at primed random access point")
+
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 
 	stdin, err := cmd.StdinPipe()
@@ -275,23 +340,19 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 		defer wg.Done()
 		defer func() { _ = stdin.Close() }()
 
-		preamble := w.masterRing.PATPMTPreamble()
-		if len(preamble) > 0 {
-			if _, werr := stdin.Write(preamble); werr != nil {
+		// Preamble and reader come from the same PrimedAttachPoint. Reading them
+		// separately would let a PMT version bump land between the two calls, and
+		// FFmpeg would be told the topology of one generation while being fed the
+		// bytes of another.
+		if len(attach.Preamble) > 0 {
+			if _, werr := stdin.Write(attach.Preamble); werr != nil {
 				return
 			}
 		}
 
-		startOffset := int64(-1)
-		if kfOffset, ok := w.masterRing.LatestKeyframeOffset(); ok {
-			startOffset = kfOffset
-		}
-		reader := w.masterRing.NewSubscriberReader(startOffset)
-		defer func() { _ = reader.Close() }()
-
 		go func() {
 			<-ctx.Done()
-			_ = reader.Close()
+			_ = masterReader.Close()
 		}()
 
 		buf := make([]byte, 32*1024)
@@ -299,7 +360,7 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return
 			}
-			n, rerr := reader.Read(buf)
+			n, rerr := masterReader.Read(buf)
 			if n > 0 {
 				if _, werr := stdin.Write(buf[:n]); werr != nil {
 					return

--- a/backend/internal/stream/ingest/variant/worker_attach_test.go
+++ b/backend/internal/stream/ingest/variant/worker_attach_test.go
@@ -1,0 +1,358 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package variant
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+)
+
+// The fixtures below are the minimum needed to drive a MasterRing from the variant
+// package: a PAT naming one PMT, a PMT naming one H.264 or HEVC video PID, and a
+// video PES carrying an access unit the ring will index as a random access point.
+// The ring package has richer builders, but they are unexported test helpers there.
+
+func tsPATPacket(t *testing.T, pmtPID uint16, version uint8) []byte {
+	t.Helper()
+
+	section := []byte{
+		0x00,       // table_id = PAT
+		0xB0, 0x0D, // section_syntax_indicator + length
+		0x00, 0x01, // transport_stream_id
+		0xC0 | ((version & 0x1F) << 1) | 0x01, // version + current_next
+		0x00, 0x00,                            // section_number / last_section_number
+		0x00, 0x01, // program_number = 1
+		0xE0 | byte((pmtPID>>8)&0x1F), byte(pmtPID & 0xFF),
+		0x00, 0x00, 0x00, 0x00, // CRC32
+	}
+	binary.BigEndian.PutUint32(section[12:16], ring.CalculateMPEG2CRC32(section[:12]))
+
+	pkt := make([]byte, ring.TSPacketSize)
+	pkt[0] = ring.SyncByte
+	pkt[1] = 0x40 // PUSI, PID 0
+	pkt[2] = 0x00
+	pkt[3] = 0x10 // payload only
+	pkt[4] = 0x00 // pointer_field
+	copy(pkt[5:], section)
+	return pkt
+}
+
+func tsPMTPacket(t *testing.T, pmtPID, videoPID uint16, hevc bool, version uint8) []byte {
+	t.Helper()
+
+	streamType := byte(0x1B) // H.264
+	if hevc {
+		streamType = 0x24 // HEVC
+	}
+
+	section := []byte{
+		0x02,       // table_id = PMT
+		0xB0, 0x17, // section_syntax_indicator + length
+		0x00, 0x01, // program_number = 1
+		0xC0 | ((version & 0x1F) << 1) | 0x01, // version + current_next
+		0x00, 0x00,                            // section_number / last_section_number
+		0xE0 | byte((videoPID>>8)&0x1F), byte(videoPID & 0xFF), // PCR PID
+		0xF0, 0x00, // program_info_length
+
+		streamType, // video ES
+		0xE0 | byte((videoPID>>8)&0x1F), byte(videoPID & 0xFF),
+		0xF0, 0x00,
+
+		0x06,       // audio ES (AC-3)
+		0xE0, 0x55, // audio PID 85
+		0xF0, 0x00,
+
+		0x00, 0x00, 0x00, 0x00, // CRC32
+	}
+	binary.BigEndian.PutUint32(section[len(section)-4:], ring.CalculateMPEG2CRC32(section[:len(section)-4]))
+
+	pkt := make([]byte, ring.TSPacketSize)
+	pkt[0] = ring.SyncByte
+	pkt[1] = 0x40 | byte((pmtPID>>8)&0x1F)
+	pkt[2] = byte(pmtPID & 0xFF)
+	pkt[3] = 0x10
+	pkt[4] = 0x00 // pointer_field
+	copy(pkt[5:], section)
+	return pkt
+}
+
+func tsVideoPacket(t *testing.T, videoPID uint16, cc uint8, es []byte) []byte {
+	t.Helper()
+
+	pkt := make([]byte, ring.TSPacketSize)
+	pkt[0] = ring.SyncByte
+	pkt[1] = 0x40 | byte((videoPID>>8)&0x1F) // PUSI
+	pkt[2] = byte(videoPID & 0xFF)
+	pkt[3] = 0x10 | (cc & 0x0F)
+
+	// Minimal PES header with PTS.
+	copy(pkt[4:], []byte{
+		0x00, 0x00, 0x01, 0xE0,
+		0x00, 0x00,
+		0x80, 0x80, 0x05,
+		0x21, 0x00, 0x01, 0x00, 0x01,
+	})
+	copy(pkt[18:], es)
+	return pkt
+}
+
+// h264IDR is an Annex-B start code followed by a NAL header of type 5 (IDR slice).
+var h264IDR = []byte{0x00, 0x00, 0x00, 0x01, 0x65, 0x88}
+
+// hevcIRAP is an Annex-B start code followed by an HEVC IRAP NAL (type 19).
+var hevcIRAP = []byte{0x00, 0x00, 0x00, 0x01, 0x26, 0x01}
+
+func newPrimedRing(t *testing.T, capacityPackets int) *ring.MasterRing {
+	t.Helper()
+
+	r := ring.NewMasterRing(capacityPackets * ring.TSPacketSize)
+	t.Cleanup(r.Close)
+
+	if _, err := r.Push(tsPATPacket(t, 100, 0)); err != nil {
+		t.Fatalf("push PAT: %v", err)
+	}
+	if _, err := r.Push(tsPMTPacket(t, 100, 256, false, 0)); err != nil {
+		t.Fatalf("push PMT: %v", err)
+	}
+	return r
+}
+
+// Invariant 2, start case: a worker must begin at a random access point, never at
+// the ring tail. The tail is deliberately moved far away from the keyframe here, so
+// a tail attach and a keyframe attach cannot be confused.
+func TestAttachPrimedMaster_AttachesAtKeyframeNotTail(t *testing.T) {
+	r := newPrimedRing(t, 200)
+
+	// Filler ahead of the keyframe, so tail != keyframe offset.
+	for i := 0; i < 20; i++ {
+		if _, err := r.Push(tsVideoPacket(t, 85, uint8(i), []byte{0xAA})); err != nil {
+			t.Fatalf("push filler: %v", err)
+		}
+	}
+
+	keyframeOffset := r.Head()
+	if _, err := r.Push(tsVideoPacket(t, 256, 0, h264IDR)); err != nil {
+		t.Fatalf("push keyframe: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if _, err := r.Push(tsVideoPacket(t, 256, uint8(i+1), []byte{0xBB})); err != nil {
+			t.Fatalf("push trailing video: %v", err)
+		}
+	}
+
+	attach, reader, err := attachPrimedMaster(context.Background(), r, time.Second)
+	if err != nil {
+		t.Fatalf("attach failed: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	if attach.KeyframeOffset != keyframeOffset {
+		t.Fatalf("attached at offset %d, want keyframe offset %d", attach.KeyframeOffset, keyframeOffset)
+	}
+	if got := reader.Offset(); got != keyframeOffset {
+		t.Fatalf("reader positioned at %d, want %d", got, keyframeOffset)
+	}
+	if attach.KeyframeOffset == r.Tail() {
+		t.Fatalf("attach offset equals ring tail %d; the tail is not a decodable entry point", r.Tail())
+	}
+	if len(attach.Preamble) == 0 {
+		t.Fatal("attach carried no PAT/PMT preamble; FFmpeg would receive elementary data without topology")
+	}
+	if !attach.HasKeyframe {
+		t.Fatal("attach reported HasKeyframe=false but returned a reader")
+	}
+}
+
+// Invariant 2, refusal case: with no random access point in the ring, the old code
+// fell back to startOffset -1, which NewSubscriberReader normalises to the tail.
+// A refusal is the only correct answer.
+func TestAttachPrimedMaster_RefusesTailWhenNoKeyframe(t *testing.T) {
+	r := newPrimedRing(t, 200)
+
+	// Audio only: nothing here is a video random access point.
+	for i := 0; i < 30; i++ {
+		if _, err := r.Push(tsVideoPacket(t, 85, uint8(i), []byte{0xAA})); err != nil {
+			t.Fatalf("push audio: %v", err)
+		}
+	}
+
+	attach, reader, err := attachPrimedMaster(context.Background(), r, 80*time.Millisecond)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatalf("attach succeeded without a keyframe at offset %d; a tail attach must never be returned", attach.KeyframeOffset)
+	}
+	if reader != nil {
+		_ = reader.Close()
+		t.Fatal("attach returned a reader alongside an error")
+	}
+	if !errors.Is(err, ring.ErrNoKeyframeAvailable) {
+		t.Fatalf("expected the wait to end on ErrNoKeyframeAvailable, got %v", err)
+	}
+}
+
+// Invariant 1 and 3: this is the sequence the old three-call attach could not
+// survive. It read the preamble, then the keyframe offset, then built the reader,
+// and a PMT version bump in between invalidated the index the second call had
+// already returned - leaving startOffset -1 and a tail attach carrying the previous
+// generation's preamble. The primed attach refuses instead, and only succeeds once
+// the new generation has produced its own random access point.
+func TestAttachPrimedMaster_PMTChangeInvalidatesRatherThanFallsBackToTail(t *testing.T) {
+	r := newPrimedRing(t, 200)
+
+	if _, err := r.Push(tsVideoPacket(t, 256, 0, h264IDR)); err != nil {
+		t.Fatalf("push first keyframe: %v", err)
+	}
+
+	first, firstReader, err := attachPrimedMaster(context.Background(), r, time.Second)
+	if err != nil {
+		t.Fatalf("first attach failed: %v", err)
+	}
+	_ = firstReader.Close()
+
+	// PMT v1 moves video to another PID and codec. The ring invalidates the video
+	// state, drops the keyframe index and bumps the generation.
+	if _, err := r.Push(tsPMTPacket(t, 100, 512, true, 1)); err != nil {
+		t.Fatalf("push PMT v1: %v", err)
+	}
+	if _, ok := r.LatestKeyframeOffset(); ok {
+		t.Fatal("keyframe index survived the PMT version change; the premise of this test no longer holds")
+	}
+
+	// Between generations there is no legal entry point at all.
+	_, reader, err := attachPrimedMaster(context.Background(), r, 80*time.Millisecond)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatal("attach succeeded between generations; the only offsets available were stale or the tail")
+	}
+
+	// The new generation produces its own random access point.
+	newKeyframe := r.Head()
+	if _, err := r.Push(tsVideoPacket(t, 512, 0, hevcIRAP)); err != nil {
+		t.Fatalf("push second keyframe: %v", err)
+	}
+
+	second, secondReader, err := attachPrimedMaster(context.Background(), r, time.Second)
+	if err != nil {
+		t.Fatalf("attach after new generation keyframe failed: %v", err)
+	}
+	defer func() { _ = secondReader.Close() }()
+
+	if second.KeyframeOffset != newKeyframe {
+		t.Fatalf("attached at %d, want the new generation's keyframe at %d", second.KeyframeOffset, newKeyframe)
+	}
+	if second.Generation == first.Generation {
+		t.Fatalf("generation did not advance across the PMT change (both %d)", first.Generation)
+	}
+}
+
+// A ring that is closed cannot become primed by waiting. The terminal branch must
+// return at once rather than burning the attach timeout. The scrambled counterpart
+// of this rule is covered against the ring itself in the ring package.
+func TestAttachPrimedMaster_ClosedRingIsTerminalAndDoesNotWait(t *testing.T) {
+	r := ring.NewMasterRing(50 * ring.TSPacketSize)
+	r.Close()
+
+	start := time.Now()
+	_, reader, err := attachPrimedMaster(context.Background(), r, 5*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		_ = reader.Close()
+		t.Fatal("attach succeeded on a closed ring")
+	}
+	if !errors.Is(err, ring.ErrRingClosed) {
+		t.Fatalf("expected ErrRingClosed, got %v", err)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("terminal error was retried for %s; it must return immediately", elapsed)
+	}
+}
+
+// Invariant 1 under churn: whatever the timing, an attach that succeeds must hand
+// back one coherent snapshot - a preamble, an offset at or after the tail, and a
+// reader standing exactly on that offset. Run with -race this also covers the
+// unsynchronised access the three separate calls used to make.
+func TestAttachPrimedMaster_ConcurrentGenerationChurnNeverMixesSnapshot(t *testing.T) {
+	r := newPrimedRing(t, 400)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Producer: alternate the PMT version and feed each generation a keyframe.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for version := uint8(1); ctx.Err() == nil && version < 30; version++ {
+			hevc := version%2 == 1
+			videoPID := uint16(256)
+			es := h264IDR
+			if hevc {
+				videoPID = 512
+				es = hevcIRAP
+			}
+			_, _ = r.Push(tsPMTPacket(t, 100, videoPID, hevc, version))
+			_, _ = r.Push(tsVideoPacket(t, videoPID, 0, es))
+			for i := 0; i < 8; i++ {
+				_, _ = r.Push(tsVideoPacket(t, videoPID, uint8(i+1), []byte{0xCC}))
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	// Consumers: attach repeatedly against the moving ring.
+	attaches := 0
+	var mu sync.Mutex
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				attach, reader, err := attachPrimedMaster(ctx, r, 50*time.Millisecond)
+				if err != nil {
+					continue
+				}
+				// Sample rather than spin: the producer changes generation every
+				// couple of milliseconds, so this still crosses many boundaries.
+				time.Sleep(time.Millisecond)
+
+				offset := reader.Offset()
+				tail := r.Tail()
+				_ = reader.Close()
+
+				mu.Lock()
+				attaches++
+				mu.Unlock()
+
+				if len(attach.Preamble) == 0 {
+					t.Errorf("primed attach carried no preamble")
+					return
+				}
+				if attach.KeyframeOffset < tail {
+					t.Errorf("attach offset %d is behind the ring tail %d", attach.KeyframeOffset, tail)
+					return
+				}
+				if offset != attach.KeyframeOffset {
+					t.Errorf("reader at %d does not match the attach offset %d", offset, attach.KeyframeOffset)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if attaches == 0 {
+		t.Fatal("no attach succeeded during the churn; the test proved nothing")
+	}
+	t.Logf("verified %d primed attaches under generation churn", attaches)
+}

--- a/backend/internal/stream/ingest/variant/worker_generation_test.go
+++ b/backend/internal/stream/ingest/variant/worker_generation_test.go
@@ -7,10 +7,12 @@ package variant
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
 
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ingeststats"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
 	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
 )
@@ -371,5 +373,29 @@ func TestAudioVariantManager_ReplacesTerminatedWorker(t *testing.T) {
 	}
 	if mgr.ActiveWorkerCount() != 1 {
 		t.Fatalf("manager holds %d workers, want exactly the replacement", mgr.ActiveWorkerCount())
+	}
+}
+
+// The reason a worker ended is what the operator sees. A topology cut and a broken
+// transcoder both end a worker, and only one of them is worth paging anyone about.
+func TestWorkerStopReason_DoesNotCountAGenerationCutAsAFailure(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"generation cut", ErrUpstreamGenerationChanged, ingeststats.WorkerStopGenerationChange},
+		{"wrapped generation cut", fmt.Errorf("ending worker: %w", ErrUpstreamGenerationChanged), ingeststats.WorkerStopGenerationChange},
+		{"clean end", nil, ingeststats.WorkerStopShutdown},
+		{"cancelled", context.Canceled, ingeststats.WorkerStopShutdown},
+		{"transcoder failure", errors.New("start ffmpeg: exec format error"), ingeststats.WorkerStopError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workerStopReason(tc.err); got != tc.want {
+				t.Fatalf("workerStopReason(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
 	}
 }

--- a/backend/internal/stream/ingest/variant/worker_generation_test.go
+++ b/backend/internal/stream/ingest/variant/worker_generation_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"testing"
@@ -226,6 +227,201 @@ func TestAudioVariantWorker_AudioCodecChange_EndsWithGenerationCut(t *testing.T)
 	err := runGenerationCut(t, "verify_final_v3.ts", "verify_seg.ts", key)
 	if !errors.Is(err, ErrUpstreamGenerationChanged) {
 		t.Fatalf("worker ended with %v, want ErrUpstreamGenerationChanged", err)
+	}
+}
+
+// The whole cut, from a client's point of view: attached to worker N, the topology
+// changes, the client's read ends cleanly rather than degrading, and the next
+// attach lands on worker N+1 primed on the new generation.
+//
+// This is what makes ending the worker a correct policy rather than just a safe
+// one. A cut the consumer cannot recover from would only move the breakage.
+func TestAudioVariant_GenerationCut_ClientReattachesToNewWorker(t *testing.T) {
+	requireFFmpeg(t)
+
+	first := loadCapture(t, "verify_final_v3.ts")
+	second := bumpPMTVersion(t, loadCapture(t, "test_hevc_stream.ts"), 1)
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+
+	push := func(data []byte) {
+		for i := 0; i < len(data); i += 64 * ring.TSPacketSize {
+			end := i + 64*ring.TSPacketSize
+			if end > len(data) {
+				end = len(data)
+			}
+			if _, err := masterRing.Push(data[i:end]); err != nil {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	push(first[:len(first)/2])
+	if _, ok := masterRing.LatestKeyframeOffset(); !ok {
+		t.Skip("skipping: first capture produced no random access point")
+	}
+
+	mgr := NewAudioVariantManager(masterRing)
+	defer mgr.Close()
+
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		StreamFingerprint: "generation-cut-reattach",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	workerN, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("initial GetOrCreateWorker: %v", err)
+	}
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		push(first[len(first)/2:])
+	}()
+
+	masterGenerationN := masterRing.Generation()
+
+	_, readerN, err := workerN.PrimedAttachWithTimeout(ctx, 15*time.Second)
+	if err != nil {
+		t.Skipf("skipping: never became primed on the first capture: %v", err)
+	}
+
+	buf := make([]byte, 32*1024)
+	if _, rerr := readerN.Read(buf); rerr != nil {
+		t.Fatalf("no output on the first generation: %v", rerr)
+	}
+
+	<-firstDone
+
+	// Generation N+1 keeps arriving for the rest of the test. A live stream does not
+	// stop while a client reconnects, and the reattach below needs input to produce
+	// the output it waits on. The capture repeats at the same PMT version, so it
+	// stays one generation.
+	secondCtx, stopSecond := context.WithCancel(ctx)
+	defer stopSecond()
+	go func() {
+		for secondCtx.Err() == nil {
+			push(second)
+		}
+	}()
+
+	// The client's read must end, and end cleanly. A reader that kept returning
+	// bytes here would be delivering the new topology through a process configured
+	// for the old one - exactly what the cut exists to prevent.
+	deadline := time.After(25 * time.Second)
+	var readErr error
+	for readErr == nil {
+		select {
+		case <-deadline:
+			t.Fatal("client read never ended after the topology changed")
+		default:
+		}
+		_, readErr = readerN.Read(buf)
+	}
+	if !errors.Is(readErr, io.EOF) {
+		t.Fatalf("client read ended with %v, want a clean io.EOF", readErr)
+	}
+	_ = readerN.Close()
+	mgr.ReleaseWorkerInstance(workerN)
+
+	if err := workerN.Err(); !errors.Is(err, ErrUpstreamGenerationChanged) {
+		t.Fatalf("worker N ended with %v, want ErrUpstreamGenerationChanged", err)
+	}
+
+	// The next attach must reach a different worker, primed on the new generation.
+	workerNext, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("reattach GetOrCreateWorker: %v", err)
+	}
+	defer mgr.ReleaseWorkerInstance(workerNext)
+
+	if workerNext == workerN {
+		t.Fatal("reattach returned the worker that was cut")
+	}
+
+	attachNext, readerNext, err := workerNext.PrimedAttachWithTimeout(ctx, 20*time.Second)
+	if err != nil {
+		t.Fatalf("reattach never became primed on the new generation: %v", err)
+	}
+	defer func() { _ = readerNext.Close() }()
+
+	if len(attachNext.Preamble) == 0 {
+		t.Fatal("reattach carried no PAT/PMT preamble")
+	}
+	// Deliberately not comparing attachNext.Generation with the first attach's.
+	// That number is the VariantRing's own epoch, and each worker builds a fresh
+	// VariantRing, so two of them count from zero along the same path and would
+	// match by construction. What matters is the upstream generation the new worker
+	// is serving.
+	if masterRing.Generation() == masterGenerationN {
+		t.Fatalf("upstream is still at generation %d; the cut was never real", masterGenerationN)
+	}
+	if n, rerr := readerNext.Read(buf); rerr != nil || n == 0 {
+		t.Fatalf("no output on the new generation: n=%d err=%v", n, rerr)
+	}
+	if workerNext.Terminated() {
+		t.Fatalf("replacement was cut immediately: %v", workerNext.Err())
+	}
+}
+
+// Releasing must credit the worker the caller attached to, not whichever one holds
+// the key now. After a cut those differ, and releasing by key alone would push the
+// live replacement toward idle on behalf of subscribers that never used it.
+func TestAudioVariantManager_ReleaseCreditsTheAttachedInstance(t *testing.T) {
+	masterRing := ring.NewMasterRing(1024 * 1024)
+	defer masterRing.Close()
+
+	mgr := NewAudioVariantManager(masterRing)
+	defer mgr.Close()
+
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		StreamFingerprint: "release-credit",
+	}
+
+	ctx := context.Background()
+	old, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("first GetOrCreateWorker: %v", err)
+	}
+
+	select {
+	case <-old.Done():
+	case <-time.After(15 * time.Second):
+		t.Fatal("worker did not end without a decodable upstream")
+	}
+
+	replacement, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("replacement GetOrCreateWorker: %v", err)
+	}
+	if got := replacement.SubscriberCount(); got != 1 {
+		t.Fatalf("replacement starts with %d subscribers, want 1", got)
+	}
+
+	// The old worker's client disconnects only now.
+	mgr.ReleaseWorkerInstance(old)
+
+	if got := replacement.SubscriberCount(); got != 1 {
+		t.Fatalf("releasing the cut worker changed the replacement's count to %d", got)
+	}
+	if got := replacement.IdleDuration(); got != 0 {
+		t.Fatalf("replacement was marked idle after %s while still subscribed", got)
 	}
 }
 

--- a/backend/internal/stream/ingest/variant/worker_generation_test.go
+++ b/backend/internal/stream/ingest/variant/worker_generation_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package variant
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+)
+
+// The captures under testdata/segments carry a single PMT version each, so none of
+// them contains a topology change on its own. Two of them do differ in topology at
+// identical PIDs, which is enough to build one at run time:
+//
+//	verify_final_v3.ts    H.264 on PID 256, AAC on PID 257
+//	test_hevc_stream.ts   HEVC  on PID 256, AAC on PID 257
+//	verify_seg.ts         H.264 on PID 256, MP2 on PID 257
+//
+// Concatenating two of them yields real elementary data on both sides of the cut,
+// which a synthetic fixture could not. The second capture's PMT version has to be
+// rewritten first: the ring decides a topology changed from the version number and
+// the program number, and both captures use version 0 for program 1. Without the
+// bump the change would be invisible - which is itself worth knowing about spliced
+// sources, even though spec-conformant DVB always increments.
+
+const capturePMTPID = 4096
+
+// bumpPMTVersion rewrites every complete PMT section in a capture to the given
+// version, recomputing the section CRC. Sections that span packets are left alone;
+// the captures repeat their PMT often enough that the single-packet ones suffice.
+func bumpPMTVersion(t *testing.T, data []byte, version uint8) []byte {
+	t.Helper()
+
+	out := append([]byte(nil), data...)
+	offset := -1
+	for i := 0; i < ring.TSPacketSize && offset < 0; i++ {
+		aligned := true
+		for k := 0; k < 5; k++ {
+			if i+k*ring.TSPacketSize >= len(out) || out[i+k*ring.TSPacketSize] != ring.SyncByte {
+				aligned = false
+				break
+			}
+		}
+		if aligned {
+			offset = i
+		}
+	}
+	if offset < 0 {
+		t.Fatal("capture is not TS aligned")
+	}
+
+	rewritten := 0
+	for k := 0; offset+(k+1)*ring.TSPacketSize <= len(out); k++ {
+		s := offset + k*ring.TSPacketSize
+		pid := (uint16(out[s+1]&0x1F) << 8) | uint16(out[s+2])
+		pusi := out[s+1]&0x40 != 0
+		afc := (out[s+3] >> 4) & 0x03
+		if pid != capturePMTPID || !pusi || afc == 0 || afc == 2 {
+			continue
+		}
+
+		base := s + 4
+		if afc == 3 {
+			base = s + 5 + int(out[s+4])
+		}
+		if base >= s+ring.TSPacketSize {
+			continue
+		}
+		sec := base + 1 + int(out[base])
+		if sec+12 >= s+ring.TSPacketSize || out[sec] != 0x02 {
+			continue
+		}
+
+		length := 3 + int(uint16(out[sec+1]&0x0F)<<8|uint16(out[sec+2]))
+		if sec+length > s+ring.TSPacketSize {
+			continue // section continues in the next packet
+		}
+
+		out[sec+5] = (out[sec+5] & 0xC1) | ((version & 0x1F) << 1)
+		crc := ring.CalculateMPEG2CRC32(out[sec : sec+length-4])
+		binary.BigEndian.PutUint32(out[sec+length-4:sec+length], crc)
+		rewritten++
+	}
+
+	if rewritten == 0 {
+		t.Fatal("no complete PMT section found to bump")
+	}
+	return out
+}
+
+func loadCapture(t *testing.T, name string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile("../../../../testdata/segments/" + name)
+	if err != nil {
+		t.Skipf("skipping: capture %s not available: %v", name, err)
+	}
+	return data
+}
+
+func requireFFmpeg(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("skipping: ffmpeg not available")
+	}
+}
+
+// runGenerationCut feeds a worker the first capture, waits for it to be producing,
+// then feeds the second one with a bumped PMT version, and reports how the worker
+// ended.
+func runGenerationCut(t *testing.T, firstCapture, secondCapture string, key AudioVariantKey) error {
+	t.Helper()
+	requireFFmpeg(t)
+
+	first := loadCapture(t, firstCapture)
+	second := bumpPMTVersion(t, loadCapture(t, secondCapture), 1)
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+
+	push := func(data []byte) {
+		for i := 0; i < len(data); i += 64 * ring.TSPacketSize {
+			end := i + 64*ring.TSPacketSize
+			if end > len(data) {
+				end = len(data)
+			}
+			if _, err := masterRing.Push(data[i:end]); err != nil {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// Generation N has to be decodable before the worker attaches, otherwise the
+	// primed attach has nothing to attach to.
+	push(first[:len(first)/2])
+	if _, ok := masterRing.LatestKeyframeOffset(); !ok {
+		t.Skip("skipping: first capture produced no random access point")
+	}
+	generationN := masterRing.Generation()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	worker := NewAudioVariantWorker(key, masterRing, 8*1024*1024)
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	// The rest of generation N has to keep flowing while the worker settles:
+	// FFmpeg needs input to produce output, and the primed attach below waits on
+	// that output.
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		push(first[len(first)/2:])
+	}()
+
+	// Let the worker settle on generation N before anything changes.
+	_, reader, err := worker.PrimedAttachWithTimeout(ctx, 15*time.Second)
+	if err != nil {
+		t.Skipf("skipping: worker never became primed on the first capture: %v", err)
+	}
+	buf := make([]byte, 32*1024)
+	if _, rerr := reader.Read(buf); rerr != nil {
+		t.Fatalf("worker produced no output on generation %d: %v", generationN, rerr)
+	}
+	_ = reader.Close()
+
+	<-firstDone
+	push(second)
+
+	select {
+	case <-worker.Done():
+	case <-time.After(20 * time.Second):
+		t.Fatal("worker did not end after the upstream topology changed")
+	}
+
+	if got := masterRing.Generation(); got == generationN {
+		t.Fatalf("ring generation never advanced past %d; the PMT bump was not seen", generationN)
+	}
+	return worker.Err()
+}
+
+// The hard case: the video codec changes under an unchanged PID while video is
+// being copied. A running FFmpeg cannot follow that, so the worker must end rather
+// than keep feeding HEVC into a process that probed H.264.
+func TestAudioVariantWorker_VideoCodecChange_EndsWithGenerationCut(t *testing.T) {
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		StreamFingerprint: "generation-cut-video",
+	}
+
+	err := runGenerationCut(t, "verify_final_v3.ts", "test_hevc_stream.ts", key)
+	if !errors.Is(err, ErrUpstreamGenerationChanged) {
+		t.Fatalf("worker ended with %v, want ErrUpstreamGenerationChanged", err)
+	}
+}
+
+// The milder case: video stays H.264 and only the audio elementary stream changes.
+// The generation is program identity, not video identity, so this must cut too -
+// FFmpeg keeps its AAC decoder and would be handed MP2 payload otherwise.
+func TestAudioVariantWorker_AudioCodecChange_EndsWithGenerationCut(t *testing.T) {
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		StreamFingerprint: "generation-cut-audio",
+	}
+
+	err := runGenerationCut(t, "verify_final_v3.ts", "verify_seg.ts", key)
+	if !errors.Is(err, ErrUpstreamGenerationChanged) {
+		t.Fatalf("worker ended with %v, want ErrUpstreamGenerationChanged", err)
+	}
+}
+
+// A terminated worker is never handed back out. The manager replaces it, so the
+// next caller gets one attached to the current topology instead of a closed ring.
+func TestAudioVariantManager_ReplacesTerminatedWorker(t *testing.T) {
+	masterRing := ring.NewMasterRing(1024 * 1024)
+	defer masterRing.Close()
+
+	mgr := NewAudioVariantManager(masterRing)
+	defer mgr.Close()
+
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		StreamFingerprint: "replace-terminated",
+	}
+
+	ctx := context.Background()
+	first, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("first GetOrCreateWorker: %v", err)
+	}
+
+	// Nothing decodable is ever pushed, so the attach times out and the worker ends.
+	select {
+	case <-first.Done():
+	case <-time.After(15 * time.Second):
+		t.Fatal("worker did not end without a decodable upstream")
+	}
+	if !first.Terminated() {
+		t.Fatal("Terminated() is false for a worker whose run loop has returned")
+	}
+
+	second, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("second GetOrCreateWorker: %v", err)
+	}
+	defer mgr.ReleaseWorker(key)
+
+	if second == first {
+		t.Fatal("manager handed back the terminated worker instead of building a new one")
+	}
+	if mgr.ActiveWorkerCount() != 1 {
+		t.Fatalf("manager holds %d workers, want exactly the replacement", mgr.ActiveWorkerCount())
+	}
+}

--- a/backend/internal/stream/ingest/variant/worker_generation_test.go
+++ b/backend/internal/stream/ingest/variant/worker_generation_test.go
@@ -6,123 +6,24 @@ package variant
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"io"
-	"os"
-	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
 )
-
-// The captures under testdata/segments carry a single PMT version each, so none of
-// them contains a topology change on its own. Two of them do differ in topology at
-// identical PIDs, which is enough to build one at run time:
-//
-//	verify_final_v3.ts    H.264 on PID 256, AAC on PID 257
-//	test_hevc_stream.ts   HEVC  on PID 256, AAC on PID 257
-//	verify_seg.ts         H.264 on PID 256, MP2 on PID 257
-//
-// Concatenating two of them yields real elementary data on both sides of the cut,
-// which a synthetic fixture could not. The second capture's PMT version has to be
-// rewritten first: the ring decides a topology changed from the version number and
-// the program number, and both captures use version 0 for program 1. Without the
-// bump the change would be invisible - which is itself worth knowing about spliced
-// sources, even though spec-conformant DVB always increments.
-
-const capturePMTPID = 4096
-
-// bumpPMTVersion rewrites every complete PMT section in a capture to the given
-// version, recomputing the section CRC. Sections that span packets are left alone;
-// the captures repeat their PMT often enough that the single-packet ones suffice.
-func bumpPMTVersion(t *testing.T, data []byte, version uint8) []byte {
-	t.Helper()
-
-	out := append([]byte(nil), data...)
-	offset := -1
-	for i := 0; i < ring.TSPacketSize && offset < 0; i++ {
-		aligned := true
-		for k := 0; k < 5; k++ {
-			if i+k*ring.TSPacketSize >= len(out) || out[i+k*ring.TSPacketSize] != ring.SyncByte {
-				aligned = false
-				break
-			}
-		}
-		if aligned {
-			offset = i
-		}
-	}
-	if offset < 0 {
-		t.Fatal("capture is not TS aligned")
-	}
-
-	rewritten := 0
-	for k := 0; offset+(k+1)*ring.TSPacketSize <= len(out); k++ {
-		s := offset + k*ring.TSPacketSize
-		pid := (uint16(out[s+1]&0x1F) << 8) | uint16(out[s+2])
-		pusi := out[s+1]&0x40 != 0
-		afc := (out[s+3] >> 4) & 0x03
-		if pid != capturePMTPID || !pusi || afc == 0 || afc == 2 {
-			continue
-		}
-
-		base := s + 4
-		if afc == 3 {
-			base = s + 5 + int(out[s+4])
-		}
-		if base >= s+ring.TSPacketSize {
-			continue
-		}
-		sec := base + 1 + int(out[base])
-		if sec+12 >= s+ring.TSPacketSize || out[sec] != 0x02 {
-			continue
-		}
-
-		length := 3 + int(uint16(out[sec+1]&0x0F)<<8|uint16(out[sec+2]))
-		if sec+length > s+ring.TSPacketSize {
-			continue // section continues in the next packet
-		}
-
-		out[sec+5] = (out[sec+5] & 0xC1) | ((version & 0x1F) << 1)
-		crc := ring.CalculateMPEG2CRC32(out[sec : sec+length-4])
-		binary.BigEndian.PutUint32(out[sec+length-4:sec+length], crc)
-		rewritten++
-	}
-
-	if rewritten == 0 {
-		t.Fatal("no complete PMT section found to bump")
-	}
-	return out
-}
-
-func loadCapture(t *testing.T, name string) []byte {
-	t.Helper()
-
-	data, err := os.ReadFile("../../../../testdata/segments/" + name)
-	if err != nil {
-		t.Skipf("skipping: capture %s not available: %v", name, err)
-	}
-	return data
-}
-
-func requireFFmpeg(t *testing.T) {
-	t.Helper()
-	if _, err := exec.LookPath("ffmpeg"); err != nil {
-		t.Skip("skipping: ffmpeg not available")
-	}
-}
 
 // runGenerationCut feeds a worker the first capture, waits for it to be producing,
 // then feeds the second one with a bumped PMT version, and reports how the worker
 // ended.
 func runGenerationCut(t *testing.T, firstCapture, secondCapture string, key AudioVariantKey) error {
 	t.Helper()
-	requireFFmpeg(t)
+	skipIfNoFFmpeg(t)
 
-	first := loadCapture(t, firstCapture)
-	second := bumpPMTVersion(t, loadCapture(t, secondCapture), 1)
+	first := tsfixture.Load(t, firstCapture)
+	second := tsfixture.BumpPMTVersion(t, tsfixture.Load(t, secondCapture), 1)
 
 	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
 	defer masterRing.Close()
@@ -237,10 +138,10 @@ func TestAudioVariantWorker_AudioCodecChange_EndsWithGenerationCut(t *testing.T)
 // This is what makes ending the worker a correct policy rather than just a safe
 // one. A cut the consumer cannot recover from would only move the breakage.
 func TestAudioVariant_GenerationCut_ClientReattachesToNewWorker(t *testing.T) {
-	requireFFmpeg(t)
+	skipIfNoFFmpeg(t)
 
-	first := loadCapture(t, "verify_final_v3.ts")
-	second := bumpPMTVersion(t, loadCapture(t, "test_hevc_stream.ts"), 1)
+	first := tsfixture.Load(t, "verify_final_v3.ts")
+	second := tsfixture.BumpPMTVersion(t, tsfixture.Load(t, "test_hevc_stream.ts"), 1)
 
 	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
 	defer masterRing.Close()


### PR DESCRIPTION
# Pull Request

## Summary

A shared-ingest variant could start a decoder mid-GOP and keep one FFmpeg process
across an upstream topology change. This completes the lifecycle instead of
replacing it: every entry into TS data is now a random access point of a known
generation, and a worker serves exactly one generation.

This is not an architecture rewrite. `ec40bc8c` had already started variant workers
at the latest keyframe; P1a finishes that intent atomically, under one ring lock,
and the rest of the stack makes the same guarantee hold on recovery, on topology
changes and at the HTTP boundary.

## Change Contract

### Fixed

- Variant FFmpeg input attaches atomically at a primed random access point: PAT/PMT,
  keyframe offset and generation come from one snapshot. No `startOffset=-1`, no
  tail fallback (`1bc0a4e3`).
- A subscriber the ring overtook re-enters at a random access point with the active
  topology restated in front of it, instead of resuming at whatever offset eviction
  left behind (`3aca1531`).
- Recovery is bound to what is actually known about the stream (`ed5d24c2`):
  topology unknown → wait; topology known and audio-only → the tail is legal;
  video present → only a random access point will do. A queued preamble is bound to
  its generation, and a stale remainder is discarded rather than finished.
- `ReleaseWorker` no longer credits a replacement worker for a client of the worker
  it replaced. Releases are instance-scoped (`90b6b201`).

### Improved

- `DroppedBytes` (pressure on the ring) and `ResyncSkippedBytes` (the deliberate
  correction on top of it) are accounted and exported separately, never summed.
- Worker terminations are attributable: an expected topology cut is not a crash.

### New

- A worker ends on an upstream topology generation change, reported as
  `ErrUpstreamGenerationChanged`; the manager builds the replacement and clients
  re-attach primed on the new topology (`d1d49c27`).
- Observability (P1d): `xg2g_ingest_subscriber_overrun_total`,
  `xg2g_ingest_subscriber_dropped_bytes_total`,
  `xg2g_ingest_subscriber_resync_skipped_bytes_total` and
  `xg2g_ingest_subscriber_lag_bytes`, all by consumer role
  (`variant_worker`, `native_client`, `variant_client`), plus
  `xg2g_ingest_variant_worker_stopped_total` by reason
  (`generation_change`, `shutdown`, `error`). Sampling runs on the read loops that
  already exist, not on additional goroutines.
- HTTP boundary regression test: a generation cut reaches the client as an ordinary
  end of stream.
- `tsfixture`: the PMT-version bump used to build a real topology change out of two
  captures, extracted so more than one package can use it.

### Removed

- None.

### Explicitly Unchanged

- Session sharing, warm hold, topology admission and the native master-ring client
  path behave exactly as before.
- Client reconnect behaviour. The backend contract asserted here is only that a
  generation cut appears to the client as a clean end of stream. Whether a
  particular iOS, Android or web player reconnects afterwards is a client question
  and is deliberately not proven in this PR.

### Risks

- A worker now ends on every upstream PMT version bump, so a channel whose upstream
  bumps often rebuilds its FFmpeg more often than before. The alternative is worse
  and was measured against real captures: a running process fed H.264 and then HEVC
  on the same PIDs decoded 77 of 1578 available frames and labelled the whole output
  h264; the milder case, AAC replaced by MP2 with the video untouched, broke the
  audio branch from the change onward.
- Lag is sampled per subscriber every 250 ms on the existing read loop.

### Acceptance Criteria

- [x] Variant input attaches only at a primed random access point of a known generation
- [x] An overrun subscriber never resumes at the tail while the stream carries video
- [x] A worker serves exactly one upstream generation, and the cut is distinguishable from a failure
- [x] A generation cut reaches the HTTP client as 200 plus a clean end of body, carrying one generation only
- [x] Dropped bytes and resync-skipped bytes are never summed into one series

### Migration Exit Condition

None. No parallel or temporary path is introduced here. The next step, the input
cutover gate, is named under Out of scope below.

### Deviations From the Agreed Scope

- Metric names carry the repository's `xg2g_ingest_` prefix rather than the bare
  names in the handover note.
- `subscriber_lag_bytes` is a histogram, not a gauge: several subscribers share a
  role, and a gauge would only ever show whichever one wrote last.
- This branch also carries `aace65a0` (background capability scan paused during HDMI
  playback and active recordings). It is unrelated to shared ingest and was already
  in the working tree when this work landed.

## Scope

- In scope: random-access and topology-generation semantics of the shared ingest
  ring, the variant worker lifecycle bound to them, the consumer lifecycle at the
  HTTP boundary, and the metrics that make all of it observable.
- Out of scope: defensive PMT content identity, for an upstream that changes PMT
  content without bumping the version (the ring keys on version and program number;
  spec-conformant DVB bumps the version). Also out of scope: the input cutover gate,
  where no new live transcode may dial the receiver directly and live representations
  must consume the shared ingest source. Only after that is it worth discussing how
  much of the old `LocalAdapter` can be replaced.

## Risk and Rollout

- Risk level: medium
- Rollout or migration notes: no configuration, API or wire-format change. The new
  metrics appear at zero for healthy consumers.
- Fallback plan: revert the branch; nothing depends on the new series.

## Verification

```bash
go test ./internal/stream/ingest/... -count=1
go test ./internal/stream/ingest/... -count=1 -race
golangci-lint run \
  ./internal/stream/ingest/ring/... \
  ./internal/stream/ingest/variant/... \
  ./internal/stream/ingest/pipeline/... \
  ./internal/stream/ingest/ingeststats/... \
  ./internal/stream/ingest/tsfixture/... \
  ./internal/metrics/...
go build ./...
```

All green (lint: 0 issues). Evidence for the new coverage:

- `TestHandler_UpstreamGenerationCut_EndsClientStreamCleanly` drives a real HTTP
  client through a topology change on a live upstream that never stops. Headers are
  written before streaming begins, so the assertion is not "no 5xx" alone but the
  whole shape of a clean end: HTTP 200, `io.Copy` reaching EOF rather than a reset,
  a body that is a whole number of TS packets with a sync byte on every one of them
  (an appended error message or a truncated packet fails here), the upstream
  generation demonstrably advanced, the master ring still running afterwards (which
  is also what rules out the fallback path - a master-attached client would still be
  receiving bytes instead of having ended), exactly one video codec in the delivered
  body, and a strict FFmpeg decode of it that succeeds. Ran 5/5 green, ~5.7s each.
- `TestSubscriberSampler_KeepsDroppedAndResyncSkippedApart` and
  `TestSubscriberSampler_PublishesDeltasNotTotals` pin the two counters apart and
  stop a sampler from multiplying a fault by how often it happened to sample.
- `TestWorkerStopReason_DoesNotCountAGenerationCutAsAFailure` pins that a topology
  cut, wrapped or not, is never counted as an error.

## Checklist

- [x] Tests added/updated for changed behavior
- [x] Documentation updated & rendered (no doc template modified; the metrics are
      documented at their definitions)
- [x] No secrets or credentials introduced
- [x] Backward compatibility considered (no API, wire or configuration change)

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
