### PR TITLE
Refuse a direct URL that points at the receiver

### DIFF
--- a/backend/internal/app/bootstrap/wiring_helpers.go
+++ b/backend/internal/app/bootstrap/wiring_helpers.go
@@ -153,6 +153,7 @@ func (f v3OrchestratorFactory) Build(cfg config.AppConfig, inputs daemon.V3Orche
 			Interval:         1 * time.Minute,
 			SessionRetention: 24 * time.Hour,
 		},
+		ReceiverBaseURL: cfg.Enigma2.BaseURL,
 		OutboundPolicy: platformnet.OutboundPolicy{
 			Enabled: cfg.Network.Outbound.Enabled,
 			Allow: platformnet.OutboundAllowlist{

--- a/backend/internal/control/http/v3/handlers_intents.go
+++ b/backend/internal/control/http/v3/handlers_intents.go
@@ -179,6 +179,15 @@ func resolveIntentServiceRef(w http.ResponseWriter, r *http.Request, deps sessio
 	serviceRef = strings.TrimSpace(rawServiceRef)
 	if intentType == model.IntentTypeStreamStart {
 		if u, ok := platformnet.ParseDirectHTTPURL(serviceRef); ok {
+			// A direct URL becomes a SourceURL session, which hands the URL to
+			// FFmpeg without a tuner lease, a zap or a readiness check. Pointed at
+			// the receiver that is a live transcode opening the receiver behind
+			// shared ingest's back, under the source class meant for external IPTV.
+			if platformnet.PointsAtReceiver(u.String(), deps.cfg.Enigma2.BaseURL) {
+				respondIntentFailure(w, r, IntentErrInvalidInput,
+					"serviceRef must not address the receiver directly; use a service reference for live TV")
+				return "", true
+			}
 			normalized, err := platformnet.ValidateOutboundURL(r.Context(), u.String(), outboundPolicyFromConfig(deps.cfg))
 			if err != nil {
 				respondIntentFailure(w, r, IntentErrInvalidInput, "direct URL serviceRef rejected by outbound policy")

--- a/backend/internal/domain/session/manager/orchestrator.go
+++ b/backend/internal/domain/session/manager/orchestrator.go
@@ -70,6 +70,10 @@ type Orchestrator struct {
 
 	PipelineStopTimeout time.Duration
 	OutboundPolicy      platformnet.OutboundPolicy
+
+	// ReceiverBaseURL identifies the receiver box so a direct-URL session can be
+	// refused when it points there. Empty disables the check.
+	ReceiverBaseURL string
 	// RecoveryProfileResolver freezes the narrow profile-building capability
 	// needed by runtime recovery without coupling orchestration to a concrete
 	// configuration loader.

--- a/backend/internal/domain/session/manager/orchestrator_leases.go
+++ b/backend/internal/domain/session/manager/orchestrator_leases.go
@@ -339,6 +339,13 @@ func (o *Orchestrator) startPipeline(
 		// In that case SourceType is File.
 		spec.Source.Type = ports.SourceFile
 	} else if u, ok := platformnet.ParseDirectHTTPURL(sessionCtx.ServiceRef); ok {
+		// Checked at the API too. Repeated here because this is the last point
+		// before the URL becomes an ffmpeg -i argument, and a session can reach
+		// this code from more than one caller.
+		if platformnet.PointsAtReceiver(u.String(), o.ReceiverBaseURL) {
+			return "", model.ProfileSpec{}, newReasonError(model.RBadRequest,
+				"serviceRef addresses the receiver directly; live input must come from shared ingest", nil)
+		}
 		normalized, err := platformnet.ValidateOutboundURL(hbCtx, u.String(), o.OutboundPolicy)
 		if err != nil {
 			return "", model.ProfileSpec{}, newReasonError(model.RBadRequest, "outbound url rejected by policy", err)

--- a/backend/internal/domain/session/manager/receiver_url_guard_test.go
+++ b/backend/internal/domain/session/manager/receiver_url_guard_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package manager
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/model"
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/ManuGH/xg2g/internal/domain/session/store"
+	platformnet "github.com/ManuGH/xg2g/internal/platform/net"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingPipeline records whether it was started and with which source, so a
+// test can assert either that the guard stopped a start or that it let one
+// through.
+type recordingPipeline struct {
+	started bool
+	source  string
+}
+
+func (p *recordingPipeline) Start(_ context.Context, spec ports.StreamSpec) (ports.RunHandle, error) {
+	p.started = true
+	p.source = spec.Source.ID
+	return "handle", nil
+}
+
+func (p *recordingPipeline) Stop(context.Context, ports.RunHandle) error { return nil }
+
+func (p *recordingPipeline) Health(context.Context, ports.RunHandle) ports.HealthStatus {
+	return ports.HealthStatus{}
+}
+
+func guardOrchestrator(t *testing.T, receiverBaseURL string) (*Orchestrator, *recordingPipeline) {
+	t.Helper()
+	pipeline := &recordingPipeline{}
+	return &Orchestrator{
+		Store:           store.NewMemoryStore(),
+		Pipeline:        pipeline,
+		ReceiverBaseURL: receiverBaseURL,
+		OutboundPolicy: platformnet.OutboundPolicy{
+			// Deliberately permissive: without it the outbound check would refuse
+			// these URLs on its own and the test would pass for the wrong reason.
+			Enabled: true,
+			Allow: platformnet.OutboundAllowlist{
+				Hosts:   []string{"192.168.1.50", "203.0.113.10"},
+				CIDRs:   []string{"192.168.0.0/16", "203.0.113.0/24"},
+				Schemes: []string{"http", "https"},
+				Ports:   []int{80, 443, 8001, 8002},
+			},
+		},
+	}, pipeline
+}
+
+// A direct URL aimed at the receiver must never become a session. It would reach
+// ffmpeg as an -i argument with no tuner lease, no zap and no readiness check -
+// the architecture break shared ingest exists to remove, under a source class
+// meant for external IPTV.
+func TestStartPipeline_RejectsReceiverURLAsSource(t *testing.T) {
+	receiverURLs := []string{
+		"http://192.168.1.50:8001/1:0:19:83:6:85:C00000:0:0:0:",
+		"http://192.168.1.50:8002/1:0:19:83:6:85:C00000:0:0:0:",
+		"http://192.168.1.50/web/stream.m3u",
+	}
+
+	for _, ref := range receiverURLs {
+		t.Run(ref, func(t *testing.T) {
+			orch, pipeline := guardOrchestrator(t, "http://192.168.1.50:8080")
+
+			_, _, err := orch.startPipeline(
+				context.Background(),
+				model.StartSessionEvent{SessionID: "sess-guard"},
+				&sessionContext{SessionID: "sess-guard", ServiceRef: ref, Mode: model.ModeLive},
+				model.ProfileSpec{Name: "compatible"},
+				0,
+				startupAttempt{},
+			)
+
+			require.Error(t, err, "a receiver URL must not start a session")
+			require.False(t, pipeline.started, "pipeline was started with %q", pipeline.source)
+			require.Contains(t, strings.ToLower(err.Error()), "receiver")
+		})
+	}
+}
+
+// The guard must not cost the feature it shares a code path with: a genuine
+// external IPTV URL still starts.
+func TestStartPipeline_AllowsExternalURLSource(t *testing.T) {
+	orch, pipeline := guardOrchestrator(t, "http://192.168.1.50:8080")
+
+	_, _, err := orch.startPipeline(
+		context.Background(),
+		model.StartSessionEvent{SessionID: "sess-iptv"},
+		&sessionContext{
+			SessionID:  "sess-iptv",
+			ServiceRef: "http://203.0.113.10:8001/live/channel.m3u8",
+			Mode:       model.ModeLive,
+		},
+		model.ProfileSpec{Name: "compatible"},
+		0,
+		startupAttempt{},
+	)
+
+	require.NoError(t, err)
+	require.True(t, pipeline.started, "external IPTV must still reach the pipeline")
+}
+
+// With no receiver configured the guard stands down rather than refusing
+// everything.
+func TestStartPipeline_GuardInertWithoutConfiguredReceiver(t *testing.T) {
+	orch, pipeline := guardOrchestrator(t, "")
+
+	_, _, err := orch.startPipeline(
+		context.Background(),
+		model.StartSessionEvent{SessionID: "sess-noreceiver"},
+		&sessionContext{
+			SessionID:  "sess-noreceiver",
+			ServiceRef: "http://192.168.1.50:8001/1:0:19:83:6:85:C00000:0:0:0:",
+			Mode:       model.ModeLive,
+		},
+		model.ProfileSpec{Name: "compatible"},
+		0,
+		startupAttempt{},
+	)
+
+	require.NoError(t, err)
+	require.True(t, pipeline.started)
+}

--- a/backend/internal/platform/net/receiver_guard.go
+++ b/backend/internal/platform/net/receiver_guard.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package net
+
+import (
+	"net/url"
+	"strings"
+)
+
+// PointsAtReceiver reports whether rawURL addresses the same host as
+// receiverBaseURL.
+//
+// It exists to close a back door in the live path. A stream-start intent may
+// carry a direct HTTP URL as its service reference, which becomes a SourceURL
+// session that hands the URL straight to FFmpeg - no tuner lease, no zap, no
+// readiness check. Point that URL at the receiver's own stream port and a live
+// transcode opens the receiver behind the back of shared ingest, under a source
+// class that was meant for external IPTV.
+//
+// The comparison is deliberately on the host alone, not host:port. The receiver's
+// stream endpoint is not a single known port: ResolveStreamURL asks
+// /web/stream.m3u and uses whatever port the receiver names, the configured
+// StreamPort is only the fallback, and the media path has its own 8001/8002
+// retry on top. Any port-specific check would have holes on exactly the ports
+// this guard exists to cover, so the rule is that a live SourceURL never points
+// at the receiver box at all. External IPTV lives somewhere else by definition.
+//
+// A receiverBaseURL that is empty or unparseable disables the check: with no
+// configured receiver there is nothing to protect, and refusing every URL would
+// be a worse failure than the one being prevented.
+func PointsAtReceiver(rawURL, receiverBaseURL string) bool {
+	receiverHost, ok := hostOf(receiverBaseURL)
+	if !ok {
+		return false
+	}
+	candidateHost, ok := hostOf(rawURL)
+	if !ok {
+		return false
+	}
+	return candidateHost == receiverHost
+}
+
+// hostOf normalizes the host of a URL that may arrive without a scheme.
+func hostOf(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	if !strings.Contains(raw, "://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" {
+		return "", false
+	}
+	host, err := NormalizeHost(u.Hostname())
+	if err != nil {
+		return "", false
+	}
+	return host, true
+}

--- a/backend/internal/platform/net/receiver_guard_test.go
+++ b/backend/internal/platform/net/receiver_guard_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package net
+
+import "testing"
+
+func TestPointsAtReceiver_RejectsEveryPortOnTheReceiver(t *testing.T) {
+	const base = "http://192.168.1.50"
+
+	// The receiver's stream endpoint is not one known port: the receiver names it
+	// via /web/stream.m3u, StreamPort is only a fallback, and the media path
+	// retries on 8001/8002. All of them are the receiver.
+	urls := []string{
+		"http://192.168.1.50:8001/1:0:19:83:6:85:C00000:0:0:0:",
+		"http://192.168.1.50:8002/1:0:19:83:6:85:C00000:0:0:0:",
+		"http://192.168.1.50:17999/1:0:19:83:6:85:C00000:0:0:0:",
+		"http://192.168.1.50/web/stream.m3u?ref=1:0:19:83",
+		"https://192.168.1.50:8001/stream",
+	}
+
+	for _, raw := range urls {
+		t.Run(raw, func(t *testing.T) {
+			if !PointsAtReceiver(raw, base) {
+				t.Errorf("PointsAtReceiver(%q, %q) = false, want true", raw, base)
+			}
+		})
+	}
+}
+
+func TestPointsAtReceiver_AllowsExternalIPTV(t *testing.T) {
+	const base = "http://192.168.1.50:8080"
+
+	urls := []string{
+		"http://provider.example.com/live/channel.m3u8",
+		"http://192.168.1.51:8001/stream", // the neighbour, not the receiver
+		"http://10.0.0.1:8001/stream",
+		"https://cdn.example.net:443/hls/index.m3u8",
+	}
+
+	for _, raw := range urls {
+		t.Run(raw, func(t *testing.T) {
+			if PointsAtReceiver(raw, base) {
+				t.Errorf("PointsAtReceiver(%q, %q) = true, want false", raw, base)
+			}
+		})
+	}
+}
+
+// The receiver is configured with a base URL that carries a scheme, a port and a
+// path; the candidate arrives as whatever the client sent. Neither shape may
+// change the answer.
+func TestPointsAtReceiver_IgnoresSchemePortAndPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate string
+		base      string
+	}{
+		{"base with port and path", "http://vuplus.local:8001/x", "http://vuplus.local:8080/web/"},
+		{"base without scheme", "http://vuplus.local:8001/x", "vuplus.local:8080"},
+		{"candidate without scheme", "vuplus.local:8001/x", "http://vuplus.local:8080"},
+		{"differing case", "http://VUPLUS.LOCAL:8001/x", "http://vuplus.local:8080"},
+		{"trailing dot on the candidate", "http://vuplus.local.:8001/x", "http://vuplus.local:8080"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !PointsAtReceiver(tc.candidate, tc.base) {
+				t.Errorf("PointsAtReceiver(%q, %q) = false, want true", tc.candidate, tc.base)
+			}
+		})
+	}
+}
+
+// With no receiver configured there is nothing to protect, and refusing every URL
+// would be a worse failure than the one this guard prevents.
+func TestPointsAtReceiver_DisabledWithoutAUsableReceiver(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate string
+		base      string
+	}{
+		{"empty base", "http://192.168.1.50:8001/x", ""},
+		{"whitespace base", "http://192.168.1.50:8001/x", "   "},
+		{"base with no host", "http://192.168.1.50:8001/x", "http://"},
+		{"empty candidate", "", "http://192.168.1.50"},
+		{"candidate with no host", "http://", "http://192.168.1.50"},
+		{"unparseable candidate", "http://[::1", "http://192.168.1.50"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if PointsAtReceiver(tc.candidate, tc.base) {
+				t.Errorf("PointsAtReceiver(%q, %q) = true, want false", tc.candidate, tc.base)
+			}
+		})
+	}
+}
+
+// An IPv6 receiver must match through the bracket form as well.
+func TestPointsAtReceiver_IPv6(t *testing.T) {
+	if !PointsAtReceiver("http://[fe80::1]:8001/x", "http://[fe80::1]:8080") {
+		t.Error("IPv6 receiver not recognised through the bracket form")
+	}
+	if PointsAtReceiver("http://[fe80::2]:8001/x", "http://[fe80::1]:8080") {
+		t.Error("a different IPv6 host was treated as the receiver")
+	}
+}


### PR DESCRIPTION
Vorcommit zu B4. Schließt die Receiver-Hintertür, bevor der Input-Cutover behauptet, kein Live-Transcode könne den Receiver mehr selbst öffnen.

## Die Lücke

Ein Stream-Start-Intent darf eine direkte HTTP-URL als ServiceRef tragen. Daraus wird eine `SourceURL`-Session, und `SourceURL` reicht die URL unverändert als `-i`-Argument an FFmpeg: **kein Tuner-Lease, kein Zap, kein Readiness-Check**. Zeigt sie auf den Stream-Port des Receivers, öffnet ein Live-Transcode den Receiver an Shared Ingest vorbei — unter der Source-Klasse, die für externes IPTV gedacht ist.

Die Lücke war eng, aber real: sie braucht `network.outbound.enabled` (Default `false`) und Host plus Port in der Allowlist. Nur schloss nichts den Receiver davon aus, und es sind dieselben Werte, die ein funktionierendes Deployment ohnehin einträgt.

## Warum jetzt

Wenn B5/B6 später sagen „kein Live-Transcode erreicht den Receiver selbst", dann muss diese Tür vorher zu sein. Sonst entfernen wir die `SourceTuner`-Dials und lassen denselben Architekturbruch unter einem allgemeineren Namen stehen.

## Host, nicht Host:Port

Der Stream-Endpunkt des Receivers ist kein einzelner bekannter Port:

- `ResolveStreamURL` fragt `/web/stream.m3u` und nimmt den Port, den der Receiver nennt
- der konfigurierte `StreamPort` ist nur der Fallback
- der Medienpfad hat darüber noch seinen eigenen 8001/8002-Retry

Eine portspezifische Regel hätte Löcher auf genau den Ports, für die der Guard existiert. Also: eine Live-`SourceURL` darf die Receiver-Box **gar nicht** adressieren. Externes IPTV liegt per Definition woanders — und der Test hält diesen Fall offen.

## Zwei Prüfstellen

| Ort | Rolle |
| --- | --- |
| `resolveIntentServiceRef` | Ablehnung an der API, mit klarer Meldung |
| `startPipeline` | letzte Linie vor dem `-i`-Argument; eine Session kann von mehr als einem Aufrufer dorthin kommen |

Ein leerer oder unparsbarer Receiver-Base-URL schaltet den Guard ab: ohne konfigurierten Receiver gibt es nichts zu schützen, und jede direkte URL abzulehnen wäre der schlimmere Fehler.

## Source-Klassen danach

```text
SourceTuner → der Receiver, über den Tuner-Pfad
SourceURL   → externes IPTV, nie der Receiver
SourceFile  → Recordings und VOD
```

## Tests

Guard-Ebene: jeder Port auf dem Receiver wird erkannt (8001, 8002, receiver-genannt, OpenWebIF), externes IPTV nicht; Schema, Port, Pfad, Groß-/Kleinschreibung, Trailing Dot und IPv6 ändern die Antwort nicht; ohne konfigurierten Receiver ist der Guard inert.

Orchestrator-Ebene: eine Receiver-URL startet keine Pipeline (mit bewusst permissiver Outbound-Policy, damit der Test nicht aus dem falschen Grund besteht), eine externe IPTV-URL startet weiterhin, und ohne Receiver-Konfiguration blockiert nichts.

## Lokale Gates

| Gate | Ergebnis |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (143 Pakete) |
| `make test-race-pr` | pass |
| `make lint` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
