### PR TITLE
Read the audio channel layout out of the stream, continuously

### DIFF
--- a/backend/internal/domain/session/ports/livesource.go
+++ b/backend/internal/domain/session/ports/livesource.go
@@ -73,6 +73,27 @@ type LiveAudioTrack struct {
 	// service-type bits this type deliberately does not interpret.
 	ComponentType    uint8
 	HasComponentType bool
+
+	// ObservedChannels is the channel count the elementary stream itself has been
+	// seen to carry, or 0 where the audio has not established one. It is the only
+	// source that can name a count above two - the descriptors above declare a
+	// class, and 5.1 and 7.1 declare the same class - and it moves with the audio
+	// rather than with the PMT, so it follows a service that changes layout
+	// between programmes.
+	ObservedChannels int
+
+	// ObservedLFE reports the low frequency effects channel, already counted in
+	// ObservedChannels.
+	ObservedLFE bool
+
+	// ObservedFrames counts the audio frames the observation rests on, so a
+	// consumer can tell a settled reading from a stream that has barely started.
+	ObservedFrames uint64
+
+	// ObservedDependentSubstream reports that E-AC-3 dependent substreams were
+	// seen. ObservedChannels then describes the independent substream only, and
+	// the programme may carry more than it says.
+	ObservedDependentSubstream bool
 }
 
 // Descrambled reports whether the receiver is delivering this service in the

--- a/backend/internal/stream/ingest/esaudio/ac3.go
+++ b/backend/internal/stream/ingest/esaudio/ac3.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+// Package esaudio reads audio facts out of elementary stream payload.
+//
+// It knows nothing about MPEG-TS, PES, or whatever carried the bytes here: the
+// input is elementary stream payload for one track, the output is what those
+// bytes say about themselves. Nothing in this package decides what to do with the
+// answer - no downmix, no rendition, no manifest, no fallback to stereo. That
+// separation is the whole point. A PMT descriptor can only declare a class
+// ("more than two channels"), and a 5.1 service and a 7.1 service declare the
+// same value, so a number can only come from the audio itself.
+package esaudio
+
+// Codec names, matching the vocabulary the rest of the ingest path uses.
+const (
+	CodecAC3  = "ac3"
+	CodecEAC3 = "eac3"
+)
+
+const (
+	syncWordHi = 0x0B
+	syncWordLo = 0x77
+
+	// headerBytes is what both syntaxes need to answer the channel question.
+	// E-AC-3 has lfeon in byte 4; AC-3 places it after a run of mix level fields
+	// whose presence acmod decides, but even the longest of those runs still ends
+	// inside byte 6.
+	headerBytes = 7
+)
+
+// acmodChannels maps audio coding mode to the number of full-bandwidth channels,
+// ATSC A/52 Table 5.8. acmod 0 is 1+1 - two independent mono programmes, which is
+// two channels of audio however it is used.
+var acmodChannels = [8]int{2, 1, 2, 3, 3, 4, 4, 5}
+
+// ac3Bitrates is A/52 Table 5.18 in kbit/s. frmsizecod indexes it in pairs; the
+// low bit distinguishes the two 44.1 kHz frame lengths that share a bitrate.
+var ac3Bitrates = [19]int{32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 448, 512, 576, 640}
+
+// FrameHeader is what one syncframe says about its own channel layout.
+type FrameHeader struct {
+	// Channels counts full-bandwidth channels plus LFE. It is 0 when the frame
+	// does not describe the programme's own layout - a dependent substream, or an
+	// independent substream belonging to another programme.
+	Channels int
+
+	Acmod uint8
+	LFE   bool
+
+	// Dependent marks an E-AC-3 dependent substream. Its channels extend the
+	// independent substream rather than replacing it, and reconstructing the
+	// total needs the channel map this parser does not read - so the frame is
+	// reported as a fact about the stream's shape, never as a count.
+	Dependent bool
+
+	// SizeBytes is the whole frame, used to step to the next syncword instead of
+	// rescanning frame payload that can contain the sync pattern by chance.
+	SizeBytes int
+}
+
+// ParseSyncFrame reads the header of a syncframe starting at b[0].
+//
+// AC-3 and E-AC-3 share a syncword and are told apart by bsid, which both
+// syntaxes happen to place in the top five bits of byte 5. Everything else about
+// the two layouts differs.
+func ParseSyncFrame(b []byte) (FrameHeader, bool) {
+	if len(b) < headerBytes || b[0] != syncWordHi || b[1] != syncWordLo {
+		return FrameHeader{}, false
+	}
+
+	switch bsid := b[5] >> 3; {
+	case bsid <= 10:
+		// bsid 9 and 10 are the alternate bit rate variants; they carry the same
+		// bit stream information syntax as 8.
+		return parseAC3(b)
+	case bsid <= 16:
+		return parseEAC3(b)
+	default:
+		// Reserved. A byte pair that happened to look like a syncword is far more
+		// likely than a bitstream this parser has never heard of.
+		return FrameHeader{}, false
+	}
+}
+
+// parseAC3 reads the A/52 syncinfo and bsi fields up to lfeon.
+func parseAC3(b []byte) (FrameHeader, bool) {
+	fscod := b[4] >> 6
+	frmsizecod := b[4] & 0x3F
+	if fscod == 0x03 || frmsizecod > 37 {
+		// Reserved sample rate or frame size code. Treated as "not a frame" rather
+		// than as a frame with unknown fields: a false syncword is the likelier
+		// explanation, and acting on one would put a wrong layout into the facts.
+		return FrameHeader{}, false
+	}
+
+	acmod := b[6] >> 5
+
+	// lfeon sits behind the mix level fields, and which of those are present is
+	// decided by acmod itself.
+	offset := 3
+	if acmod&0x01 != 0 && acmod != 0x01 {
+		offset += 2 // cmixlev, present for the modes with a centre channel
+	}
+	if acmod&0x04 != 0 {
+		offset += 2 // surmixlev, present for the modes with surround channels
+	}
+	if acmod == 0x02 {
+		offset += 2 // dsurmod, only 2/0 declares Dolby Surround encoding
+	}
+	lfe := (b[6]>>(7-offset))&0x01 == 1
+
+	channels := acmodChannels[acmod]
+	if lfe {
+		channels++
+	}
+	return FrameHeader{
+		Channels:  channels,
+		Acmod:     acmod,
+		LFE:       lfe,
+		SizeBytes: ac3FrameBytes(fscod, frmsizecod),
+	}, true
+}
+
+// ac3FrameBytes is A/52 Table 5.18. At 48 and 32 kHz the frame is a whole number
+// of words per kbit/s; at 44.1 kHz it is not, which is why the table lists two
+// lengths per bitrate and frmsizecod's low bit picks between them.
+func ac3FrameBytes(fscod, frmsizecod uint8) int {
+	bitrate := ac3Bitrates[frmsizecod>>1]
+
+	var words int
+	switch fscod {
+	case 0x00: // 48 kHz
+		words = bitrate * 2
+	case 0x01: // 44.1 kHz
+		words = (bitrate*1536*1000)/(44100*16) + int(frmsizecod&0x01)
+	default: // 32 kHz
+		words = bitrate * 3
+	}
+	return words * 2
+}
+
+// parseEAC3 reads the A/52 Annex E bit stream information.
+func parseEAC3(b []byte) (FrameHeader, bool) {
+	strmtyp := b[2] >> 6
+	if strmtyp == 0x03 {
+		return FrameHeader{}, false // reserved
+	}
+	substreamID := (b[2] >> 3) & 0x07
+	frmsiz := (uint16(b[2]&0x07) << 8) | uint16(b[3])
+
+	acmod := (b[4] >> 1) & 0x07
+	lfe := b[4]&0x01 == 1
+
+	h := FrameHeader{
+		Acmod:     acmod,
+		LFE:       lfe,
+		SizeBytes: (int(frmsiz) + 1) * 2,
+	}
+
+	switch {
+	case strmtyp == 0x01:
+		// Dependent substream: its acmod describes the channels it adds, not the
+		// programme's total.
+		h.Dependent = true
+	case substreamID != 0:
+		// An independent substream other than 0 is a different programme in the
+		// same elementary stream. Not this track's layout.
+	default:
+		h.Channels = acmodChannels[acmod]
+		if lfe {
+			h.Channels++
+		}
+	}
+	return h, true
+}

