### PR TITLE
Count where each audio track's channel information came from

### DIFF
--- a/backend/internal/infra/media/ffmpeg/adapter_process.go
+++ b/backend/internal/infra/media/ffmpeg/adapter_process.go
@@ -121,7 +121,7 @@ func (a *LocalAdapter) Start(ctx context.Context, spec ports.StreamSpec) (ports.
 			attribute.String("xg2g.source_type", fmt.Sprintf("%v", spec.Source.Type)),
 		),
 	)
-	plan, err := a.buildArgsWithPlan(planCtx, spec, inputURL, pmtTrackObservations(ingestInput.Facts().AudioTracks))
+	plan, err := a.buildArgsWithPlan(planCtx, spec, inputURL, ingestInput.Facts().AudioTracks)
 	if err != nil {
 		planSpan.RecordError(err)
 		planSpan.SetStatus(codes.Error, "plan build failed")

--- a/backend/internal/infra/media/ffmpeg/live_audio_map.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_map.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	infraffmpeg "github.com/ManuGH/xg2g/internal/infra/ffmpeg"
+	"github.com/ManuGH/xg2g/internal/metrics"
 )
 
 const defaultLiveAudioMap = "0:a:0?"
@@ -101,6 +102,7 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 			Str("input_url", sanitizeURLForLog(inputURL)).
 			Str("fallback_map", defaultLiveAudioMap).
 			Msg("live audio stream probe failed; using first audio stream")
+		metrics.IncAudioProbe(metrics.AudioProbeFailed)
 		return defaultSel
 	}
 
@@ -111,6 +113,9 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		}
 	}
 	if len(audioStreams) == 0 {
+		// Not the same thing as a failed probe. The run completed and reported no
+		// audio, which is a statement about the service rather than about ffprobe.
+		metrics.IncAudioProbe(metrics.AudioProbeEmpty)
 		return defaultSel
 	}
 
@@ -172,8 +177,14 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		clientCaps.PrefersPassthrough = true
 	}
 
+	// Two dimensions, recorded at the one point where both are known: that the
+	// probe was there to be classified at all, and - given that it was - which
+	// source supplied each track's channel information. Neither number may hide
+	// the other, so they are separate series rather than one enum.
+	//
 	// Recorded before the merge consumes them, because the merge is where the two
 	// sources become one answer and the question here is which of them supplied it.
+	metrics.IncAudioProbe(metrics.AudioProbeAvailable)
 	recordAudioEvidence(pmtAudio, streamByPID)
 
 	topo := audiotopology.BuildTopology(spec.Source.ID, pmtTrackObservations(pmtAudio), probeObs, nil, time.Now())

--- a/backend/internal/infra/media/ffmpeg/live_audio_map.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_map.go
@@ -71,7 +71,7 @@ func parsedStreamPID(value uint64) uint16 {
 	return uint16(value)
 }
 
