### PR TITLE
Give a shared variant worker a lifetime of its own

### DIFF
--- a/backend/internal/stream/ingest/pipeline/handler.go
+++ b/backend/internal/stream/ingest/pipeline/handler.go
@@ -351,9 +351,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer sampler.Flush()
 
 	// Runtime Plan Transparency Headers
+	//
+	// They describe what is actually being sent, not what was decided. Attaching to
+	// a variant can fail - no transcoder, a worker that cannot start - and this
+	// request then falls back to the master stream unchanged. A header still
+	// claiming "transcode" would leave the client expecting AAC on a stream that is
+	// still carrying MP2, which is the one thing these headers exist to prevent.
+	servedFromVariant := releaseVariant != nil
+
 	videoMode := "direct"
 	effectiveVideoCodec := srcVideoCodec
-	if needsVideoTranscode {
+	if needsVideoTranscode && servedFromVariant {
 		videoMode = "transcode"
 		effectiveVideoCodec = targetVideoCodec
 	}
@@ -361,9 +369,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		effectiveVideoCodec = "unknown"
 	}
 
+	// The scan policy is a property of the transcode, so a passthrough stream has
+	// none to report either.
+	effectiveScanPolicy := scanPolicy
+	if !servedFromVariant {
+		effectiveScanPolicy = "passthrough"
+	}
+
 	audioMode := "direct"
 	effectiveAudioCodec := selectedTrack.Codec
-	if needsAudioTranscode {
+	if needsAudioTranscode && servedFromVariant {
 		audioMode = "transcode"
 		effectiveAudioCodec = targetAudioCodec
 	}
@@ -374,7 +389,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Xg2g-Video-Mode", videoMode)
 	w.Header().Set("X-Xg2g-Video-Source", srcVideoCodec)
 	w.Header().Set("X-Xg2g-Video-Effective", effectiveVideoCodec)
-	w.Header().Set("X-Xg2g-Scan-Policy", scanPolicy)
+	w.Header().Set("X-Xg2g-Scan-Policy", effectiveScanPolicy)
 	w.Header().Set("X-Xg2g-Audio-Mode", audioMode)
 	w.Header().Set("X-Xg2g-Audio-Source", selectedTrack.Codec)
 	w.Header().Set("X-Xg2g-Audio-Effective", effectiveAudioCodec)

--- a/backend/internal/stream/ingest/pipeline/handler_plan_headers_test.go
+++ b/backend/internal/stream/ingest/pipeline/handler_plan_headers_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/session"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
+)
+
+// The plan headers must describe the stream the client is actually getting.
+//
+// A capability gap routes a request to a variant worker, but that attach can fail -
+// no transcoder on the host, a worker that cannot start - and the request then falls
+// back to the master stream, unchanged and untranscoded. The headers used to keep
+// announcing the plan that was attempted rather than the one that happened, so a
+// client was told "transcode" and "deinterlace_50p" while being handed the original
+// interlaced stream in its original codec.
+//
+// The transcoder is made unavailable here rather than mocked: an empty PATH is
+// exactly the production failure this guards against, and it needs no ffmpeg to run.
+func TestHandler_FallbackToMaster_DoesNotAnnounceATranscode(t *testing.T) {
+	capture := tsfixture.Load(t, "verify_final_v3.ts")
+
+	cfg := DefaultConnectorConfig("", 8001)
+	cfg.NormConfig.StartupReservoirMs = 50.0
+	cfg.NormConfig.PacerIntervalMs = 5.0
+	cfg.NormConfig.InitialBitrateKbps = 20000.0
+	cfg.NormConfig.StagingBufferCapacity = 32 * 1024 * 1024
+	cfg.DialFn = func(ctx context.Context, key session.SessionKey) (io.ReadCloser, error) {
+		pr, pw := io.Pipe()
+		go func() {
+			defer func() { _ = pw.Close() }()
+			for {
+				for i := 0; i < len(capture); i += feedChunkPackets * ring.TSPacketSize {
+					end := i + feedChunkPackets*ring.TSPacketSize
+					if end > len(capture) {
+						end = len(capture)
+					}
+					if _, err := pw.Write(capture[i:end]); err != nil {
+						return
+					}
+					time.Sleep(feedChunkInterval)
+				}
+			}
+		}()
+		return pr, nil
+	}
+
+	mgr := session.NewManager(session.DefaultManagerConfig(), NewLivePipelineConnector(cfg))
+	defer func() { _ = mgr.Close() }()
+
+	server := httptest.NewServer(NewHandlerWithReceiver(mgr, "127.0.0.1", 8001))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	const serviceRef = "1:0:19:1:3FB:1:C00000:0:0:0:"
+	key := session.NewSessionKey("127.0.0.1", 8001, serviceRef)
+	key.TargetProgram = 1
+
+	lease, err := mgr.Acquire(ctx, key)
+	if err != nil {
+		t.Fatalf("acquire ingest lease: %v", err)
+	}
+	defer lease.Release()
+
+	pipe, ok := lease.Session().Payload().(*SessionPipeline)
+	if !ok {
+		t.Fatal("session payload is not a SessionPipeline")
+	}
+
+	waitUntil(t, 30*time.Second, "upstream never became decodable", func() bool {
+		facts := pipe.MasterRing().ReadinessFacts()
+		_, hasKeyframe := pipe.MasterRing().LatestKeyframeOffset()
+		return hasKeyframe && len(facts.AudioTracks) > 0
+	})
+
+	// No transcoder anywhere on PATH, so every variant attach fails and every
+	// capability gap resolves to the master stream.
+	t.Setenv("PATH", "")
+
+	// Both gaps at once: a client that claims to need HEVC video and AAC audio.
+	reqURL := fmt.Sprintf("%s/api/v3/stream/live/%s?audio=aac", server.URL, serviceRef)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("X-Client-Video-Codecs", "hevc")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("stream request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		t.Fatalf("fallback answered %d: %s", resp.StatusCode, body)
+	}
+
+	// The request is genuinely being served, from the master ring.
+	chunk := make([]byte, 32*1024)
+	if n, rerr := io.ReadFull(resp.Body, chunk); rerr != nil || n == 0 {
+		t.Fatalf("fallback delivered no stream: n=%d err=%v", n, rerr)
+	}
+
+	for _, tc := range []struct{ header, want, why string }{
+		{"X-Xg2g-Video-Mode", "direct", "video is being passed through, not transcoded"},
+		{"X-Xg2g-Audio-Mode", "direct", "audio is being passed through, not transcoded"},
+		{"X-Xg2g-Scan-Policy", "passthrough", "no transcode is running, so no scan policy is being applied"},
+	} {
+		if got := resp.Header.Get(tc.header); got != tc.want {
+			t.Errorf("%s = %q, want %q: %s", tc.header, got, tc.want, tc.why)
+		}
+	}
+
+	// And what it does announce is the stream it is actually sending.
+	if src, eff := resp.Header.Get("X-Xg2g-Audio-Source"), resp.Header.Get("X-Xg2g-Audio-Effective"); src != eff {
+		t.Errorf("audio source %q and effective %q disagree while passing through untouched", src, eff)
+	}
+	if src, eff := resp.Header.Get("X-Xg2g-Video-Source"), resp.Header.Get("X-Xg2g-Video-Effective"); src != eff {
+		t.Errorf("video source %q and effective %q disagree while passing through untouched", src, eff)
+	}
+}

