### PR TITLE
Read the declared audio channel count out of the PMT

### DIFF
--- a/backend/internal/stream/ingest/ring/audio_declaration_test.go
+++ b/backend/internal/stream/ingest/ring/audio_declaration_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import "testing"
+
+// descriptor assembles one PMT descriptor: tag, length, body.
+func descriptor(tag byte, body ...byte) []byte {
+	return append([]byte{tag, byte(len(body))}, body...)
+}
+
+// ac3Desc builds an AC-3 descriptor whose component_type_flag is set, so the
+// component type is the byte that follows the flags.
+func ac3Desc(componentType byte) []byte {
+	return descriptor(descriptorAC3, ac3ComponentTypeFlagBit, componentType)
+}
+
+// aacDesc builds an AAC descriptor: profile_and_level, the AAC_type_flag byte,
+// then AAC_type.
+func aacDesc(aacType byte) []byte {
+	return descriptor(descriptorAAC, 0x50, aacTypeFlagBit, aacType)
+}
+
+func TestAudioChannelsFromDescriptors_AC3(t *testing.T) {
+	tests := []struct {
+		name          string
+		componentType byte
+		wantChannels  int
+		wantMulti     bool
+	}{
+		{"mono", ac3ChannelsMono, 1, false},
+		{"dual mono is two carried channels", ac3ChannelsDualMono, 2, false},
+		{"stereo", ac3ChannelsStereo, 2, false},
+		{"dolby surround encoded stereo is still two channels", ac3ChannelsStereoDsur, 2, false},
+		{"multichannel declares no count", ac3ChannelsMultiFirst, 0, true},
+		{"multichannel upper value", ac3ChannelsMultiLast, 0, true},
+		{"reserved names nothing", 0x07, 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AudioChannelsFromDescriptors(ac3Desc(tc.componentType))
+
+			if got.Channels != tc.wantChannels {
+				t.Errorf("Channels = %d, want %d", got.Channels, tc.wantChannels)
+			}
+			if got.Multichannel != tc.wantMulti {
+				t.Errorf("Multichannel = %v, want %v", got.Multichannel, tc.wantMulti)
+			}
+			if !got.HasComponentType {
+				t.Error("HasComponentType = false, want true: the descriptor carried one")
+			}
+			if got.ComponentType != tc.componentType {
+				t.Errorf("ComponentType = %#x, want %#x", got.ComponentType, tc.componentType)
+			}
+		})
+	}
+}
+
+// The service type occupies the high bits of the same byte. Reading the whole
+// byte as a channel count instead of masking the low nibble would turn every
+// non-complete-main service into a wrong answer.
+func TestAudioChannelsFromDescriptors_IgnoresServiceTypeBits(t *testing.T) {
+	// full_service_flag set, service_type 5 (commentary), channels = stereo.
+	const componentType = 0x80 | (5 << 4) | ac3ChannelsStereo
+
+	got := AudioChannelsFromDescriptors(ac3Desc(componentType))
+
+	if got.Channels != 2 {
+		t.Errorf("Channels = %d, want 2", got.Channels)
+	}
+	if got.ComponentType != componentType {
+		t.Errorf("ComponentType = %#x, want %#x: the raw byte must survive for the policy layer",
+			got.ComponentType, componentType)
+	}
+}
+
+func TestAudioChannelsFromDescriptors_AAC(t *testing.T) {
+	tests := []struct {
+		name         string
+		aacType      byte
+		wantChannels int
+		wantMulti    bool
+	}{
+		{"aac mono", aacTypeMono, 1, false},
+		{"aac stereo", aacTypeStereo, 2, false},
+		{"aac surround declares no count", aacTypeSurround, 0, true},
+		{"he-aac mono", aacTypeHEMono, 1, false},
+		{"he-aac stereo", aacTypeHEStereo, 2, false},
+		{"he-aac surround declares no count", aacTypeHESurr, 0, true},
+		{"audio description names no channel count", 0x40, 0, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AudioChannelsFromDescriptors(aacDesc(tc.aacType))
+
+			if got.Channels != tc.wantChannels {
+				t.Errorf("Channels = %d, want %d", got.Channels, tc.wantChannels)
+			}
+			if got.Multichannel != tc.wantMulti {
+				t.Errorf("Multichannel = %v, want %v", got.Multichannel, tc.wantMulti)
+			}
+		})
+	}
+}
+
+// Absent, truncated and flag-less descriptors must all report unknown rather
+// than a plausible default. A wrong number here reaches the encoder as a real
+// channel count; "unknown" lets the policy layer keep its own fallback.
+func TestAudioChannelsFromDescriptors_UnknownCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		descriptors []byte
+	}{
+		{"nil", nil},
+		{"empty", []byte{}},
+		{"no audio descriptor at all", descriptor(0x0A, 'd', 'e', 'u', 0x00)},
+		{"ac3 without component_type_flag", descriptor(descriptorAC3, 0x00)},
+		{"ac3 flag set but body truncated", descriptor(descriptorAC3, ac3ComponentTypeFlagBit)},
+		{"aac without AAC_type_flag", descriptor(descriptorAAC, 0x50, 0x00)},
+		{"aac flag set but body truncated", descriptor(descriptorAAC, 0x50, aacTypeFlagBit)},
+		{"mp2 declares nothing in a descriptor", descriptor(0x0A, 'e', 'n', 'g', 0x00)},
+		{"dts is not declared here", descriptor(descriptorDTS, 0x01, 0x02)},
+		{"length runs past the buffer", []byte{descriptorAC3, 0x7F, 0x80}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AudioChannelsFromDescriptors(tc.descriptors)
+
+			if got.Known() {
+				t.Errorf("Known() = true (%+v), want unknown", got)
+			}
+			if got.Channels != 0 {
+				t.Errorf("Channels = %d, want 0", got.Channels)
+			}
+		})
+	}
+}
+
+// A descriptor loop carries several descriptors; the audio one is rarely first.
+func TestAudioChannelsFromDescriptors_WalksPastOtherDescriptors(t *testing.T) {
+	descriptors := append(
+		descriptor(0x0A, 'd', 'e', 'u', 0x00), // ISO 639 language
+		ac3Desc(ac3ChannelsStereo)...,
+	)
+
+	got := AudioChannelsFromDescriptors(descriptors)
+
+	if got.Channels != 2 {
+		t.Errorf("Channels = %d, want 2", got.Channels)
+	}
+}
+
+// Known() is the distinction the policy layer branches on, so a stereo
+// declaration and a silent stream must not look alike.
+func TestAudioChannelDeclaration_Known(t *testing.T) {
+	tests := []struct {
+		name string
+		decl AudioChannelDeclaration
+		want bool
+	}{
+		{"zero value", AudioChannelDeclaration{}, false},
+		{"counted", AudioChannelDeclaration{Channels: 2}, true},
+		{"multichannel without a count", AudioChannelDeclaration{Multichannel: true}, true},
+		{"component type but no channel meaning", AudioChannelDeclaration{ComponentType: 0x40, HasComponentType: true}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.decl.Known(); got != tc.want {
+				t.Errorf("Known() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/stream/ingest/ring/randomaccess.go
+++ b/backend/internal/stream/ingest/ring/randomaccess.go
@@ -334,6 +334,153 @@ type AudioTrackInfo struct {
 	StreamType byte   `json:"streamType"`
 	Codec      string `json:"codec"`    // "mp2", "aac", "ac3", "eac3", "dts", "unknown"
 	Language   string `json:"language"` // e.g. "deu", "eng", "und"
+
+	// Declared is what the PMT says about this track's channel count. It is a
+	// declaration read from a descriptor, never a measurement of the audio.
+	Declared AudioChannelDeclaration `json:"declared"`
+}
+
+// AudioChannelDeclaration is the channel information a DVB descriptor declares
+// for an audio track.
+//
+// It is deliberately not an ffmpeg channel count. The descriptors carry a coarse
+// class, and above stereo they say "more than two channels" without naming a
+// number - an AC-3 service at 5.1 and one at 7.1 declare the same value. Turning
+// that into a 6 is an inference, and it belongs in the policy layer that knows
+// what it will do with the answer, not here.
+//
+// The zero value means the stream declared nothing usable, which is a distinct
+// state from declaring stereo. Guessing here would put a plausible wrong number
+// in front of the encoder, which is worse than admitting the stream is silent on
+// the subject.
+type AudioChannelDeclaration struct {
+	// Channels is the declared count where the declaration names one, and 0 where
+	// it does not. A multichannel declaration leaves this 0 and sets Multichannel.
+	Channels int `json:"channels,omitempty"`
+
+	// Multichannel reports a declaration of more than two channels that carries no
+	// exact count.
+	Multichannel bool `json:"multichannel,omitempty"`
+
+	// ComponentType is the raw ETSI EN 300 468 component_type byte this was read
+	// from, kept so a policy layer can reach conclusions this type deliberately
+	// does not - service type, audio description, hearing impaired.
+	ComponentType uint8 `json:"componentType,omitempty"`
+
+	// HasComponentType separates "the descriptor carried a component type" from a
+	// component type that happens to be zero.
+	HasComponentType bool `json:"hasComponentType,omitempty"`
+}
+
+// Known reports whether the declaration says anything about the channel count.
+func (d AudioChannelDeclaration) Known() bool {
+	return d.Channels > 0 || d.Multichannel
+}
+
+// AC-3 component_type, ETSI EN 300 468 Annex D. The low nibble is the declared
+// number of channels; everything at or above ac3ChannelsMultiFirst says only that
+// there are more than two.
+const (
+	ac3ComponentTypeFlagBit = 0x80 // component_type_flag in the descriptor's first body byte
+	ac3ChannelsMask         = 0x0F
+
+	ac3ChannelsMono       = 0x00
+	ac3ChannelsDualMono   = 0x01 // 1+1, two independent mono programmes
+	ac3ChannelsStereo     = 0x02
+	ac3ChannelsStereoDsur = 0x03 // 2 channel, Dolby surround encoded
+	ac3ChannelsMultiFirst = 0x04 // multichannel, no count declared
+	ac3ChannelsMultiLast  = 0x06
+)
+
+// AAC_type, ETSI EN 300 468 Table 26. Only the values whose channel meaning is
+// unambiguous are mapped; anything else stays unknown rather than being guessed.
+const (
+	aacTypeFlagBit = 0x80 // AAC_type_flag, first bit after profile_and_level
+
+	aacTypeMono     = 0x01
+	aacTypeStereo   = 0x03
+	aacTypeSurround = 0x05
+	aacTypeHEMono   = 0x43
+	aacTypeHEStereo = 0x45
+	aacTypeHESurr   = 0x47
+)
+
+// AudioChannelsFromDescriptors reads the declared channel information out of an
+// elementary stream's PMT descriptors.
+//
+// Only AC-3, E-AC-3 and AAC declare channels in a descriptor, and only when the
+// optional component type is present. MPEG-1/2 layer II carries its channel mode
+// in the audio frame header, which is elementary stream payload this package does
+// not parse, so it returns unknown. DTS is likewise not declared here.
+func AudioChannelsFromDescriptors(descriptors []byte) AudioChannelDeclaration {
+	for i := 0; i+2 <= len(descriptors); {
+		tag := descriptors[i]
+		length := int(descriptors[i+1])
+		if i+2+length > len(descriptors) {
+			break
+		}
+		body := descriptors[i+2 : i+2+length]
+
+		switch tag {
+		case descriptorAC3, descriptorEnhAC3:
+			if d, ok := ac3ChannelDeclaration(body); ok {
+				return d
+			}
+		case descriptorAAC:
+			if d, ok := aacChannelDeclaration(body); ok {
+				return d
+			}
+		}
+		i += 2 + length
+	}
+	return AudioChannelDeclaration{}
+}
+
+// ac3ChannelDeclaration reads the AC-3 / E-AC-3 descriptor body. Its first byte
+// is a set of presence flags; component_type, when the flag says it is there,
+// follows immediately.
+func ac3ChannelDeclaration(body []byte) (AudioChannelDeclaration, bool) {
+	if len(body) < 2 || body[0]&ac3ComponentTypeFlagBit == 0 {
+		return AudioChannelDeclaration{}, false
+	}
+	componentType := body[1]
+
+	d := AudioChannelDeclaration{ComponentType: componentType, HasComponentType: true}
+	switch componentType & ac3ChannelsMask {
+	case ac3ChannelsMono:
+		d.Channels = 1
+	case ac3ChannelsDualMono, ac3ChannelsStereo, ac3ChannelsStereoDsur:
+		d.Channels = 2
+	case ac3ChannelsMultiFirst, ac3ChannelsMultiFirst + 1, ac3ChannelsMultiLast:
+		d.Multichannel = true
+	default:
+		// Reserved. The component type is still worth carrying, but it names no
+		// channel count this code is willing to claim.
+	}
+	return d, true
+}
+
+// aacChannelDeclaration reads the AAC descriptor body: profile_and_level, then a
+// flag bit, then AAC_type when that flag is set.
+func aacChannelDeclaration(body []byte) (AudioChannelDeclaration, bool) {
+	if len(body) < 3 || body[1]&aacTypeFlagBit == 0 {
+		return AudioChannelDeclaration{}, false
+	}
+	aacType := body[2]
+
+	d := AudioChannelDeclaration{ComponentType: aacType, HasComponentType: true}
+	switch aacType {
+	case aacTypeMono, aacTypeHEMono:
+		d.Channels = 1
+	case aacTypeStereo, aacTypeHEStereo:
+		d.Channels = 2
+	case aacTypeSurround, aacTypeHESurr:
+		d.Multichannel = true
+	default:
+		// Table 26 also names audio description, hard of hearing and mixed
+		// supplementary variants whose channel count is not fixed by the value.
+	}
+	return d, true
 }
 
 // AudioCodecFromStreamType identifies the audio codec normalized from stream type and descriptors.

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -673,11 +673,13 @@ func (r *MasterRing) processCompletePSISectionLocked(isPAT bool, table []byte, r
 							r.audioPIDs = appendPID(r.audioPIDs, elemPID)
 							codec := AudioCodecFromStreamType(st, descriptors)
 							lang := LanguageFromDescriptors(descriptors)
+							declared := AudioChannelsFromDescriptors(descriptors)
 							r.audioTracks = appendAudioTrack(r.audioTracks, AudioTrackInfo{
 								PID:        elemPID,
 								StreamType: st,
 								Codec:      codec,
 								Language:   lang,
+								Declared:   declared,
 							})
 						}
 					}


### PR DESCRIPTION
Phase B, Schritt B2b.1. Additiv, kein Verhaltenswechsel — nichts liest das neue Feld bisher.

## Warum

Der Ring lief für Codec und Sprache schon über die Deskriptor-Schleife jedes Audiostreams, warf den Deskriptor-Body aber weg. AC-3, E-AC-3 und AAC deklarieren ihre Kanalkonfiguration genau dort. Ein Teil der Information, für die die Startzeit-`ffprobe` eine zweite Receiver-Verbindung öffnet, kommt also ohnehin schon vorbei.

## Drei Zustände, nicht zwei

Ein DVB-Deskriptor nennt eine grobe Klasse: mono, 1+1, stereo, Dolby-Surround-kodiertes Stereo, oder „mehr als zwei Kanäle" ohne Zahl. **Ein AC-3-Dienst mit 5.1 und einer mit 7.1 deklarieren denselben Wert.** Der Typ trennt deshalb:

```go
type AudioChannelDeclaration struct {
    Channels         int   // deklarierte Zahl, wo eine genannt wird; sonst 0
    Multichannel     bool  // >2 Kanäle deklariert, ohne Zahl
    ComponentType    uint8 // rohes ETSI-EN-300-468-Byte
    HasComponentType bool
}

func (d AudioChannelDeclaration) Known() bool
```

Der dritte Zustand ist der Punkt. Eine fehlende Deklaration auf Stereo zu defaulten würde eine plausible falsche Zahl vor den Encoder setzen — schlechter, als zu melden, dass der Stream dazu schweigt. Der Policy-Layer behält seinen eigenen Fallback und kann die beiden Fälle jetzt unterscheiden.

Aus demselben Grund wird das rohe `component_type`-Byte durchgereicht statt hier interpretiert: Service-Type, Audiodeskription und Hörgeschädigten-Varianten sind Entscheidungen der Schicht, die weiß, was sie damit tut.

## Was ausdrücklich unknown bleibt

MPEG-1/2 Layer II trägt seinen Kanalmodus im Audio-Frame-Header — Nutzlast, die dieses Paket bewusst nicht parst (`ring.go:352`). DTS wird so ebenfalls nicht deklariert. Beide melden unknown. Ein Observed-Pfad mit `acmod`/`lfeon` bzw. `channel_configuration` wäre eine eigene, bewusste neue Fähigkeit des Ingests — nicht ein Nebeneffekt dieses PRs.

## Tests

37 Fälle, darunter jeder Weg in den unknown-Zustand: kein Deskriptor, falscher Deskriptor, Flag nicht gesetzt, Body abgeschnitten, Länge läuft über den Puffer hinaus, reservierter Wert. Dazu der Fall, der beim Bitfeld am leichtesten schiefgeht: die Service-Type-Bits im oberen Nibble dürfen die Kanalzahl im unteren nicht verfälschen.

## Lokale Gates

| Gate | Ergebnis |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (143 Pakete) |
| `make test-race-pr` | pass |
| `make lint` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