-func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.StreamSpec, inputURL string, pmtTracks []audiotopology.PMTTrackObservation) liveAudioSelection {
+func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.StreamSpec, inputURL string, pmtAudio []ports.LiveAudioTrack) liveAudioSelection {
 	defaultSel := liveAudioSelection{
 		Maps:      []string{defaultLiveAudioMap},
 		AudioArgs: appendLiveAudioArgs(nil, spec, 2),
@@ -172,7 +172,11 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		clientCaps.PrefersPassthrough = true
 	}
 
-	topo := audiotopology.BuildTopology(spec.Source.ID, pmtTracks, probeObs, nil, time.Now())
+	// Recorded before the merge consumes them, because the merge is where the two
+	// sources become one answer and the question here is which of them supplied it.
+	recordAudioEvidence(pmtAudio, streamByPID)
+
+	topo := audiotopology.BuildTopology(spec.Source.ID, pmtTrackObservations(pmtAudio), probeObs, nil, time.Now())
 	multiPlan := audiotopology.PlanMultiAudioOutput(topo, clientCaps)
 
 	a.Logger.Info().

--- a/backend/internal/infra/media/ffmpeg/live_audio_probe_metrics_test.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_probe_metrics_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ffmpeg
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/domain/session/model"
+	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/ManuGH/xg2g/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/rs/zerolog"
+)
+
+// counterVecTotal sums a counter vector across every label combination it
+// currently carries. The evidence counter's labels are not known up front - a
+// wrongly counted track would appear under whichever codec it declared - so a
+// test that only read the labels it expects could not see the increment it is
+// meant to rule out.
+func counterVecTotal(t *testing.T, vec *prometheus.CounterVec) float64 {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 256)
+	vec.Collect(ch)
+	close(ch)
+
+	var sum float64
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		sum += pb.GetCounter().GetValue()
+	}
+	return sum
+}
+
+func probeResultCount(t *testing.T, result string) float64 {
+	t.Helper()
+
+	var pb dto.Metric
+	if err := metrics.AudioProbeTotal.WithLabelValues(result).Write(&pb); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return pb.GetCounter().GetValue()
+}
+
+func evidenceCount(t *testing.T, codec, result string) float64 {
+	t.Helper()
+
+	var pb dto.Metric
+	if err := metrics.AudioTopologyEvidenceTotal.WithLabelValues(codec, result).Write(&pb); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return pb.GetCounter().GetValue()
+}
+
+func probeMetricsAdapter(t *testing.T) *LocalAdapter {
+	t.Helper()
+
+	return NewLocalAdapter(
+		"ffmpeg", "ffprobe", t.TempDir(), nil, zerolog.New(io.Discard),
+		"", "", 0, 0, false, 2*time.Second, 6, 0, 0, "",
+	)
+}
+
+// probeMetricsSpec reaches the startup probe: live HLS, video transcoded into
+// fmp4, and not the native Android TV client that skips the probe by design.
+func probeMetricsSpec() ports.StreamSpec {
+	return ports.StreamSpec{
+		SessionID: "probe-metrics",
+		Mode:      ports.ModeLive,
+		Format:    ports.FormatHLS,
+		Quality:   ports.QualityStandard,
+		Profile: model.ProfileSpec{
+			Name:             "av1_hw",
+			Container:        "fmp4",
+			VideoCodec:       "av1",
+			VideoSourceCodec: "h264",
+			TranscodeVideo:   true,
+			AudioBitrateK:    192,
+		},
+		Source: ports.StreamSource{
+			ID:   "http://10.10.55.64:17999/1:0:19:11:6:85:C00000:0:0:0",
+			Type: ports.SourceTuner,
+		},
+	}
+}
+
+// A broken ffprobe run and a run that saw no audio are different observations,
+// and B2 draws different conclusions from them. Neither may be reported as
+// topology evidence: no source of channel information was compared, so counting
+// one there would put a case in the evidence denominator that was never
+// classifiable.
+func TestLiveAudioProbeMetrics_FailedAndEmptyAreDistinct(t *testing.T) {
+	tests := []struct {
+		name    string
+		streams []liveAudioStream
+		err     error
+		want    string
+		notWant string
+	}{
+		{
+			name:    "the probe did not complete",
+			err:     errors.New("ffprobe exit status 1"),
+			want:    metrics.AudioProbeFailed,
+			notWant: metrics.AudioProbeEmpty,
+		},
+		{
+			name:    "the probe completed and saw no audio",
+			streams: []liveAudioStream{{Index: 0, CodecType: "video", CodecName: "h264"}},
+			want:    metrics.AudioProbeEmpty,
+			notWant: metrics.AudioProbeFailed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := probeMetricsAdapter(t)
+			adapter.liveAudioProbeFn = func(context.Context, string) ([]liveAudioStream, error) {
+				return tc.streams, tc.err
+			}
+
+			// The tables declare a track even though the probe supplies nothing.
+			// This is the shape that must not be mistaken for evidence.
+			pmt := []ports.LiveAudioTrack{{PID: 101, Codec: "ac3", Channels: 2}}
+
+			spec := probeMetricsSpec()
+			beforeWant := probeResultCount(t, tc.want)
+			beforeOther := probeResultCount(t, tc.notWant)
+			beforeAvailable := probeResultCount(t, metrics.AudioProbeAvailable)
+			beforeEvidence := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal)
+
+			adapter.planLiveAudioSelection(context.Background(), spec, spec.Source.ID, pmt)
+
+			if got := probeResultCount(t, tc.want) - beforeWant; got != 1 {
+				t.Errorf("%s delta = %v, want 1", tc.want, got)
+			}
+			if got := probeResultCount(t, tc.notWant) - beforeOther; got != 0 {
+				t.Errorf("%s delta = %v, want 0 - the two outcomes must stay distinguishable", tc.notWant, got)
+			}
+			if got := probeResultCount(t, metrics.AudioProbeAvailable) - beforeAvailable; got != 0 {
+				t.Errorf("available delta = %v, want 0", got)
+			}
+			if got := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal) - beforeEvidence; got != 0 {
+				t.Errorf("topology evidence delta = %v, want 0 - nothing was classified", got)
+			}
+		})
+	}
+}
+
+// The successful path records both dimensions exactly once per plan and per
+// track: one statement that the probe was there, one statement about where the
+// track's channel information came from.
+func TestLiveAudioProbeMetrics_AvailableAccompaniesTheClassification(t *testing.T) {
+	adapter := probeMetricsAdapter(t)
+	adapter.liveAudioProbeFn = func(context.Context, string) ([]liveAudioStream, error) {
+		return []liveAudioStream{
+			{Index: 1, ID: "101", CodecType: "audio", CodecName: "ac3", Channels: 2, ChannelLayout: "stereo", Tags: map[string]string{"language": "deu"}},
+		}, nil
+	}
+
+	pmt := []ports.LiveAudioTrack{{PID: 101, Codec: "ac3", Language: "deu", Channels: 2}}
+
+	spec := probeMetricsSpec()
+	beforeAvailable := probeResultCount(t, metrics.AudioProbeAvailable)
+	beforeFailed := probeResultCount(t, metrics.AudioProbeFailed)
+	beforeEmpty := probeResultCount(t, metrics.AudioProbeEmpty)
+	beforeEvidence := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal)
+	beforeExact := evidenceCount(t, "ac3", metrics.AudioEvidenceDeclaredExact)
+
+	adapter.planLiveAudioSelection(context.Background(), spec, spec.Source.ID, pmt)
+
+	if got := probeResultCount(t, metrics.AudioProbeAvailable) - beforeAvailable; got != 1 {
+		t.Errorf("available delta = %v, want 1", got)
+	}
+	if got := probeResultCount(t, metrics.AudioProbeFailed) - beforeFailed; got != 0 {
+		t.Errorf("failed delta = %v, want 0", got)
+	}
+	if got := probeResultCount(t, metrics.AudioProbeEmpty) - beforeEmpty; got != 0 {
+		t.Errorf("empty delta = %v, want 0", got)
+	}
+	if got := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal) - beforeEvidence; got != 1 {
+		t.Errorf("topology evidence delta = %v, want exactly one outcome for the one track", got)
+	}
+	if got := evidenceCount(t, "ac3", metrics.AudioEvidenceDeclaredExact) - beforeExact; got != 1 {
+		t.Errorf("declared_exact{ac3} delta = %v, want 1", got)
+	}
+}
+
+// Native Android TV never runs the probe. Counting it would report an absence
+// that was never asked for and would drag the availability ratio down with
+// sessions the question does not concern.
+func TestLiveAudioProbeMetrics_AndroidTVNativeIsNotCounted(t *testing.T) {
+	adapter := probeMetricsAdapter(t)
+	adapter.liveAudioProbeFn = func(context.Context, string) ([]liveAudioStream, error) {
+		t.Fatal("the probe must not run for native Android TV")
+		return nil, nil
+	}
+
+	spec := probeMetricsSpec()
+	spec.ClientFamily = "android_tv_native"
+
+	before := counterVecTotal(t, metrics.AudioProbeTotal)
+	beforeEvidence := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal)
+
+	adapter.planLiveAudioSelection(context.Background(), spec, spec.Source.ID, []ports.LiveAudioTrack{{PID: 101, Codec: "ac3", Channels: 2}})
+
+	if got := counterVecTotal(t, metrics.AudioProbeTotal) - before; got != 0 {
+		t.Errorf("probe counter delta = %v, want 0", got)
+	}
+	if got := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal) - beforeEvidence; got != 0 {
+		t.Errorf("topology evidence delta = %v, want 0", got)
+	}
+}