--- a/backend/internal/stream/ingest/pipeline/variant_lifetime_test.go
+++ b/backend/internal/stream/ingest/pipeline/variant_lifetime_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package pipeline
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/normalizer"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/variant"
+)
+
+// passthroughFFmpeg puts a stand-in ffmpeg on PATH that ignores its arguments and
+// copies stdin to stdout, so the variant ring receives the same indexable capture
+// the master ring holds. Worker lifetime is what is under test, not encoding, and a
+// real ffmpeg would make this skip in the PR gate.
+func passthroughFFmpeg(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ffmpeg"), []byte("#!/bin/sh\nexec cat\n"), 0o700); err != nil {
+		t.Fatalf("write stand-in ffmpeg: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// feedRingDirectly replays a real capture straight into the master ring until the
+// test ends. Straight in, rather than through the connector: the normalizer's pacing
+// has its own tests, and this one is about how long a variant worker lives.
+func feedRingDirectly(t *testing.T, master *ring.MasterRing) {
+	t.Helper()
+
+	capture := tsfixture.Load(t, "verify_final_v3.ts")
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+		<-done
+	})
+
+	go func() {
+		defer close(done)
+		const chunk = 64 * ring.TSPacketSize
+		for {
+			for i := 0; i+chunk <= len(capture); i += chunk {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := master.Push(capture[i : i+chunk]); err != nil {
+					return
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+}
+
+// readWithin performs one blocking read bounded by timeout.
+func readWithin(t *testing.T, reader *ring.SubscriberReader, timeout time.Duration) (int, error) {
+	t.Helper()
+
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 32*1024)
+		n, err := reader.Read(buf)
+		ch <- result{n: n, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		return res.n, res.err
+	case <-time.After(timeout):
+		t.Fatalf("read did not return within %s", timeout)
+		return 0, nil
+	}
+}
+
+// The ownership rule at the level a client actually meets it.
+//
+// Two clients coalesce onto one variant worker. The first disconnects - which in
+// production is exactly an HTTP request context being cancelled - and the second
+// must keep receiving bytes. The worker belongs to the pipeline, not to whichever
+// subscriber happened to create it.
+func TestPipeline_VariantWorkerSurvivesFirstClientDisconnect(t *testing.T) {
+	passthroughFFmpeg(t)
+
+	normCfg := normalizer.DefaultConfig()
+	normCfg.StartupReservoirMs = 0.0
+
+	pipe, err := NewSessionPipeline(normCfg, 20000*ring.TSPacketSize, 0)
+	if err != nil {
+		t.Fatalf("create pipeline: %v", err)
+	}
+	defer pipe.Close()
+
+	feedRingDirectly(t, pipe.MasterRing())
+
+	if _, reader, aerr := pipe.PrimedAttachWithTimeout(context.Background(), 10*time.Second); aerr != nil {
+		t.Fatalf("master stream never became attachable: %v", aerr)
+	} else {
+		_ = reader.Close()
+	}
+
+	key := variant.StreamVariantKey{
+		StreamFingerprint: "two-client-lifetime",
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		SourceAudioCodec:  "aac",
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		Role:              "main",
+		SampleRate:        48000,
+		Channels:          2,
+		BitrateKbps:       192,
+	}
+
+	// Client 1 arrives on its own request context.
+	firstRequest, disconnectFirst := context.WithCancel(context.Background())
+	defer disconnectFirst()
+	_, firstReader, releaseFirst, err := pipe.AttachAudioVariantWithTimeout(firstRequest, key, 10*time.Second)
+	if err != nil {
+		t.Fatalf("first client failed to attach to the variant: %v", err)
+	}
+
+	// Client 2 coalesces onto the same worker.
+	secondRequest, disconnectSecond := context.WithCancel(context.Background())
+	defer disconnectSecond()
+	_, secondReader, releaseSecond, err := pipe.AttachAudioVariantWithTimeout(secondRequest, key, 10*time.Second)
+	if err != nil {
+		t.Fatalf("second client failed to attach to the variant: %v", err)
+	}
+	defer func() { _ = secondReader.Close() }()
+	defer releaseSecond()
+
+	if got := pipe.AudioVariants().ActiveWorkerCount(); got != 1 {
+		t.Fatalf("the two clients did not share one worker: %d workers active", got)
+	}
+	if n, rerr := readWithin(t, secondReader, 10*time.Second); rerr != nil || n == 0 {
+		t.Fatalf("no variant bytes before any disconnect: n=%d err=%v", n, rerr)
+	}
+
+	// Client 1 disconnects: reader closed, hold released, request context cancelled.
+	_ = firstReader.Close()
+	releaseFirst()
+	disconnectFirst()
+
+	// Client 2 must keep streaming.
+	deadline := time.Now().Add(2 * time.Second)
+	total := 0
+	for time.Now().Before(deadline) {
+		n, rerr := readWithin(t, secondReader, 10*time.Second)
+		if rerr != nil {
+			t.Fatalf("the second client's stream ended when the first disconnected: %v (bytes since: %d)", rerr, total)
+		}
+		total += n
+	}
+	if total == 0 {
+		t.Fatal("the second client received no bytes after the first client disconnected")
+	}
+	if got := pipe.AudioVariants().ActiveWorkerCount(); got != 1 {
+		t.Fatalf("the shared worker is no longer active: %d workers", got)
+	}
+}

--- a/backend/internal/stream/ingest/variant/manager.go
+++ b/backend/internal/stream/ingest/variant/manager.go
@@ -14,6 +14,21 @@ import (
 	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
 )
 
+const (
+	// idleWorkerTimeout is how long a worker with no subscribers is kept before it
+	// is stopped. A worker costs one FFmpeg process, so it cannot be held
+	// indefinitely - and it is not free to recreate either, being a process start
+	// plus the wait for the next random access point, so a client that switches
+	// audio track and back finds it still running. The ingest sessions upstream
+	// hold open for a comparable window for the same reason.
+	idleWorkerTimeout = 10 * time.Second
+
+	// idleSweepInterval is how often idle workers are looked for. The last
+	// subscriber's release is deliberately not the moment to reap: the point of the
+	// timeout is the window after it.
+	idleSweepInterval = 2 * time.Second
+)
+
 // AudioVariantManager manages active AudioVariantWorkers for a single SessionPipeline.
 // It ensures that multiple concurrent clients requesting the same variant key share
 // the exact same transcode worker, avoiding duplicate FFmpeg processes and CPU overhead.
@@ -35,17 +50,38 @@ type AudioVariantManager struct {
 	// things being shared between.
 	workerCtx      context.Context
 	stopAllWorkers context.CancelFunc
+
+	// The idle policy is what reclaims a worker now that no subscriber's context
+	// can. It is held per manager rather than as a constant so a test does not have
+	// to wait out the production timeout to observe it.
+	idleTimeout   time.Duration
+	sweepInterval time.Duration
+	sweepDone     chan struct{}
 }
 
 // NewAudioVariantManager creates a manager downstream of the given MasterRing.
 func NewAudioVariantManager(masterRing *ring.MasterRing) *AudioVariantManager {
+	return newAudioVariantManager(masterRing, idleWorkerTimeout, idleSweepInterval)
+}
+
+// newAudioVariantManager takes the idle policy as parameters so it can be exercised
+// without a test waiting out the production timeout.
+func newAudioVariantManager(masterRing *ring.MasterRing, idleTimeout, sweepInterval time.Duration) *AudioVariantManager {
 	workerCtx, stopAllWorkers := context.WithCancel(context.Background())
-	return &AudioVariantManager{
+
+	m := &AudioVariantManager{
 		masterRing:     masterRing,
 		workers:        make(map[string]*AudioVariantWorker),
 		workerCtx:      workerCtx,
 		stopAllWorkers: stopAllWorkers,
+		idleTimeout:    idleTimeout,
+		sweepInterval:  sweepInterval,
+		sweepDone:      make(chan struct{}),
 	}
+
+	go m.sweepIdle()
+
+	return m
 }
 
 // GetOrCreateWorker retrieves an existing running worker for the given key, or spawns and starts a new one.
@@ -120,54 +156,61 @@ func (m *AudioVariantManager) ReleaseWorker(key AudioVariantKey) {
 // ReleaseWorkerInstance releases one subscriber's hold on the worker it actually
 // attached to, whether or not it is still the one mapped to its key.
 //
-// The last hold to go stops the worker. That is the whole reclaim path: a
-// subscriber's own context ends its own subscription and nothing more, so the
-// refcount is what decides when the process is no longer needed. Without this the
-// ownership fix would trade one fault for another - no client could kill a shared
-// worker any more, and nothing else would ever reclaim one either, because
-// CleanupIdle has no caller.
+// Releasing does not stop anything. Whether the worker is still wanted is a
+// question about all of its subscribers, not about the one that just left, and
+// answering it here would make a client that switches audio track pay for a new
+// FFmpeg process every time. The idle policy decides, once the worker has actually
+// been unwanted for a while.
 func (m *AudioVariantManager) ReleaseWorkerInstance(worker *AudioVariantWorker) {
 	if worker == nil {
 		return
 	}
-
-	m.mu.Lock()
 	worker.RemoveSubscriber()
-	reclaim := worker.SubscriberCount() == 0
-	if reclaim {
-		// Only if it is still the mapped one. After a generation cut the key points
-		// at the replacement, and the entry being dropped here must not be it.
-		keyStr := worker.Key().String()
-		if current, ok := m.workers[keyStr]; ok && current == worker {
+}
+
+// CleanupIdle stops and removes any workers that have had 0 active subscribers for
+// at least idleTimeout. It is driven by sweepIdle, and stays exported so a caller
+// can force the policy without waiting for the next tick.
+func (m *AudioVariantManager) CleanupIdle(idleTimeout time.Duration) {
+	m.mu.Lock()
+	var idle []*AudioVariantWorker
+	for keyStr, worker := range m.workers {
+		// Subscribed is not idle, whatever the timeout says. At idleTimeout 0 the
+		// duration alone would match a worker clients are watching right now, which
+		// is the failure the ownership rule exists to prevent, reached from the
+		// other direction.
+		if worker.SubscriberCount() > 0 {
+			continue
+		}
+		if worker.IdleDuration() >= idleTimeout {
+			idle = append(idle, worker)
 			delete(m.workers, keyStr)
 		}
 	}
 	m.mu.Unlock()
 
-	// Outside the lock: Stop waits for the process to go, and holding the manager
-	// mutex across that would block every other client's attach behind one
-	// disconnect.
-	if reclaim {
+	// Stop outside the lock: it waits for FFmpeg to exit, and a client attaching to
+	// an unrelated variant must not queue behind that. Removal happened under the
+	// lock, so a worker being stopped can no longer be handed out.
+	for _, worker := range idle {
 		worker.Stop()
 	}
 }
 
-// CleanupIdle stops and removes any workers that have had 0 active subscribers for
-// at least idleTimeout.
-//
-// It has no production caller, and with reclaim happening at refcount zero it
-// normally finds nothing: a worker does not survive its last subscriber long
-// enough to become idle. It is kept as a sweep for a worker whose release path was
-// somehow missed, and is where a warm-hold policy would go if variant workers ever
-// need to outlive a zap the way ingest sessions already do.
-func (m *AudioVariantManager) CleanupIdle(idleTimeout time.Duration) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+// sweepIdle enforces the idle policy until the manager is closed. Nothing else
+// drives it: a subscriber's own context ends its own subscription and nothing more.
+func (m *AudioVariantManager) sweepIdle() {
+	defer close(m.sweepDone)
 
-	for keyStr, worker := range m.workers {
-		if worker.IdleDuration() >= idleTimeout {
-			worker.Stop()
-			delete(m.workers, keyStr)
+	ticker := time.NewTicker(m.sweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.workerCtx.Done():
+			return
+		case <-ticker.C:
+			m.CleanupIdle(m.idleTimeout)
 		}
 	}
 }
@@ -187,13 +230,18 @@ func (m *AudioVariantManager) Close() {
 		return
 	}
 	m.closed = true
-	m.stopAllWorkers()
 	workersToStop := make([]*AudioVariantWorker, 0, len(m.workers))
 	for _, w := range m.workers {
 		workersToStop = append(workersToStop, w)
 	}
 	m.workers = make(map[string]*AudioVariantWorker)
 	m.mu.Unlock()
+
+	// Cancelling first starts every worker's teardown at once, so the Stop calls
+	// below only wait for them rather than serialize them. The sweep is joined
+	// before that, so it cannot be reaping into a map that is being torn down.
+	m.stopAllWorkers()
+	<-m.sweepDone
 
 	for _, w := range workersToStop {
 		w.Stop()

--- a/backend/internal/stream/ingest/variant/manager.go
+++ b/backend/internal/stream/ingest/variant/manager.go
@@ -22,19 +22,46 @@ type AudioVariantManager struct {
 	masterRing *ring.MasterRing
 	workers    map[string]*AudioVariantWorker
 	closed     bool
+
+	// workerCtx is the lifetime every worker runs on, and it belongs to this
+	// manager rather than to whichever subscriber happened to create the worker.
+	//
+	// Starting a worker on a caller's context made an FFmpeg process the property
+	// of one client: when that client's HTTP request ended, its context was
+	// cancelled, exec.CommandContext killed the process, and every other client
+	// coalesced onto the same worker lost its stream - reported as a clean shutdown,
+	// because from the process's point of view it was one. Sharing a worker is the
+	// entire purpose of this manager, so its lifetime cannot hang off one of the
+	// things being shared between.
+	workerCtx      context.Context
+	stopAllWorkers context.CancelFunc
 }
 
 // NewAudioVariantManager creates a manager downstream of the given MasterRing.
 func NewAudioVariantManager(masterRing *ring.MasterRing) *AudioVariantManager {
+	workerCtx, stopAllWorkers := context.WithCancel(context.Background())
 	return &AudioVariantManager{
-		masterRing: masterRing,
-		workers:    make(map[string]*AudioVariantWorker),
+		masterRing:     masterRing,
+		workers:        make(map[string]*AudioVariantWorker),
+		workerCtx:      workerCtx,
+		stopAllWorkers: stopAllWorkers,
 	}
 }
 
 // GetOrCreateWorker retrieves an existing running worker for the given key, or spawns and starts a new one.
-// The returned worker has its subscriber count incremented. The caller MUST call ReleaseWorker when done.
+// The returned worker has its subscriber count incremented. The caller MUST call
+// ReleaseWorkerInstance when done.
+//
+// ctx is the caller's, and it governs only this call: a caller that has already
+// given up does not get an FFmpeg process started on its behalf. It deliberately
+// does not govern the worker, which outlives any single subscriber and is stopped
+// by ReleaseWorkerInstance at refcount zero, by Close, by a topology generation
+// cut, or by its own failure.
 func (m *AudioVariantManager) GetOrCreateWorker(ctx context.Context, key AudioVariantKey) (*AudioVariantWorker, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -69,7 +96,7 @@ func (m *AudioVariantManager) GetOrCreateWorker(ctx context.Context, key AudioVa
 
 	worker := NewAudioVariantWorker(key, m.masterRing, 8*1024*1024)
 	worker.AddSubscriber()
-	worker.Start(ctx)
+	worker.Start(m.workerCtx)
 
 	m.workers[keyStr] = worker
 	return worker, nil
@@ -84,24 +111,55 @@ func (m *AudioVariantManager) GetOrCreateWorker(ctx context.Context, key AudioVa
 // pushing a worker toward idle on behalf of subscribers that never used it.
 func (m *AudioVariantManager) ReleaseWorker(key AudioVariantKey) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
+	worker := m.workers[key.String()]
+	m.mu.Unlock()
 
-	keyStr := key.String()
-	if worker, exists := m.workers[keyStr]; exists {
-		worker.RemoveSubscriber()
-	}
+	m.ReleaseWorkerInstance(worker)
 }
 
-// ReleaseWorkerInstance decrements the subscriber count on the worker the caller
-// actually attached to, whether or not it is still the one mapped to its key.
+// ReleaseWorkerInstance releases one subscriber's hold on the worker it actually
+// attached to, whether or not it is still the one mapped to its key.
+//
+// The last hold to go stops the worker. That is the whole reclaim path: a
+// subscriber's own context ends its own subscription and nothing more, so the
+// refcount is what decides when the process is no longer needed. Without this the
+// ownership fix would trade one fault for another - no client could kill a shared
+// worker any more, and nothing else would ever reclaim one either, because
+// CleanupIdle has no caller.
 func (m *AudioVariantManager) ReleaseWorkerInstance(worker *AudioVariantWorker) {
 	if worker == nil {
 		return
 	}
+
+	m.mu.Lock()
 	worker.RemoveSubscriber()
+	reclaim := worker.SubscriberCount() == 0
+	if reclaim {
+		// Only if it is still the mapped one. After a generation cut the key points
+		// at the replacement, and the entry being dropped here must not be it.
+		keyStr := worker.Key().String()
+		if current, ok := m.workers[keyStr]; ok && current == worker {
+			delete(m.workers, keyStr)
+		}
+	}
+	m.mu.Unlock()
+
+	// Outside the lock: Stop waits for the process to go, and holding the manager
+	// mutex across that would block every other client's attach behind one
+	// disconnect.
+	if reclaim {
+		worker.Stop()
+	}
 }
 
-// CleanupIdle stops and removes any workers that have had 0 active subscribers for at least idleTimeout.
+// CleanupIdle stops and removes any workers that have had 0 active subscribers for
+// at least idleTimeout.
+//
+// It has no production caller, and with reclaim happening at refcount zero it
+// normally finds nothing: a worker does not survive its last subscriber long
+// enough to become idle. It is kept as a sweep for a worker whose release path was
+// somehow missed, and is where a warm-hold policy would go if variant workers ever
+// need to outlive a zap the way ingest sessions already do.
 func (m *AudioVariantManager) CleanupIdle(idleTimeout time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -129,6 +187,7 @@ func (m *AudioVariantManager) Close() {
 		return
 	}
 	m.closed = true
+	m.stopAllWorkers()
 	workersToStop := make([]*AudioVariantWorker, 0, len(m.workers))
 	for _, w := range m.workers {
 		workersToStop = append(workersToStop, w)

--- a/backend/internal/stream/ingest/variant/worker_ownership_test.go
+++ b/backend/internal/stream/ingest/variant/worker_ownership_test.go
@@ -7,6 +7,8 @@ package variant
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,24 +16,47 @@ import (
 	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
 )
 
-// feedMasterRing keeps a real capture flowing into a ring for the life of ctx, and
-// returns once the ring holds a random access point. A worker needs continuous
-// input: FFmpeg produces no output without it, and a test that stopped feeding
-// would prove a worker died of starvation rather than of ownership.
-func feedMasterRing(t *testing.T, ctx context.Context, r *ring.MasterRing, capture []byte) {
+// passthroughFFmpeg puts a stand-in ffmpeg on PATH that ignores its arguments and
+// copies stdin to stdout, so the variant ring receives the same indexable capture
+// the master ring holds.
+//
+// What these tests are about is worker lifetime, not encoding. Depending on a real
+// ffmpeg would make them skip in the PR gate, which deliberately does not install
+// one - and a lifetime regression that only fails on a developer's machine is a
+// regression that reaches main.
+func passthroughFFmpeg(t *testing.T) {
 	t.Helper()
 
-	push := func(data []byte) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ffmpeg"), []byte("#!/bin/sh\nexec cat\n"), 0o700); err != nil {
+		t.Fatalf("write stand-in ffmpeg: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// feedCapture replays a real capture into the ring until the test ends, and returns
+// once the ring holds a random access point.
+//
+// A real capture rather than filler: a worker attaches at a primed random access
+// point, so a stream carrying no PSI and no keyframes can never start one, and the
+// test would be measuring starvation instead of ownership.
+func feedCapture(t *testing.T, r *ring.MasterRing) {
+	t.Helper()
+
+	capture := tsfixture.Load(t, "verify_final_v3.ts")
+
+	push := func(data []byte) bool {
 		for i := 0; i < len(data); i += 64 * ring.TSPacketSize {
 			end := i + 64*ring.TSPacketSize
 			if end > len(data) {
 				end = len(data)
 			}
 			if _, err := r.Push(data[i:end]); err != nil {
-				return
+				return false
 			}
 			time.Sleep(time.Millisecond)
 		}
+		return true
 	}
 
 	push(capture[:len(capture)/2])
@@ -39,12 +64,67 @@ func feedMasterRing(t *testing.T, ctx context.Context, r *ring.MasterRing, captu
 		t.Skip("skipping: capture produced no random access point")
 	}
 
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+		<-done
+	})
+
 	go func() {
-		push(capture[len(capture)/2:])
-		for ctx.Err() == nil {
-			push(capture)
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if !push(capture) {
+				return
+			}
 		}
 	}()
+}
+
+// readWithin performs one blocking read bounded by timeout.
+func readWithin(t *testing.T, reader *ring.SubscriberReader, timeout time.Duration) (int, error) {
+	t.Helper()
+
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		buf := make([]byte, 32*1024)
+		n, err := reader.Read(buf)
+		ch <- result{n: n, err: err}
+	}()
+
+	select {
+	case res := <-ch:
+		return res.n, res.err
+	case <-time.After(timeout):
+		t.Fatalf("read did not return within %s", timeout)
+		return 0, nil
+	}
+}
+
+func ownershipTestKey(fingerprint string) AudioVariantKey {
+	return AudioVariantKey{
+		StreamFingerprint: fingerprint,
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		SourceAudioCodec:  "aac",
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		Role:              "main",
+		SampleRate:        48000,
+		Channels:          2,
+		BitrateKbps:       192,
+	}
 }
 
 // Ownership of a shared transcode worker.
@@ -69,33 +149,18 @@ func feedMasterRing(t *testing.T, ctx context.Context, r *ring.MasterRing, captu
 //	        |
 //	client B, attached by luck
 //
-// A single request context may end its own subscription and nothing else. The
-// worker ends on refcount zero, manager shutdown, a topology generation cut, or a
-// real transcoder failure - never because one viewer closed a browser tab.
+// A single request context may end its own subscription and nothing else.
 func TestAudioVariantManager_SharedWorkerOutlivesItsCreator(t *testing.T) {
-	skipIfNoFFmpeg(t)
-
-	capture := tsfixture.Load(t, "verify_final_v3.ts")
+	passthroughFFmpeg(t)
 
 	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
 	defer masterRing.Close()
+	feedCapture(t, masterRing)
 
-	feedCtx, stopFeed := context.WithCancel(context.Background())
-	defer stopFeed()
-	feedMasterRing(t, feedCtx, masterRing, capture)
-
-	mgr := NewAudioVariantManager(masterRing)
+	mgr := newAudioVariantManager(masterRing, time.Hour, time.Hour)
 	defer mgr.Close()
 
-	key := AudioVariantKey{
-		ProgramNumber:     1,
-		SourceVideoCodec:  "h264",
-		TargetVideoCodec:  "copy",
-		AudioPID:          257,
-		TargetAudioCodec:  "aac",
-		Language:          "deu",
-		StreamFingerprint: "shared-worker-ownership",
-	}
+	key := ownershipTestKey("shared-worker-ownership")
 
 	// Client A arrives first and therefore creates the worker. Its context is the
 	// HTTP request context the handler passes down.
@@ -123,12 +188,11 @@ func TestAudioVariantManager_SharedWorkerOutlivesItsCreator(t *testing.T) {
 	// B is streaming before anything happens to A.
 	_, readerB, err := workerB.PrimedAttachWithTimeout(requestB, 20*time.Second)
 	if err != nil {
-		t.Skipf("skipping: client B never became primed: %v", err)
+		t.Fatalf("client B never became primed: %v", err)
 	}
 	defer func() { _ = readerB.Close() }()
 
-	buf := make([]byte, 32*1024)
-	if n, rerr := readerB.Read(buf); rerr != nil || n == 0 {
+	if n, rerr := readWithin(t, readerB, 5*time.Second); rerr != nil || n == 0 {
 		t.Fatalf("client B received no output before the disconnect: n=%d err=%v", n, rerr)
 	}
 
@@ -140,86 +204,171 @@ func TestAudioVariantManager_SharedWorkerOutlivesItsCreator(t *testing.T) {
 	if got := workerB.SubscriberCount(); got != 1 {
 		t.Fatalf("after A left, the shared worker has %d subscribers, want 1", got)
 	}
-
-	// The worker must simply keep running. A cancelled request context reaching the
-	// FFmpeg process would end it here, and B's stream with it.
 	select {
 	case <-workerB.Done():
 		t.Fatalf("the shared worker ended when its creator disconnected: %v", workerB.Err())
-	case <-time.After(3 * time.Second):
+	case <-time.After(500 * time.Millisecond):
 	}
 
-	if n, rerr := readerB.Read(buf); rerr != nil || n == 0 {
-		t.Fatalf("client B lost its stream when client A disconnected: n=%d err=%v", n, rerr)
+	// Not even the most aggressive sweep may take the stream away from the
+	// subscriber that is still attached. The count that matters here has just been
+	// decremented, which is precisely when an idle check is most tempted to fire.
+	mgr.CleanupIdle(0)
+	if got := mgr.ActiveWorkerCount(); got != 1 {
+		t.Fatalf("a sweep removed a worker with %d subscriber(s) still attached", workerB.SubscriberCount())
+	}
+
+	// B keeps receiving, and keeps receiving.
+	deadline := time.Now().Add(time.Second)
+	total := 0
+	for time.Now().Before(deadline) {
+		n, rerr := readWithin(t, readerB, 5*time.Second)
+		if rerr != nil {
+			t.Fatalf("client B lost its stream when A disconnected: %v (bytes since: %d)", rerr, total)
+		}
+		total += n
+	}
+	if total == 0 {
+		t.Fatal("client B received no bytes after client A disconnected")
 	}
 }
 
-// The other half of the ownership rule. Detaching a worker from its creator's
-// request context removes the only thing that used to reclaim one, because
-// CleanupIdle has no caller. If nothing replaced it, every variant a session ever
-// served would hold an FFmpeg process open until the whole pipeline closed.
-//
-// The refcount is what decides: the last subscriber to leave stops the worker.
-func TestAudioVariantManager_LastReleaseStopsTheWorker(t *testing.T) {
-	skipIfNoFFmpeg(t)
-
-	capture := tsfixture.Load(t, "verify_final_v3.ts")
+// The reclaim rule, from the other side. Detaching a worker from its creator's
+// request context removes what had been the only thing that ever reclaimed one, so
+// the idle policy has to take it over - but it must not answer the question early.
+// The last subscriber leaving is not proof the worker is unwanted: a client
+// switching audio track is gone for a moment and back.
+func TestAudioVariantManager_LastReleaseDefersToTheIdlePolicy(t *testing.T) {
+	passthroughFFmpeg(t)
 
 	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
 	defer masterRing.Close()
+	feedCapture(t, masterRing)
 
-	feedCtx, stopFeed := context.WithCancel(context.Background())
-	defer stopFeed()
-	feedMasterRing(t, feedCtx, masterRing, capture)
-
-	mgr := NewAudioVariantManager(masterRing)
+	mgr := newAudioVariantManager(masterRing, time.Hour, time.Hour)
 	defer mgr.Close()
 
-	key := AudioVariantKey{
-		ProgramNumber:     1,
-		SourceVideoCodec:  "h264",
-		TargetVideoCodec:  "copy",
-		AudioPID:          257,
-		TargetAudioCodec:  "aac",
-		Language:          "deu",
-		StreamFingerprint: "refcount-reclaim",
-	}
-
+	key := ownershipTestKey("idle-handoff")
 	ctx := context.Background()
-	first, err := mgr.GetOrCreateWorker(ctx, key)
-	if err != nil {
-		t.Fatalf("first GetOrCreateWorker: %v", err)
-	}
-	second, err := mgr.GetOrCreateWorker(ctx, key)
-	if err != nil {
-		t.Fatalf("second GetOrCreateWorker: %v", err)
-	}
-	if second != first {
-		t.Fatal("the two clients did not share a worker, so this test proves nothing")
-	}
 
-	// Let it actually become a running transcode, so what is reclaimed below is a
-	// live process rather than a worker that never started.
-	if _, reader, aerr := first.PrimedAttachWithTimeout(ctx, 20*time.Second); aerr != nil {
-		t.Skipf("skipping: worker never became primed: %v", aerr)
+	worker, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("GetOrCreateWorker: %v", err)
+	}
+	if _, reader, aerr := worker.PrimedAttachWithTimeout(ctx, 20*time.Second); aerr != nil {
+		t.Fatalf("worker never became primed: %v", aerr)
 	} else {
 		_ = reader.Close()
 	}
 
-	mgr.ReleaseWorkerInstance(first)
-	if first.Terminated() {
-		t.Fatalf("the worker was reclaimed while a subscriber was still attached: %v", first.Err())
+	mgr.ReleaseWorkerInstance(worker)
+
+	select {
+	case <-worker.Done():
+		t.Fatalf("the worker stopped on its last release instead of deferring to the idle policy: %v", worker.Err())
+	case <-time.After(500 * time.Millisecond):
 	}
 	if got := mgr.ActiveWorkerCount(); got != 1 {
-		t.Fatalf("manager holds %d workers while one is still subscribed, want 1", got)
+		t.Fatalf("the idle worker was deregistered immediately: %d workers", got)
 	}
 
-	mgr.ReleaseWorkerInstance(second)
-	if !first.Terminated() {
-		t.Fatal("the last subscriber left and the worker kept its FFmpeg process running")
+	// Once the policy does run, it reclaims.
+	mgr.CleanupIdle(0)
+	select {
+	case <-worker.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("CleanupIdle left an abandoned worker running")
 	}
 	if got := mgr.ActiveWorkerCount(); got != 0 {
-		t.Fatalf("manager still holds %d workers after the last release, want 0", got)
+		t.Fatalf("manager still holds %d workers after the sweep, want 0", got)
+	}
+}
+
+// The idle policy runs on its own. Nothing else reaps a worker whose subscribers
+// have all left, so without the sweep every variant a session ever served would
+// hold an FFmpeg process open until the whole pipeline closed.
+func TestAudioVariantManager_IdleSweepStopsAbandonedWorker(t *testing.T) {
+	passthroughFFmpeg(t)
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+	feedCapture(t, masterRing)
+
+	mgr := newAudioVariantManager(masterRing, 50*time.Millisecond, 10*time.Millisecond)
+	defer mgr.Close()
+
+	worker, err := mgr.GetOrCreateWorker(context.Background(), ownershipTestKey("idle-sweep"))
+	if err != nil {
+		t.Fatalf("GetOrCreateWorker: %v", err)
+	}
+
+	mgr.ReleaseWorkerInstance(worker)
+
+	select {
+	case <-worker.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("the idle sweep never stopped the abandoned worker")
+	}
+	if got := mgr.ActiveWorkerCount(); got != 0 {
+		t.Fatalf("the swept worker is still registered: %d workers", got)
+	}
+}
+
+// The same failure the ownership rule exists to prevent, reached from the reclaim
+// side: an aggressive sweep must not take a stream away from a client that is
+// watching it. Only the subscriber count answers that, never the idle duration.
+func TestAudioVariantManager_CleanupIdleSparesSubscribedWorkers(t *testing.T) {
+	passthroughFFmpeg(t)
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+	feedCapture(t, masterRing)
+
+	mgr := newAudioVariantManager(masterRing, time.Hour, time.Hour)
+	defer mgr.Close()
+
+	worker, err := mgr.GetOrCreateWorker(context.Background(), ownershipTestKey("cleanup-spares"))
+	if err != nil {
+		t.Fatalf("GetOrCreateWorker: %v", err)
+	}
+
+	mgr.CleanupIdle(0)
+
+	if got := mgr.ActiveWorkerCount(); got != 1 {
+		t.Fatalf("cleanup removed a worker with %d subscriber(s)", worker.SubscriberCount())
+	}
+	select {
+	case <-worker.Done():
+		t.Fatalf("cleanup stopped a worker a client is watching: %v", worker.Err())
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// Close stops the workers it owns, subscribed or not: the pipeline going away is
+// the one event that outranks every subscriber.
+func TestAudioVariantManager_CloseStopsSubscribedWorker(t *testing.T) {
+	passthroughFFmpeg(t)
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+	feedCapture(t, masterRing)
+
+	mgr := newAudioVariantManager(masterRing, time.Hour, time.Hour)
+
+	worker, err := mgr.GetOrCreateWorker(context.Background(), ownershipTestKey("close-stops"))
+	if err != nil {
+		t.Fatalf("GetOrCreateWorker: %v", err)
+	}
+
+	mgr.Close()
+
+	select {
+	case <-worker.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("a worker was still running after the manager closed")
+	}
+	if got := mgr.ActiveWorkerCount(); got != 0 {
+		t.Fatalf("manager holds %d workers after Close, want 0", got)
 	}
 }
 
@@ -232,19 +381,10 @@ func TestAudioVariantManager_DoesNotStartAWorkerForAnAbandonedCaller(t *testing.
 	mgr := NewAudioVariantManager(masterRing)
 	defer mgr.Close()
 
-	key := AudioVariantKey{
-		ProgramNumber:     1,
-		SourceVideoCodec:  "h264",
-		TargetVideoCodec:  "copy",
-		AudioPID:          257,
-		TargetAudioCodec:  "aac",
-		StreamFingerprint: "abandoned-caller",
-	}
-
 	abandoned, giveUp := context.WithCancel(context.Background())
 	giveUp()
 
-	if _, err := mgr.GetOrCreateWorker(abandoned, key); !errors.Is(err, context.Canceled) {
+	if _, err := mgr.GetOrCreateWorker(abandoned, ownershipTestKey("abandoned-caller")); !errors.Is(err, context.Canceled) {
 		t.Fatalf("GetOrCreateWorker returned %v for a cancelled caller, want context.Canceled", err)
 	}
 	if got := mgr.ActiveWorkerCount(); got != 0 {

--- a/backend/internal/stream/ingest/variant/worker_ownership_test.go
+++ b/backend/internal/stream/ingest/variant/worker_ownership_test.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package variant
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/ring"
+	"github.com/ManuGH/xg2g/internal/stream/ingest/tsfixture"
+)
+
+// feedMasterRing keeps a real capture flowing into a ring for the life of ctx, and
+// returns once the ring holds a random access point. A worker needs continuous
+// input: FFmpeg produces no output without it, and a test that stopped feeding
+// would prove a worker died of starvation rather than of ownership.
+func feedMasterRing(t *testing.T, ctx context.Context, r *ring.MasterRing, capture []byte) {
+	t.Helper()
+
+	push := func(data []byte) {
+		for i := 0; i < len(data); i += 64 * ring.TSPacketSize {
+			end := i + 64*ring.TSPacketSize
+			if end > len(data) {
+				end = len(data)
+			}
+			if _, err := r.Push(data[i:end]); err != nil {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	push(capture[:len(capture)/2])
+	if _, ok := r.LatestKeyframeOffset(); !ok {
+		t.Skip("skipping: capture produced no random access point")
+	}
+
+	go func() {
+		push(capture[len(capture)/2:])
+		for ctx.Err() == nil {
+			push(capture)
+		}
+	}()
+}
+
+// Ownership of a shared transcode worker.
+//
+// Two clients that need the same variant coalesce onto one FFmpeg process. That
+// sharing is the point of the manager - but it also means the process is not the
+// property of whichever client happened to ask for it first.
+//
+// The lifecycle that must hold:
+//
+//	manager (shared worker lifecycle)
+//	        |
+//	     worker
+//	    /       \
+//	client A   client B
+//
+// and not:
+//
+//	client A request context
+//	        |
+//	     worker
+//	        |
+//	client B, attached by luck
+//
+// A single request context may end its own subscription and nothing else. The
+// worker ends on refcount zero, manager shutdown, a topology generation cut, or a
+// real transcoder failure - never because one viewer closed a browser tab.
+func TestAudioVariantManager_SharedWorkerOutlivesItsCreator(t *testing.T) {
+	skipIfNoFFmpeg(t)
+
+	capture := tsfixture.Load(t, "verify_final_v3.ts")
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+
+	feedCtx, stopFeed := context.WithCancel(context.Background())
+	defer stopFeed()
+	feedMasterRing(t, feedCtx, masterRing, capture)
+
+	mgr := NewAudioVariantManager(masterRing)
+	defer mgr.Close()
+
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		StreamFingerprint: "shared-worker-ownership",
+	}
+
+	// Client A arrives first and therefore creates the worker. Its context is the
+	// HTTP request context the handler passes down.
+	requestA, disconnectA := context.WithCancel(context.Background())
+	defer disconnectA()
+	workerA, err := mgr.GetOrCreateWorker(requestA, key)
+	if err != nil {
+		t.Fatalf("client A GetOrCreateWorker: %v", err)
+	}
+
+	// Client B coalesces onto the same process.
+	requestB, disconnectB := context.WithCancel(context.Background())
+	defer disconnectB()
+	workerB, err := mgr.GetOrCreateWorker(requestB, key)
+	if err != nil {
+		t.Fatalf("client B GetOrCreateWorker: %v", err)
+	}
+	if workerB != workerA {
+		t.Fatal("the two clients did not share a worker, so this test proves nothing")
+	}
+	if got := workerB.SubscriberCount(); got != 2 {
+		t.Fatalf("shared worker has %d subscribers, want 2", got)
+	}
+
+	// B is streaming before anything happens to A.
+	_, readerB, err := workerB.PrimedAttachWithTimeout(requestB, 20*time.Second)
+	if err != nil {
+		t.Skipf("skipping: client B never became primed: %v", err)
+	}
+	defer func() { _ = readerB.Close() }()
+
+	buf := make([]byte, 32*1024)
+	if n, rerr := readerB.Read(buf); rerr != nil || n == 0 {
+		t.Fatalf("client B received no output before the disconnect: n=%d err=%v", n, rerr)
+	}
+
+	// Client A's HTTP connection ends: its request context is cancelled and its
+	// lease is released. Nothing about that is a statement about B.
+	disconnectA()
+	mgr.ReleaseWorkerInstance(workerA)
+
+	if got := workerB.SubscriberCount(); got != 1 {
+		t.Fatalf("after A left, the shared worker has %d subscribers, want 1", got)
+	}
+
+	// The worker must simply keep running. A cancelled request context reaching the
+	// FFmpeg process would end it here, and B's stream with it.
+	select {
+	case <-workerB.Done():
+		t.Fatalf("the shared worker ended when its creator disconnected: %v", workerB.Err())
+	case <-time.After(3 * time.Second):
+	}
+
+	if n, rerr := readerB.Read(buf); rerr != nil || n == 0 {
+		t.Fatalf("client B lost its stream when client A disconnected: n=%d err=%v", n, rerr)
+	}
+}
+
+// The other half of the ownership rule. Detaching a worker from its creator's
+// request context removes the only thing that used to reclaim one, because
+// CleanupIdle has no caller. If nothing replaced it, every variant a session ever
+// served would hold an FFmpeg process open until the whole pipeline closed.
+//
+// The refcount is what decides: the last subscriber to leave stops the worker.
+func TestAudioVariantManager_LastReleaseStopsTheWorker(t *testing.T) {
+	skipIfNoFFmpeg(t)
+
+	capture := tsfixture.Load(t, "verify_final_v3.ts")
+
+	masterRing := ring.NewMasterRing(16 * 1024 * 1024)
+	defer masterRing.Close()
+
+	feedCtx, stopFeed := context.WithCancel(context.Background())
+	defer stopFeed()
+	feedMasterRing(t, feedCtx, masterRing, capture)
+
+	mgr := NewAudioVariantManager(masterRing)
+	defer mgr.Close()
+
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		Language:          "deu",
+		StreamFingerprint: "refcount-reclaim",
+	}
+
+	ctx := context.Background()
+	first, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("first GetOrCreateWorker: %v", err)
+	}
+	second, err := mgr.GetOrCreateWorker(ctx, key)
+	if err != nil {
+		t.Fatalf("second GetOrCreateWorker: %v", err)
+	}
+	if second != first {
+		t.Fatal("the two clients did not share a worker, so this test proves nothing")
+	}
+
+	// Let it actually become a running transcode, so what is reclaimed below is a
+	// live process rather than a worker that never started.
+	if _, reader, aerr := first.PrimedAttachWithTimeout(ctx, 20*time.Second); aerr != nil {
+		t.Skipf("skipping: worker never became primed: %v", aerr)
+	} else {
+		_ = reader.Close()
+	}
+
+	mgr.ReleaseWorkerInstance(first)
+	if first.Terminated() {
+		t.Fatalf("the worker was reclaimed while a subscriber was still attached: %v", first.Err())
+	}
+	if got := mgr.ActiveWorkerCount(); got != 1 {
+		t.Fatalf("manager holds %d workers while one is still subscribed, want 1", got)
+	}
+
+	mgr.ReleaseWorkerInstance(second)
+	if !first.Terminated() {
+		t.Fatal("the last subscriber left and the worker kept its FFmpeg process running")
+	}
+	if got := mgr.ActiveWorkerCount(); got != 0 {
+		t.Fatalf("manager still holds %d workers after the last release, want 0", got)
+	}
+}
+
+// A caller that has already given up must not start an FFmpeg process on its way
+// out. This is the only thing the caller's context still governs.
+func TestAudioVariantManager_DoesNotStartAWorkerForAnAbandonedCaller(t *testing.T) {
+	masterRing := ring.NewMasterRing(1024 * 1024)
+	defer masterRing.Close()
+
+	mgr := NewAudioVariantManager(masterRing)
+	defer mgr.Close()
+
+	key := AudioVariantKey{
+		ProgramNumber:     1,
+		SourceVideoCodec:  "h264",
+		TargetVideoCodec:  "copy",
+		AudioPID:          257,
+		TargetAudioCodec:  "aac",
+		StreamFingerprint: "abandoned-caller",
+	}
+
+	abandoned, giveUp := context.WithCancel(context.Background())
+	giveUp()
+
+	if _, err := mgr.GetOrCreateWorker(abandoned, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetOrCreateWorker returned %v for a cancelled caller, want context.Canceled", err)
+	}
+	if got := mgr.ActiveWorkerCount(); got != 0 {
+		t.Fatalf("manager started %d workers for a caller that had already gone", got)
+	}
+}


### PR DESCRIPTION
Follows #873. A shared variant worker now has a lifetime of its own, and what the
pipeline reports is what actually ran.

## The bug

A variant worker was started on the context of whichever client happened to create it:

```
handler r.Context()
  -> AttachAudioVariantWithTimeout(ctx, ...)
  -> GetOrCreateWorker(ctx, ...)
  -> worker.Start(ctx)
  -> exec.CommandContext(ctx, "ffmpeg", ...)
```

Coalescing several clients onto one FFmpeg process is the entire purpose of the
manager, so this made a shared resource the property of one of the things sharing it.
When the first client's request ended, its context was cancelled, the process was
killed, the ring closed, and every other attached client lost its stream.

## What changes

**Ownership.** The worker owns its own lifetime instead of borrowing a subscriber's
context.

**Reclaim by idle policy, not by last release.** Stopping the worker the moment its
last subscriber left made an audio-track switch cost a new FFmpeg process and a wait
for the next random access point every time. Workers now hold open on a ten second
idle timeout, swept every two seconds — comparable to what the ingest sessions
upstream already do. `CleanupIdle` had no caller and compared idle durations without
checking for subscribers, so `CleanupIdle(0)` would have stopped a worker clients were
watching; it now spares any worker with subscribers and stops the rest outside the
manager lock.

**Honest plan headers.** A capability gap routes a request to a variant worker, but
that attach can fail and the request then falls back to the master stream, unchanged.
The headers kept announcing the attempted plan: a client was told `transcode` and
`deinterlace_50p` while being handed the original interlaced stream. Headers now
follow whether a variant was actually attached — a stream passing through reports
`direct`, `passthrough`, and an effective codec equal to its source.

## Tests

The lifetime tests no longer need a real ffmpeg. A stand-in on PATH that copies stdin
to stdout is enough to prove how long a worker lives, and the PR gate deliberately
installs no ffmpeg — as written before, these regression tests would have skipped in
exactly the place they need to run. The master ring is still fed a real capture,
because a worker only attaches at a primed random access point and filler produces
none.

Adds the pipeline-level test of the same rule: two clients on one worker, the first
disconnects, the second keeps receiving.

## Local gates

Rebased onto `main` at 4707b8f3 (post-#873), clean, no conflicts.

| Gate | Result |
| --- | --- |
| `go build ./...` | pass |
| `go test ./...` | pass (143 packages) |
| `make test-race-pr` | pass |
| `make lint` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
