### PR TITLE
Feed the PMT's audio declarations into the topology

### DIFF
--- a/backend/internal/domain/session/ports/livesource.go
+++ b/backend/internal/domain/session/ports/livesource.go
@@ -41,6 +41,38 @@ type LiveSourceFacts struct {
 
 	ScrambledVideoPackets uint64
 	ClearVideoPackets     uint64
+
+	// AudioTracks are the elementary audio streams the PMT names, in the order it
+	// names them.
+	AudioTracks []LiveAudioTrack
+}
+
+// LiveAudioTrack is one audio elementary stream as the PMT declares it.
+//
+// Everything here is declared, not measured: it comes from the descriptor loop,
+// which is why there is no sample rate, no bitrate and no measured channel count.
+// A consumer that needs those still has to look at the audio itself.
+type LiveAudioTrack struct {
+	PID        uint16
+	StreamType byte
+	Codec      string
+	Language   string
+
+	// Channels is the declared channel count where the descriptor names one, and
+	// 0 where it does not. Zero means "the stream did not say", which is a
+	// different thing from stereo.
+	Channels int
+
+	// Multichannel reports a declaration of more than two channels carrying no
+	// exact count - an AC-3 service at 5.1 and one at 7.1 declare the same value,
+	// so turning this into a number would be an invention.
+	Multichannel bool
+
+	// ComponentType is the raw ETSI EN 300 468 component type the declaration was
+	// read from, carried through for a consumer that knows what to do with the
+	// service-type bits this type deliberately does not interpret.
+	ComponentType    uint8
+	HasComponentType bool
 }
 
 // Descrambled reports whether the receiver is delivering this service in the

--- a/backend/internal/infra/media/ffmpeg/adapter_args_test.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_args_test.go
@@ -326,7 +326,7 @@ func TestBuildArgsWithPlan_RecordsEffectiveRuntimeModeAfterRuntimeRemux(t *testi
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, spec.Source.ID)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, spec.Source.ID, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, plan.args)
 	assert.Equal(t, ports.RuntimeModeCopy, plan.effectiveProfile.EffectiveRuntimeMode)
@@ -667,7 +667,7 @@ func TestBuildArgs_SafariHQAllowlistKeepsProgressive50fpsSourcesProgressive(t *t
 	streamURL := "http://127.0.0.1:17999/1:0:19:132F:3EF:1:C00000:0:0:0"
 	adapter.setLastKnownFPS(fpsCacheKey(spec.Source, streamURL), 50)
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL, nil)
 	require.NoError(t, err)
 	args := plan.args
 
@@ -745,7 +745,7 @@ func TestBuildArgs_SafariHQAllowlistCanForceProgressiveSourcesToHQ25(t *testing.
 	streamURL := "http://127.0.0.1:17999/1:0:19:132F:3EF:1:C00000:0:0:0"
 	adapter.setLastKnownFPS(fpsCacheKey(spec.Source, streamURL), 50)
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL, nil)
 	require.NoError(t, err)
 	args := plan.args
 
@@ -796,7 +796,7 @@ func TestBuildArgs_SafariHQ25AllowlistStartsProgressiveSourcesDirectlyInHQ25(t *
 	streamURL := "http://127.0.0.1:17999/1:0:19:132F:3EF:1:C00000:0:0:0"
 	adapter.setLastKnownFPS(fpsCacheKey(spec.Source, streamURL), 50)
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL, nil)
 	require.NoError(t, err)
 	args := plan.args
 
@@ -851,7 +851,7 @@ func TestBuildArgs_SafariHEVCHQ25ClampsProgressiveSourcesAndHardensBitstream(t *
 	streamURL := "http://127.0.0.1:17999/1:0:19:132F:3EF:1:C00000:0:0:0"
 	adapter.setLastKnownFPS(fpsCacheKey(spec.Source, streamURL), 50)
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL, nil)
 	require.NoError(t, err)
 	args := plan.args
 
