### PR TITLE
Make the observed stream its own evidence source in the audio merge

### DIFF
--- a/backend/internal/domain/audiotopology/audiotopology_test.go
+++ b/backend/internal/domain/audiotopology/audiotopology_test.go
@@ -21,7 +21,7 @@ func TestORF1HD_RealWorldDiscovery(t *testing.T) {
 		{TrackID: 1, PID: 1922, Description: "MPEG (Miscellaneous languages)", Active: false},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, e2, now)
+	topo := BuildTopology(sref, pmt, nil, nil, e2, now)
 
 	require.Len(t, topo.Tracks, 2)
 	require.Equal(t, sref, topo.ServiceRef)
@@ -62,7 +62,7 @@ func TestDasErsteHD_RealWorldDiscovery(t *testing.T) {
 		{TrackID: 3, PID: 5106, Description: "AC3 (Dolby Digital 2.0)", Active: false},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, e2, now)
+	topo := BuildTopology(sref, pmt, nil, nil, e2, now)
 
 	require.Len(t, topo.Tracks, 4)
 
@@ -104,7 +104,7 @@ func TestZDFHD_RealWorldDiscovery(t *testing.T) {
 		{TrackID: 3, PID: 6122, Description: "AC3 (Dolby Digital 5.1)", Active: false},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, e2, now)
+	topo := BuildTopology(sref, pmt, nil, nil, e2, now)
 
 	require.Len(t, topo.Tracks, 4)
 
@@ -138,7 +138,7 @@ func TestArteHD_ConflictPreservation(t *testing.T) {
 		{TrackID: 3, PID: 5117, Description: "MPEG (ohne Audiodeskription)", Active: false},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, e2, now)
+	topo := BuildTopology(sref, pmt, nil, nil, e2, now)
 	require.Len(t, topo.Tracks, 4)
 
 	var frenchTrack *AudioTrack
@@ -169,18 +169,18 @@ func TestPresenceStates_VerifiedVsProvisionalVsEmpty(t *testing.T) {
 
 	// 1. PMT only -> Verified Presence
 	pmt := []PMTTrackObservation{{PID: 100, Codec: "mp2", Language: "deu"}}
-	topoVerified := BuildTopology(sref, pmt, nil, nil, now)
+	topoVerified := BuildTopology(sref, pmt, nil, nil, nil, now)
 	assert.Equal(t, PresenceVerified, topoVerified.Presence)
 	require.Len(t, topoVerified.Tracks, 1)
 
 	// 2. Enigma2 only (unprobed stream) -> Provisional Presence
 	e2 := []Enigma2TrackObservation{{PID: 200, Description: "MPEG (stereo)"}}
-	topoProvisional := BuildTopology(sref, nil, nil, e2, now)
+	topoProvisional := BuildTopology(sref, nil, nil, nil, e2, now)
 	assert.Equal(t, PresenceProvisional, topoProvisional.Presence)
 	require.Len(t, topoProvisional.Tracks, 1)
 
 	// 3. No observations -> Empty Presence
-	topoEmpty := BuildTopology(sref, nil, nil, nil, now)
+	topoEmpty := BuildTopology(sref, nil, nil, nil, nil, now)
 	assert.Equal(t, PresenceEmpty, topoEmpty.Presence)
 	assert.Empty(t, topoEmpty.Tracks)
 }
@@ -195,7 +195,7 @@ func TestPrimaryLanguage_NotDependentOnPIDOrdering(t *testing.T) {
 		{PID: 800, Codec: "mp2", Language: "deu", IsDefault: true},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, nil, now)
+	topo := BuildTopology(sref, pmt, nil, nil, nil, now)
 	require.Len(t, topo.Tracks, 2)
 
 	// PID 200 (numerically smaller) MUST NOT be classified as Main Anchor
@@ -236,8 +236,8 @@ func TestDualRevisions_StructuralVsMetadata(t *testing.T) {
 		{PID: 100, Description: "Stereo", Active: false},
 	}
 
-	topo1 := BuildTopology(sref, pmt, nil, e2Active, now)
-	topo2 := BuildTopology(sref, pmt, nil, e2Inactive, now)
+	topo1 := BuildTopology(sref, pmt, nil, nil, e2Active, now)
+	topo2 := BuildTopology(sref, pmt, nil, nil, e2Inactive, now)
 
 	// Structural revision is IDENTICAL (same PID, codec, channels)
 	assert.Equal(t, topo1.StructuralRevision, topo2.StructuralRevision)