--- a/backend/internal/stream/ingest/esaudio/ac3_test.go
+++ b/backend/internal/stream/ingest/esaudio/ac3_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package esaudio
+
+import "testing"
+
+// The byte 6 values below are written out from A/52 rather than produced by the
+// same offset arithmetic the parser uses, so a mistake in that arithmetic cannot
+// hide behind a test that repeats it.
+//
+//	5.1  acmod=111 cmixlev=01 surmixlev=01 lfeon=1  -> 1110 1011 = 0xEB
+//	3/2  acmod=111 cmixlev=01 surmixlev=01 lfeon=0  -> 1110 1010 = 0xEA
+//	2/0  acmod=010 dsurmod=00 lfeon=0               -> 0100 0000 = 0x40
+//	1/0  acmod=001 lfeon=0                          -> 0010 0000 = 0x20
+const (
+	ac3Byte6Surround51 = 0xEB
+	ac3Byte6Surround50 = 0xEA
+	ac3Byte6Stereo     = 0x40
+	ac3Byte6Mono       = 0x20
+)
+
+// ac3Frame builds a complete AC-3 syncframe. frmsizecod 0 at 48 kHz is 32 kbit/s,
+// which no broadcaster would use for 5.1 - it is chosen because it makes the
+// smallest legal frame and the header fields under test do not depend on it.
+func ac3Frame(byte6 byte) []byte {
+	const (
+		fscod      = 0x00 // 48 kHz
+		frmsizecod = 0x00 // 32 kbit/s -> 64 words -> 128 bytes
+		bsid       = 8
+	)
+	f := make([]byte, 128)
+	f[0], f[1] = 0x0B, 0x77
+	f[2], f[3] = 0xAA, 0xBB // crc1, not checked
+	f[4] = fscod<<6 | frmsizecod
+	f[5] = bsid << 3
+	f[6] = byte6
+	return f
+}
+
+// eac3Frame builds an E-AC-3 syncframe. frmsiz counts 16-bit words minus one.
+func eac3Frame(strmtyp, substreamID, acmod uint8, lfe bool) []byte {
+	const size = 128
+	frmsiz := uint16(size/2 - 1)
+
+	f := make([]byte, size)
+	f[0], f[1] = 0x0B, 0x77
+	f[2] = strmtyp<<6 | substreamID<<3 | byte(frmsiz>>8)
+	f[3] = byte(frmsiz & 0xFF)
+	f[4] = acmod << 1
+	if lfe {
+		f[4] |= 0x01
+	}
+	f[5] = 16 << 3 // bsid 16 selects the Annex E syntax
+	return f
+}
+
+func TestParseSyncFrame_AC3ChannelLayouts(t *testing.T) {
+	tests := []struct {
+		name     string
+		byte6    byte
+		channels int
+		lfe      bool
+		acmod    uint8
+	}{
+		{"5.1", ac3Byte6Surround51, 6, true, 7},
+		{"3/2 without LFE", ac3Byte6Surround50, 5, false, 7},
+		{"stereo", ac3Byte6Stereo, 2, false, 2},
+		{"mono", ac3Byte6Mono, 1, false, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, ok := ParseSyncFrame(ac3Frame(tc.byte6))
+			if !ok {
+				t.Fatal("frame not parsed")
+			}
+			if h.Channels != tc.channels {
+				t.Errorf("Channels = %d, want %d", h.Channels, tc.channels)
+			}
+			if h.LFE != tc.lfe {
+				t.Errorf("LFE = %v, want %v", h.LFE, tc.lfe)
+			}
+			if h.Acmod != tc.acmod {
+				t.Errorf("Acmod = %d, want %d", h.Acmod, tc.acmod)
+			}
+			if h.SizeBytes != 128 {
+				t.Errorf("SizeBytes = %d, want 128", h.SizeBytes)
+			}
+		})
+	}
+}
+
+// 32 kHz and 44.1 kHz frames are a different length for the same bitrate, and the
+// 44.1 kHz table lists two lengths per bitrate. Stepping by the wrong one would
+// land the scan inside frame payload.
+func TestParseSyncFrame_AC3FrameSizes(t *testing.T) {
+	tests := []struct {
+		name       string
+		fscod      byte
+		frmsizecod byte
+		want       int
+	}{
+		{"48 kHz 32 kbit/s", 0x00, 0, 128},
+		{"48 kHz 448 kbit/s", 0x00, 30, 1792},
+		{"32 kHz 32 kbit/s", 0x02, 0, 192},
+		{"44.1 kHz 64 kbit/s even", 0x01, 8, 278},
+		{"44.1 kHz 64 kbit/s odd", 0x01, 9, 280},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := ac3Frame(ac3Byte6Stereo)
+			f[4] = tc.fscod<<6 | tc.frmsizecod
+			h, ok := ParseSyncFrame(f)
+			if !ok {
+				t.Fatal("frame not parsed")
+			}
+			if h.SizeBytes != tc.want {
+				t.Errorf("SizeBytes = %d, want %d", h.SizeBytes, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseSyncFrame_EAC3(t *testing.T) {
+	h, ok := ParseSyncFrame(eac3Frame(0, 0, 7, true))
+	if !ok {
+		t.Fatal("frame not parsed")
+	}
+	if h.Channels != 6 {
+		t.Errorf("Channels = %d, want 6", h.Channels)
+	}
+	if !h.LFE || h.Acmod != 7 {
+		t.Errorf("LFE = %v, Acmod = %d, want true / 7", h.LFE, h.Acmod)
+	}
+	if h.SizeBytes != 128 {
+		t.Errorf("SizeBytes = %d, want 128", h.SizeBytes)
+	}
+}
+
+// A dependent substream adds channels to the independent one rather than
+// describing the programme, and reconstructing the total needs the channel map
+// this parser does not read. Reporting its acmod as a count would be an
+// invention, so the frame is recognised and reported without one.
+func TestParseSyncFrame_EAC3DependentSubstreamCarriesNoCount(t *testing.T) {
+	h, ok := ParseSyncFrame(eac3Frame(1, 0, 7, true))
+	if !ok {
+		t.Fatal("frame not parsed")
+	}
+	if !h.Dependent {
+		t.Error("Dependent = false, want true")
+	}
+	if h.Channels != 0 {
+		t.Errorf("Channels = %d, want 0 - a dependent substream is not the programme's layout", h.Channels)
+	}
+}
+
+// A second independent substream is another programme in the same elementary
+// stream, not another view of this one.
+func TestParseSyncFrame_EAC3ForeignSubstreamCarriesNoCount(t *testing.T) {
+	h, ok := ParseSyncFrame(eac3Frame(0, 3, 7, true))
+	if !ok {
+		t.Fatal("frame not parsed")
+	}
+	if h.Channels != 0 {
+		t.Errorf("Channels = %d, want 0", h.Channels)
+	}
+	if h.Dependent {
+		t.Error("Dependent = true, want false")
+	}
+}
+
+// Anything that fails a field check is reported as "not a frame". The alternative
+// - a frame with fields we did not trust - is how a stray byte pair becomes a
+// channel layout.
+func TestParseSyncFrame_Rejects(t *testing.T) {
+	reserved := ac3Frame(ac3Byte6Stereo)
+	reserved[4] = 0x03 << 6 // fscod = 3
+
+	badSize := ac3Frame(ac3Byte6Stereo)
+	badSize[4] = 38 // frmsizecod above the table
+
+	badBSID := ac3Frame(ac3Byte6Stereo)
+	badBSID[5] = 17 << 3
+
+	noSync := ac3Frame(ac3Byte6Stereo)
+	noSync[1] = 0x78
+
+	tests := []struct {
+		name  string
+		frame []byte
+	}{
+		{"reserved sample rate", reserved},
+		{"frame size code above the table", badSize},
+		{"bit stream id we do not know", badBSID},
+		{"no syncword", noSync},
+		{"too short to hold a header", ac3Frame(ac3Byte6Stereo)[:headerBytes-1]},
+		{"empty", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := ParseSyncFrame(tc.frame); ok {
+				t.Error("parsed, want rejected")
+			}
+		})
+	}
+}

--- a/backend/internal/stream/ingest/esaudio/observer.go
+++ b/backend/internal/stream/ingest/esaudio/observer.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package esaudio
+
+// stableFrames is how many consecutive frames must agree before the observation
+// changes.
+//
+// A syncword is two bytes and audio payload contains them by chance, so a single
+// parse is a guess. Requiring a run costs about a tenth of a second at the ~31
+// frames per second an AC-3 stream runs at - fast enough to follow a real change
+// between programmes, slow enough that a stray match cannot move the fact. A run
+// broken by noise simply restarts; the previous observation stands until a new
+// one is actually established, so the failure direction is "keeps saying what it
+// last proved", never "invents something new".
+const stableFrames = 3
+
+// carryBytes is how much tail is kept for the next chunk. A syncframe header
+// split across two chunks is completed from it; anything longer cannot be the
+// start of an unexamined header.
+const carryBytes = headerBytes - 1
+
+// Observation is what an elementary stream has been seen to carry.
+//
+// The zero value means nothing has been established, which is a different state
+// from stereo. Nothing here fills that in - a stream that has not said how many
+// channels it has does not have two.
+type Observation struct {
+	// Channels counts full-bandwidth channels plus LFE, or 0 when no layout has
+	// been established.
+	Channels int `json:"channels,omitempty"`
+
+	// LFE reports the low frequency effects channel, which is included in
+	// Channels and named separately because a layout decision may want it.
+	LFE bool `json:"lfe,omitempty"`
+
+	// Acmod is the raw audio coding mode the count was derived from, carried so a
+	// consumer can reach layout conclusions this type does not draw.
+	Acmod    uint8 `json:"acmod,omitempty"`
+	HasAcmod bool  `json:"hasAcmod,omitempty"`
+
+	// DependentSubstream reports that E-AC-3 dependent substream frames were seen
+	// on this stream. Channels then describes the independent substream only, and
+	// the programme may carry more than it says.
+	DependentSubstream bool `json:"dependentSubstream,omitempty"`
+
+	// Frames counts the syncframes parsed since the observation started, so a
+	// consumer can tell a settled reading from a stream that has barely arrived.
+	Frames uint64 `json:"frames,omitempty"`
+}
+
+// Known reports whether the stream has said how many channels it carries.
+func (o Observation) Known() bool { return o.Channels > 0 }
+
+// sameLayout compares only the fields a change has to be proved for.
+func (o Observation) sameLayout(other Observation) bool {
+	return o.Channels == other.Channels && o.LFE == other.LFE && o.Acmod == other.Acmod
+}
+
+// Observer follows one audio elementary stream and reports what its frames say
+// about the channel layout.
+//
+// It never stops looking. A service changes its audio between programmes as a
+// matter of course - the same PID going from AC-3 2.0 to 5.1 for a film and back
+// for the advertisements - so a single reading taken at session start is not an
+// answer, it is an answer with an expiry date nobody recorded. Feed it for as
+// long as the stream runs and Current() follows.
+//
+// Not safe for concurrent use; the caller holds the lock it already holds to feed
+// the stream.
+type Observer struct {
+	carry []byte
+
+	// skip is frame payload that ran past the end of a chunk, dropped from the
+	// front of the next one instead of being scanned for syncwords it cannot
+	// legitimately contain.
+	skip int
+
+	current      Observation
+	candidate    Observation
+	candidateRun int
+
+	frames        uint64
+	dependentSeen bool
+}
+
+// NewObserver returns an observer with nothing established yet.
+func NewObserver() *Observer { return &Observer{} }
+
+// Feed consumes elementary stream bytes. Chunk boundaries are arbitrary: a
+// syncframe split across two calls is parsed from the second.
+func (o *Observer) Feed(es []byte) {
+	if len(es) == 0 {
+		return
+	}
+
+	if o.skip > 0 {
+		if o.skip >= len(es) {
+			o.skip -= len(es)
+			return
+		}
+		es = es[o.skip:]
+		o.skip = 0
+	}
+
+	buf := es
+	if len(o.carry) > 0 {
+		buf = append(o.carry, es...)
+	}
+
+	i := 0
+	for i+headerBytes <= len(buf) {
+		if buf[i] != syncWordHi || buf[i+1] != syncWordLo {
+			i++
+			continue
+		}
+		h, ok := ParseSyncFrame(buf[i:])
+		if !ok {
+			i++
+			continue
+		}
+		o.observe(h)
+
+		// Step over the whole frame. Its payload is compressed audio and carries
+		// the sync pattern by chance often enough to matter, so rescanning it is
+		// how a parser talks itself into a layout the stream never had.
+		if h.SizeBytes > headerBytes {
+			i += h.SizeBytes
+		} else {
+			i += headerBytes
+		}
+	}
+
+	if i > len(buf) {
+		o.skip = i - len(buf)
+		o.carry = o.carry[:0]
+		return
+	}
+
+	tail := buf[i:]
+	if len(tail) > carryBytes {
+		tail = tail[len(tail)-carryBytes:]
+	}
+	o.carry = append(o.carry[:0], tail...)
+}
+
+// observe folds one frame into the running state.
+func (o *Observer) observe(h FrameHeader) {
+	if h.Dependent {
+		o.dependentSeen = true
+		return
+	}
+	if h.Channels <= 0 {
+		return
+	}
+	o.frames++
+
+	next := Observation{Channels: h.Channels, LFE: h.LFE, Acmod: h.Acmod, HasAcmod: true}
+	if o.candidateRun > 0 && next.sameLayout(o.candidate) {
+		o.candidateRun++
+	} else {
+		o.candidate = next
+		o.candidateRun = 1
+	}
+	if o.candidateRun >= stableFrames {
+		o.current = next
+	}
+}
+
+// Current returns the established observation, or the zero value while none has
+// been.
+func (o *Observer) Current() Observation {
+	obs := o.current
+	obs.Frames = o.frames
+	obs.DependentSubstream = o.dependentSeen
+	return obs
+}

--- a/backend/internal/stream/ingest/esaudio/observer_test.go
+++ b/backend/internal/stream/ingest/esaudio/observer_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package esaudio
+
+import (
+	"bytes"
+	"testing"
+)
+
+// frames concatenates n identical syncframes into one elementary stream run.
+func frames(byte6 byte, n int) []byte {
+	var out []byte
+	for i := 0; i < n; i++ {
+		out = append(out, ac3Frame(byte6)...)
+	}
+	return out
+}
+
+func TestObserver_NothingSeenIsNotStereo(t *testing.T) {
+	o := NewObserver()
+
+	if got := o.Current(); got.Known() || got.Channels != 0 {
+		t.Errorf("Current() = %+v, want the zero observation", got)
+	}
+
+	o.Feed(bytes.Repeat([]byte{0x00, 0x11, 0x22}, 200))
+
+	if got := o.Current(); got.Known() {
+		t.Errorf("Current() = %+v, want nothing established from payload that says nothing", got)
+	}
+}
+
+// One frame is a guess. The layout is only reported once the stream has repeated
+// it, so a byte pair that happened to look like a syncword cannot become a fact.
+func TestObserver_EstablishesOnlyAfterAgreement(t *testing.T) {
+	o := NewObserver()
+
+	for i := 1; i < stableFrames; i++ {
+		o.Feed(ac3Frame(ac3Byte6Surround51))
+		if got := o.Current(); got.Known() {
+			t.Fatalf("established after %d frame(s): %+v, want to wait for %d", i, got, stableFrames)
+		}
+	}
+
+	o.Feed(ac3Frame(ac3Byte6Surround51))
+
+	got := o.Current()
+	if got.Channels != 6 || !got.LFE || got.Acmod != 7 {
+		t.Errorf("Current() = %+v, want 6 channels with LFE from acmod 7", got)
+	}
+	if got.Frames != uint64(stableFrames) {
+		t.Errorf("Frames = %d, want %d", got.Frames, stableFrames)
+	}
+}
+
+// The case the whole observer exists for: a service that runs stereo between
+// programmes and 5.1 during the film, on one PID, with no PMT change to announce
+// it. A reading taken once at session start is wrong for the rest of the session.
+func TestObserver_FollowsALayoutChangeOnTheSameStream(t *testing.T) {
+	o := NewObserver()
+
+	o.Feed(frames(ac3Byte6Stereo, stableFrames))
+	if got := o.Current(); got.Channels != 2 {
+		t.Fatalf("Channels = %d, want 2 to start", got.Channels)
+	}
+
+	o.Feed(frames(ac3Byte6Surround51, stableFrames))
+	if got := o.Current(); got.Channels != 6 || !got.LFE {
+		t.Errorf("Current() = %+v, want the stream's move to 5.1 to be followed", got)
+	}
+
+	o.Feed(frames(ac3Byte6Stereo, stableFrames))
+	if got := o.Current(); got.Channels != 2 || got.LFE {
+		t.Errorf("Current() = %+v, want the move back to stereo to be followed", got)
+	}
+}
+
+// Until the new layout has proved itself the old one stands. It never falls back
+// to unknown and never falls back to stereo in between.
+func TestObserver_HoldsTheProvenLayoutWhileANewOneIsStillArriving(t *testing.T) {
+	o := NewObserver()
+	o.Feed(frames(ac3Byte6Surround51, stableFrames))
+
+	for i := 1; i < stableFrames; i++ {
+		o.Feed(ac3Frame(ac3Byte6Stereo))
+		if got := o.Current(); got.Channels != 6 {
+			t.Fatalf("Channels = %d after %d stereo frame(s), want 6 until the change is proved", got.Channels, i)
+		}
+	}
+}
+
+// A run broken by noise starts over rather than counting toward a change.
+func TestObserver_InterruptedRunDoesNotEstablish(t *testing.T) {
+	o := NewObserver()
+	o.Feed(frames(ac3Byte6Surround51, stableFrames))
+
+	for i := 0; i < stableFrames*3; i++ {
+		o.Feed(ac3Frame(ac3Byte6Stereo))
+		o.Feed(ac3Frame(ac3Byte6Mono))
+	}
+
+	if got := o.Current(); got.Channels != 6 {
+		t.Errorf("Channels = %d, want 6 - neither alternating layout ever agreed with itself", got.Channels)
+	}
+}
+
+// Elementary stream bytes arrive in transport-sized pieces that cut frames
+// anywhere, including inside a header.
+func TestObserver_FrameSplitAcrossChunks(t *testing.T) {
+	es := frames(ac3Byte6Surround51, stableFrames+1)
+
+	for _, chunk := range []int{1, 3, 7, 64, 127} {
+		t.Run("chunk size", func(t *testing.T) {
+			o := NewObserver()
+			for i := 0; i < len(es); i += chunk {
+				end := i + chunk
+				if end > len(es) {
+					end = len(es)
+				}
+				o.Feed(es[i:end])
+			}
+			if got := o.Current(); got.Channels != 6 {
+				t.Errorf("chunk %d: Channels = %d, want 6", chunk, got.Channels)
+			}
+		})
+	}
+}
+
+// A frame cut short at the end of the stream contributes nothing and does not
+// disturb what was already established.
+func TestObserver_TruncatedTrailingFrame(t *testing.T) {
+	o := NewObserver()
+	es := frames(ac3Byte6Surround51, stableFrames)
+	o.Feed(append(es, ac3Frame(ac3Byte6Stereo)[:4]...))
+
+	got := o.Current()
+	if got.Channels != 6 {
+		t.Errorf("Channels = %d, want 6", got.Channels)
+	}
+	if got.Frames != uint64(stableFrames) {
+		t.Errorf("Frames = %d, want %d - a partial frame is not a frame", got.Frames, stableFrames)
+	}
+}
+
+// Frame payload is compressed audio and contains the sync pattern by chance. The
+// scan steps over a parsed frame rather than through it, so bytes inside one are
+// never read as a header.
+func TestObserver_SyncPatternInsideFramePayloadIsNotAFrame(t *testing.T) {
+	o := NewObserver()
+
+	for i := 0; i < stableFrames; i++ {
+		f := ac3Frame(ac3Byte6Surround51)
+		// A complete, well-formed stereo header buried in the payload.
+		copy(f[64:], ac3Frame(ac3Byte6Stereo)[:headerBytes])
+		o.Feed(f)
+	}
+
+	got := o.Current()
+	if got.Channels != 6 {
+		t.Errorf("Channels = %d, want 6", got.Channels)
+	}
+	if got.Frames != uint64(stableFrames) {
+		t.Errorf("Frames = %d, want %d - payload was scanned as headers", got.Frames, stableFrames)
+	}
+}
+
+// Garbage between frames is skipped without disturbing the run, because the scan
+// resumes looking for a syncword rather than giving up.
+func TestObserver_ResumesAfterGarbage(t *testing.T) {
+	o := NewObserver()
+	junk := bytes.Repeat([]byte{0x0B, 0x00, 0xFF}, 40)
+
+	for i := 0; i < stableFrames; i++ {
+		o.Feed(junk)
+		o.Feed(ac3Frame(ac3Byte6Surround51))
+	}
+
+	if got := o.Current(); got.Channels != 6 {
+		t.Errorf("Channels = %d, want 6", got.Channels)
+	}
+}
+
+// A dependent substream is recorded as a fact about the stream's shape without
+// becoming a count, so a consumer can tell that the independent substream's
+// number may not be the whole programme.
+func TestObserver_DependentSubstreamIsFlaggedNotCounted(t *testing.T) {
+	o := NewObserver()
+
+	for i := 0; i < stableFrames; i++ {
+		o.Feed(eac3Frame(0, 0, 7, true))
+		o.Feed(eac3Frame(1, 0, 2, false))
+	}
+
+	got := o.Current()
+	if got.Channels != 6 {
+		t.Errorf("Channels = %d, want 6 from the independent substream", got.Channels)
+	}
+	if !got.DependentSubstream {
+		t.Error("DependentSubstream = false, want true")
+	}
+}

--- a/backend/internal/stream/ingest/livesource/livesource.go
+++ b/backend/internal/stream/ingest/livesource/livesource.go
@@ -155,9 +155,11 @@ func factsFrom(f ring.ReadinessFacts) ports.LiveSourceFacts {
 	}
 }
 
-// audioTracksFrom carries the PMT's audio declarations across the port boundary
-// without reinterpreting them. In particular a multichannel declaration stays a
-// flag: the descriptor names a class, not a count.
+// audioTracksFrom carries the PMT's audio declarations and the elementary
+// stream's own observation across the port boundary without reinterpreting
+// either. In particular a multichannel declaration stays a flag: the descriptor
+// names a class, not a count, and the count - where there is one - comes from the
+// observation beside it rather than from turning the class into a number.
 func audioTracksFrom(tracks []ring.AudioTrackInfo) []ports.LiveAudioTrack {
 	if len(tracks) == 0 {
 		return nil
@@ -173,6 +175,11 @@ func audioTracksFrom(tracks []ring.AudioTrackInfo) []ports.LiveAudioTrack {
 			Multichannel:     t.Declared.Multichannel,
 			ComponentType:    t.Declared.ComponentType,
 			HasComponentType: t.Declared.HasComponentType,
+
+			ObservedChannels:           t.Observed.Channels,
+			ObservedLFE:                t.Observed.LFE,
+			ObservedFrames:             t.Observed.Frames,
+			ObservedDependentSubstream: t.Observed.DependentSubstream,
 		})
 	}
 	return out

--- a/backend/internal/stream/ingest/ring/audio_multitrack_test.go
+++ b/backend/internal/stream/ingest/ring/audio_multitrack_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import "testing"
+
+// Live TV is not one audio track with properties. A programme carries 0..N tracks
+// at once - the broadcast language, a second language, audio description, the
+// original soundtrack - and that whole set changes while the session runs: a
+// track's layout moves, a track appears, a track goes away. These tests exist so
+// what was built is a multi-track observer rather than an excellent single-track
+// one.
+
+const (
+	mtGerman  = 101
+	mtEnglish = 102
+	mtThird   = 103
+)
+
+type mtStream struct {
+	pid uint16
+	es  []byte
+}
+
+// pushInterleaved feeds the streams packet by packet in turn, the way a
+// transponder delivers them. Feeding one track to completion and then the next
+// would let a shared-state bug pass unnoticed.
+func pushInterleaved(t *testing.T, r *MasterRing, streams ...mtStream) {
+	t.Helper()
+
+	packets := make([][][]byte, len(streams))
+	longest := 0
+	for i, s := range streams {
+		packets[i] = audioPackets(s.pid, s.es, false)
+		if len(packets[i]) > longest {
+			longest = len(packets[i])
+		}
+	}
+
+	for i := 0; i < longest; i++ {
+		for _, p := range packets {
+			if i < len(p) {
+				pushAll(t, r, p[i])
+			}
+		}
+	}
+}
+
+func audioPIDsOf(r *MasterRing) []uint16 {
+	var pids []uint16
+	for _, track := range r.ReadinessFacts().AudioTracks {
+		pids = append(pids, track.PID)
+	}
+	return pids
+}
+
+func assertPIDs(t *testing.T, r *MasterRing, want ...uint16) {
+	t.Helper()
+
+	got := audioPIDsOf(r)
+	if len(got) != len(want) {
+		t.Fatalf("AudioTracks PIDs = %v, want exactly %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("AudioTracks PIDs = %v, want exactly %v", got, want)
+		}
+	}
+}
+
+func assertObserved(t *testing.T, r *MasterRing, pid uint16, channels int) {
+	t.Helper()
+
+	if got := observedTrack(t, r, pid).Observed.Channels; got != channels {
+		t.Errorf("PID %d observed %d channels, want %d", pid, got, channels)
+	}
+}
+
+// Two AC-3 tracks running side by side hold different layouts at the same time,
+// and a change on one does not move the other. A single shared observation would
+// pass the first half of this and fail the second.
+func TestMasterRing_TracksAreObservedIndependently(t *testing.T) {
+	r := NewMasterRing(8000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0,
+		ac3Track(mtGerman, "deu", 0x85),
+		ac3Track(mtEnglish, "eng", 0x82),
+	))
+
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Surround51, 4)},
+		mtStream{mtEnglish, obsAC3Run(obsByte6Stereo, 4)},
+	)
+
+	assertObserved(t, r, mtGerman, 6)
+	assertObserved(t, r, mtEnglish, 2)
+
+	// The two swap layouts. Each must follow its own stream.
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Stereo, 4)},
+		mtStream{mtEnglish, obsAC3Run(obsByte6Surround51, 4)},
+	)
+
+	assertObserved(t, r, mtGerman, 2)
+	assertObserved(t, r, mtEnglish, 6)
+
+	// And the languages stayed with their own tracks.
+	if lang := observedTrack(t, r, mtGerman).Language; lang != "deu" {
+		t.Errorf("PID %d language = %q, want deu", mtGerman, lang)
+	}
+	if lang := observedTrack(t, r, mtEnglish).Language; lang != "eng" {
+		t.Errorf("PID %d language = %q, want eng", mtEnglish, lang)
+	}
+}
+
+// A track that has carried no audio stays unknown, however much its neighbour has
+// established. One track's observation is never evidence about another.
+func TestMasterRing_ObservationDoesNotLeakToASilentTrack(t *testing.T) {
+	r := NewMasterRing(8000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0,
+		ac3Track(mtGerman, "deu", 0x85),
+		ac3Track(mtEnglish, "eng", 0x85),
+	))
+	pushAudio(t, r, mtGerman, obsAC3Run(obsByte6Surround51, 4))
+
+	assertObserved(t, r, mtGerman, 6)
+
+	if got := observedTrack(t, r, mtEnglish).Observed; got.Known() {
+		t.Errorf("PID %d observed %+v, want nothing - it has carried no audio", mtEnglish, got)
+	}
+
+	// The declaration is still there on both. Declared and Observed are separate
+	// statements about the same track, and one being empty says nothing about the
+	// other.
+	for _, pid := range []uint16{mtGerman, mtEnglish} {
+		if d := observedTrack(t, r, pid).Declared; !d.Multichannel {
+			t.Errorf("PID %d declared %+v, want the multichannel class", pid, d)
+		}
+	}
+}
+
+// The whole set moves while the session runs: layouts change, a track appears, a
+// track goes away. At every point AudioTracks is exactly the current set and each
+// PID carries its own observation.
+func TestMasterRing_TrackSetFollowsThePMTThroughAProgramme(t *testing.T) {
+	r := NewMasterRing(8000 * TSPacketSize)
+	defer r.Close()
+
+	// Advertisements: German 5.1, English stereo.
+	pushAll(t, r, obsPAT(), obsPMT(0,
+		ac3Track(mtGerman, "deu", 0x85),
+		ac3Track(mtEnglish, "eng", 0x82),
+	))
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Surround51, 4)},
+		mtStream{mtEnglish, obsAC3Run(obsByte6Stereo, 4)},
+	)
+
+	assertPIDs(t, r, mtGerman, mtEnglish)
+	assertObserved(t, r, mtGerman, 6)
+	assertObserved(t, r, mtEnglish, 2)
+
+	// The film starts: a third track appears, and the two existing ones swap
+	// layouts. No session restart.
+	pushAll(t, r, obsPMT(1,
+		ac3Track(mtGerman, "deu", 0x82),
+		ac3Track(mtEnglish, "eng", 0x85),
+		ac3Track(mtThird, "deu", 0x85),
+	))
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Stereo, 4)},
+		mtStream{mtEnglish, obsAC3Run(obsByte6Surround51, 4)},
+		mtStream{mtThird, obsAC3Run(obsByte6Surround51, 4)},
+	)
+
+	assertPIDs(t, r, mtGerman, mtEnglish, mtThird)
+	assertObserved(t, r, mtGerman, 2)
+	assertObserved(t, r, mtEnglish, 6)
+	assertObserved(t, r, mtThird, 6)
+
+	// The English track goes away.
+	pushAll(t, r, obsPMT(2,
+		ac3Track(mtGerman, "deu", 0x82),
+		ac3Track(mtThird, "deu", 0x85),
+	))
+
+	assertPIDs(t, r, mtGerman, mtThird)
+
+	// Payload still arriving on the PID the table dropped reaches nothing.
+	pushAudio(t, r, mtEnglish, obsAC3Run(obsByte6Surround51, 8))
+	assertPIDs(t, r, mtGerman, mtThird)
+
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Stereo, 4)},
+		mtStream{mtThird, obsAC3Run(obsByte6Surround51, 4)},
+	)
+	assertObserved(t, r, mtGerman, 2)
+	assertObserved(t, r, mtThird, 6)
+}
+
+// A PID reused for a different codec gets a fresh observer, not the previous
+// stream's history. The codec here is one this path does read, so an observer is
+// built either way - what must not survive is what the old one had established.
+func TestMasterRing_PIDReusedForAnotherReadCodecStartsClean(t *testing.T) {
+	r := NewMasterRing(8000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, ac3Track(mtGerman, "deu", 0x85)))
+	pushAudio(t, r, mtGerman, obsAC3Run(obsByte6Surround51, 4))
+	assertObserved(t, r, mtGerman, 6)
+
+	// Same PID, now E-AC-3.
+	pushAll(t, r, obsPMT(1, obsTrack{mtGerman, 0x06, append([]byte{0x7A, 0x02, 0x80, 0x85}, langDescriptor("deu")...)}))
+
+	track := observedTrack(t, r, mtGerman)
+	if track.Codec != "eac3" {
+		t.Fatalf("Codec = %q, want eac3", track.Codec)
+	}
+	if track.Observed.Known() {
+		t.Errorf("Observed = %+v, want nothing - that is the previous stream's layout", track.Observed)
+	}
+}
+
+// An audio layout change is a new fact about a track, not a new stream. Faking a
+// generation would tell every subscriber to re-attach because a film started.
+func TestMasterRing_LayoutChangeAcrossTracksDoesNotMoveTheGeneration(t *testing.T) {
+	r := NewMasterRing(8000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0,
+		ac3Track(mtGerman, "deu", 0x85),
+		ac3Track(mtEnglish, "eng", 0x85),
+	))
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Stereo, 4)},
+		mtStream{mtEnglish, obsAC3Run(obsByte6Stereo, 4)},
+	)
+
+	before := r.ReadinessFacts().Generation
+
+	pushInterleaved(t, r,
+		mtStream{mtGerman, obsAC3Run(obsByte6Surround51, 4)},
+		mtStream{mtEnglish, obsAC3Run(obsByte6Surround51, 4)},
+	)
+
+	assertObserved(t, r, mtGerman, 6)
+	assertObserved(t, r, mtEnglish, 6)
+
+	if now := r.ReadinessFacts().Generation; now != before {
+		t.Errorf("Generation moved from %d to %d - an observed layout change is not a new stream", before, now)
+	}
+}

