### PR TITLE
Stop the facts layer inventing stereo for an unstated channel count

### DIFF
--- a/backend/internal/domain/audiotopology/channels_test.go
+++ b/backend/internal/domain/audiotopology/channels_test.go
@@ -210,3 +210,46 @@ func TestBuildTopology_ObservedChangeMovesTheStructuralRevision(t *testing.T) {
 	assert.NotEqual(t, stereo.StructuralRevision, surround.StructuralRevision,
 		"the same PMT with a different observed layout is a different topology")
 }
+
+// A track no source named a count for enters the topology as unknown. It used to
+// enter as stereo, which is a statement the stream never made and which nothing
+// downstream could afterwards tell apart from one it had.
+func TestBuildTopology_UnstatedChannelsStayUnknown(t *testing.T) {
+	topo := BuildTopology(chSref,
+		[]PMTTrackObservation{{PID: 101, Codec: "ac3", Language: "deu"}},
+		nil, nil, nil, time.Now())
+
+	require.Len(t, topo.Tracks, 1)
+	assert.Equal(t, 0, topo.Tracks[0].Channels, "unknown is a state, not two channels")
+	assert.Empty(t, evidenceFor(topo.Tracks[0], "channels"), "no source answered, so nothing may be recorded as having answered")
+}
+
+// The policy still has to write a number, and stereo is the safe one. What must
+// not happen is the number looking like knowledge.
+func TestPlanSingleTrack_UnknownChannelsAreDecidedNotKnown(t *testing.T) {
+	caps := ClientAudioCapabilities{SupportsAAC: true}
+
+	tests := []struct {
+		name         string
+		channels     int
+		wantChannels int
+		wantAssumed  bool
+	}{
+		{"the stream never said", 0, 2, true},
+		{"the stream said stereo", 2, 2, false},
+		{"the stream said mono", 1, 2, false},
+		{"the stream said 5.1", 6, 6, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := planSingleTrack(
+				AudioTrack{PID: 101, Codec: CodecAC3, Channels: tc.channels},
+				ClientAudioCapabilities{SupportsAAC: caps.SupportsAAC, SupportsSpatial51: true},
+			)
+
+			assert.Equal(t, tc.wantChannels, plan.Channels)
+			assert.Equal(t, tc.wantAssumed, plan.ChannelsAssumed)
+		})
+	}
+}