--- a/backend/internal/domain/audiotopology/channels.go
+++ b/backend/internal/domain/audiotopology/channels.go
@@ -1,0 +1,56 @@
+package audiotopology
+
+// Source precedence is a per-field question, not a ranking of sources.
+//
+// For the channel count the elementary stream wins, because it is the only place
+// the number exists: a DVB descriptor declares a class, and above stereo the
+// class does not name a number at all - a 5.1 service and a 7.1 service declare
+// the same value. A source that reads the audio frames can say six; one that
+// reads the tables cannot.
+//
+// That does not make the stream the better source for everything. Language,
+// purpose and accessibility are carried by the descriptors and not by an audio
+// frame header, so for those fields the declaration stays authoritative and the
+// observation has nothing to say. ESTrackObservation holds only the fields the
+// frames answer, which is what keeps that honest: there is no channel-count
+// precedence leaking into a language decision, because there is no language in
+// the observation to leak.
+//
+// Between the two sources that do read frames, the continuous one wins. Both
+// ffprobe and shared ingest read the same syntax; ffprobe reads it once, at
+// session start, and a service that moves from stereo to 5.1 for a film leaves
+// that reading describing a programme that has ended.
+var channelSourcePrecedence = []EvidenceSource{
+	EvidenceObserved, // read from the frames, continuously
+	EvidenceProbe,    // read from the frames, once, at session start
+	EvidencePMT,      // declared by a descriptor, and above stereo only as a class
+}
+
+// resolveChannels picks the channel count and names the source it came from.
+//
+// A source that names no count is skipped rather than treated as zero: silence
+// about the channel count is not a claim that there are none, and it must not
+// displace a source that did answer.
+func resolveChannels(
+	pmt *PMTTrackObservation,
+	probe *ProbeTrackObservation,
+	es *ESTrackObservation,
+) (int, EvidenceSource, bool) {
+	for _, source := range channelSourcePrecedence {
+		switch source {
+		case EvidenceObserved:
+			if es != nil && es.Channels > 0 {
+				return es.Channels, EvidenceObserved, true
+			}
+		case EvidenceProbe:
+			if probe != nil && probe.Channels > 0 {
+				return probe.Channels, EvidenceProbe, true
+			}
+		case EvidencePMT:
+			if pmt != nil && pmt.Channels > 0 {
+				return pmt.Channels, EvidencePMT, true
+			}
+		}
+	}
+	return 0, "", false
+}