--- a/backend/internal/stream/ingest/ring/audio_observation_test.go
+++ b/backend/internal/stream/ingest/ring/audio_observation_test.go
@@ -1,0 +1,356 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// --- transport fixtures -----------------------------------------------------
+//
+// Built here rather than reused from the video tests because these need a
+// configurable audio PID, a real AC-3 descriptor and a PMT version that can be
+// moved, which is what the generation cases turn on.
+
+const (
+	obsPMTPID   = 100
+	obsVideoPID = 256
+	obsAudioPID = 257
+	obsOtherPID = 258
+)
+
+func psiPacket(pid uint16, section []byte) []byte {
+	pkt := make([]byte, TSPacketSize)
+	pkt[0] = SyncByte
+	pkt[1] = 0x40 | byte((pid>>8)&0x1F) // PUSI
+	pkt[2] = byte(pid & 0xFF)
+	pkt[3] = 0x10 // payload only, CC 0
+	pkt[4] = 0x00 // pointer_field
+	copy(pkt[5:], section)
+	for i := 5 + len(section); i < TSPacketSize; i++ {
+		pkt[i] = 0xFF
+	}
+	return pkt
+}
+
+func obsPAT() []byte {
+	s := []byte{
+		0x00,
+		0xB0, 0x0D,
+		0x00, 0x01, // transport stream id
+		0xC1,       // version 0, current
+		0x00, 0x00, // section 0 of 0
+		0x00, 0x01, // program 1
+		0xE0 | byte(obsPMTPID>>8), byte(obsPMTPID & 0xFF),
+		0, 0, 0, 0,
+	}
+	binary.BigEndian.PutUint32(s[len(s)-4:], CalculateMPEG2CRC32(s[:len(s)-4]))
+	return psiPacket(0, s)
+}
+
+// obsPMT names one video and one audio elementary stream. streamType and the
+// descriptors decide which codec the audio is taken to be.
+func obsPMT(version uint8, audioPID uint16, streamType byte, descriptors []byte) []byte {
+	es := []byte{
+		0x1B, // H.264
+		0xE0 | byte(obsVideoPID>>8), byte(obsVideoPID & 0xFF),
+		0xF0, 0x00,
+
+		streamType,
+		0xE0 | byte(audioPID>>8), byte(audioPID & 0xFF),
+		0xF0 | byte(len(descriptors)>>8), byte(len(descriptors) & 0xFF),
+	}
+	es = append(es, descriptors...)
+
+	sectionLen := 9 + len(es) + 4
+	s := []byte{
+		0x02,
+		0xB0 | byte(sectionLen>>8), byte(sectionLen & 0xFF),
+		0x00, 0x01, // program 1
+		0xC0 | ((version & 0x1F) << 1) | 0x01,
+		0x00, 0x00,
+		0xE0 | byte(obsVideoPID>>8), byte(obsVideoPID & 0xFF), // PCR PID
+		0xF0, 0x00, // program_info_length
+	}
+	s = append(s, es...)
+	s = append(s, 0, 0, 0, 0)
+	binary.BigEndian.PutUint32(s[len(s)-4:], CalculateMPEG2CRC32(s[:len(s)-4]))
+	return psiPacket(obsPMTPID, s)
+}
+
+// ac3Descriptor is descriptor tag 0x6A with the component type flag set, which is
+// what makes the PMT declare a channel class.
+func ac3Descriptor(componentType byte) []byte {
+	return []byte{0x6A, 0x02, 0x80, componentType}
+}
+
+// audioPackets frames elementary stream bytes into TS packets, the first of them
+// carrying a private_stream_1 PES header the way DVB carries AC-3.
+func audioPackets(pid uint16, es []byte, scrambled bool) [][]byte {
+	var out [][]byte
+	first := true
+
+	for len(es) > 0 {
+		pkt := make([]byte, TSPacketSize)
+		pkt[0] = SyncByte
+		pkt[2] = byte(pid & 0xFF)
+		pkt[1] = byte((pid >> 8) & 0x1F)
+		pkt[3] = 0x10
+		if scrambled {
+			pkt[3] |= 0x80
+		}
+
+		body := 4
+		if first {
+			pkt[1] |= 0x40 // PUSI
+			copy(pkt[4:], []byte{
+				0x00, 0x00, 0x01, 0xBD, // private_stream_1
+				0x00, 0x00, // PES packet length, unbounded
+				0x80, 0x00, 0x00, // flags, flags, header_data_length = 0
+			})
+			body = 13
+			first = false
+		}
+
+		n := copy(pkt[body:], es)
+		es = es[n:]
+		for i := body + n; i < TSPacketSize; i++ {
+			pkt[i] = 0xFF
+		}
+		out = append(out, pkt)
+	}
+	return out
+}
+
+// --- elementary stream fixtures ---------------------------------------------
+//
+// The header bytes are the same spec-derived values the esaudio tests use.
+const (
+	obsByte6Surround51 = 0xEB
+	obsByte6Stereo     = 0x40
+)
+
+func obsAC3Frame(byte6 byte) []byte {
+	f := make([]byte, 128)
+	f[0], f[1] = 0x0B, 0x77
+	f[4] = 0x00 // 48 kHz, smallest frame
+	f[5] = 8 << 3
+	f[6] = byte6
+	return f
+}
+
+func obsAC3Run(byte6 byte, n int) []byte {
+	var out []byte
+	for i := 0; i < n; i++ {
+		out = append(out, obsAC3Frame(byte6)...)
+	}
+	return out
+}
+
+func pushAll(t *testing.T, r *MasterRing, packets ...[]byte) {
+	t.Helper()
+	for _, pkt := range packets {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push: %v", err)
+		}
+	}
+}
+
+func pushAudio(t *testing.T, r *MasterRing, pid uint16, es []byte) {
+	t.Helper()
+	pushAll(t, r, audioPackets(pid, es, false)...)
+}
+
+func observedTrack(t *testing.T, r *MasterRing, pid uint16) AudioTrackInfo {
+	t.Helper()
+	for _, track := range r.ReadinessFacts().AudioTracks {
+		if track.PID == pid {
+			return track
+		}
+	}
+	t.Fatalf("no track for PID %d in %+v", pid, r.ReadinessFacts().AudioTracks)
+	return AudioTrackInfo{}
+}
+
+// --- tests ------------------------------------------------------------------
+
+// The descriptor declares a class and the audio carries the count. Both reach the
+// facts, side by side, neither standing in for the other.
+func TestMasterRing_ObservesAC3ChannelsFromTheStream(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	// Component type 0x85: multichannel, no count declared.
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+
+	track := observedTrack(t, r, obsAudioPID)
+
+	if track.Codec != "ac3" {
+		t.Fatalf("Codec = %q, want ac3", track.Codec)
+	}
+	if !track.Declared.Multichannel || track.Declared.Channels != 0 {
+		t.Errorf("Declared = %+v, want the class without a count", track.Declared)
+	}
+	if track.Observed.Channels != 6 || !track.Observed.LFE {
+		t.Errorf("Observed = %+v, want 6 channels with LFE", track.Observed)
+	}
+}
+
+// Stereo AC-3 must not be read as anything else, or a downmix decision would be
+// made on an invented surround layout.
+func TestMasterRing_ObservesAC3Stereo(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x82)))
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Stereo, 4))
+
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 2 || got.LFE {
+		t.Errorf("Observed = %+v, want 2 channels without LFE", got)
+	}
+}
+
+// The case a startup probe cannot answer: the same PID moves from stereo to 5.1
+// and back between programmes, with no PMT change to announce either move.
+func TestMasterRing_FollowsALayoutChangeWithoutAPMTChange(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Stereo, 4))
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 2 {
+		t.Fatalf("Observed.Channels = %d, want 2 to start", got.Channels)
+	}
+
+	generation := r.ReadinessFacts().Generation
+
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 6 {
+		t.Errorf("Observed.Channels = %d, want 6 after the stream moved to 5.1", got.Channels)
+	}
+
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Stereo, 4))
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 2 {
+		t.Errorf("Observed.Channels = %d, want 2 after the stream moved back", got.Channels)
+	}
+
+	if now := r.ReadinessFacts().Generation; now != generation {
+		t.Errorf("Generation moved from %d to %d - an audio layout change is not a new stream", generation, now)
+	}
+}
+
+// A new PMT can put a different elementary stream on a PID. Carrying the old
+// observation across would describe audio that is no longer there.
+func TestMasterRing_PMTChangeDropsTheObservation(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 6 {
+		t.Fatalf("Observed.Channels = %d, want 6 before the change", got.Channels)
+	}
+
+	// Same PID, new table.
+	pushAll(t, r, obsPMT(1, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Known() {
+		t.Errorf("Observed = %+v, want nothing carried across the PMT change", got)
+	}
+
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Stereo, 4))
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 2 {
+		t.Errorf("Observed.Channels = %d, want the new stream's own layout", got.Channels)
+	}
+}
+
+// The sharp edge of the same rule. A new table can keep the PID and change the
+// codec to one this path does not read, so no new observer is built for it - and
+// then nothing but the reset stops the previous stream's 5.1 from being attached
+// to a track that is now MP2.
+func TestMasterRing_PMTChangeToAnUnreadCodecDropsTheObservation(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 6 {
+		t.Fatalf("Observed.Channels = %d, want 6 before the change", got.Channels)
+	}
+
+	// Same PID, now MPEG-1 layer II.
+	pushAll(t, r, obsPMT(1, obsAudioPID, 0x03, nil))
+
+	track := observedTrack(t, r, obsAudioPID)
+	if track.Codec != "mp2" {
+		t.Fatalf("Codec = %q, want mp2", track.Codec)
+	}
+	if track.Observed.Known() {
+		t.Errorf("Observed = %+v, want nothing - this is the previous stream's layout", track.Observed)
+	}
+}
+
+// The audio moving to a different PID is the same problem seen from the other
+// side: nothing may survive on either PID.
+func TestMasterRing_AudioPIDChangeDropsTheObservation(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+
+	pushAll(t, r, obsPMT(1, obsOtherPID, 0x06, ac3Descriptor(0x85)))
+
+	facts := r.ReadinessFacts()
+	for _, track := range facts.AudioTracks {
+		if track.PID == obsAudioPID {
+			t.Errorf("PID %d still present after it left the PMT", obsAudioPID)
+		}
+	}
+	if got := observedTrack(t, r, obsOtherPID).Observed; got.Known() {
+		t.Errorf("Observed = %+v on the new PID, want nothing before it has carried audio", got)
+	}
+
+	// Payload still arriving on the PID the table no longer names changes nothing.
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+	if got := observedTrack(t, r, obsOtherPID).Observed; got.Known() {
+		t.Errorf("Observed = %+v, want a stream the PMT dropped to reach no track", got)
+	}
+}
+
+// MP2 carries its channel mode in the audio frame header too, but this path does
+// not read that syntax. It must produce no observation rather than a wrong one.
+func TestMasterRing_UnreadCodecProducesNoObservation(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x03, nil)) // MPEG-1 layer II
+	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
+
+	track := observedTrack(t, r, obsAudioPID)
+	if track.Codec != "mp2" {
+		t.Fatalf("Codec = %q, want mp2", track.Codec)
+	}
+	if track.Observed.Known() {
+		t.Errorf("Observed = %+v, want nothing for a codec this path does not read", track.Observed)
+	}
+}
+
+// Scrambled payload is ciphertext. Parsing it would index random bytes as frame
+// headers, which is the same mistake the video path already refuses to make.
+func TestMasterRing_ScrambledAudioIsNotObserved(t *testing.T) {
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, audioPackets(obsAudioPID, obsAC3Run(obsByte6Surround51, 4), true)...)
+
+	if got := observedTrack(t, r, obsAudioPID).Observed; got.Known() {
+		t.Errorf("Observed = %+v, want nothing read out of scrambled payload", got)
+	}
+}