--- a/backend/internal/domain/audiotopology/merge.go
+++ b/backend/internal/domain/audiotopology/merge.go
@@ -184,11 +184,12 @@ func buildTrack(
 
 	// 3. Resolve Channels & Bitrates
 	//
-	// channels still starts at 2 where no source names one. That default is wrong
-	// - a stream that has not said how many channels it carries does not have two
-	// - and removing it is its own change, because every consumer downstream has
-	// to be able to carry "unknown" first.
-	channels := 2
+	// Unknown stays unknown. Where no source named a count this used to start at
+	// 2, which meant a track nobody had measured entered the topology as stereo -
+	// a fact the stream never stated, indistinguishable afterwards from one it
+	// had. Deciding what to do about an unstated layout is the policy layer's
+	// job; stating it is nobody's.
+	channels := 0
 	sampleRate := 48000
 	bitrateKbps := 0
 

--- a/backend/internal/domain/audiotopology/policy.go
+++ b/backend/internal/domain/audiotopology/policy.go
@@ -34,12 +34,16 @@ type ClientAudioCapabilities struct {
 
 // TrackPlan specifies the planned encoding, FFmpeg args, and HLS rendition parameters.
 type TrackPlan struct {
-	PID             uint16             `json:"pid"`
-	InputCodec      AudioCodec         `json:"inputCodec"`
-	Strategy        CodecStrategy      `json:"strategy"`
-	EncoderCodec    string             `json:"encoderCodec"` // FFmpeg codec: "copy", "aac", "ac3", "eac3"
-	HLSCodec        string             `json:"hlsCodec"`     // HLS RFC 6381 CODECS: "mp4a.40.2", "ac-3", "ec-3"
-	Channels        int                `json:"channels"`     // 2 or 6
+	PID          uint16        `json:"pid"`
+	InputCodec   AudioCodec    `json:"inputCodec"`
+	Strategy     CodecStrategy `json:"strategy"`
+	EncoderCodec string        `json:"encoderCodec"` // FFmpeg codec: "copy", "aac", "ac3", "eac3"
+	HLSCodec     string        `json:"hlsCodec"`     // HLS RFC 6381 CODECS: "mp4a.40.2", "ac-3", "ec-3"
+	Channels     int           `json:"channels"`     // 2 or 6
+	// ChannelsAssumed marks a plan whose channel count was chosen rather than
+	// known: the track never stated its layout, and an encoder argument has to say
+	// something. The number below is real - this says it was decided here.
+	ChannelsAssumed bool               `json:"channelsAssumed,omitempty"`
 	BitrateKbps     int                `json:"bitrateKbps"`
 	Rendition       AudioRenditionKind `json:"rendition"`
 	HLSChannels     string             `json:"hlsChannels"` // "2" or "6"
@@ -337,10 +341,19 @@ func planSingleTrack(
 		return plan
 	}
 
-	// 2. Stereo (2 channels)
+	// 2. Stereo, and everything the stream has not established as 5.1.
+	//
+	// An unknown layout lands here too, and that is a decision rather than
+	// knowledge. The facts layer reports that the track never stated its channel
+	// count; something still has to be written on the command line, and stereo is
+	// the safe choice because it is what a downmix produces either way. What
+	// changed is where the choice is made: here, in the layer allowed to choose,
+	// and marked as chosen - instead of being written into the facts as if the
+	// stream had said it.
 	plan.Rendition = RenditionStereo
 	plan.HLSChannels = "2"
 	plan.Channels = 2
+	plan.ChannelsAssumed = track.Channels <= 0
 
 	if (track.Codec == CodecAC3 && clientCaps.SupportsAC3) || (track.Codec == CodecEAC3 && clientCaps.SupportsEAC3) {
 		if clientCaps.PrefersPassthrough {

--- a/backend/internal/domain/audiotopology/types.go
+++ b/backend/internal/domain/audiotopology/types.go
@@ -95,9 +95,12 @@ type Conflict struct {
 
 // AudioTrack represents a fully resolved, evidence-backed audio track.
 type AudioTrack struct {
-	ID               string             `json:"id"`
-	PID              uint16             `json:"pid"`
-	Codec            AudioCodec         `json:"codec"`
+	ID    string     `json:"id"`
+	PID   uint16     `json:"pid"`
+	Codec AudioCodec `json:"codec"`
+	// Channels is the resolved count, or 0 where no source stated one. Zero means
+	// unknown and never stereo - a track nobody measured is not a track with two
+	// channels, and a consumer that needs a number has to choose one knowingly.
 	Channels         int                `json:"channels"`
 	SampleRate       int                `json:"sampleRate,omitempty"`
 	BitrateKbps      int                `json:"bitrateKbps,omitempty"`

--- a/backend/internal/infra/media/ffmpeg/live_audio_map.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_map.go
@@ -255,14 +255,10 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 				if bitrateKbps <= 0 {
 					bitrateKbps = 192
 				}
-				channels := tp.Channels
-				if channels <= 0 {
-					channels = 2
-				}
 				audioArgs = append(audioArgs,
 					fmt.Sprintf("-c:a:%d", i), encoderCodec,
 					fmt.Sprintf("-b:a:%d", i), fmt.Sprintf("%dk", bitrateKbps),
-					fmt.Sprintf("-ac:a:%d", i), fmt.Sprintf("%d", channels),
+					fmt.Sprintf("-ac:a:%d", i), fmt.Sprintf("%d", tp.Channels),
 					fmt.Sprintf("-ar:a:%d", i), "48000",
 				)
 			}
@@ -331,6 +327,7 @@ func (a *LocalAdapter) planLiveAudioSelection(ctx context.Context, spec ports.St
 		Str("encoder_codec", selectedPlan.EncoderCodec).
 		Str("hls_codec", selectedPlan.HLSCodec).
 		Int("channels", selectedPlan.Channels).
+		Bool("channels_assumed", selectedPlan.ChannelsAssumed).
 		Int("bitrate_kbps", selectedPlan.BitrateKbps).
 		Str("track_name", selectedPlan.Name).
 		Msg("selected live audio stream for playback pipeline")
@@ -358,6 +355,10 @@ func appendPlannedAudioArgs(args []string, spec ports.StreamSpec, plan audiotopo
 		bitrateKbps = 192
 	}
 
+	// Not an unknown channel count - a planned track always carries a decided one.
+	// This guards the empty-plan case above, where selectedPlan is the zero value
+	// because no track was planned at all, and an encoder still needs an argument.
+	// It goes away when that case produces a plan rather than a zero value.
 	channels := plan.Channels
 	if channels <= 0 {
 		channels = 2

--- a/backend/internal/infra/media/ffmpeg/live_audio_probe_metrics_test.go
+++ b/backend/internal/infra/media/ffmpeg/live_audio_probe_metrics_test.go
@@ -7,6 +7,7 @@ package ffmpeg
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -218,5 +219,42 @@ func TestLiveAudioProbeMetrics_AndroidTVNativeIsNotCounted(t *testing.T) {
 	}
 	if got := counterVecTotal(t, metrics.AudioTopologyEvidenceTotal) - beforeEvidence; got != 0 {
 		t.Errorf("topology evidence delta = %v, want 0", got)
+	}
+}
+
+// The facts layer now reports an unstated channel count as unknown instead of as
+// stereo, and the multi-track argument builder no longer carries a fallback for a
+// zero. Neither may change what reaches ffmpeg: the policy decides stereo, and
+// the command line says 2. A regression here would read as "-ac:a:0 0".
+func TestPlanLiveAudio_UnknownChannelsStillEncodeAsStereo(t *testing.T) {
+	adapter := probeMetricsAdapter(t)
+	adapter.liveAudioProbeFn = func(context.Context, string) ([]liveAudioStream, error) {
+		// Channels 0 throughout: nothing anywhere names a count.
+		return []liveAudioStream{
+			{Index: 1, ID: "101", CodecType: "audio", CodecName: "ac3", Tags: map[string]string{"language": "deu"}},
+			{Index: 2, ID: "102", CodecType: "audio", CodecName: "ac3", Tags: map[string]string{"language": "eng"}},
+		}, nil
+	}
+
+	pmt := []ports.LiveAudioTrack{
+		{PID: 101, Codec: "ac3", Language: "deu"},
+		{PID: 102, Codec: "ac3", Language: "eng"},
+	}
+
+	spec := probeMetricsSpec()
+	sel := adapter.planLiveAudioSelection(context.Background(), spec, spec.Source.ID, pmt)
+
+	if len(sel.Maps) < 2 {
+		t.Fatalf("Maps = %v, want both tracks planned", sel.Maps)
+	}
+	for i := range sel.Maps {
+		flag := fmt.Sprintf("-ac:a:%d", i)
+		got, ok := valueAfter(sel.AudioArgs, flag)
+		if !ok {
+			t.Fatalf("%s missing from %v", flag, sel.AudioArgs)
+		}
+		if got != "2" {
+			t.Errorf("%s = %q, want 2 - an unknown layout is still encoded as stereo", flag, got)
+		}
 	}
 }


### PR DESCRIPTION
Step 4 of the audio sequence. `unknown ≠ stereo` — fixed at the source, not at the symptoms.

## The source, not a fallback

```go
// 3. Resolve Channels & Bitrates
channels := 2        // ← before any evidence was consulted
```

This sat at the **top** of the channel resolution in `merge.go`, not at the end. A track no source had named a count for entered the topology as stereo, and afterwards nothing could tell it apart from one the stream had actually declared stereo — the exact confusion the declared/observed split exists to prevent. The two `channels <= 0` guards further down are downstream of it.

The facts layer now says `0`, meaning unknown.

## The decision moved, it did not disappear

An encoder argument still has to say something. `planSingleTrack` already routed everything that is not exactly 6 to stereo, so an unknown track was going to be planned as stereo either way. What changes is **where** the choice is made and that it is visible:

```
TrackPlan.ChannelsAssumed   // true when the track never stated a count
```

The number beside it is real, the command line is unchanged, and the startup log now carries `channels_assumed`.

## No plan output moves — verified, not assumed

The only consumers of `AudioTrack.Channels`:

| consumer | with 0 instead of 2 |
|---|---|
| `planSingleTrack` `== 6` | same branch |
| scoring bonus `== 6` | same score |
| `computeStructuralRevision` | hash input only |
| `computeMetadataRevision` | hash input only |

Not exposed through any API surface (`playbackplanner.TrackPlan` is an unrelated type in its own package). All four are blind to the difference.

## Of the two guards, one was dead and one is not

**Removed** — `live_audio_map.go` multi-track builder. Every `TrackPlan` in `multiPlan.Tracks` comes from `planSingleTrack`, which sets `Channels` to 2 or 6 on every path. It was checking for a zero that could not arrive.

**Kept** — `appendPlannedAudioArgs`. This one is **not** an unknown-channels fallback, and that matters: it covers the empty-plan case, where `selectedPlan` is the zero value because no track was planned at all. Removing it on the strength of this commit's own rule would emit `-ac 0`. Real hole, different hole — it closes when the empty-plan case produces a plan instead of a zero value. Its comment now says so.

## Tests

- A track no source named a count for resolves to `Channels == 0`, and no evidence entry claims a source answered.
- `planSingleTrack` table: unstated → 2 with `ChannelsAssumed`, stated stereo → 2 without, mono → 2 without, 5.1 → 6 without.
- End to end through `planLiveAudioSelection`: two tracks with no count anywhere still produce `-ac:a:0 2` and `-ac:a:1 2`. A regression would read as `-ac:a:0 0`.

Mutation-verified: restoring `channels := 2` fails the first test.

## Unchanged

ffprobe. The B2b.3 counters. The VU+ measurement stays valid.

## Gates

`go build ./...` · `go test ./...` · `make test-race-pr` · `make lint` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)