@@ -2064,7 +2064,7 @@ func TestBuildArgsWithPlan_AV1HWProgressiveProbePreservesAV1(t *testing.T) {
 	}
 
 	streamURL := "http://127.0.0.1:17999/1:0:19:132F:3EF:1:C00000:0:0:0:"
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL, nil)
 	require.NoError(t, err)
 
 	assert.Contains(t, plan.args, "av1_vaapi")
@@ -2248,7 +2248,7 @@ func TestBuildArgs_AV1HWHQ50ServiceRefPreserves50fpsMotion(t *testing.T) {
 	streamURL := "http://127.0.0.1:17999/1:0:19:91:4:85:C00000:0:0:0:"
 	adapter.setLastKnownFPS(fpsCacheKey(spec.Source, streamURL), 50)
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL)
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, streamURL, nil)
 	require.NoError(t, err)
 	args := plan.args
 

--- a/backend/internal/infra/media/ffmpeg/adapter_process.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_process.go
@@ -121,7 +121,7 @@ func (a *LocalAdapter) Start(ctx context.Context, spec ports.StreamSpec) (ports.
 			attribute.String("xg2g.source_type", fmt.Sprintf("%v", spec.Source.Type)),
 		),
 	)
-	plan, err := a.buildArgsWithPlan(planCtx, spec, inputURL)
+	plan, err := a.buildArgsWithPlan(planCtx, spec, inputURL, pmtTrackObservations(ingestInput.Facts().AudioTracks))
 	if err != nil {
 		planSpan.RecordError(err)
 		planSpan.SetStatus(codes.Error, "plan build failed")

--- a/backend/internal/infra/media/ffmpeg/android_tv_native_startup_test.go
+++ b/backend/internal/infra/media/ffmpeg/android_tv_native_startup_test.go
@@ -75,13 +75,13 @@ func TestAndroidTVNativeStartupSkipsAudioProbeWithoutChangingWeb(t *testing.T) {
 		return []liveAudioStream{{Index: 2, CodecType: "audio", CodecName: "mp2", Channels: 2}}, nil
 	}
 
-	native := adapter.planLiveAudioSelection(context.Background(), androidTVNativeTranscodeSpec(), "http://example.com/live")
+	native := adapter.planLiveAudioSelection(context.Background(), androidTVNativeTranscodeSpec(), "http://example.com/live", nil)
 	assert.Equal(t, []string{defaultLiveAudioMap}, native.Maps)
 	assert.Zero(t, probeCalls)
 
 	webSpec := androidTVNativeTranscodeSpec()
 	webSpec.ClientFamily = "chromium_hlsjs"
-	web := adapter.planLiveAudioSelection(context.Background(), webSpec, "http://example.com/live")
+	web := adapter.planLiveAudioSelection(context.Background(), webSpec, "http://example.com/live", nil)
 	assert.Equal(t, []string{"0:2?"}, web.Maps)
 	assert.Equal(t, 1, probeCalls, "web audio selection must retain its compatibility probe")
 }

--- a/backend/internal/infra/media/ffmpeg/ingest_input.go
+++ b/backend/internal/infra/media/ffmpeg/ingest_input.go
@@ -146,6 +146,15 @@ func (in *sharedIngestInput) ProbePath() string {
 	return in.snapshotPath
 }
 