--- a/backend/internal/infra/media/ffmpeg/plan_builder.go
+++ b/backend/internal/infra/media/ffmpeg/plan_builder.go
@@ -2,7 +2,6 @@ package ffmpeg
 
 import (
 	"context"
-	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
 	"github.com/ManuGH/xg2g/internal/pipeline/profiles"
 )
@@ -16,7 +15,12 @@ type inputPlan struct {
 	// pmtAudio is what the transport stream's own PMT declares about its audio
 	// tracks, taken from shared ingest. It is empty for a source that has no
 	// ingest session behind it, which is what BuildTopology has always been given.
-	pmtAudio []audiotopology.PMTTrackObservation
+	//
+	// Carried in the declaration's own shape rather than the domain observation:
+	// the difference between "declared two channels" and "declared more than two
+	// without saying how many" survives here and is lost in the conversion, and
+	// the evidence counter needs to tell those apart.
+	pmtAudio []ports.LiveAudioTrack
 
 	// authURL preserves the original input URL with userinfo credentials
 	// before they are stripped from inputURL.  Probe functions (ffprobe,
@@ -70,7 +74,7 @@ type liveSegmentLayout struct {
 	listSize               int
 }
 
-func (a *LocalAdapter) buildArgsWithPlan(ctx context.Context, spec ports.StreamSpec, inputURL string, pmtAudio []audiotopology.PMTTrackObservation) (finalizedPlan, error) {
+func (a *LocalAdapter) buildArgsWithPlan(ctx context.Context, spec ports.StreamSpec, inputURL string, pmtAudio []ports.LiveAudioTrack) (finalizedPlan, error) {
 	inputPhase, err := a.planInput(spec, inputURL)
 	if err != nil {
 		return finalizedPlan{}, err

--- a/backend/internal/infra/media/ffmpeg/pmt_audio.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio.go
@@ -7,6 +7,7 @@ package ffmpeg
 import (
 	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/ManuGH/xg2g/internal/metrics"
 )
 
 // pmtTrackObservations turns the PMT's audio declarations into the domain's PMT
@@ -41,4 +42,74 @@ func pmtTrackObservations(tracks []ports.LiveAudioTrack) []audiotopology.PMTTrac
 		})
 	}
 	return out
+}
+
+// audioEvidence is one planned track's codec and where its channel information
+// came from.
+type audioEvidence struct {
+	codec  string
+	result string
+}
+
+// classifyAudioEvidence reports, per audio track, which source supplied the
+// channel information and whether the two sources agreed.
+//
+// It exists to answer a question that cannot be reasoned out: DVB descriptors may
+// omit the channel information, and where they carry it they name a class rather
+// than a count, so how far the declarations alone would carry can only be counted
+// on real services. Nothing here influences the plan.
+//
+// The union of both sources is walked, not just the intersection, because a track
+// only one of them knows about is itself one of the answers.
+func classifyAudioEvidence(pmt []ports.LiveAudioTrack, probes map[uint16]liveAudioStream) []audioEvidence {
+	if len(pmt) == 0 && len(probes) == 0 {
+		return nil
+	}
+
+	out := make([]audioEvidence, 0, len(pmt)+len(probes))
+	seen := make(map[uint16]struct{}, len(pmt))
+
+	for _, track := range pmt {
+		seen[track.PID] = struct{}{}
+		probe, probed := probes[track.PID]
+		if !probed {
+			// Not a fault. A startup snapshot is short, and a track the tables
+			// already name can simply not have arrived in it yet.
+			out = append(out, audioEvidence{codec: track.Codec, result: metrics.AudioEvidencePMTOnly})
+			continue
+		}
+		out = append(out, audioEvidence{codec: track.Codec, result: declaredResult(track, probe)})
+	}
+
+	for pid, probe := range probes {
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		out = append(out, audioEvidence{codec: probe.CodecName, result: metrics.AudioEvidenceProbeOnly})
+	}
+	return out
+}
+
+// declaredResult classifies a track both sources know about.
+func declaredResult(track ports.LiveAudioTrack, probe liveAudioStream) string {
+	switch {
+	case track.Channels > 0 && probe.Channels > 0 && track.Channels != probe.Channels:
+		return metrics.AudioEvidenceConflict
+	case track.Channels > 0:
+		return metrics.AudioEvidenceDeclaredExact
+	case track.Multichannel:
+		// Its own outcome on purpose. "More than two, count unstated" is neither a
+		// number nor silence, and folding it into either would answer the question
+		// this counter exists to ask.
+		return metrics.AudioEvidenceDeclaredMulti
+	default:
+		return metrics.AudioEvidenceDeclaredNone
+	}
+}
+
+// recordAudioEvidence publishes the classification. Measurement only.
+func recordAudioEvidence(pmt []ports.LiveAudioTrack, probes map[uint16]liveAudioStream) {
+	for _, ev := range classifyAudioEvidence(pmt, probes) {
+		metrics.IncAudioTopologyEvidence(ev.codec, ev.result)
+	}
 }