--- a/backend/internal/domain/audiotopology/channels_test.go
+++ b/backend/internal/domain/audiotopology/channels_test.go
@@ -1,0 +1,212 @@
+package audiotopology
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const chSref = "1:0:19:83:6:85:C00000:0:0:0:"
+
+func evidenceFor(track AudioTrack, field string) map[EvidenceSource]string {
+	out := map[EvidenceSource]string{}
+	for _, o := range track.Evidence {
+		if o.Field == field {
+			out[o.Source] = o.Value
+		}
+	}
+	return out
+}
+
+func conflictsFor(track AudioTrack, field string) []Conflict {
+	var out []Conflict
+	for _, c := range track.Conflicts {
+		if c.Field == field {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// The precedence is stated once, in one place, and the table is the contract.
+func TestResolveChannels_Precedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		pmt        *PMTTrackObservation
+		probe      *ProbeTrackObservation
+		es         *ESTrackObservation
+		want       int
+		wantSource EvidenceSource
+		wantOK     bool
+	}{
+		{
+			name:       "the stream is read over both others",
+			pmt:        &PMTTrackObservation{Channels: 2},
+			probe:      &ProbeTrackObservation{Channels: 2},
+			es:         &ESTrackObservation{Channels: 6},
+			want:       6,
+			wantSource: EvidenceObserved,
+			wantOK:     true,
+		},
+		{
+			name:       "the probe is read over the declaration",
+			pmt:        &PMTTrackObservation{Channels: 2},
+			probe:      &ProbeTrackObservation{Channels: 6},
+			want:       6,
+			wantSource: EvidenceProbe,
+			wantOK:     true,
+		},
+		{
+			name:       "the declaration answers when nothing read the frames",
+			pmt:        &PMTTrackObservation{Channels: 2},
+			want:       2,
+			wantSource: EvidencePMT,
+			wantOK:     true,
+		},
+		{
+			name:       "a source that named nothing does not displace one that did",
+			pmt:        &PMTTrackObservation{Channels: 2},
+			probe:      &ProbeTrackObservation{Channels: 0},
+			es:         &ESTrackObservation{Channels: 0},
+			want:       2,
+			wantSource: EvidencePMT,
+			wantOK:     true,
+		},
+		{
+			name:   "nobody named a count",
+			pmt:    &PMTTrackObservation{},
+			probe:  &ProbeTrackObservation{},
+			es:     &ESTrackObservation{},
+			wantOK: false,
+		},
+		{
+			name:   "no sources at all",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, source, ok := resolveChannels(tc.pmt, tc.probe, tc.es)
+			assert.Equal(t, tc.wantOK, ok)
+			if !tc.wantOK {
+				return
+			}
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.wantSource, source)
+		})
+	}
+}
+
+// The case the observer was built for. The probe read stereo at session start and
+// the film has since started; the continuous reading is the current one, and the
+// disagreement stays on the record instead of being silently dropped.
+func TestBuildTopology_ObservedChannelsWinAndTheDisagreementStays(t *testing.T) {
+	topo := BuildTopology(chSref,
+		[]PMTTrackObservation{{PID: 101, Codec: "ac3", Language: "deu"}},
+		[]ProbeTrackObservation{{PID: 101, Codec: "ac3", Channels: 2}},
+		[]ESTrackObservation{{PID: 101, Channels: 6, LFE: true, Frames: 300}},
+		nil, time.Now())
+
+	require.Len(t, topo.Tracks, 1)
+	track := topo.Tracks[0]
+
+	assert.Equal(t, 6, track.Channels)
+
+	// Both statements are on the record, whichever one was used.
+	ev := evidenceFor(track, "channels")
+	assert.Equal(t, "2", ev[EvidenceProbe])
+	assert.Equal(t, "6", ev[EvidenceObserved])
+
+	conflicts := conflictsFor(track, "channels")
+	require.Len(t, conflicts, 1)
+	assert.Equal(t, EvidenceProbe, conflicts[0].SourceA)
+	assert.Equal(t, "2", conflicts[0].ValueA)
+	assert.Equal(t, EvidenceObserved, conflicts[0].SourceB)
+	assert.Equal(t, "6", conflicts[0].ValueB)
+	assert.Equal(t, "preferred_continuous_stream_observation", conflicts[0].Resolution)
+}
+
+// A multichannel declaration names no count, so it cannot contradict one. The
+// descriptor saying "more than two" beside an observed 6 is two sources agreeing,
+// and recording a conflict there would bury the real ones.
+func TestBuildTopology_MultichannelDeclarationIsNotAConflict(t *testing.T) {
+	topo := BuildTopology(chSref,
+		[]PMTTrackObservation{{PID: 101, Codec: "ac3", Language: "deu", Channels: 0}},
+		nil,
+		[]ESTrackObservation{{PID: 101, Channels: 6, LFE: true}},
+		nil, time.Now())
+
+	require.Len(t, topo.Tracks, 1)
+	track := topo.Tracks[0]
+
+	assert.Equal(t, 6, track.Channels)
+	assert.Empty(t, conflictsFor(track, "channels"))
+	assert.Equal(t, "6", evidenceFor(track, "channels")[EvidenceObserved])
+}
+
+// Precedence is per field, not a ranking of sources. The observation supplies the
+// channel count and says nothing about language, so the descriptor keeps it - and
+// there is no way for one to leak into the other, because an audio frame header
+// carries no language for ESTrackObservation to hold.
+func TestBuildTopology_ObservedChannelsDoNotDisplaceTheDeclaredLanguage(t *testing.T) {
+	topo := BuildTopology(chSref,
+		[]PMTTrackObservation{{PID: 101, Codec: "ac3", Language: "deu", VisualImpaired: true}},
+		[]ProbeTrackObservation{{PID: 101, Codec: "ac3", Channels: 2, Language: "eng"}},
+		[]ESTrackObservation{{PID: 101, Channels: 6, LFE: true}},
+		nil, time.Now())
+
+	require.Len(t, topo.Tracks, 1)
+	track := topo.Tracks[0]
+
+	assert.Equal(t, 6, track.Channels, "the stream answered the channel question")
+	assert.Equal(t, "deu", track.Language.ISO639_2, "the descriptor still answers the language question")
+	assert.True(t, track.Accessibility.AudioDescription, "and the accessibility one")
+}
+
+// Live TV is 0..N tracks. An observation belongs to one PID and must not reach
+// another, whatever the neighbouring track established.
+func TestBuildTopology_ObservationsStayWithTheirTrack(t *testing.T) {
+	topo := BuildTopology(chSref,
+		[]PMTTrackObservation{
+			{PID: 101, Codec: "ac3", Language: "deu"},
+			{PID: 102, Codec: "ac3", Language: "eng"},
+			{PID: 103, Codec: "mp2", Language: "deu"},
+		},
+		nil,
+		[]ESTrackObservation{
+			{PID: 101, Channels: 6, LFE: true},
+			{PID: 102, Channels: 2},
+		},
+		nil, time.Now())
+
+	require.Len(t, topo.Tracks, 3)
+	byPID := map[uint16]AudioTrack{}
+	for _, tr := range topo.Tracks {
+		byPID[tr.PID] = tr
+	}
+
+	assert.Equal(t, 6, byPID[101].Channels)
+	assert.Equal(t, 2, byPID[102].Channels)
+
+	// PID 103 has no observation and no declared count. It must not inherit its
+	// neighbours' 6, and the evidence must not claim the stream answered for it.
+	assert.Empty(t, evidenceFor(byPID[103], "channels"))
+	assert.NotEqual(t, 6, byPID[103].Channels)
+}
+
+// An observed layout change moves the topology's own revision, which is what a
+// downstream consumer watches. It is derived from the resolved facts, so it needs
+// no counter of its own and never borrows the PMT generation.
+func TestBuildTopology_ObservedChangeMovesTheStructuralRevision(t *testing.T) {
+	pmt := []PMTTrackObservation{{PID: 101, Codec: "ac3", Language: "deu"}}
+	now := time.Now()
+
+	stereo := BuildTopology(chSref, pmt, nil, []ESTrackObservation{{PID: 101, Channels: 2}}, nil, now)
+	surround := BuildTopology(chSref, pmt, nil, []ESTrackObservation{{PID: 101, Channels: 6, LFE: true}}, nil, now)
+
+	assert.NotEqual(t, stereo.StructuralRevision, surround.StructuralRevision,
+		"the same PMT with a different observed layout is a different topology")
+}