+// Facts reports what the ingest knows about the stream. A nil input has none,
+// which is the honest answer for a source that has no ingest session behind it.
+func (in *sharedIngestInput) Facts() ports.LiveSourceFacts {
+	if in == nil || in.source == nil {
+		return ports.LiveSourceFacts{}
+	}
+	return in.source.Facts()
+}
+
 // Stdin is the byte stream handed to FFmpeg.
 func (in *sharedIngestInput) Stdin() io.Reader {
 	if in == nil {

--- a/backend/internal/infra/media/ffmpeg/live_audio_map.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_map.go
@@ -184,15 +184,38 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		Int("tracks_count", len(multiPlan.Tracks)).
 		Msg("evaluated audio topology and output policy")
 
+	// A planned track can now exist for a PID ffprobe never reported. Feeding the
+	// PMT's declarations into BuildTopology is what makes that possible, and it is
+	// the point of doing so - the declaration knows about a track the startup
+	// snapshot missed. But there is no input stream to map such a track to.
+	//
+	// Mapping it anyway is what the code did until this filter existed: the PID
+	// lookup missed, the plan fell back to the first audio stream, and that stream
+	// was published twice - once correctly, once carrying another track's language
+	// in the manifest. Silently, because a fallback is not an error.
+	//
+	// Dropping the track has to happen before the argv and the var_stream_map are
+	// built, because both are derived from this slice and skipping inside either
+	// loop alone would shift them against each other.
+	if mappable, unmappable := splitMappableTracks(multiPlan.Tracks, streamByPID); len(unmappable) > 0 {
+		for _, tp := range unmappable {
+			a.Logger.Warn().
+				Str("session_id", spec.SessionID).
+				Str("startup_phase", "live_audio_track_unmappable").
+				Uint16("pid", tp.PID).
+				Str("track_name", tp.Name).
+				Msg("declared audio track has no probed input stream; leaving it out rather than mapping another stream under its name")
+		}
+		multiPlan.Tracks = mappable
+	}
+
 	if len(multiPlan.Tracks) > 1 {
 		var maps []string
 		var audioArgs []string
 
 		for i, tp := range multiPlan.Tracks {
-			matchedStream, ok := streamByPID[tp.PID]
-			if !ok {
-				matchedStream = audioStreams[0]
-			}
+			// Guaranteed to hit: the filter above removed every track without one.
+			matchedStream := streamByPID[tp.PID]
 			mapArg := fmt.Sprintf("0:%d?", matchedStream.Index)
 			maps = append(maps, mapArg)
 
@@ -253,6 +276,9 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		selectedPlan = multiPlan.Tracks[0]
 	}
 
+	// After the filter the only way this misses is the genuine empty-plan case,
+	// where selectedPlan is the zero value and the first audio stream is the right
+	// default rather than a substitute for something else.
 	matchedStream, ok := streamByPID[selectedPlan.PID]
 	if !ok {
 		matchedStream = audioStreams[0]
@@ -431,4 +457,21 @@ func (a *LocalAdapter) buildLiveAudioProbeArgs(spec ports.StreamSpec, inputURL s
 		"-of", "json",
 		inputURL,
 	)
+}
+
+// splitMappableTracks separates the planned tracks that have an input stream to
+// be mapped to from those that do not.
+//
+// Both halves are returned rather than filtering in place, because the caller
+// reports what it dropped: an in-place filter rewrites the backing array under
+// the very slice a second pass would read.
+func splitMappableTracks(tracks []audiotopology.TrackPlan, streamByPID map[uint16]liveAudioStream) (mappable, unmappable []audiotopology.TrackPlan) {
+	for _, tp := range tracks {
+		if _, ok := streamByPID[tp.PID]; ok {
+			mappable = append(mappable, tp)
+			continue
+		}
+		unmappable = append(unmappable, tp)
+	}
+	return mappable, unmappable
 }

--- a/backend/internal/infra/media/ffmpeg/live_audio_map.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_map.go
@@ -71,7 +71,7 @@ func parsedStreamPID(value uint64) uint16 {
 	return uint16(value)
 }
 
-func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.StreamSpec, inputURL string) liveAudioSelection {
+func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.StreamSpec, inputURL string, pmtTracks []audiotopology.PMTTrackObservation) liveAudioSelection {
 	defaultSel := liveAudioSelection{
 		Maps:      []string{defaultLiveAudioMap},
 		AudioArgs: appendLiveAudioArgs(nil, spec, 2),
@@ -172,7 +172,7 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		clientCaps.PrefersPassthrough = true
 	}
 
-	topo := audiotopology.BuildTopology(spec.Source.ID, nil, probeObs, nil, time.Now())
+	topo := audiotopology.BuildTopology(spec.Source.ID, pmtTracks, probeObs, nil, time.Now())
 	multiPlan := audiotopology.PlanMultiAudioOutput(topo, clientCaps)
 
 	a.Logger.Info().

--- a/backend/internal/infra/media/ffmpeg/plan_abr_test.go
+++ b/backend/internal/infra/media/ffmpeg/plan_abr_test.go
@@ -51,7 +51,7 @@ func TestABR_RegressionGuard_SingleRendition(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "index.m3u8", plan.primaryPlaylist)
 
@@ -124,7 +124,7 @@ func TestABR_RegressionGuard_DirectCopy(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "index.m3u8", plan.primaryPlaylist)
 
@@ -186,7 +186,7 @@ func TestABR_2Tier_VBVParameters(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec720, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec720, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan.primaryPlaylist)
 
@@ -242,7 +242,7 @@ func TestABR_UnknownSourceHeight_DefaultsTo2Tier(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), specUnknown, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), specUnknown, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan.primaryPlaylist)
 
@@ -275,7 +275,7 @@ func TestABR_3Tier_Source1080p_DynamicGOP(t *testing.T) {
 		},
 	}
 