--- a/backend/internal/stream/ingest/ring/audio_observation_test.go
+++ b/backend/internal/stream/ingest/ring/audio_observation_test.go
@@ -51,19 +51,36 @@ func obsPAT() []byte {
 	return psiPacket(0, s)
 }
 
-// obsPMT names one video and one audio elementary stream. streamType and the
-// descriptors decide which codec the audio is taken to be.
-func obsPMT(version uint8, audioPID uint16, streamType byte, descriptors []byte) []byte {
+// obsTrack is one audio elementary stream for the PMT builder to name.
+type obsTrack struct {
+	pid         uint16
+	streamType  byte
+	descriptors []byte
+}
+
+// ac3Track is the shorthand a multi-track case needs: an AC-3 stream declaring a
+// channel class and a language.
+func ac3Track(pid uint16, lang string, componentType byte) obsTrack {
+	d := append(ac3Descriptor(componentType), langDescriptor(lang)...)
+	return obsTrack{pid: pid, streamType: 0x06, descriptors: d}
+}
+
+// obsPMT names one video stream and the given audio streams. streamType and the
+// descriptors decide which codec each audio track is taken to be.
+func obsPMT(version uint8, tracks ...obsTrack) []byte {
 	es := []byte{
 		0x1B, // H.264
 		0xE0 | byte(obsVideoPID>>8), byte(obsVideoPID & 0xFF),
 		0xF0, 0x00,
-
-		streamType,
-		0xE0 | byte(audioPID>>8), byte(audioPID & 0xFF),
-		0xF0 | byte(len(descriptors)>>8), byte(len(descriptors) & 0xFF),
 	}
-	es = append(es, descriptors...)
+	for _, tr := range tracks {
+		es = append(es,
+			tr.streamType,
+			0xE0|byte(tr.pid>>8), byte(tr.pid&0xFF),
+			0xF0|byte(len(tr.descriptors)>>8), byte(len(tr.descriptors)&0xFF),
+		)
+		es = append(es, tr.descriptors...)
+	}
 
 	sectionLen := 9 + len(es) + 4
 	s := []byte{
@@ -85,6 +102,11 @@ func obsPMT(version uint8, audioPID uint16, streamType byte, descriptors []byte)
 // what makes the PMT declare a channel class.
 func ac3Descriptor(componentType byte) []byte {
 	return []byte{0x6A, 0x02, 0x80, componentType}
+}
+
+// langDescriptor is the ISO 639 language descriptor, tag 0x0A.
+func langDescriptor(lang string) []byte {
+	return []byte{0x0A, 0x04, lang[0], lang[1], lang[2], 0x00}
 }
 
 // audioPackets frames elementary stream bytes into TS packets, the first of them
@@ -184,7 +206,7 @@ func TestMasterRing_ObservesAC3ChannelsFromTheStream(t *testing.T) {
 	defer r.Close()
 
 	// Component type 0x85: multichannel, no count declared.
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
 
 	track := observedTrack(t, r, obsAudioPID)
@@ -206,7 +228,7 @@ func TestMasterRing_ObservesAC3Stereo(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x82)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x82)}))
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Stereo, 4))
 
 	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 2 || got.LFE {
@@ -220,7 +242,7 @@ func TestMasterRing_FollowsALayoutChangeWithoutAPMTChange(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Stereo, 4))
 	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 2 {
@@ -250,14 +272,14 @@ func TestMasterRing_PMTChangeDropsTheObservation(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
 	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 6 {
 		t.Fatalf("Observed.Channels = %d, want 6 before the change", got.Channels)
 	}
 
 	// Same PID, new table.
-	pushAll(t, r, obsPMT(1, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPMT(1, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 
 	if got := observedTrack(t, r, obsAudioPID).Observed; got.Known() {
 		t.Errorf("Observed = %+v, want nothing carried across the PMT change", got)
@@ -277,14 +299,14 @@ func TestMasterRing_PMTChangeToAnUnreadCodecDropsTheObservation(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
 	if got := observedTrack(t, r, obsAudioPID).Observed; got.Channels != 6 {
 		t.Fatalf("Observed.Channels = %d, want 6 before the change", got.Channels)
 	}
 
 	// Same PID, now MPEG-1 layer II.
-	pushAll(t, r, obsPMT(1, obsAudioPID, 0x03, nil))
+	pushAll(t, r, obsPMT(1, obsTrack{obsAudioPID, 0x03, nil}))
 
 	track := observedTrack(t, r, obsAudioPID)
 	if track.Codec != "mp2" {
@@ -301,10 +323,10 @@ func TestMasterRing_AudioPIDChangeDropsTheObservation(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
 
-	pushAll(t, r, obsPMT(1, obsOtherPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPMT(1, obsTrack{obsOtherPID, 0x06, ac3Descriptor(0x85)}))
 
 	facts := r.ReadinessFacts()
 	for _, track := range facts.AudioTracks {
@@ -329,7 +351,7 @@ func TestMasterRing_UnreadCodecProducesNoObservation(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x03, nil)) // MPEG-1 layer II
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x03, nil})) // MPEG-1 layer II
 	pushAudio(t, r, obsAudioPID, obsAC3Run(obsByte6Surround51, 4))
 
 	track := observedTrack(t, r, obsAudioPID)
@@ -347,7 +369,7 @@ func TestMasterRing_ScrambledAudioIsNotObserved(t *testing.T) {
 	r := NewMasterRing(4000 * TSPacketSize)
 	defer r.Close()
 
-	pushAll(t, r, obsPAT(), obsPMT(0, obsAudioPID, 0x06, ac3Descriptor(0x85)))
+	pushAll(t, r, obsPAT(), obsPMT(0, obsTrack{obsAudioPID, 0x06, ac3Descriptor(0x85)}))
 	pushAll(t, r, audioPackets(obsAudioPID, obsAC3Run(obsByte6Surround51, 4), true)...)
 
 	if got := observedTrack(t, r, obsAudioPID).Observed; got.Known() {

--- a/backend/internal/stream/ingest/ring/randomaccess.go
+++ b/backend/internal/stream/ingest/ring/randomaccess.go
@@ -4,6 +4,8 @@
 
 package ring
 
+import "github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
+
 // Random access classification.
 //
 // A subscriber that joins mid-broadcast has no reference pictures, so it can only
@@ -338,6 +340,17 @@ type AudioTrackInfo struct {
 	// Declared is what the PMT says about this track's channel count. It is a
 	// declaration read from a descriptor, never a measurement of the audio.
 	Declared AudioChannelDeclaration `json:"declared"`
+
+	// Observed is what the elementary stream itself has been seen to carry. It is
+	// the only source that can name a count above two: the descriptors declare a
+	// class, so 5.1 and 7.1 declare the same thing, and the difference exists only
+	// in the audio. Empty until enough frames have agreed, and empty for the
+	// codecs this path does not read.
+	//
+	// Kept beside Declared rather than merged into it. They answer differently
+	// often enough - a descriptor can be absent, stale, or wrong - that collapsing
+	// them would throw away the evidence needed to tell which happened.
+	Observed esaudio.Observation `json:"observed,omitzero"`
 }
 
 // AudioChannelDeclaration is the channel information a DVB descriptor declares

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"errors"
 	"sync"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
 )
 
 const (
@@ -204,6 +206,16 @@ type MasterRing struct {
 	// audioPIDs holds the elementary audio streams named by the active PMT.
 	audioPIDs   []uint16
 	audioTracks []AudioTrackInfo
+
+	// audioObservers follow the audio payload of the tracks whose codec this path
+	// can read, one per PID. They exist because the audio topology is not a
+	// property of the session start: a service moves between stereo and 5.1 on the
+	// same PID as programmes change, and a reading taken once at attach describes
+	// only whatever happened to be running then.
+	//
+	// Keyed by PID and rebuilt from scratch whenever the PMT changes, so an
+	// observation can never outlive the table that named the stream it came from.
+	audioObservers map[uint16]*esaudio.Observer
 }
 
 // NewMasterRing creates a new MasterRing with the specified capacity (aligned to 188 bytes).
@@ -349,21 +361,67 @@ func (r *MasterRing) indexPacketLocked(pkt []byte, offset int64) {
 		return
 	}
 
-	// 4. Audio elementary streams, observed for descrambling only. Their payload is
-	//    never parsed here - the client selects and decodes the track - but whether
-	//    it arrives clear decides whether a channel is presentable.
+	// 4. Audio elementary streams. Whether the payload arrives clear decides
+	//    whether a channel is presentable, and for the codecs that carry their
+	//    channel layout in the frame header the payload is also the only place a
+	//    channel count above two can be read at all.
 	for _, apid := range r.audioPIDs {
 		if pid == apid {
 			if (pkt[3]>>6)&0x03 != 0 {
 				r.scrambledAudioPackets++
 				r.audioClearRun = 0
-			} else {
-				r.clearAudioPackets++
-				r.audioClearRun++
+				return
 			}
+			r.clearAudioPackets++
+			r.audioClearRun++
+			r.observeAudioPayloadLocked(apid, pusi, payload)
 			return
 		}
 	}
+}
+
+// observableAudioCodec reports whether the frame headers of a codec are read for
+// their channel layout. Everything else is left to the declaration and to
+// whatever the media path already does; a codec this parser cannot read produces
+// no observation rather than a guessed one.
+func observableAudioCodec(codec string) bool {
+	return codec == esaudio.CodecAC3 || codec == esaudio.CodecEAC3
+}
+
+// observeAudioPayloadLocked hands one clear audio packet's elementary stream
+// bytes to the observer for that PID.
+//
+// This is where transport ends. The observer is given elementary stream payload
+// and nothing else - no PID, no packet, no PMT - so what it reads is a property
+// of the audio rather than of how the audio arrived.
+func (r *MasterRing) observeAudioPayloadLocked(pid uint16, pusi bool, payload []byte) {
+	obs := r.audioObservers[pid]
+	if obs == nil {
+		return
+	}
+
+	es := payload
+	if pusi {
+		// A PES packet starts here, so the elementary stream does not: skip the
+		// header. Audio arrives either as an audio stream id or, for AC-3 in DVB,
+		// as private_stream_1.
+		if len(payload) < 9 || payload[0] != 0x00 || payload[1] != 0x00 || payload[2] != 0x01 {
+			return
+		}
+		if sid := payload[3]; sid != 0xBD && sid != 0xFD && (sid < 0xC0 || sid > 0xDF) {
+			return
+		}
+		esStart := 9 + int(payload[8])
+		if esStart >= len(payload) {
+			// The optional header ran past this packet. Rare, and not worth state of
+			// its own: the remainder is fed as if it were elementary stream, where it
+			// has to survive a syncword check and a run of agreeing frames before it
+			// could reach the observation.
+			return
+		}
+		es = payload[esStart:]
+	}
+	obs.Feed(es)
 }
 
 func (r *MasterRing) feedBytesToAssemblerLocked(isPAT bool, assembler *psiStreamAssembler, chunk []byte, pkt []byte) int {
@@ -681,6 +739,12 @@ func (r *MasterRing) processCompletePSISectionLocked(isPAT bool, table []byte, r
 								Language:   lang,
 								Declared:   declared,
 							})
+							if observableAudioCodec(codec) {
+								if r.audioObservers == nil {
+									r.audioObservers = make(map[uint16]*esaudio.Observer, 2)
+								}
+								r.audioObservers[elemPID] = esaudio.NewObserver()
+							}
 						}
 					}
 
@@ -741,6 +805,10 @@ func (r *MasterRing) invalidateVideoStateLocked() {
 	r.audioClearRun = 0
 	r.audioPIDs = nil
 	r.audioTracks = nil
+	// Observations do not survive the table that named their stream. The same PID
+	// can carry a different elementary stream after a PMT change, and carrying the
+	// old layout across would describe audio that is no longer there.
+	r.audioObservers = nil
 	r.raObs = RandomAccessObservation{}
 	r.cleanRAPCount = 0
 	r.cleanAccessUnits = 0
@@ -1333,6 +1401,15 @@ func (r *MasterRing) ReadinessFacts() ReadinessFacts {
 
 	tracks := make([]AudioTrackInfo, len(r.audioTracks))
 	copy(tracks, r.audioTracks)
+	// The declaration is fixed by the PMT and only changes with it; the
+	// observation moves with the audio. Reading it here rather than storing it on
+	// the track is what makes a mid-programme change to 5.1 visible to the next
+	// snapshot instead of to the next PMT version.
+	for i := range tracks {
+		if obs := r.audioObservers[tracks[i].PID]; obs != nil {
+			tracks[i].Observed = obs.Current()
+		}
+	}
 
 	parameterSets := false
 	switch r.videoCodec {


### PR DESCRIPTION
B2b.4 — the observed half of the audio facts layer. **Facts only: nothing consumes it yet.**

## Why

The PMT declares a class, not a count. ETSI EN 300 468 Annex D gives AC-3 three multichannel component types and none names a number, so 5.1 and 7.1 declare the same value. Two consequences follow from the code as it stands on `main`:

- `ac3ChannelDeclaration` sets `Channels` to 1 or 2 only; above stereo it sets `Multichannel` and leaves `Channels` at 0.
- `policy.go:291` branches on `track.Channels == 6` for surround rendition, `-ac 6`, `CHANNELS="6"` and AC-3 passthrough.

So the 6 can only ever come from reading the audio. Today the only thing reading the audio is one ffprobe run at session start — which cannot name channels for a track it missed, and, more importantly, describes a single moment. A service moves between stereo and 5.1 between programmes on the same PID, with no PMT change to announce it.

## What

```
shared ingest → PMT → audio PIDs → per-PID frame observer → facts → (policy, unchanged)
```

`internal/stream/ingest/esaudio` — a new package that reads AC-3/E-AC-3 syncframe headers (`acmod`, `lfeon`) and reports the layout they describe. It receives elementary stream bytes and nothing else: no PID, no packet, no PMT. It has no dependency on `audiotopology` or `ports`, so the "no policy in the parser" boundary is structural rather than a convention.

The ring feeds it from the audio PID dispatch, where the payload was previously discarded, and exposes the result as `AudioTrackInfo.Observed` beside the existing `Declared`. `ports.LiveAudioTrack` carries `ObservedChannels` / `ObservedLFE` / `ObservedFrames` / `ObservedDependentSubstream` to the port boundary.

## What it refuses to invent

- **A layout changes only after consecutive frames agree.** A syncword is two bytes and compressed audio carries that pattern by chance. The scan also steps over a parsed frame rather than through it. A run broken by noise restarts; the previously proven layout stands, so the failure direction is "keeps saying what it last proved", never "invents something new".
- **An E-AC-3 dependent substream is flagged, never counted.** Its channels extend the independent substream and the total needs a channel map this parser does not read, so the fact records that the number may be incomplete instead of being quietly wrong.
- **Nothing seen stays nothing seen.** The zero observation is not stereo.

## Generation and PID safety

Observers are dropped on every PMT change and rebuilt from the new table. The case that needs this: a PMT that keeps the PID and changes the codec to one this path does not read — no new observer is built, and without the reset the previous stream's 5.1 would be attached to a track that is now MP2. That case has its own test, and it fails when the reset is removed (verified by mutation).

Scrambled payload is not parsed, for the reason the video path already does not parse it.

## Tests

`esaudio` — layouts (5.1 / 3.2 / stereo / mono) against byte 6 values written out from A/52 rather than produced by the parser's own offset arithmetic; frame sizes at 48/44.1/32 kHz; reserved-field and non-sync rejection; E-AC-3 dependent and foreign substreams; establish-only-after-agreement; 2.0→5.1→2.0 on one stream; holding the proven layout while a change is still arriving; interrupted runs; frames split across chunk sizes 1/3/7/64/127; truncated trailing frame; a valid header buried in frame payload; garbage between frames.

`ring` — AC-3 5.1 and stereo end to end from TS; layout change without a PMT change (and the generation must *not* move); PMT change; PMT change to an unread codec; audio PID change; MP2 produces no observation; scrambled audio produces no observation.

## Out of scope, deliberately

`BuildTopology`, the channel policy and the `channels <= 0 → 2` fallback are untouched, and the startup probe still does exactly what it did. Those are the next steps in that order, each as its own change. The B2b.3 metrics are unaffected and stay valid for the pending VU+ run.

## Gates

`go build ./...` · `go test ./...` · `make test-race-pr` · `make lint` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)