--- a/backend/internal/domain/audiotopology/conflict.go
+++ b/backend/internal/domain/audiotopology/conflict.go
@@ -9,6 +9,7 @@ import (
 func DetectConflicts(
 	pmt *PMTTrackObservation,
 	probe *ProbeTrackObservation,
+	es *ESTrackObservation,
 	e2 *Enigma2TrackObservation,
 ) []Conflict {
 	var conflicts []Conflict
@@ -58,19 +59,35 @@ func DetectConflicts(
 		}
 	}
 
+	// 3. Channel count divergence, recorded between every pair of sources that
+	//    each named a count. A source that named none cannot contradict anything -
+	//    a multichannel declaration leaves the count at 0, so a descriptor saying
+	//    "more than two" beside an observed 6 is agreement, not conflict.
 	if pmt != nil && probe != nil {
-		// 3. Channel count divergence
-		if pmt.Channels > 0 && probe.Channels > 0 && pmt.Channels != probe.Channels {
-			conflicts = append(conflicts, Conflict{
-				Field:      "channels",
-				SourceA:    EvidencePMT,
-				ValueA:     fmt.Sprintf("%d", pmt.Channels),
-				SourceB:    EvidenceProbe,
-				ValueB:     fmt.Sprintf("%d", probe.Channels),
-				Resolution: "preferred_active_probe_measurement",
-			})
+		conflicts = appendChannelConflict(conflicts,
+			EvidencePMT, pmt.Channels,
+			EvidenceProbe, probe.Channels,
+			"preferred_active_probe_measurement")
+	}
+	if es != nil {
+		if pmt != nil {
+			conflicts = appendChannelConflict(conflicts,
+				EvidencePMT, pmt.Channels,
+				EvidenceObserved, es.Channels,
+				"preferred_continuous_stream_observation")
 		}
+		if probe != nil {
+			// The two read the same syntax, so a disagreement here is not a
+			// measurement error - it usually means the programme changed after the
+			// probe ran, which is the case the observation exists to follow.
+			conflicts = appendChannelConflict(conflicts,
+				EvidenceProbe, probe.Channels,
+				EvidenceObserved, es.Channels,
+				"preferred_continuous_stream_observation")
+		}
+	}
 
+	if pmt != nil && probe != nil {
 		// 4. Codec divergence
 		pmtCodec := NormalizeCodec(pmt.Codec)
 		probeCodec := NormalizeCodec(probe.Codec)
@@ -87,6 +104,27 @@ func DetectConflicts(
 	}
 
 	return conflicts
+}
+
+// appendChannelConflict records a contradiction only where both sources named a
+// count. Everything else is silence, and silence contradicts nothing.
+func appendChannelConflict(
+	conflicts []Conflict,
+	sourceA EvidenceSource, valueA int,
+	sourceB EvidenceSource, valueB int,
+	resolution string,
+) []Conflict {
+	if valueA <= 0 || valueB <= 0 || valueA == valueB {
+		return conflicts
+	}
+	return append(conflicts, Conflict{
+		Field:      "channels",
+		SourceA:    sourceA,
+		ValueA:     fmt.Sprintf("%d", valueA),
+		SourceB:    sourceB,
+		ValueB:     fmt.Sprintf("%d", valueB),
+		Resolution: resolution,
+	})
 }
 
 func streamNormIsGeneric(code string) bool {

--- a/backend/internal/domain/audiotopology/diff_test.go
+++ b/backend/internal/domain/audiotopology/diff_test.go
@@ -14,8 +14,8 @@ func TestDiffTopologies_NoChange(t *testing.T) {
 		{PID: 6120, Codec: "mp2", Channels: 2, Language: "deu"},
 		{PID: 6122, Codec: "ac3", Channels: 6, Language: "deu"},
 	}
-	topo1 := BuildTopology("sref1", pmt, nil, nil, now)
-	topo2 := BuildTopology("sref1", pmt, nil, nil, now)
+	topo1 := BuildTopology("sref1", pmt, nil, nil, nil, now)
+	topo2 := BuildTopology("sref1", pmt, nil, nil, nil, now)
 
 	diff := DiffTopologies(topo1, topo2)
 	assert.False(t, diff.HasChange)
@@ -29,13 +29,13 @@ func TestDiffTopologies_ChannelLayoutChange_2_0_to_5_1(t *testing.T) {
 	pmtBefore := []PMTTrackObservation{
 		{PID: 6122, Codec: "ac3", Channels: 2, Language: "deu"},
 	}
-	topoBefore := BuildTopology("sref1", pmtBefore, nil, nil, now)
+	topoBefore := BuildTopology("sref1", pmtBefore, nil, nil, nil, now)
 
 	// Movie start: Deutsch AC-3 5.1
 	pmtAfter := []PMTTrackObservation{
 		{PID: 6122, Codec: "ac3", Channels: 6, Language: "deu"},
 	}
-	topoAfter := BuildTopology("sref1", pmtAfter, nil, nil, now.Add(time.Minute))
+	topoAfter := BuildTopology("sref1", pmtAfter, nil, nil, nil, now.Add(time.Minute))
 
 	diff := DiffTopologies(topoBefore, topoAfter)
 	require.True(t, diff.HasChange)
@@ -53,7 +53,7 @@ func TestDiffTopologies_TrackAppearedAndDisappeared(t *testing.T) {
 	pmt1 := []PMTTrackObservation{
 		{PID: 5101, Codec: "mp2", Channels: 2, Language: "deu"},
 	}
-	topo1 := BuildTopology("sref1", pmt1, nil, nil, now)
+	topo1 := BuildTopology("sref1", pmt1, nil, nil, nil, now)
 
 	// Game starts: Stadium sound (PID 5102) added
 	pmt2 := []PMTTrackObservation{
@@ -64,7 +64,7 @@ func TestDiffTopologies_TrackAppearedAndDisappeared(t *testing.T) {
 		{PID: 5101, Description: "Kommentar"},
 		{PID: 5102, Description: "Stadionton"},
 	}
-	topo2 := BuildTopology("sref1", pmt2, nil, e22, now.Add(time.Minute))
+	topo2 := BuildTopology("sref1", pmt2, nil, nil, e22, now.Add(time.Minute))
 
 	diff := DiffTopologies(topo1, topo2)
 	require.True(t, diff.HasChange)
@@ -85,13 +85,13 @@ func TestDiffTopologies_MetadataOnlyChange(t *testing.T) {
 	pmt := []PMTTrackObservation{
 		{PID: 6120, Codec: "mp2", Channels: 2, Language: "deu"},
 	}
-	topo1 := BuildTopology("sref1", pmt, nil, nil, now)
+	topo1 := BuildTopology("sref1", pmt, nil, nil, nil, now)
 
 	// Receiver provides description without any elementary stream changes
 	e2 := []Enigma2TrackObservation{
 		{PID: 6120, Description: "Stereo (Standard)"},
 	}
-	topo2 := BuildTopology("sref1", pmt, nil, e2, now.Add(time.Second))
+	topo2 := BuildTopology("sref1", pmt, nil, nil, e2, now.Add(time.Second))
 
 	diff := DiffTopologies(topo1, topo2)
 	require.True(t, diff.HasChange)

--- a/backend/internal/domain/audiotopology/merge.go
+++ b/backend/internal/domain/audiotopology/merge.go
@@ -12,6 +12,7 @@ func BuildTopology(
 	serviceRef string,
 	pmtTracks []PMTTrackObservation,
 	probeTracks []ProbeTrackObservation,
+	esTracks []ESTrackObservation,
 	e2Tracks []Enigma2TrackObservation,
 	now time.Time,
 ) AudioTopology {
@@ -23,6 +24,11 @@ func BuildTopology(
 	probeMap := make(map[uint16]ProbeTrackObservation, len(probeTracks))
 	for _, pr := range probeTracks {
 		probeMap[pr.PID] = pr
+	}
+
+	esMap := make(map[uint16]ESTrackObservation, len(esTracks))
+	for _, es := range esTracks {
+		esMap[es.PID] = es
 	}
 
 	e2Map := make(map[uint16]Enigma2TrackObservation, len(e2Tracks))
@@ -83,12 +89,17 @@ func BuildTopology(
 			probePtr = &pr
 		}
 
+		var esPtr *ESTrackObservation
+		if e, ok := esMap[pid]; ok {
+			esPtr = &e
+		}
+
 		var e2Ptr *Enigma2TrackObservation
 		if e, ok := e2Map[pid]; ok {
 			e2Ptr = &e
 		}
 
-		track := buildTrack(pid, primaryLangCode, pmtPtr, probePtr, e2Ptr)
+		track := buildTrack(pid, primaryLangCode, pmtPtr, probePtr, esPtr, e2Ptr)
 		tracks = append(tracks, track)
 	}
 
@@ -135,6 +146,7 @@ func buildTrack(
 	primaryLangCode string,
 	pmt *PMTTrackObservation,
 	probe *ProbeTrackObservation,
+	es *ESTrackObservation,
 	e2 *Enigma2TrackObservation,
 ) AudioTrack {
 	var evidence []Observation
@@ -171,15 +183,31 @@ func buildTrack(
 	lang := NormalizeLanguage(rawLang)
 
 	// 3. Resolve Channels & Bitrates
+	//
+	// channels still starts at 2 where no source names one. That default is wrong
+	// - a stream that has not said how many channels it carries does not have two
+	// - and removing it is its own change, because every consumer downstream has
+	// to be able to carry "unknown" first.
 	channels := 2
 	sampleRate := 48000
 	bitrateKbps := 0
 
+	// Every source that named a count is recorded, whichever one is used. The
+	// evidence list is the audit trail of what was said, not of what won.
+	if pmt != nil && pmt.Channels > 0 {
+		evidence = append(evidence, Observation{Source: EvidencePMT, Field: "channels", Value: fmt.Sprintf("%d", pmt.Channels)})
+	}
+	if probe != nil && probe.Channels > 0 {
+		evidence = append(evidence, Observation{Source: EvidenceProbe, Field: "channels", Value: fmt.Sprintf("%d", probe.Channels)})
+	}
+	if es != nil && es.Channels > 0 {
+		evidence = append(evidence, Observation{Source: EvidenceObserved, Field: "channels", Value: fmt.Sprintf("%d", es.Channels)})
+	}
+	if resolved, _, ok := resolveChannels(pmt, probe, es); ok {
+		channels = resolved
+	}
+
 	if pmt != nil {
-		if pmt.Channels > 0 {
-			channels = pmt.Channels
-			evidence = append(evidence, Observation{Source: EvidencePMT, Field: "channels", Value: fmt.Sprintf("%d", pmt.Channels)})
-		}
 		if pmt.SampleRate > 0 {
 			sampleRate = pmt.SampleRate
 		}
@@ -187,15 +215,8 @@ func buildTrack(
 			bitrateKbps = pmt.BitrateKbps
 		}
 	}
-
-	if probe != nil {
-		if probe.Channels > 0 {
-			channels = probe.Channels
-			evidence = append(evidence, Observation{Source: EvidenceProbe, Field: "channels", Value: fmt.Sprintf("%d", probe.Channels)})
-		}
-		if probe.BitrateKbps > 0 {
-			bitrateKbps = probe.BitrateKbps
-		}
+	if probe != nil && probe.BitrateKbps > 0 {
+		bitrateKbps = probe.BitrateKbps
 	}
 
 	// 4. Resolve Accessibility & Purpose
@@ -252,7 +273,7 @@ func buildTrack(
 	isPrimary := broadcastDefault || receiverSelected || (lang.ISO639_2 == primaryLangCode)
 	purpose, confidence := ClassifyPurpose(lang, e2Desc, cleanEffects, isPrimary)
 	label := BuildTrackLabel(lang, codec, channels, purpose, acc, e2Desc)
-	conflicts := DetectConflicts(pmt, probe, e2)
+	conflicts := DetectConflicts(pmt, probe, es, e2)
 
 	return AudioTrack{
 		ID:               fmt.Sprintf("audio-%d", pid),

--- a/backend/internal/domain/audiotopology/policy_test.go
+++ b/backend/internal/domain/audiotopology/policy_test.go
@@ -17,7 +17,7 @@ func TestAudioOutputPolicy_51PassthroughForAppleClients(t *testing.T) {
 		{PID: 6122, Codec: "ac3", Channels: 6, Language: "deu", BitrateKbps: 448},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, nil, now)
+	topo := BuildTopology(sref, pmt, nil, nil, nil, now)
 	require.Len(t, topo.Tracks, 2)
 	assert.Equal(t, PresenceVerified, topo.Presence)
 
@@ -61,7 +61,7 @@ func TestAudioOutputPolicy_ExactlyOneDefaultAcrossMultipleSurroundTracks(t *test
 		{PID: 103, Codec: "mp2", Channels: 2, Language: "deu", BitrateKbps: 192, VisualImpaired: true},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, nil, now)
+	topo := BuildTopology(sref, pmt, nil, nil, nil, now)
 	require.Len(t, topo.Tracks, 3)
 
 	appleCaps := ClientAudioCapabilities{SupportsAC3: true, SupportsAAC: true}
@@ -86,7 +86,7 @@ func TestAudioOutputPolicy_PresenceGate(t *testing.T) {
 	appleCaps := ClientAudioCapabilities{SupportsAC3: true, SupportsAAC: true}
 
 	e2 := []Enigma2TrackObservation{{PID: 200, Description: "Stereo"}}
-	topoProvisional := BuildTopology(sref, nil, nil, e2, now)
+	topoProvisional := BuildTopology(sref, nil, nil, nil, e2, now)
 	assert.Equal(t, PresenceProvisional, topoProvisional.Presence)
 
 	planProvisional := PlanAudioOutput(topoProvisional, appleCaps)
@@ -115,7 +115,7 @@ func TestPlanMultiAudioOutput_ZDFHD(t *testing.T) {
 		{TrackID: 3, PID: 6122, Description: "AC3 (Dolby Digital 5.1)"},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, e2, now)
+	topo := BuildTopology(sref, pmt, nil, nil, e2, now)
 	require.Len(t, topo.Tracks, 4)
 
 	appleCaps := ClientAudioCapabilities{
@@ -176,7 +176,7 @@ func TestPlanMultiAudioOutput_DasErsteHD(t *testing.T) {
 		{TrackID: 3, PID: 5106, Description: "AC3 (Dolby Digital 2.0)"},
 	}
 
-	topo := BuildTopology(sref, pmt, nil, e2, now)
+	topo := BuildTopology(sref, pmt, nil, nil, e2, now)
 	appleCaps := ClientAudioCapabilities{SupportsAC3: true, SupportsAAC: true, PrefersPassthrough: true}
 
 	multiPlan := PlanMultiAudioOutput(topo, appleCaps)

--- a/backend/internal/domain/audiotopology/types.go
+++ b/backend/internal/domain/audiotopology/types.go
@@ -11,6 +11,11 @@ const (
 	EvidencePMT     EvidenceSource = "pmt"
 	EvidenceEnigma2 EvidenceSource = "enigma2"
 	EvidenceProbe   EvidenceSource = "probe"
+	// EvidenceObserved is the elementary stream read continuously by shared
+	// ingest. Its own source rather than a better PMT, because a declaration and
+	// a measurement of the same track can differ and which one answered has to
+	// stay legible afterwards.
+	EvidenceObserved EvidenceSource = "observed"
 )
 
 // PresenceState indicates the degree of physical verification for the topology.
@@ -133,6 +138,31 @@ type PMTTrackObservation struct {
 	HearingImpaired bool   `json:"hearingImpaired"`
 	CleanEffects    bool   `json:"cleanEffects"`
 	IsDefault       bool   `json:"isDefault"`
+}
+
+// ESTrackObservation is what an audio elementary stream was seen to carry, read
+// from its own frame headers by shared ingest.
+//
+// It holds only the fields the frames actually answer. Language, purpose and
+// accessibility are not here because an audio frame header does not carry them -
+// which is what keeps source precedence a per-field question rather than a
+// ranking of sources.
+type ESTrackObservation struct {
+	PID uint16 `json:"pid"`
+
+	// Channels is the count the stream established, or 0 while it has not. Zero
+	// means "not yet seen", never stereo.
+	Channels int `json:"channels"`
+
+	LFE bool `json:"lfe,omitempty"`
+
+	// Frames is how many frames the observation rests on.
+	Frames uint64 `json:"frames,omitempty"`
+
+	// DependentSubstream reports that E-AC-3 dependent substreams were present, so
+	// Channels describes the independent substream and the programme may carry
+	// more.
+	DependentSubstream bool `json:"dependentSubstream,omitempty"`
 }
 
 // Enigma2TrackObservation represents metadata from OpenWebIF /web/getaudiotracks.

--- a/backend/internal/infra/media/ffmpeg/live_audio_map.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_map.go
@@ -187,7 +187,14 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 	metrics.IncAudioProbe(metrics.AudioProbeAvailable)
 	recordAudioEvidence(pmtAudio, streamByPID)
 
-	topo := audiotopology.BuildTopology(spec.Source.ID, pmtTrackObservations(pmtAudio), probeObs, nil, time.Now())
+	topo := audiotopology.BuildTopology(
+		spec.Source.ID,
+		pmtTrackObservations(pmtAudio),
+		probeObs,
+		esTrackObservations(pmtAudio),
+		nil,
+		time.Now(),
+	)
 	multiPlan := audiotopology.PlanMultiAudioOutput(topo, clientCaps)
 
 	a.Logger.Info().

--- a/backend/internal/infra/media/ffmpeg/pmt_audio.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio.go
@@ -18,9 +18,9 @@ import (
 // the transport stream's own tables. Shared ingest does, so this fills an argument
 // that has always existed rather than adding a path.
 //
-// The merge resolves the two sources itself - a probe observation still overrides
-// a PMT declaration for the same PID, and a disagreement is recorded as a conflict
-// - so this deliberately makes no decision beyond translating.
+// The merge resolves the sources itself, by a precedence named per field rather
+// than by whichever wrote last, and records a disagreement as a conflict - so this
+// deliberately makes no decision beyond translating.
 func pmtTrackObservations(tracks []ports.LiveAudioTrack) []audiotopology.PMTTrackObservation {
 	if len(tracks) == 0 {
 		return nil
@@ -39,6 +39,29 @@ func pmtTrackObservations(tracks []ports.LiveAudioTrack) []audiotopology.PMTTrac
 			// gave. What the declaration does carry either way is the codec and
 			// the language, and those are exact.
 			Channels: t.Channels,
+		})
+	}
+	return out
+}
+
+// esTrackObservations carries what shared ingest has observed on each audio
+// elementary stream into the domain, as its own evidence rather than folded into
+// the PMT declaration beside it.
+//
+// A track the stream has not established a layout for is left out entirely. An
+// entry with a zero count would be a source claiming to have answered.
+func esTrackObservations(tracks []ports.LiveAudioTrack) []audiotopology.ESTrackObservation {
+	var out []audiotopology.ESTrackObservation
+	for _, t := range tracks {
+		if t.ObservedChannels <= 0 {
+			continue
+		}
+		out = append(out, audiotopology.ESTrackObservation{
+			PID:                t.PID,
+			Channels:           t.ObservedChannels,
+			LFE:                t.ObservedLFE,
+			Frames:             t.ObservedFrames,
+			DependentSubstream: t.ObservedDependentSubstream,
 		})
 	}
 	return out

--- a/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
+++ b/backend/internal/infra/media/ffmpeg/pmt_audio_test.go
@@ -65,7 +65,7 @@ func TestBuildTopology_UsesThePMTDeclaration(t *testing.T) {
 		{PID: 257, StreamType: 0x81, Codec: "ac3", Language: "deu", Channels: 2},
 	})
 
-	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, nil, nil, time.Now())
+	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, nil, nil, nil, time.Now())
 
 	if len(topo.Tracks) != 1 {
 		t.Fatalf("topology has %d tracks, want 1 from the PMT alone", len(topo.Tracks))
@@ -90,7 +90,7 @@ func TestBuildTopology_ProbeOverridesTheDeclaration(t *testing.T) {
 		{PID: 257, StreamIndex: 0, Codec: "ac3", Channels: 6, Language: "deu"},
 	}
 
-	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, probe, nil, time.Now())
+	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, probe, nil, nil, time.Now())
 
 	if len(topo.Tracks) != 1 {
 		t.Fatalf("topology has %d tracks, want the two observations merged into 1", len(topo.Tracks))
@@ -111,7 +111,7 @@ func TestBuildTopology_KeepsADeclarationTheProbeMissed(t *testing.T) {
 		{PID: 257, StreamIndex: 0, Codec: "ac3", Channels: 2, Language: "deu"},
 	}
 
-	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, probe, nil, time.Now())
+	topo := audiotopology.BuildTopology("1:0:19:83:6:85:C00000:0:0:0:", pmt, probe, nil, nil, time.Now())
 
 	if len(topo.Tracks) != 2 {
 		t.Fatalf("topology has %d tracks, want both PIDs", len(topo.Tracks))


### PR DESCRIPTION
Follows [#883](https://github.com/ManuGH/xg2g/pull/883). Connects the last stretch — `Ring → LiveSourceFacts → BuildTopology` — as a **third evidence source**, not as a better second one.

## Not an overwrite

```
Declared ─┐
          ├→ merge (named rule per field) → resolved fact + conflict record
Observed ─┘
Probe   ──┘
```

Both statements stay on the record. `Evidence` lists every source that named a count, whichever one was used — it is the audit trail of what was *said*, not of what won. A real disagreement becomes a `Conflict` with both values and a named `Resolution`.

## Precedence is per field, not a source ranking

For **channels**, the stream wins. It is the only place the number exists: a descriptor declares a class, and above stereo the class names no number at all, so 5.1 and 7.1 declare the same value.

For **language, purpose, accessibility**, the descriptor stays authoritative, because an audio frame header does not carry them.

`ESTrackObservation` holds only the fields the frames answer. That is what keeps the split honest — there is no language in the observation for a channel-count precedence to leak into. The rule cannot be misapplied because the data to misapply it with does not exist.

Between the two sources that *do* read frames, the continuous one wins:

| source | reads | when |
|---|---|---|
| `observed` | audio frame headers | continuously |
| `probe` | audio frame headers | once, at session start |
| `pmt` | a descriptor | a class, not a count, above stereo |

A probe/observed disagreement is not a measurement error — it usually means the programme changed after the probe ran, which is the case the observer exists to follow. Recorded as `preferred_continuous_stream_observation`.

## Silence is not a claim

A source that named no count is skipped rather than read as zero. So a multichannel declaration — which leaves the count at 0 — beside an observed 6 is two sources **agreeing**, not a conflict. Recording one there would bury the real ones.

## Tests

- `resolveChannels` precedence table, including "a source that named nothing does not displace one that did" and both empty cases.
- Observed 6 over probe 2: resolved to 6, both values in `Evidence`, one `Conflict` with the named resolution.
- Multichannel declaration + observed 6: no conflict.
- Observed supplies channels while the descriptor keeps language *and* accessibility — the field-scoped rule, proven rather than asserted.
- Three tracks, two observations: each stays with its PID, and the third inherits nothing.
- An observed layout change moves `StructuralRevision` — derived from the resolved facts, no counter of its own, and it never borrows the PMT generation.

Precedence order verified by mutation: swapping `observed`/`probe` in the list fails the tests.

## Deliberately unchanged

- **ffprobe stays.** Nothing removed. The B2b.3 counters still classify declaration against probe — still the question they were built to answer.
- **`channels := 2` in `merge.go` stays.** It is wrong for the same reason as everything else here, but it is the *source* of "unknown becomes stereo", not a symptom, and removing it needs every downstream consumer to carry `unknown` first. Next change — and it starts there, not at the two `channels <= 0` fallbacks below it.

## Gates

`go build ./...` · `go test ./...` · `make test-race-pr` · `make lint` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)