-	plan25, err := adapter25.buildArgsWithPlan(context.Background(), spec25, "http://localhost:8080/stream")
+	plan25, err := adapter25.buildArgsWithPlan(context.Background(), spec25, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan25.primaryPlaylist)
 
@@ -311,7 +311,7 @@ func TestABR_3Tier_Source1080p_DynamicGOP(t *testing.T) {
 		},
 	}
 
-	plan50, err := adapter50.buildArgsWithPlan(context.Background(), spec50, "http://localhost:8080/stream")
+	plan50, err := adapter50.buildArgsWithPlan(context.Background(), spec50, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan50.primaryPlaylist)
 
@@ -338,7 +338,7 @@ func TestABR_2Tier_Source720p_NoFakeUpscaling(t *testing.T) {
 		},
 	}
 
-	plan720, err := adapter.buildArgsWithPlan(context.Background(), spec720, "http://localhost:8080/stream")
+	plan720, err := adapter.buildArgsWithPlan(context.Background(), spec720, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan720.primaryPlaylist)
 

--- a/backend/internal/infra/media/ffmpeg/plan_builder.go
+++ b/backend/internal/infra/media/ffmpeg/plan_builder.go
@@ -2,6 +2,7 @@ package ffmpeg
 
 import (
 	"context"
+	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/ManuGH/xg2g/internal/pipeline/profiles"
 )