--- a/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ManuGH/xg2g/internal/domain/audiotopology"
 	"github.com/ManuGH/xg2g/internal/domain/session/ports"
+	"github.com/ManuGH/xg2g/internal/metrics"
 )
 
 func TestPMTTrackObservations_CarriesTheDeclaration(t *testing.T) {
@@ -184,5 +185,114 @@ func TestSplitMappableTracks_KeepsEverythingWhenAllProbed(t *testing.T) {
 	}
 	if len(unmappable) != 0 {
 		t.Errorf("unmappable = %+v, want none", unmappable)
+	}
+}
+
+func TestClassifyAudioEvidence_Outcomes(t *testing.T) {
+	tests := []struct {
+		name   string
+		pmt    []ports.LiveAudioTrack
+		probes map[uint16]liveAudioStream
+		want   []audioEvidence
+	}{
+		{
+			name:   "the pmt named a count and the probe agrees",
+			pmt:    []ports.LiveAudioTrack{{PID: 101, Codec: "ac3", Channels: 2}},
+			probes: map[uint16]liveAudioStream{101: {CodecName: "ac3", Channels: 2}},
+			want:   []audioEvidence{{codec: "ac3", result: metrics.AudioEvidenceDeclaredExact}},
+		},
+		{
+			name:   "more than two channels, count unstated",
+			pmt:    []ports.LiveAudioTrack{{PID: 101, Codec: "ac3", Multichannel: true}},
+			probes: map[uint16]liveAudioStream{101: {CodecName: "ac3", Channels: 6}},
+			want:   []audioEvidence{{codec: "ac3", result: metrics.AudioEvidenceDeclaredMulti}},
+		},
+		{
+			name:   "the descriptor carried nothing usable",
+			pmt:    []ports.LiveAudioTrack{{PID: 101, Codec: "mp2"}},
+			probes: map[uint16]liveAudioStream{101: {CodecName: "mp2", Channels: 2}},
+			want:   []audioEvidence{{codec: "mp2", result: metrics.AudioEvidenceDeclaredNone}},
+		},
+		{
+			name:   "both named a count and disagreed",
+			pmt:    []ports.LiveAudioTrack{{PID: 101, Codec: "ac3", Channels: 2}},
+			probes: map[uint16]liveAudioStream{101: {CodecName: "ac3", Channels: 6}},
+			want:   []audioEvidence{{codec: "ac3", result: metrics.AudioEvidenceConflict}},
+		},
+		{
+			name:   "only the tables know this track",
+			pmt:    []ports.LiveAudioTrack{{PID: 102, Codec: "aac", Channels: 2}},
+			probes: map[uint16]liveAudioStream{},
+			want:   []audioEvidence{{codec: "aac", result: metrics.AudioEvidencePMTOnly}},
+		},
+		{
+			name:   "only the probe knows this track",
+			pmt:    nil,
+			probes: map[uint16]liveAudioStream{103: {CodecName: "eac3", Channels: 6}},
+			want:   []audioEvidence{{codec: "eac3", result: metrics.AudioEvidenceProbeOnly}},
+		},
+		{
+			name:   "nothing at all",
+			pmt:    nil,
+			probes: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyAudioEvidence(tc.pmt, tc.probes)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d outcomes %+v, want %d", len(got), got, len(tc.want))
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("outcome %d = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// A count matching on both sides is agreement, not a conflict, and a probe that
+// reported nothing cannot contradict anything.
+func TestClassifyAudioEvidence_ConflictNeedsTwoCounts(t *testing.T) {
+	tests := []struct {
+		name  string
+		track ports.LiveAudioTrack
+		probe liveAudioStream
+		want  string
+	}{
+		{"same count", ports.LiveAudioTrack{Channels: 2}, liveAudioStream{Channels: 2}, metrics.AudioEvidenceDeclaredExact},
+		{"probe silent", ports.LiveAudioTrack{Channels: 2}, liveAudioStream{Channels: 0}, metrics.AudioEvidenceDeclaredExact},
+		{"pmt silent", ports.LiveAudioTrack{}, liveAudioStream{Channels: 6}, metrics.AudioEvidenceDeclaredNone},
+		{"multichannel is not a disagreement", ports.LiveAudioTrack{Multichannel: true}, liveAudioStream{Channels: 6}, metrics.AudioEvidenceDeclaredMulti},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := declaredResult(tc.track, tc.probe); got != tc.want {
+				t.Errorf("declaredResult = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Every track is counted exactly once, whichever source knows it.
+func TestClassifyAudioEvidence_CountsEachTrackOnce(t *testing.T) {
+	pmt := []ports.LiveAudioTrack{
+		{PID: 101, Codec: "ac3", Channels: 2},
+		{PID: 102, Codec: "aac"},
+	}
+	probes := map[uint16]liveAudioStream{
+		101: {CodecName: "ac3", Channels: 2},
+		103: {CodecName: "mp2", Channels: 2},
+	}
+
+	got := classifyAudioEvidence(pmt, probes)
+
+	if len(got) != 3 {
+		t.Fatalf("got %d outcomes %+v, want one per distinct PID (3)", len(got), got)
 	}
 }

--- a/backend/internal/metrics/audio_probe.go
+++ b/backend/internal/metrics/audio_probe.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Startup audio probe outcomes, recorded once per live plan that reaches the
+// probe.
+//
+// This is a different measurement dimension from the topology evidence next to
+// it. AudioTopologyEvidenceTotal describes how two present sources of evidence
+// relate to each other; this one describes whether one of them was there at all.
+// Without it every evidence series would be conditioned on a successful probe,
+// and the case that argues hardest for reducing the probe - it delivers nothing
+// while the tables declare the tracks - would be absent from the denominator
+// rather than counted.
+const (
+	// AudioProbeAvailable means the probe returned usable audio streams and the
+	// topology classification ran on them.
+	AudioProbeAvailable = "available"
+	// AudioProbeFailed means the probe itself did not complete.
+	AudioProbeFailed = "failed"
+	// AudioProbeEmpty means the probe completed and reported no audio stream.
+	// Kept apart from failed on purpose: a broken ffprobe run and a service the
+	// probe saw no audio in lead to different conclusions, and folding them
+	// together now would mean rebuilding this telemetry to tell them apart later.
+	AudioProbeEmpty = "empty"
+)
+
+// AudioProbeTotal counts live audio plans by whether the startup probe supplied
+// anything to classify.
+//
+// Deliberately not labelled by codec. On a failed probe there is no probe codec
+// to name, and putting the PMT's codec there instead would make the label mean
+// one thing in some series and another thing in the rest - which is the mixing
+// of dimensions this metric exists to avoid.
+//
+// A path that never runs the probe is not counted here. Native Android TV skips
+// it by design, so counting it would report an absence that was never asked for.
+var AudioProbeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "xg2g_ingest_audio_probe_total",
+	Help: "Live audio plans by whether the startup probe supplied streams to classify",
+}, []string{"result"})
+
+// IncAudioProbe records one live audio plan's probe outcome.
+func IncAudioProbe(result string) {
+	AudioProbeTotal.WithLabelValues(result).Inc()
+}

--- a/backend/internal/metrics/audio_topology.go
+++ b/backend/internal/metrics/audio_topology.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Audio topology evidence outcomes. One series per planned audio track, recorded
+// where the PMT declaration and the ffprobe observation sit next to each other.
+//
+// The question these answer is whether the declarations that shared ingest reads
+// out of the PMT are enough on their own, or whether the startup probe is still
+// carrying the load. DVB descriptors may omit the channel information, and when
+// they carry it they name a class rather than a count, so the answer cannot be
+// reasoned out - only counted, on real services.
+const (
+	// AudioEvidenceDeclaredExact means the PMT named a channel count.
+	AudioEvidenceDeclaredExact = "declared_exact"
+	// AudioEvidenceDeclaredMulti means the PMT declared more than two channels
+	// without naming how many. Deliberately its own outcome: it is neither a
+	// number nor silence, and folding it into either would answer the question
+	// this metric exists to ask.
+	AudioEvidenceDeclaredMulti = "declared_multi"
+	// AudioEvidenceDeclaredNone means the PMT carried no usable channel
+	// information for this track.
+	AudioEvidenceDeclaredNone = "declared_none"
+	// AudioEvidenceProbeOnly means only ffprobe saw this track.
+	AudioEvidenceProbeOnly = "probe_only"
+	// AudioEvidencePMTOnly means only the PMT declared this track. It is an
+	// observation, not a fault: a short startup snapshot can simply not have
+	// reached a track the tables already name.
+	AudioEvidencePMTOnly = "pmt_only"
+	// AudioEvidenceConflict means both sources named a channel count and the two
+	// disagreed.
+	AudioEvidenceConflict = "conflict"
+)
+
+// AudioTopologyEvidenceTotal counts what each planned audio track's channel
+// information came from.
+//
+// Labelled by codec and outcome only. A PID, a language or a service name would
+// each multiply the series by the size of the channel list for no gain: the
+// decision this feeds - can the probe be reduced - is per codec, because whether
+// a descriptor carries channels is a property of the codec's descriptor, not of
+// the individual service.
+var AudioTopologyEvidenceTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "xg2g_ingest_audio_topology_evidence_total",
+	Help: "Planned audio tracks by codec and where their channel information came from",
+}, []string{"codec", "result"})
+
+// IncAudioTopologyEvidence records one planned audio track's evidence outcome.
+func IncAudioTopologyEvidence(codec, result string) {
+	if codec == "" {
+		codec = "unknown"
+	}
+	AudioTopologyEvidenceTotal.WithLabelValues(codec, result).Inc()
+}


### PR DESCRIPTION
**B2b.3 — Observability.** Nur Messung: keine ffprobe entfernt, keine Auswahlpolicy geändert, kein Audio-Frame-Parser.

## Warum eine Metrik statt Nachdenken

B2b.2 hat die PMT-Deklarationen an den Topologie-Merge angeschlossen und damit eine Frage aufgeworfen, die sich **nicht aus dem Code beantworten lässt**: Wie weit tragen die Deklarationen allein? DVB-Deskriptoren dürfen die Kanalinformation ganz weglassen, und wo sie sie tragen, nennen sie eine Klasse — mono, stereo, „mehr als zwei". Ob die Startzeit-Probe noch die Arbeit macht, ist eine Eigenschaft echter Sender, nicht der Spezifikation.

```text
xg2g_ingest_audio_topology_evidence_total{codec, result}
```

| result | Bedeutung |
| --- | --- |
| `declared_exact` | das PMT nannte eine Kanalzahl |
| `declared_multi` | mehr als zwei Kanäle, Zahl nicht genannt |
| `declared_none` | der Deskriptor trug nichts Brauchbares |
| `probe_only` | nur ffprobe sah diese Spur |
| `pmt_only` | nur die Tabellen deklarierten sie |
| `conflict` | beide nannten eine Zahl und widersprachen sich |

## Zwei Entscheidungen im Detail

**`declared_multi` ist ein eigener Ausgang**, nicht in einen Nachbarn gefaltet. Es ist weder eine Zahl noch Schweigen — und genau hier entscheidet sich B2b.3: ein AC-3-Dienst mit 5.1 und einer mit 7.1 deklarieren denselben Wert, also ist ein hoher Zählstand hier exakt der Fall, in dem die Probe **nicht** wegkann.

**`pmt_only` ist Beobachtung, kein Fehler.** Ein Startup-Snapshot ist kurz; eine Spur, die die Tabellen nennen, kann darin schlicht noch nicht angekommen sein.

## Labels bewusst klein

Nur `codec` und `result`. Eine PID, eine Sprache oder ein Sendername würde die Serienzahl jeweils mit der Länge der Kanalliste multiplizieren — ohne Gewinn: die Entscheidung, die das hier speist, fällt **pro Codec**, weil es eine Eigenschaft des jeweiligen Deskriptors ist, ob er Kanäle trägt, nicht des einzelnen Dienstes.

## Erfassungspunkt

Vor `BuildTopology`. Der Merge ist die Stelle, an der aus zwei Quellen eine Antwort wird — und die Frage hier ist, welche der beiden sie geliefert hat.

`planLiveAudioSelection` nimmt die Deklarationen dafür in ihrer eigenen Form statt als Domain-Beobachtung: der Unterschied zwischen „zwei Kanäle" und „mehr als zwei, ungenannt" geht in dieser Umwandlung verloren und ist der ganze Punkt der obigen Unterscheidung. Die Umwandlung wandert damit eine Ebene tiefer, was den Aufrufweg nebenbei vereinfacht.

## Tests

Alle sechs Ausgänge, plus die Fälle, die beim Klassifizieren leicht falsch geraten: gleiche Zahl auf beiden Seiten ist Übereinstimmung und kein Konflikt, eine schweigende Probe kann nichts widersprechen, `Multichannel` gegen eine gemessene 6 ist keine Uneinigkeit, und jede Spur wird genau einmal gezählt, welche Quelle sie auch kennt.

## Lokale Gates

| Gate | Ergebnis |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (144 Pakete) |
| `make test-race-pr` | pass |
| `make lint` | pass |
| `make verify-generated-artifacts` | pass |
| `make verify-monitoring-contract` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