@@ -11,6 +12,11 @@ const experimentalInterlacedVAAPICodecsEnv = "XG2G_EXPERIMENTAL_ALLOW_UNVERIFIED
 type inputPlan struct {
 	args     []string
 	inputURL string
+
+	// pmtAudio is what the transport stream's own PMT declares about its audio
+	// tracks, taken from shared ingest. It is empty for a source that has no
+	// ingest session behind it, which is what BuildTopology has always been given.
+	pmtAudio []audiotopology.PMTTrackObservation
 
 	// authURL preserves the original input URL with userinfo credentials
 	// before they are stripped from inputURL.  Probe functions (ffprobe,
@@ -64,11 +70,12 @@ type liveSegmentLayout struct {
 	listSize               int
 }
 
-func (a *LocalAdapter) buildArgsWithPlan(ctx context.Context, spec ports.StreamSpec, inputURL string) (finalizedPlan, error) {
+func (a *LocalAdapter) buildArgsWithPlan(ctx context.Context, spec ports.StreamSpec, inputURL string, pmtAudio []audiotopology.PMTTrackObservation) (finalizedPlan, error) {
 	inputPhase, err := a.planInput(spec, inputURL)
 	if err != nil {
 		return finalizedPlan{}, err
 	}
+	inputPhase.pmtAudio = pmtAudio
 	if spec.Mode == ports.ModeLive {
 		// Pass the original (pre-sanitisation) URL so that any probe calls
 		// inside FinalizePlan (e.g. safari runtime probe) can authenticate

--- a/backend/internal/infra/media/ffmpeg/plan_output.go
+++ b/backend/internal/infra/media/ffmpeg/plan_output.go
@@ -45,7 +45,7 @@ func (a *LocalAdapter) planLiveOutput(ctx context.Context, spec ports.StreamSpec
 		}
 	}
 
-	audioSelection := a.planLiveAudioSelection(ctx, spec, probeURL)
+	audioSelection := a.planLiveAudioSelection(ctx, spec, probeURL, input.pmtAudio)
 
 	out := outputPlan{
 		effectiveProfile: spec.Profile,

--- a/backend/internal/infra/media/ffmpeg/plan_vaapi_abr_test.go
+++ b/backend/internal/infra/media/ffmpeg/plan_vaapi_abr_test.go
@@ -30,7 +30,7 @@ func TestABR_VAAPI_3Tier_Plan(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan.primaryPlaylist)
 
@@ -64,7 +64,7 @@ func TestABR_VAAPI_2Tier_Deinterlace_Plan(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan.primaryPlaylist)
 
@@ -97,7 +97,7 @@ func TestABR_UnverifiedVAAPI_FallsBackToCPU(t *testing.T) {
 		},
 	}
 
-	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream")
+	plan, err := adapter.buildArgsWithPlan(context.Background(), spec, "http://localhost:8080/stream", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "master.m3u8", plan.primaryPlaylist)
 

--- a/backend/internal/infra/media/ffmpeg/pmt_audio.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+)
+
+// pmtTrackObservations turns the PMT's audio declarations into the domain's PMT
+// observations.
+//
+// BuildTopology has taken pmtTracks since it was written and has been handed nil
+// for as long: nothing could supply them, because the media path had no view of
+// the transport stream's own tables. Shared ingest does, so this fills an argument
+// that has always existed rather than adding a path.
+//
+// The merge resolves the two sources itself - a probe observation still overrides
+// a PMT declaration for the same PID, and a disagreement is recorded as a conflict
+// - so this deliberately makes no decision beyond translating.
+func pmtTrackObservations(tracks []ports.LiveAudioTrack) []audiotopology.PMTTrackObservation {
+	if len(tracks) == 0 {
+		return nil
+	}
+	out := make([]audiotopology.PMTTrackObservation, 0, len(tracks))
+	for _, t := range tracks {
+		out = append(out, audiotopology.PMTTrackObservation{
+			PID:        t.PID,
+			StreamType: t.StreamType,
+			Codec:      t.Codec,
+			Language:   t.Language,
+			// Channels stays 0 for a multichannel declaration on purpose. The
+			// merge treats 0 as "not declared" and lets the probe answer, which is
+			// correct: the descriptor said "more than two" and inventing 6 here
+			// would put a number in front of the encoder that the stream never
+			// gave. What the declaration does carry either way is the codec and
+			// the language, and those are exact.
+			Channels: t.Channels,
+		})
+	}
+	return out
+}

--- a/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
@@ -125,3 +125,64 @@ func TestBuildTopology_KeepsADeclarationTheProbeMissed(t *testing.T) {
 		t.Error("the PMT-only track was dropped; a declaration the probe missed is exactly what this feeds in for")
 	}
 }
+
+// The scenario review found once the declarations started reaching the plan: the
+// PMT names two languages, the startup snapshot only shows one. Before the filter
+// the missing track fell back to the first audio stream, so the German stream was
+// published twice - once correctly, once advertised as English.
+func TestSplitMappableTracks_DropsATrackWithNoInputStream(t *testing.T) {
+	streams := map[uint16]liveAudioStream{
+		101: {Index: 0, ID: "0x65", CodecName: "ac3", Channels: 2},
+	}
+	tracks := []audiotopology.TrackPlan{
+		{PID: 101, Name: "Deutsch"},
+		{PID: 102, Name: "English"},
+	}
+
+	mappable, unmappable := splitMappableTracks(tracks, streams)
+
+	if len(mappable) != 1 || mappable[0].PID != 101 {
+		t.Errorf("mappable = %+v, want only the probed PID 101", mappable)
+	}
+	if len(unmappable) != 1 || unmappable[0].PID != 102 {
+		t.Errorf("unmappable = %+v, want the PMT-only PID 102", unmappable)
+	}
+}
+
+// The input must survive the split intact, because the caller logs one half after
+// reading the other. An in-place filter would rewrite the array under it.
+func TestSplitMappableTracks_LeavesTheInputIntact(t *testing.T) {
+	streams := map[uint16]liveAudioStream{101: {Index: 0}}
+	tracks := []audiotopology.TrackPlan{
+		{PID: 101, Name: "Deutsch"},
+		{PID: 102, Name: "English"},
+		{PID: 103, Name: "Français"},
+	}
+
+	_, unmappable := splitMappableTracks(tracks, streams)
+
+	if len(tracks) != 3 || tracks[1].PID != 102 || tracks[2].PID != 103 {
+		t.Errorf("input was mutated: %+v", tracks)
+	}
+	if len(unmappable) != 2 {
+		t.Fatalf("unmappable has %d entries, want 2", len(unmappable))
+	}
+	if unmappable[0].Name != "English" || unmappable[1].Name != "Français" {
+		t.Errorf("unmappable = %+v, want the two names preserved for the log", unmappable)
+	}
+}
+
+// Nothing to drop is the ordinary case and must stay untouched.
+func TestSplitMappableTracks_KeepsEverythingWhenAllProbed(t *testing.T) {
+	streams := map[uint16]liveAudioStream{101: {Index: 0}, 102: {Index: 1}}
+	tracks := []audiotopology.TrackPlan{{PID: 101}, {PID: 102}}
+
+	mappable, unmappable := splitMappableTracks(tracks, streams)
+
+	if len(mappable) != 2 {
+		t.Errorf("mappable has %d entries, want 2", len(mappable))
+	}
+	if len(unmappable) != 0 {
+		t.Errorf("unmappable = %+v, want none", unmappable)
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+)
+
+func TestPMTTrackObservations_CarriesTheDeclaration(t *testing.T) {
+	got := pmtTrackObservations([]ports.LiveAudioTrack{
+		{PID: 257, StreamType: 0x81, Codec: "ac3", Language: "deu", Channels: 2, ComponentType: 0x82, HasComponentType: true},
+		{PID: 258, StreamType: 0x0F, Codec: "aac", Language: "eng", Channels: 1},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("got %d observations, want 2", len(got))
+	}
+	if got[0].PID != 257 || got[0].Codec != "ac3" || got[0].Language != "deu" || got[0].Channels != 2 {
+		t.Errorf("first observation = %+v, want the AC-3 stereo declaration", got[0])
+	}
+	if got[1].StreamType != 0x0F || got[1].Channels != 1 {
+		t.Errorf("second observation = %+v, want the AAC mono declaration", got[1])
+	}
+}
+
+// The rule that survives every layer: a multichannel declaration names no count,
+// so Channels stays 0 and the merge falls through to whatever measured it. Turning
+// it into 6 here would put a number in front of the encoder that the stream never
+// gave.
+func TestPMTTrackObservations_MultichannelDeclaresNoCount(t *testing.T) {
+	got := pmtTrackObservations([]ports.LiveAudioTrack{
+		{PID: 257, Codec: "ac3", Language: "deu", Multichannel: true, ComponentType: 0x84, HasComponentType: true},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("got %d observations, want 1", len(got))
+	}
+	if got[0].Channels != 0 {
+		t.Errorf("Channels = %d, want 0: the descriptor said \"more than two\", not a number", got[0].Channels)
+	}
+	// The parts that are exact still come through.
+	if got[0].Codec != "ac3" || got[0].Language != "deu" {
+		t.Errorf("observation = %+v, want codec and language preserved", got[0])
+	}
+}
+
+func TestPMTTrackObservations_EmptyStaysNil(t *testing.T) {
+	if got := pmtTrackObservations(nil); got != nil {
+		t.Errorf("got %+v, want nil so BuildTopology sees what it always saw", got)
+	}
+}
+
+// The point of the whole chain: BuildTopology has taken pmtTracks since it was
+// written and been handed nil for as long. Feeding it real declarations must make
+// the merge use them, and must record where each fact came from.
+func TestBuildTopology_UsesThePMTDeclaration(t *testing.T) {
+	pmt := pmtTrackObservations([]ports.LiveAudioTrack{
+		{PID: 257, StreamType: 0x81, Codec: "ac3", Language: "deu", Channels: 2},
+	})
+
+	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, nil, nil, time.Now())
+
+	if len(topo.Tracks) != 1 {
+		t.Fatalf("topology has %d tracks, want 1 from the PMT alone", len(topo.Tracks))
+	}
+	track := topo.Tracks[0]
+	if track.PID != 257 {
+		t.Errorf("PID = %d, want 257", track.PID)
+	}
+	if track.Channels != 2 {
+		t.Errorf("Channels = %d, want the declared 2", track.Channels)
+	}
+}
+
+// A probe still overrides a declaration for the same PID - the measurement is the
+// stronger fact - and the disagreement has to be visible rather than silently
+// resolved.
+func TestBuildTopology_ProbeOverridesTheDeclaration(t *testing.T) {
+	pmt := pmtTrackObservations([]ports.LiveAudioTrack{
+		{PID: 257, StreamType: 0x81, Codec: "ac3", Language: "deu", Channels: 2},
+	})
+	probe := []audiotopology.ProbeTrackObservation{
+		{PID: 257, StreamIndex: 0, Codec: "ac3", Channels: 6, Language: "deu"},
+	}
+
+	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, probe, nil, time.Now())
+
+	if len(topo.Tracks) != 1 {
+		t.Fatalf("topology has %d tracks, want the two observations merged into 1", len(topo.Tracks))
+	}
+	if topo.Tracks[0].Channels != 6 {
+		t.Errorf("Channels = %d, want the probed 6 to win over the declared 2", topo.Tracks[0].Channels)
+	}
+}
+
+// A declaration for a PID the probe never saw must not vanish: that is the case
+// this whole change exists for, where the PMT knows something the probe missed.
+func TestBuildTopology_KeepsADeclarationTheProbeMissed(t *testing.T) {
+	pmt := pmtTrackObservations([]ports.LiveAudioTrack{
+		{PID: 257, Codec: "ac3", Language: "deu", Channels: 2},
+		{PID: 258, Codec: "mp2", Language: "eng", Channels: 2},
+	})
+	probe := []audiotopology.ProbeTrackObservation{
+		{PID: 257, StreamIndex: 0, Codec: "ac3", Channels: 2, Language: "deu"},
+	}
+
+	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, probe, nil, time.Now())
+
+	if len(topo.Tracks) != 2 {
+		t.Fatalf("topology has %d tracks, want both PIDs", len(topo.Tracks))
+	}
+	found := false
+	for _, tr := range topo.Tracks {
+		if tr.PID == 258 && tr.Language.Code == "eng" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the PMT-only track was dropped; a declaration the probe missed is exactly what this feeds in for")
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/test_helpers_test.go
+++ b/backend/internal/infra/media/ffmpeg/test_helpers_test.go
@@ -18,7 +18,7 @@ func noopStartupSpan() trace.Span {
 }
 
 func (a *LocalAdapter) buildArgs(ctx context.Context, spec ports.StreamSpec, inputURL string) ([]string, error) {
-	plan, err := a.buildArgsWithPlan(ctx, spec, inputURL)
+	plan, err := a.buildArgsWithPlan(ctx, spec, inputURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/stream/ingest/livesource/livesource.go
+++ b/backend/internal/stream/ingest/livesource/livesource.go
@@ -151,5 +151,29 @@ func factsFrom(f ring.ReadinessFacts) ports.LiveSourceFacts {
 		CleanAccessUnits:      f.CleanAccessUnits,
 		ScrambledVideoPackets: f.Scrambling.VideoScrambled,
 		ClearVideoPackets:     f.Scrambling.VideoClear,
+		AudioTracks:           audioTracksFrom(f.AudioTracks),
 	}
+}
+
+// audioTracksFrom carries the PMT's audio declarations across the port boundary
+// without reinterpreting them. In particular a multichannel declaration stays a
+// flag: the descriptor names a class, not a count.
+func audioTracksFrom(tracks []ring.AudioTrackInfo) []ports.LiveAudioTrack {
+	if len(tracks) == 0 {
+		return nil
+	}
+	out := make([]ports.LiveAudioTrack, 0, len(tracks))
+	for _, t := range tracks {
+		out = append(out, ports.LiveAudioTrack{
+			PID:              t.PID,
+			StreamType:       t.StreamType,
+			Codec:            t.Codec,
+			Language:         t.Language,
+			Channels:         t.Declared.Channels,
+			Multichannel:     t.Declared.Multichannel,
+			ComponentType:    t.Declared.ComponentType,
+			HasComponentType: t.Declared.HasComponentType,
+		})
+	}
+	return out
 }


### PR DESCRIPTION
**B2b.2 — die letzte Naht.** Genau die vier Schritte, keine ffprobe entfernt, keine neue Audio-Policy, kein Observed-Parser.

## Ein Argument, das immer schon da war

`BuildTopology` nimmt seit jeher ein `pmtTracks`-Argument — und bekam ebenso lange `nil`. Es konnte niemand liefern: der Medienpfad sah die Tabellen des Transportstroms nicht, nur das, was ffprobe ihm über die Bytes erzählte.

Seit **B4** hält der Adapter eine Shared-Ingest-Session, seit **#877** liest der Ring die Kanaldeklaration aus den PMT-Deskriptoren, die er ohnehin durchläuft. Dieser PR verbindet beides:

```text
ring.AudioTrackInfo
  → ports.LiveAudioTrack           uninterpretiert über den Port
  → audiotopology.PMTTrackObservation
  → BuildTopology(ref, pmtTracks, probeTracks, …)
```

## Keine Entscheidung kommt hinzu

Der Merge löst die zwei Quellen bereits auf: eine Probe-Beobachtung überschreibt eine Deklaration für dieselbe PID — die Messung ist die stärkere Aussage — und ein Widerspruch wird als Konflikt mit Evidenz pro Quelle festgehalten. Diese Logik lag die ganze Zeit im Domainmodell, mit nur einem ihrer beiden Eingänge verbunden.

## Multichannel bleibt ohne Zahl

`Channels` bleibt `0` für eine Multichannel-Deklaration. Der Merge liest das als „nicht deklariert" und lässt die Probe antworten. Ein AC-3-Dienst mit 5.1 und einer mit 7.1 deklarieren denselben Deskriptorwert — daraus hier eine `6` zu machen hieße, dem Encoder eine Zahl vorzusetzen, die der Stream nie genannt hat.

Was die Deklaration **exakt** trägt — Codec, Sprache, PID — kommt trotzdem an. Und eine Spur, die die Probe ganz übersehen hat, existiert jetzt in der Topologie, statt nicht zu existieren.

## Tests

| Test | Aussage |
| --- | --- |
| `CarriesTheDeclaration` | PID, Streamtyp, Codec, Sprache, Kanalzahl kommen durch |
| `MultichannelDeclaresNoCount` | `Channels = 0`, Codec und Sprache bleiben erhalten |
| `EmptyStaysNil` | ohne Ingest sieht `BuildTopology` genau das, was es immer sah |
| `UsesThePMTDeclaration` | die Deklaration allein baut eine Topologie |
| `ProbeOverridesTheDeclaration` | die Messung gewinnt bei derselben PID |
| `KeepsADeclarationTheProbeMissed` | genau der Fall, für den das hier existiert |

## Bewusst nicht enthalten

Keine ffprobe entfernt, keine Audio-Policy verschoben, kein Elementarstrom geparst. Ob und wie weit die Probe weichen kann, ist eine Frage für Messungen an echten DVB-Diensten — die **erst jetzt lohnen**, weil die Deklarationen bis hierher nie den Merge erreichten, um verglichen zu werden.

`AudioType` und die Dispositions-Flags auf `PMTTrackObservation` bleiben ungesetzt. Sie stammen aus dem `audio_type`-Byte des ISO-639-Deskriptors und aus der Interpretation von Component-Type-Service-Bits pro Codec — beides liest der Ring heute nicht. Sie aus dem Component-Type zu füllen wäre eine Vermutung im Gewand einer Tatsache.

## Lokale Gates

| Gate | Ergebnis |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (144 Pakete) |
| `make test-race-pr` | pass |
| `make lint` | pass |
| `make verify-generated-artifacts` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
