### PR TITLE
Cut the ring in two: bytes here, meaning there

### DIFF
--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -1,0 +1,1159 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package mediafacts
+
+import (
+	"bytes"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
+)
+
+// Core reads transport stream bytes and reports what they say.
+//
+// The contract is deliberately coarse and deliberately synchronous. Coarse,
+// because a call per 188-byte packet would put a boundary crossing on the hot
+// path ten thousand times a second per service and hand the core none of the
+// state it needs to answer anything. Synchronous, because the caller has to know
+// what a chunk meant before it lets anyone read those bytes - a caller that
+// commits bytes first and learns afterwards that they began a new program has
+// already handed a subscriber the old stream's truth.
+//
+//	chunk in -> facts and ordered events out -> caller commits the bytes
+//
+// An implementation may live in this process or behind a socket. Nothing in the
+// contract assumes either, which is the point of it existing.
+type Core interface {
+	// Ingest consumes one chunk of transport stream. startOffset is the chunk's
+	// position in the caller's own monotonic byte coordinate system, and every
+	// offset in the result is expressed in that same system.
+	Ingest(startOffset int64, data []byte) (ParseResult, error)
+
+	// Snapshot returns what the core currently knows. Facts only move when a chunk
+	// is ingested, so a caller that keeps the facts from the last Ingest never
+	// needs to call this on a hot path.
+	Snapshot() Facts
+
+	// SetTargetProgram selects which program of a multi-program transport is
+	// followed. Changing it discards everything read about the previous one.
+	SetTargetProgram(programNumber uint16) ParseResult
+
+	// Reset discards all parser state.
+	Reset() ParseResult
+}
+
+// EventKind names something the core saw that the caller has to act on. Facts
+// describe a state; events describe a moment in the byte stream, and their order
+// within a chunk is the order they happened in.
+type EventKind uint8
+
+const (
+	// EventProgramIdentityChanged reports that the program this stream carries is
+	// no longer the one it was: a new PMT version, a different program number, a
+	// changed elementary stream layout.
+	//
+	// It is not a generation. What a caller does with it - bump an epoch, cut
+	// workers, invalidate an index - is the caller's decision, and this event
+	// carries no opinion about it.
+	EventProgramIdentityChanged EventKind = iota
+
+	// EventRandomAccessPoint reports an access unit a decoder can be started on,
+	// at Offset in the caller's coordinate system.
+	EventRandomAccessPoint
+)
+
+// Event is one ordered occurrence within an ingested chunk.
+type Event struct {
+	Kind   EventKind
+	Offset int64
+
+	// Joinable reports that the entry point's own access unit contained no
+	// scrambled packet. An entry point that classified perfectly out of encrypted
+	// payload is not one a decoder can start on.
+	Joinable bool
+}
+
+// ParseResult is what one chunk meant.
+type ParseResult struct {
+	// ProcessedThroughOffset is the offset one past the last byte interpreted.
+	ProcessedThroughOffset int64
+
+	// Events are ordered as they occurred within the chunk. A caller must replay
+	// them in order: an entry point found before an identity change and one found
+	// after it belong to different programs.
+	Events []Event
+
+	// Facts is the state after the chunk.
+	Facts Facts
+
+	// PSI carries the raw tables for a caller that has to deliver them, unparsed,
+	// ahead of an entry point.
+	PSI ActivePSI
+}
+
+// ActivePSI is the raw PAT and PMT packets of the current program.
+//
+// The core parses these; it hands the bytes back anyway because the subscriber
+// preamble is a transport concern and reconstructing it would mean parsing PSI a
+// second time, in a second place, with a second answer.
+type ActivePSI struct {
+	PAT [][]byte
+	PMT [][]byte
+}
+
+// Facts is what the core knows about the stream right now.
+//
+// Deliberately without a generation and without any statement about whether an
+// entry point is still reachable: the first is a lifecycle decision and the
+// second depends on a buffer this package cannot see.
+type Facts struct {
+	HasPAT        bool
+	HasPMT        bool
+	PMTVersion    uint8
+	ProgramNumber uint16
+
+	// PMTPID is the PID the PAT names for the target program, or 0 while no PAT
+	// naming it has been accepted.
+	PMTPID uint16
+
+	VideoPID    uint16
+	VideoCodec  VideoCodec
+	AudioPIDs   []uint16
+	AudioTracks []AudioTrackInfo
+
+	// ParameterSetsSeen reports whether the decoder configuration for the current
+	// codec has been observed: SPS and PPS, plus VPS for HEVC.
+	ParameterSetsSeen bool
+
+	RandomAccess RandomAccessObservation
+	Scrambling   StreamScrambling
+
+	// CleanEntryPoints counts entry points whose own access unit contained no
+	// scrambled packet.
+	CleanEntryPoints uint64
+
+	// CleanAccessUnits counts every complete picture that arrived without an
+	// encrypted packet in it, joinable or not.
+	CleanAccessUnits uint64
+
+	// ScrambledVideoConfirmed reports that the video elementary stream is encrypted
+	// and enough packets have arrived with none of them clear. It is a judgement
+	// about bytes, so it is made here - the caller only has to act on it.
+	ScrambledVideoConfirmed bool
+}
+
+// GoCore is the in-process implementation: the parser xg2g has always had, now
+// behind the boundary instead of inside the ring.
+//
+// Not safe for concurrent use. The caller serialises Ingest with whatever lock it
+// already holds over its own buffer.
+type GoCore struct {
+	// PSI Table Assembly & Selection
+	targetProgramNumber uint16
+	patAssembler        psiStreamAssembler
+	pmtAssembler        psiStreamAssembler
+	patTracker          tableSectionTracker
+	pmtTracker          tableSectionTracker
+	rawPATPackets       [][]byte
+	rawPMTPackets       [][]byte
+	hasPATVersion       bool
+	patVersion          uint8
+	hasPMTVersion       bool
+	pmtVersion          uint8
+	pmtProgramNumber    uint16
+	pmtPID              uint16
+	videoPID            uint16
+	videoCodec          VideoCodec
+
+	// Stateful Video Parsing & Keyframe Indexing
+	currentPESOffset int64
+	pesHasKeyframe   bool
+	pesHasSPS        bool
+	pesHasPPS        bool
+	pesHasVPS        bool
+	annexBState      uint32 // 4-byte shift register for startcode scanning
+	expectingNALByte bool
+
+	// Random access classification for the access unit currently being assembled.
+	// Held per access unit because joinability is a property of all of its slices,
+	// which is only known once the next access unit begins.
+	auHasIRAP       bool
+	auHasRecoveryPt bool
+	auVCLCount      int
+	auIntraVCLCount int
+	// auScrambledPackets counts scrambled packets inside the access unit being
+	// assembled. An entry point whose own access unit was partly encrypted is not
+	// one a decoder can be started on.
+	auScrambledPackets int
+	cleanRAPCount      uint64
+	cleanAccessUnits   uint64
+	nalBuf             []byte
+	nalKind            nalCaptureKind
+	nalLeft            int
+	// nalSkip is the number of bytes of the NAL header still to pass over before
+	// the capture starts. H.264 has a one byte header, which is already consumed by
+	// the classification step; HEVC has two, and capturing from the first of the
+	// remaining bytes would read nuh_layer_id as if it were an SEI payload type.
+	nalSkip int
+	raObs   RandomAccessObservation
+
+	// Scrambling observation, kept per elementary stream rather than as one total.
+	// A service whose video descrambles while its audio does not is a different
+	// fault from one where neither does, and a single counter cannot tell them apart.
+	scrambledVideoPackets uint64
+	clearVideoPackets     uint64
+	scrambledAudioPackets uint64
+	clearAudioPackets     uint64
+	// videoClearRun counts consecutive clear video packets, reset by any scrambled
+	// one. Descrambling on this receiver was measured coming up intermittently -
+	// 733 scrambled packets interleaved with clear ones on one tune - so "a clear
+	// packet was seen" is not evidence that the stream is clear.
+	videoClearRun uint64
+	// audioClearRun is the same measure on the audio streams, kept separately so a
+	// service whose video is through but whose audio is not can be told apart.
+	audioClearRun uint64
+	// audioPIDs holds the elementary audio streams named by the active PMT.
+	audioPIDs   []uint16
+	audioTracks []AudioTrackInfo
+
+	// audioObservers follow the audio payload of the tracks whose codec this path
+	// can read, one per PID. They exist because the audio topology is not a
+	// property of the session start: a service moves between stereo and 5.1 on the
+	// same PID as programmes change, and a reading taken once at attach describes
+	// only whatever happened to be running then.
+	//
+	// Keyed by PID and rebuilt from scratch whenever the PMT changes, so an
+	// observation can never outlive the table that named the stream it came from.
+	audioObservers map[uint16]*esaudio.Observer
+
+	// events accumulates what the chunk being ingested meant, in order.
+	events []Event
+}
+
+// NewGoCore returns a core with no stream state.
+func NewGoCore(targetProgramNumber uint16) *GoCore {
+	c := &GoCore{targetProgramNumber: targetProgramNumber}
+	c.currentPESOffset = -1
+	c.annexBState = 0xFFFFFFFF
+	c.videoCodec = CodecUnknown
+	return c
+}
+
+// Ingest interprets one chunk of transport stream.
+func (c *GoCore) Ingest(startOffset int64, data []byte) (ParseResult, error) {
+	if len(data)%TSPacketSize != 0 {
+		return ParseResult{}, ErrInvalidPacketSize
+	}
+
+	c.events = c.events[:0]
+	for i := 0; i < len(data); i += TSPacketSize {
+		c.indexPacketLocked(data[i:i+TSPacketSize], startOffset+int64(i))
+	}
+	return c.result(startOffset + int64(len(data))), nil
+}
+
+// SetTargetProgram selects the program to follow.
+func (c *GoCore) SetTargetProgram(programNumber uint16) ParseResult {
+	c.events = c.events[:0]
+	if c.targetProgramNumber != programNumber {
+		c.targetProgramNumber = programNumber
+		c.hasPATVersion = false
+		c.hasPMTVersion = false
+		c.pmtPID = 0
+		c.patAssembler.reset()
+		c.pmtAssembler.reset()
+		c.patTracker.reset()
+		c.pmtTracker.reset()
+		c.rawPATPackets = nil
+		c.resetProgramStateLocked()
+	}
+	return c.result(0)
+}
+
+// Reset discards everything read so far.
+func (c *GoCore) Reset() ParseResult {
+	target := c.targetProgramNumber
+	*c = *NewGoCore(target)
+	c.events = append(c.events, Event{Kind: EventProgramIdentityChanged})
+	return c.result(0)
+}
+
+func (c *GoCore) result(through int64) ParseResult {
+	events := make([]Event, len(c.events))
+	copy(events, c.events)
+	return ParseResult{
+		ProcessedThroughOffset: through,
+		Events:                 events,
+		Facts:                  c.Snapshot(),
+		PSI:                    c.activePSI(),
+	}
+}
+
+func (c *GoCore) activePSI() ActivePSI {
+	return ActivePSI{PAT: cloneSliceList(c.rawPATPackets), PMT: cloneSliceList(c.rawPMTPackets)}
+}
+
+// Snapshot returns what the core knows about the stream right now.
+func (c *GoCore) Snapshot() Facts {
+	pids := make([]uint16, len(c.audioPIDs))
+	copy(pids, c.audioPIDs)
+
+	tracks := make([]AudioTrackInfo, len(c.audioTracks))
+	copy(tracks, c.audioTracks)
+	// The declaration is fixed by the PMT and only changes with it; the
+	// observation moves with the audio. Reading it here rather than storing it on
+	// the track is what makes a mid-programme change to 5.1 visible to the next
+	// snapshot instead of to the next PMT version.
+	for i := range tracks {
+		if obs := c.audioObservers[tracks[i].PID]; obs != nil {
+			tracks[i].Observed = obs.Current()
+		}
+	}
+
+	parameterSets := false
+	switch c.videoCodec {
+	case CodecMPEG2:
+		parameterSets = c.pesHasSPS // MPEG-2 Sequence Header (0xB3)
+	case CodecH265:
+		parameterSets = c.pesHasSPS && c.pesHasPPS && c.pesHasVPS
+	default:
+		parameterSets = c.pesHasSPS && c.pesHasPPS
+	}
+
+	return Facts{
+		HasPAT:            c.hasPATVersion,
+		HasPMT:            c.hasPMTVersion,
+		PMTVersion:        c.pmtVersion,
+		ProgramNumber:     c.pmtProgramNumber,
+		PMTPID:            c.pmtPID,
+		VideoPID:          c.videoPID,
+		VideoCodec:        c.videoCodec,
+		AudioPIDs:         pids,
+		AudioTracks:       tracks,
+		ParameterSetsSeen: parameterSets,
+		RandomAccess:      c.raObs,
+		Scrambling: StreamScrambling{
+			VideoScrambled: c.scrambledVideoPackets,
+			VideoClear:     c.clearVideoPackets,
+			AudioScrambled: c.scrambledAudioPackets,
+			AudioClear:     c.clearAudioPackets,
+			VideoClearRun:  c.videoClearRun,
+			AudioClearRun:  c.audioClearRun,
+			AudioPIDs:      pids,
+		},
+		CleanEntryPoints:        c.cleanRAPCount,
+		CleanAccessUnits:        c.cleanAccessUnits,
+		ScrambledVideoConfirmed: c.scrambledVideoConfirmedLocked(),
+	}
+}
+
+// ScrambledVideoConfirmed reports that the video elementary stream is encrypted
+// and no clear packet has been seen.
+func (c *GoCore) ScrambledVideoConfirmed() bool { return c.scrambledVideoConfirmedLocked() }
+
+var _ Core = (*GoCore)(nil)
+
+func (c *GoCore) indexPacketLocked(pkt []byte, offset int64) {
+	if len(pkt) < TSPacketSize || pkt[0] != SyncByte {
+		return
+	}
+
+	pid := (uint16(pkt[1]&0x1F) << 8) | uint16(pkt[2])
+	pusi := (pkt[1] & 0x40) != 0
+	afc := (pkt[3] >> 4) & 0x03
+	hasPayload := (afc == 0x01 || afc == 0x03)
+	if !hasPayload {
+		return
+	}
+
+	payloadOffset := 4
+	if afc == 0x03 {
+		afLen := int(pkt[4])
+		payloadOffset = 5 + afLen
+		if payloadOffset >= TSPacketSize {
+			return
+		}
+	}
+	payload := pkt[payloadOffset:]
+
+	// 1. PAT (PID 0) Section Assembly
+	if pid == 0 {
+		c.feedPSIPacketLocked(true, pkt, pusi, payload)
+		return
+	}
+
+	// 2. PMT Section Assembly
+	if c.pmtPID > 0 && pid == c.pmtPID {
+		c.feedPSIPacketLocked(false, pkt, pusi, payload)
+		return
+	}
+
+	// 3. Video Elementary Stream Keyframe / IDR Indexing
+	if c.videoPID > 0 && pid == c.videoPID {
+		c.parseVideoPacketLocked(pkt, offset, pusi, payload)
+		return
+	}
+
+	// 4. Audio elementary streams. Whether the payload arrives clear decides
+	//    whether a channel is presentable, and for the codecs that carry their
+	//    channel layout in the frame header the payload is also the only place a
+	//    channel count above two can be read at all.
+	for _, apid := range c.audioPIDs {
+		if pid == apid {
+			if (pkt[3]>>6)&0x03 != 0 {
+				c.scrambledAudioPackets++
+				c.audioClearRun = 0
+				return
+			}
+			c.clearAudioPackets++
+			c.audioClearRun++
+			c.observeAudioPayloadLocked(apid, pusi, payload)
+			return
+		}
+	}
+}
+
+// observeAudioPayloadLocked hands one clear audio packet's elementary stream
+// bytes to the observer for that PID.
+//
+// This is where transport ends. The observer is given elementary stream payload
+// and nothing else - no PID, no packet, no PMT - so what it reads is a property
+// of the audio rather than of how the audio arrived.
+func (c *GoCore) observeAudioPayloadLocked(pid uint16, pusi bool, payload []byte) {
+	obs := c.audioObservers[pid]
+	if obs == nil {
+		return
+	}
+
+	es := payload
+	if pusi {
+		// A PES packet starts here, so the elementary stream does not: skip the
+		// header. Audio arrives either as an audio stream id or, for AC-3 in DVB,
+		// as private_stream_1.
+		if len(payload) < 9 || payload[0] != 0x00 || payload[1] != 0x00 || payload[2] != 0x01 {
+			return
+		}
+		if sid := payload[3]; sid != 0xBD && sid != 0xFD && (sid < 0xC0 || sid > 0xDF) {
+			return
+		}
+		esStart := 9 + int(payload[8])
+		if esStart >= len(payload) {
+			// The optional header ran past this packet. Rare, and not worth state of
+			// its own: the remainder is fed as if it were elementary stream, where it
+			// has to survive a syncword check and a run of agreeing frames before it
+			// could reach the observation.
+			return
+		}
+		es = payload[esStart:]
+	}
+	obs.Feed(es)
+}
+func (c *GoCore) feedBytesToAssemblerLocked(isPAT bool, assembler *psiStreamAssembler, chunk []byte, pkt []byte) int {
+	if len(chunk) == 0 {
+		return 0
+	}
+
+	consumed := 0
+
+	// Phase 1: Complete 3-byte header if incomplete
+	if len(assembler.buf) < 3 {
+		needHeader := 3 - len(assembler.buf)
+		toTake := len(chunk)
+		if toTake > needHeader {
+			toTake = needHeader
+		}
+		assembler.buf = append(assembler.buf, chunk[:toTake]...)
+		assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
+		chunk = chunk[toTake:]
+		consumed += toTake
+
+		if len(assembler.buf) >= 3 {
+			secLen := int((uint16(assembler.buf[1]&0x0F) << 8) | uint16(assembler.buf[2]))
+			assembler.sectionLen = secLen + 3
+		} else {
+			return consumed
+		}
+	}
+
+	// Phase 2: Complete body up to sectionLen
+	if assembler.sectionLen > 0 && len(assembler.buf) < assembler.sectionLen {
+		needed := assembler.sectionLen - len(assembler.buf)
+		toTake := len(chunk)
+		if toTake > needed {
+			toTake = needed
+		}
+		assembler.buf = append(assembler.buf, chunk[:toTake]...)
+		if consumed == 0 { // Not added in Phase 1 for this packet
+			assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
+		}
+		consumed += toTake
+
+		if len(assembler.buf) >= assembler.sectionLen {
+			c.processCompletePSISectionLocked(isPAT, assembler.buf[:assembler.sectionLen], assembler.rawPackets)
+			assembler.buf = assembler.buf[:0]
+			assembler.sectionLen = 0
+			assembler.rawPackets = assembler.rawPackets[:0]
+		}
+	}
+
+	return consumed
+}
+func (c *GoCore) feedPSIPacketLocked(isPAT bool, pkt []byte, pusi bool, payload []byte) {
+	var assembler *psiStreamAssembler
+	if isPAT {
+		assembler = &c.patAssembler
+	} else {
+		assembler = &c.pmtAssembler
+	}
+
+	cc := pkt[3] & 0x0F
+	if assembler.hasCC {
+		if cc == assembler.lastCC {
+			if bytes.Equal(pkt, assembler.lastPacket) {
+				// Exact byte-for-byte duplicate TS packet: silently ignore
+				return
+			}
+			// Same CC but different content: glitch / discontinuity!
+			assembler.reset()
+			if !pusi {
+				return
+			}
+		} else if cc != (assembler.lastCC+1)&0x0F {
+			// Continuity gap detected: abort corrupted in-flight assembly
+			assembler.reset()
+			if !pusi {
+				return
+			}
+		}
+	}
+	assembler.lastCC = cc
+	assembler.hasCC = true
+	assembler.lastPacket = cloneSlice(pkt)
+
+	offset := 0
+
+	if pusi {
+		if len(payload) < 1 {
+			return
+		}
+		pointerField := int(payload[0])
+
+		if pointerField > 0 {
+			// Case A: Bytes before pointer complete previous in-flight section
+			if len(assembler.buf) > 0 {
+				toTake := pointerField
+				if 1+toTake > len(payload) {
+					assembler.reset()
+					return
+				}
+				c.feedBytesToAssemblerLocked(isPAT, assembler, payload[1:1+toTake], pkt)
+				if len(assembler.buf) > 0 {
+					// Still incomplete after pointer field: missing data, discard
+					assembler.buf = assembler.buf[:0]
+					assembler.sectionLen = 0
+					assembler.rawPackets = assembler.rawPackets[:0]
+				}
+			}
+			offset = 1 + pointerField
+		} else {
+			// Case B: pointerField == 0. Discard any unfinished prior section
+			assembler.buf = assembler.buf[:0]
+			assembler.sectionLen = 0
+			assembler.rawPackets = assembler.rawPackets[:0]
+			offset = 1
+		}
+	} else {
+		// pusi == false: continue in-flight section
+		if len(assembler.buf) > 0 {
+			consumed := c.feedBytesToAssemblerLocked(isPAT, assembler, payload, pkt)
+			offset = consumed
+		} else {
+			return
+		}
+	}
+
+	// Parse subsequent sections in this payload (supporting multiple sections per packet)
+	for offset < len(payload) {
+		if payload[offset] == 0xFF {
+			// MPEG-TS PSI padding / stuffing bytes reached
+			break
+		}
+
+		avail := len(payload) - offset
+		if avail < 3 {
+			// Fragmented section header (1-2 bytes) spanning into next packet!
+			assembler.buf = append(assembler.buf, payload[offset:]...)
+			assembler.sectionLen = 0
+			assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
+			break
+		}
+
+		tableID := payload[offset]
+		expectedTableID := byte(0x00)
+		if !isPAT {
+			expectedTableID = 0x02
+		}
+		if tableID != expectedTableID {
+			break
+		}
+
+		secLen := int((uint16(payload[offset+1]&0x0F) << 8) | uint16(payload[offset+2]))
+		fullSecLen := secLen + 3
+
+		if avail >= fullSecLen {
+			// Complete section self-contained in this payload chunk!
+			sectionBytes := payload[offset : offset+fullSecLen]
+			c.processCompletePSISectionLocked(isPAT, sectionBytes, [][]byte{cloneSlice(pkt)})
+			offset += fullSecLen
+			continue
+		}
+
+		// Section spans across to next TS packet
+		assembler.buf = append(assembler.buf, payload[offset:]...)
+		assembler.sectionLen = fullSecLen
+		assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
+		break
+	}
+}
+func (c *GoCore) processCompletePSISectionLocked(isPAT bool, table []byte, rawPackets [][]byte) {
+	if len(table) < 12 {
+		return
+	}
+
+	// Validate MPEG-2 CRC32
+	if CalculateMPEG2CRC32(table) != 0 {
+		return
+	}
+
+	currentNext := table[5] & 0x01
+	if currentNext != 1 {
+		return
+	}
+
+	version := (table[5] >> 1) & 0x1F
+	sectionNum := table[6]
+	lastSectionNum := table[7]
+
+	if isPAT {
+		tableComplete := c.patTracker.addSection(version, sectionNum, lastSectionNum, table, rawPackets)
+		if !tableComplete {
+			return
+		}
+
+		// Full PAT Table Generation Complete: scan all sections for target program
+		matchedPID := uint16(0)
+		for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
+			sData := c.patTracker.sections[sIdx]
+			if len(sData) < 12 {
+				continue
+			}
+			programs := sData[8 : len(sData)-4]
+			for i := 0; i+4 <= len(programs); i += 4 {
+				progNum := (uint16(programs[i]) << 8) | uint16(programs[i+1])
+				progPID := ((uint16(programs[i+2]) & 0x1F) << 8) | uint16(programs[i+3])
+				if progNum == 0 {
+					continue
+				}
+
+				if c.targetProgramNumber > 0 {
+					if progNum == c.targetProgramNumber {
+						matchedPID = progPID
+						break
+					}
+				} else {
+					matchedPID = progPID
+					break
+				}
+			}
+			if matchedPID > 0 && c.targetProgramNumber > 0 {
+				break
+			}
+		}
+
+		if matchedPID > 0 {
+			if !c.hasPMTVersion || c.pmtPID != matchedPID || !c.hasPATVersion || c.patVersion != version {
+				if c.pmtPID != matchedPID {
+					c.pmtPID = matchedPID
+					c.pmtAssembler.reset()
+					c.pmtTracker.reset()
+					c.hasPMTVersion = false
+					c.resetProgramStateLocked()
+				}
+			}
+			c.hasPATVersion = true
+			c.patVersion = version
+
+			// Build deduplicated rawPATPackets from all sections 0..lastSectionNum
+			var allPATPackets [][]byte
+			for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
+				for _, pkt := range c.patTracker.rawPackets[sIdx] {
+					if !containsPacket(allPATPackets, pkt) {
+						allPATPackets = append(allPATPackets, cloneSlice(pkt))
+					}
+				}
+			}
+			c.rawPATPackets = allPATPackets
+		}
+	} else {
+		progNum := (uint16(table[3]) << 8) | uint16(table[4])
+		tableComplete := c.pmtTracker.addSection(version, sectionNum, lastSectionNum, table, rawPackets)
+		if !tableComplete {
+			return
+		}
+
+		// Full PMT Table Generation Complete
+		isChanged := !c.hasPMTVersion || version != c.pmtVersion || progNum != c.pmtProgramNumber
+		if isChanged {
+			c.hasPMTVersion = true
+			c.pmtVersion = version
+			c.pmtProgramNumber = progNum
+			c.resetProgramStateLocked()
+
+			// Scan elementary streams across all sections 0..lastSectionNum
+			for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
+				sData := c.pmtTracker.sections[sIdx]
+				if len(sData) < 12 {
+					continue
+				}
+				progInfoLen := int((uint16(sData[10]&0x0F) << 8) | uint16(sData[11]))
+				esStart := 12 + progInfoLen
+				esEnd := len(sData) - 4
+
+				for i := esStart; i+5 <= esEnd && i < len(sData); {
+					st := sData[i]
+					elemPID := ((uint16(sData[i+1]) & 0x1F) << 8) | uint16(sData[i+2])
+					esInfoLen := int((uint16(sData[i+3]&0x0F) << 8) | uint16(sData[i+4]))
+
+					switch st {
+					case 0x1B: // H.264 / AVC
+						if c.videoPID == 0 {
+							c.videoPID = elemPID
+							c.videoCodec = CodecH264
+						}
+					case 0x24, 0x27: // H.265 / HEVC
+						if c.videoPID == 0 {
+							c.videoPID = elemPID
+							c.videoCodec = CodecH265
+						}
+					case 0x02, 0x01: // MPEG-2 / MPEG-1 Video
+						if c.videoPID == 0 {
+							c.videoPID = elemPID
+							c.videoCodec = CodecMPEG2
+						}
+					default:
+						// The elementary stream loop is now walked to its end rather
+						// than stopped at the video entry: the audio streams that
+						// follow it are needed to tell "video descrambled, audio did
+						// not" apart from "nothing descrambled".
+						descriptors := []byte(nil)
+						if dStart := i + 5; dStart+esInfoLen <= len(sData) {
+							descriptors = sData[dStart : dStart+esInfoLen]
+						}
+						if isAudioStreamType(st, descriptors) {
+							c.audioPIDs = appendPID(c.audioPIDs, elemPID)
+							codec := AudioCodecFromStreamType(st, descriptors)
+							lang := LanguageFromDescriptors(descriptors)
+							declared := AudioChannelsFromDescriptors(descriptors)
+							c.audioTracks = appendAudioTrack(c.audioTracks, AudioTrackInfo{
+								PID:        elemPID,
+								StreamType: st,
+								Codec:      codec,
+								Language:   lang,
+								Declared:   declared,
+							})
+							if observableAudioCodec(codec) {
+								if c.audioObservers == nil {
+									c.audioObservers = make(map[uint16]*esaudio.Observer, 2)
+								}
+								c.audioObservers[elemPID] = esaudio.NewObserver()
+							}
+						}
+					}
+
+					i += 5 + esInfoLen
+				}
+			}
+		}
+
+		// Build deduplicated rawPMTPackets from all sections 0..lastSectionNum
+		var allPMTPackets [][]byte
+		for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
+			for _, pkt := range c.pmtTracker.rawPackets[sIdx] {
+				if !containsPacket(allPMTPackets, pkt) {
+					allPMTPackets = append(allPMTPackets, cloneSlice(pkt))
+				}
+			}
+		}
+		c.rawPMTPackets = allPMTPackets
+	}
+}
+func (c *GoCore) resetProgramStateLocked() {
+	c.videoPID = 0
+	c.videoCodec = CodecUnknown
+	c.currentPESOffset = -1
+	c.pesHasKeyframe = false
+	c.pesHasSPS = false
+	c.pesHasPPS = false
+	c.pesHasVPS = false
+	c.annexBState = 0xFFFFFFFF
+	c.expectingNALByte = false
+	c.rawPMTPackets = nil
+	c.scrambledVideoPackets = 0
+	c.clearVideoPackets = 0
+	c.scrambledAudioPackets = 0
+	c.clearAudioPackets = 0
+	c.videoClearRun = 0
+	c.audioClearRun = 0
+	c.audioPIDs = nil
+	c.audioTracks = nil
+	// Observations do not survive the table that named their stream. The same PID
+	// can carry a different elementary stream after a PMT change, and carrying the
+	// old layout across would describe audio that is no longer there.
+	c.audioObservers = nil
+	c.raObs = RandomAccessObservation{}
+	c.cleanRAPCount = 0
+	c.cleanAccessUnits = 0
+	c.resetAccessUnitStateLocked()
+
+	// The caller owns the generation. What changed here is the identity of the
+	// program this stream carries; whether that begins a new lifecycle epoch - and
+	// what happens to subscribers when it does - is not this layer's call.
+	c.events = append(c.events, Event{Kind: EventProgramIdentityChanged})
+}
+func (c *GoCore) parseVideoPacketLocked(pkt []byte, offset int64, pusi bool, payload []byte) {
+	// transport_scrambling_control != 0 means the payload is encrypted. Feeding it to the
+	// Annex-B scanner would index random bytes as NAL units, so it is never parsed. The
+	// observation is recorded instead, allowing attach to fail fast with ErrScrambledStream.
+	if (pkt[3]>>6)&0x03 != 0 {
+		c.scrambledVideoPackets++
+		c.auScrambledPackets++
+		c.videoClearRun = 0
+		return
+	}
+	c.clearVideoPackets++
+	c.videoClearRun++
+
+	esData := payload
+
+	if pusi {
+		// Video PES packet start: verify PES startcode prefix (00 00 01 E0..EF)
+		if len(payload) >= 9 && payload[0] == 0x00 && payload[1] == 0x00 && payload[2] == 0x01 && (payload[3] >= 0xE0 && payload[3] <= 0xEF) {
+			// Whether an access unit is joinable depends on every slice in it, which
+			// is only known once it ends - and it ends where the next one begins.
+			c.finalizeAccessUnitLocked()
+
+			c.currentPESOffset = offset
+			c.pesHasKeyframe = false
+			c.pesHasSPS = false
+			c.pesHasPPS = false
+			c.pesHasVPS = false
+			c.annexBState = 0xFFFFFFFF
+			c.expectingNALByte = false
+			c.resetAccessUnitStateLocked()
+
+			pesHeaderDataLen := int(payload[8])
+			esStart := 9 + pesHeaderDataLen
+			if esStart < len(payload) {
+				esData = payload[esStart:]
+			} else {
+				esData = nil
+			}
+		}
+	}
+
+	if len(esData) == 0 {
+		return
+	}
+
+	// Stateful Annex-B NAL unit parser across packet boundaries.
+	for _, b := range esData {
+		c.annexBState = (c.annexBState << 8) | uint32(b)
+
+		// Bytes immediately following a NAL header, held for slice-header and SEI
+		// parsing. Collected here because a NAL unit routinely spans TS packets and
+		// the fields that matter sit in its first bytes.
+		if c.nalLeft > 0 {
+			if c.nalSkip > 0 {
+				c.nalSkip--
+			} else {
+				c.nalBuf = append(c.nalBuf, b)
+				c.nalLeft--
+				if c.nalLeft == 0 {
+					c.consumeNALCaptureLocked()
+				}
+			}
+		}
+
+		if c.expectingNALByte {
+			c.expectingNALByte = false
+			// A start code inside a captured NAL means the capture budget outran the
+			// unit; read what was collected before moving on.
+			c.consumeNALCaptureLocked()
+
+			switch c.videoCodec {
+			case CodecH264:
+				c.classifyH264NALLocked(b & 0x1F)
+			case CodecH265:
+				c.classifyHEVCNALLocked((b >> 1) & 0x3F)
+			case CodecMPEG2:
+				c.classifyMPEG2StartCodeLocked(b)
+			}
+		}
+
+		// Check for 3-byte (00 00 01) or 4-byte (00 00 00 01) Annex-B startcode
+		if (c.annexBState & 0x00FFFFFF) == 0x00000001 {
+			c.expectingNALByte = true
+		}
+	}
+}
+
+// classifyMPEG2StartCodeLocked records what an MPEG-2 Video Elementary Stream start code
+// contributes to the current access unit and stream configuration.
+// ISO/IEC 13818-2:
+// - 0xB3: sequence_header_code (SPS equivalent / Codec Config)
+// - 0xB8: group_start_code (GOP Header / Entry Point)
+// - 0x00: picture_start_code (Picture Header -> contains picture_coding_type I/P/B)
+func (c *GoCore) classifyMPEG2StartCodeLocked(startCode uint8) {
+	switch startCode {
+	case 0xB3: // Sequence Header
+		c.pesHasSPS = true
+	case 0xB8: // Group of Pictures Header
+		c.pesHasVPS = true
+	case 0x00: // Picture Header
+		c.auVCLCount++
+		c.beginNALCaptureLocked(captureMPEG2PictureHeader, mpeg2PictureHeaderCaptureBytes, 0)
+	}
+}
+
+// classifyH264NALLocked records what one H.264 NAL unit contributes to the access
+// unit being assembled, and starts a capture where the following bytes are needed.
+func (c *GoCore) classifyH264NALLocked(nalType uint8) {
+	switch nalType {
+	case h264NALSliceIDR:
+		c.auHasIRAP = true
+		c.auVCLCount++
+		c.auIntraVCLCount++
+		// An IDR needs nothing else to be joinable, so it is indexed without waiting
+		// for the access unit to end. This keeps streams that do emit IDRs attaching
+		// exactly as fast as before.
+		c.indexRandomAccessPointLocked(true)
+	case h264NALSliceNonIDR, h264NALSlicePartA:
+		c.auVCLCount++
+		c.beginNALCaptureLocked(captureH264SliceHeader, sliceHeaderCaptureBytes, 0)
+	case h264NALSPS:
+		c.pesHasSPS = true
+	case h264NALPPS:
+		c.pesHasPPS = true
+	case h264NALSEI:
+		// The one byte H.264 NAL header has already been consumed, so the SEI
+		// payload starts with the very next byte.
+		c.beginNALCaptureLocked(captureSEI, seiCaptureBytes, 0)
+	}
+}
+
+// classifyHEVCNALLocked mirrors classifyH264NALLocked for HEVC.
+//
+// The whole IRAP range qualifies, not only IDR: a CRA or BLA picture is equally a
+// point a decoder can be started on. HEVC slice headers are not parsed for intra
+// coding - the fields needed sit behind the active parameter sets - so a stream that
+// never emits an IRAP is admitted on its recovery_point SEI instead, which is the
+// stream's own declaration of a random access point.
+func (c *GoCore) classifyHEVCNALLocked(nalType uint8) {
+	switch {
+	case nalType >= hevcNALIRAPFirst && nalType <= hevcNALIRAPLast:
+		c.auHasIRAP = true
+		c.auVCLCount++
+		c.auIntraVCLCount++
+		c.indexRandomAccessPointLocked(true)
+	case nalType <= 9:
+		c.auVCLCount++
+	case nalType == hevcNALVPS:
+		c.pesHasVPS = true
+	case nalType == hevcNALSPS:
+		c.pesHasSPS = true
+	case nalType == hevcNALPPS:
+		c.pesHasPPS = true
+	case nalType == hevcNALPrefixSEI:
+		// The HEVC NAL header is two bytes. Only the first has been consumed by the
+		// classification above, so the second is passed over: reading it as the SEI
+		// payload type shifts every field that follows and hides the recovery point,
+		// which on a stream that emits no IRAP is the only signal there is.
+		c.beginNALCaptureLocked(captureSEI, seiCaptureBytes, 1)
+	}
+}
+func (c *GoCore) beginNALCaptureLocked(kind nalCaptureKind, budget, skipHeaderBytes int) {
+	c.nalKind = kind
+	c.nalLeft = budget
+	c.nalSkip = skipHeaderBytes
+	c.nalBuf = c.nalBuf[:0]
+}
+
+// consumeNALCaptureLocked reads whatever was captured and clears the capture.
+func (c *GoCore) consumeNALCaptureLocked() {
+	if c.nalKind == captureNone || len(c.nalBuf) == 0 {
+		c.nalKind = captureNone
+		c.nalLeft = 0
+		c.nalSkip = 0
+		return
+	}
+
+	switch c.nalKind {
+	case captureH264SliceHeader:
+		isIntra, ok := h264SliceIsIntra(c.nalBuf)
+		switch {
+		case !ok:
+			c.raObs.UnreadableSlices++
+		case isIntra:
+			c.auIntraVCLCount++
+		}
+	case captureSEI:
+		if seiHasRecoveryPoint(c.nalBuf) {
+			c.auHasRecoveryPt = true
+		}
+	case captureMPEG2PictureHeader:
+		isIntra, ok := mpeg2PictureIsIntra(c.nalBuf)
+		switch {
+		case !ok:
+			c.raObs.UnreadableSlices++
+		case isIntra:
+			c.auHasIRAP = true
+			c.auIntraVCLCount++
+			c.indexRandomAccessPointLocked(true)
+		}
+	}
+
+	c.nalKind = captureNone
+	c.nalLeft = 0
+	c.nalSkip = 0
+	c.nalBuf = c.nalBuf[:0]
+}
+
+// finalizeAccessUnitLocked decides whether the access unit that just ended was a
+// random access point, now that all of its slices have been seen.
+func (c *GoCore) finalizeAccessUnitLocked() {
+	c.consumeNALCaptureLocked()
+
+	if c.currentPESOffset < 0 || c.auVCLCount == 0 {
+		return
+	}
+
+	// Descrambling is proven by any complete picture that arrived without an
+	// encrypted packet in it, not only by one a decoder could start on. Measured
+	// against the receiver, tying the two together made them true at the same
+	// millisecond in every zap, so the descrambling observation carried no
+	// information of its own. A clear predicted picture arrives up to a GOP before
+	// the next clear entry point does.
+	if c.auScrambledPackets == 0 {
+		c.cleanAccessUnits++
+	}
+
+	if c.pesHasKeyframe {
+		return
+	}
+
+	// An access unit with no parameter sets cannot configure a decoder that is
+	// starting cold, whatever its slices contain.
+	hasParameterSets := c.pesHasSPS && c.pesHasPPS
+	if c.videoCodec == CodecH265 {
+		hasParameterSets = hasParameterSets && c.pesHasVPS
+	}
+	if !hasParameterSets {
+		return
+	}
+
+	joinable := false
+	switch c.videoCodec {
+	case CodecH264:
+		// Every coded slice intra means the picture stands alone. One predicted
+		// slice is enough to disqualify it: the decoder would be missing exactly
+		// the references that slice names.
+		joinable = c.auIntraVCLCount == c.auVCLCount
+	case CodecH265:
+		joinable = c.auHasRecoveryPt
+	}
+
+	if !joinable {
+		if c.auHasRecoveryPt || c.auVCLCount > c.auIntraVCLCount {
+			c.raObs.PredictedRejected++
+		}
+		return
+	}
+
+	c.indexRandomAccessPointLocked(false)
+}
+
+// indexRandomAccessPointLocked records the current access unit as an attach point.
+func (c *GoCore) indexRandomAccessPointLocked(irap bool) {
+	if c.pesHasKeyframe || c.currentPESOffset < 0 {
+		return
+	}
+	c.pesHasKeyframe = true
+
+	if irap {
+		c.raObs.IRAPPoints++
+	} else {
+		c.raObs.IntraPoints++
+	}
+	if c.auHasRecoveryPt {
+		c.raObs.RecoveryPointSEIs++
+	}
+	// An entry point whose own access unit carried scrambled packets is not one a
+	// decoder can be started on, however well it classified.
+	if c.auScrambledPackets == 0 {
+		c.cleanRAPCount++
+	}
+
+	// Reported in the caller's own byte coordinate system, so the offset can be
+	// handed straight to a reader without translation. Indexing it, ageing it out
+	// and deciding it is still reachable belong to whoever owns the buffer.
+	c.events = append(c.events, Event{
+		Kind:     EventRandomAccessPoint,
+		Offset:   c.currentPESOffset,
+		Joinable: c.auScrambledPackets == 0,
+	})
+}
+func (c *GoCore) resetAccessUnitStateLocked() {
+	c.auHasIRAP = false
+	c.auHasRecoveryPt = false
+	c.auVCLCount = 0
+	c.auIntraVCLCount = 0
+	c.auScrambledPackets = 0
+	c.nalKind = captureNone
+	c.nalLeft = 0
+	c.nalSkip = 0
+	c.nalBuf = c.nalBuf[:0]
+}
+
+// scrambledVideoConfirmedLocked reports whether the video stream is conclusively scrambled.
+// It requires a minimum sample so that a handful of packets observed mid key-change cannot
+// trip the verdict, and demands that not one clear payload packet has been seen: a receiver
+// that descrambles clears transport_scrambling_control on every packet it emits.
+func (c *GoCore) scrambledVideoConfirmedLocked() bool {
+	return c.clearVideoPackets == 0 && c.scrambledVideoPackets >= ScrambledVerdictMinPackets
+}
+
+// observableAudioCodec reports whether the frame headers of a codec are read for
+// their channel layout. Everything else is left to the declaration and to
+// whatever the media path already does; a codec this parser cannot read produces
+// no observation rather than a guessed one.
+func observableAudioCodec(codec string) bool {
+	return codec == esaudio.CodecAC3 || codec == esaudio.CodecEAC3
+}
+func containsPacket(list [][]byte, pkt []byte) bool {
+	for _, existing := range list {
+		if bytes.Equal(existing, pkt) {
+			return true
+		}
+	}
+	return false
+}
+func appendAudioTrack(list []AudioTrackInfo, track AudioTrackInfo) []AudioTrackInfo {
+	for i, existing := range list {
+		if existing.PID == track.PID {
+			list[i] = track
+			return list
+		}
+	}
+	return append(list, track)
+}

--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -22,8 +22,13 @@ import (
 //
 //	chunk in -> facts and ordered events out -> caller commits the bytes
 //
-// An implementation may live in this process or behind a socket. Nothing in the
-// contract assumes either, which is the point of it existing.
+// The contract is shaped so an implementation could live behind a socket, but
+// that is a statement about this interface, not about the caller. MasterRing
+// currently calls Ingest while holding the lock its readers use, so a remote core
+// that hung would block subscribers, readiness and Close along with it. The
+// semantic boundary is here; the fault-isolation boundary is not, and the
+// changeset that introduces a remote core has to move the call out of the reader
+// lock and give it a deadline before that sentence becomes true.
 type Core interface {
 	// Ingest consumes one chunk of transport stream. startOffset is the chunk's
 	// position in the caller's own monotonic byte coordinate system, and every
@@ -49,6 +54,13 @@ type Core interface {
 type EventKind uint8
 
 const (
+	// EventUnknown is the zero value and means nothing. It exists so that a
+	// missing, uninitialised or badly decoded event cannot arrive as a lifecycle
+	// change: across a wire boundary the zero value is what a truncated frame or a
+	// failed decode produces, and "advance the generation" is the last thing that
+	// should mean.
+	EventUnknown EventKind = iota
+
 	// EventProgramIdentityChanged reports that the program this stream carries is
 	// no longer the one it was: a new PMT version, a different program number, a
 	// changed elementary stream layout.
@@ -56,7 +68,7 @@ const (
 	// It is not a generation. What a caller does with it - bump an epoch, cut
 	// workers, invalidate an index - is the caller's decision, and this event
 	// carries no opinion about it.
-	EventProgramIdentityChanged EventKind = iota
+	EventProgramIdentityChanged
 
 	// EventRandomAccessPoint reports an access unit a decoder can be started on,
 	// at Offset in the caller's coordinate system.
@@ -76,7 +88,11 @@ type Event struct {
 
 // ParseResult is what one chunk meant.
 type ParseResult struct {
-	// ProcessedThroughOffset is the offset one past the last byte interpreted.
+	// ProcessedThroughOffset is the offset one past the last byte interpreted. A
+	// core that consumed less than it was given must say so here; the caller
+	// rejects the chunk rather than committing bytes whose meaning it does not
+	// have. Partial processing is not a supported outcome - this field exists to
+	// make the unsupported case detectable rather than silent.
 	ProcessedThroughOffset int64
 
 	// Events are ordered as they occurred within the chunk. A caller must replay

--- a/backend/internal/stream/ingest/mediafacts/declaration_test.go
+++ b/backend/internal/stream/ingest/mediafacts/declaration_test.go
@@ -2,7 +2,7 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0
 // Since v2.0.0, this software is restricted to non-commercial use only.
 
-package ring
+package mediafacts
 
 import "testing"
 

--- a/backend/internal/stream/ingest/mediafacts/fuzz_test.go
+++ b/backend/internal/stream/ingest/mediafacts/fuzz_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package mediafacts
+
+import "testing"
+
+// These parsers read bit-packed fields out of a broadcast the receiver hands over
+// unverified. A truncated PES, a scrambled payload misread as clear, or a NAL cut
+// short by a lost packet all arrive here as arbitrary bytes, so the property that
+// matters is that no input crashes the ingest and none of them opens the attach
+// gate by accident.
+
+func FuzzH264SliceIsIntra(f *testing.F) {
+	f.Add([]byte{sliceHeaderI})
+	f.Add([]byte{sliceHeaderP})
+	f.Add([]byte{})
+	f.Add([]byte{0x00})
+	f.Add([]byte{0x00, 0x00, 0x03, 0x88})       // emulation prevention
+	f.Add([]byte{0x00, 0x00, 0x00, 0x00, 0x00}) // long zero run, no terminator
+	f.Add([]byte{0x01, 0x88, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		isIntra, ok := h264SliceIsIntra(data)
+		// An unreadable header must never be reported as intra: that is what keeps a
+		// truncated capture from admitting a predicted picture as an entry point.
+		if !ok && isIntra {
+			t.Fatalf("unreadable slice header reported as intra: %x", data)
+		}
+	})
+}
+
+func FuzzSEIHasRecoveryPoint(f *testing.F) {
+	f.Add(seiRecoveryPoint)
+	f.Add([]byte{})
+	f.Add([]byte{0x80})
+	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF})             // payload type run with no terminator
+	f.Add([]byte{0x01, 0xFF, 0xFF, 0xFF})             // payload size run with no terminator
+	f.Add([]byte{0x01, 0x7F, 0x00})                   // payload size larger than the bytes present
+	f.Add([]byte{0x00, 0x00, 0x06, 0x01, 0x84, 0x80}) // recovery point behind another message
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// The contract is termination without panic; the walk advances at least two
+		// bytes per message, so a malformed payload cannot loop forever.
+		_ = seiHasRecoveryPoint(data)
+	})
+}
+
+func FuzzHasAudioDescriptor(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{descriptorAC3, 0x00})
+	f.Add([]byte{descriptorAudioReg, 0x04, 'A', 'C', '-', '3'})
+	f.Add([]byte{descriptorAudioReg, 0x02, 'A', 'C'}) // registration shorter than a format id
+	f.Add([]byte{0x0A, 0xFF, 0x01})                   // length running past the buffer
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_ = hasAudioDescriptor(data)
+	})
+}
+
+// The ring is what actually meets the receiver's bytes, so it is fuzzed as a whole:
+// packets with a broken sync byte, an adaptation field longer than the packet, or a
+// PES header claiming more data than it carries must not take the process down.

--- a/backend/internal/stream/ingest/mediafacts/parse.go
+++ b/backend/internal/stream/ingest/mediafacts/parse.go
@@ -2,7 +2,7 @@
 // Licensed under the PolyForm Noncommercial License 1.0.0
 // Since v2.0.0, this software is restricted to non-commercial use only.
 
-package ring
+package mediafacts
 
 import "github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
 

--- a/backend/internal/stream/ingest/mediafacts/psi.go
+++ b/backend/internal/stream/ingest/mediafacts/psi.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+// Package mediafacts reads what a transport stream says about itself.
+//
+// It owns interpretation and nothing else. It does not store bytes, hand them
+// out, decide when a stream becomes a new lifecycle epoch, or choose what to do
+// with what it finds - those belong to the caller, and the split is deliberate:
+//
+//	the caller owns the bytes, their offsets and the generation
+//	this package owns what the bytes mean
+//
+// Every offset it reports is in the caller's own monotonic byte coordinate
+// system, so an entry point it finds can be handed straight back to a reader
+// without translation. It reports that the program's identity changed; it does
+// not decide that a new generation has begun.
+package mediafacts
+
+import "errors"
+
+const (
+	TSPacketSize = 188
+	SyncByte     = 0x47
+
+	// ScrambledVerdictMinPackets is the number of scrambled video packets that must be observed,
+	// with zero clear ones, before the stream is declared scrambled. At broadcast video rates this
+	// threshold is crossed within a few tens of milliseconds.
+	ScrambledVerdictMinPackets = 100
+)
+
+// ErrInvalidPacketSize reports data that is not 188-byte packet aligned.
+var ErrInvalidPacketSize = errors.New("data slice is not 188-byte packet aligned")
+
+// VideoCodec identifies the elementary video stream codec parsed from PMT.
+type VideoCodec string
+
+const (
+	CodecUnknown VideoCodec = "unknown"
+	CodecH264    VideoCodec = "h264"
+	CodecH265    VideoCodec = "h265"
+	CodecMPEG2   VideoCodec = "mpeg2"
+)
+
+var mpeg2CRCTable [256]uint32
+
+func init() {
+	// Counted as uint32 so the shift needs no narrowing conversion; the bound
+	// makes the two identical, but only one of them is checkable.
+	for i := uint32(0); i < 256; i++ {
+		crc := i << 24
+		for j := 0; j < 8; j++ {
+			if (crc & 0x80000000) != 0 {
+				crc = (crc << 1) ^ 0x04C11DB7
+			} else {
+				crc <<= 1
+			}
+		}
+		mpeg2CRCTable[i] = crc
+	}
+}
+
+// CalculateMPEG2CRC32 calculates the standard ISO/IEC 13818-1 32-bit CRC.
+func CalculateMPEG2CRC32(data []byte) uint32 {
+	crc := uint32(0xFFFFFFFF)
+	for _, b := range data {
+		crc = (crc << 8) ^ mpeg2CRCTable[byte(crc>>24)^b]
+	}
+	return crc
+}
+
+type psiStreamAssembler struct {
+	buf        []byte
+	sectionLen int
+	lastCC     uint8
+	hasCC      bool
+	lastPacket []byte
+	rawPackets [][]byte
+}
+
+func (s *psiStreamAssembler) reset() {
+	s.buf = s.buf[:0]
+	s.sectionLen = 0
+	s.hasCC = false
+	s.lastPacket = nil
+	s.rawPackets = s.rawPackets[:0]
+}
+
+type tableSectionTracker struct {
+	inFlightVersion uint8
+	hasInFlight     bool
+	lastSectionNum  uint8
+	sections        map[uint8][]byte
+	rawPackets      map[uint8][][]byte
+}
+
+func (t *tableSectionTracker) reset() {
+	t.hasInFlight = false
+	t.lastSectionNum = 0
+	t.sections = make(map[uint8][]byte)
+	t.rawPackets = make(map[uint8][][]byte)
+}
+
+func (t *tableSectionTracker) addSection(version uint8, sectionNum uint8, lastSectionNum uint8, sectionBytes []byte, packets [][]byte) bool {
+	if !t.hasInFlight || t.inFlightVersion != version || t.lastSectionNum != lastSectionNum {
+		t.inFlightVersion = version
+		t.hasInFlight = true
+		t.lastSectionNum = lastSectionNum
+		t.sections = make(map[uint8][]byte)
+		t.rawPackets = make(map[uint8][][]byte)
+	}
+
+	t.sections[sectionNum] = cloneSlice(sectionBytes)
+	t.rawPackets[sectionNum] = cloneSliceList(packets)
+
+	if len(t.sections) == int(lastSectionNum)+1 {
+		for i := uint8(0); i <= lastSectionNum; i++ {
+			if _, ok := t.sections[i]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+type StreamScrambling struct {
+	VideoScrambled uint64
+	VideoClear     uint64
+	AudioScrambled uint64
+	AudioClear     uint64
+	// VideoClearRun is the number of clear video packets since the last scrambled
+	// one. Descrambling was measured coming up intermittently on this receiver, so
+	// the run length - not the total - is what says the stream is clear now.
+	VideoClearRun uint64
+	// AudioClearRun is the same measure across the audio streams.
+	AudioClearRun uint64
+	// AudioPIDs are the audio elementary streams named by the active PMT.
+	AudioPIDs []uint16
+}
+
+func cloneSlice(in []byte) []byte {
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSliceList(in [][]byte) [][]byte {
+	out := make([][]byte, len(in))
+	for i, s := range in {
+		out[i] = cloneSlice(s)
+	}
+	return out
+}

--- a/backend/internal/stream/ingest/mediafacts/slice_test.go
+++ b/backend/internal/stream/ingest/mediafacts/slice_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package mediafacts
+
+import "testing"
+
+// Slice headers, bit-packed. first_mb_in_slice is ue(0) = "1" in both.
+//
+//	sliceI: "1" + ue(7)="0001000"  -> 0b10001000, slice_type 7 (I, all slices)
+//	sliceP: "1" + ue(0)="1"        -> 0b11000000, slice_type 0 (P)
+const (
+	sliceHeaderI = 0x88
+	sliceHeaderP = 0xC0
+)
+
+// seiRecoveryPoint is one SEI NAL payload carrying recovery_point: payload type 6,
+// size 1, body 0x84 (recovery_frame_cnt=0, exact_match_flag=0), then trailing bits.
+// This is the exact payload measured on the reference receiver.
+var seiRecoveryPoint = []byte{0x06, 0x01, 0x84, 0x80}
+
+// Emulation prevention bytes shift every field that follows them. A slice header
+// that reads as intra only after they are removed proves the removal happens.
+func TestRandomAccess_EmulationPreventionInSliceHeader(t *testing.T) {
+	// Raw bytes 00 00 03 88: with the 0x03 removed the header is 00 00 88.
+	// first_mb_in_slice then reads as a long Exp-Golomb value rather than 0, so this
+	// asserts the parse is attempted over the unescaped bytes and rejected cleanly
+	// rather than silently admitting the picture.
+	if _, ok := h264SliceIsIntra([]byte{0x00, 0x00, 0x03, 0x88}); ok {
+		t.Fatal("a header of leading zero bits must be reported unreadable, not intra")
+	}
+	if intra, ok := h264SliceIsIntra([]byte{sliceHeaderI}); !ok || !intra {
+		t.Fatal("slice_type 7 must read as intra")
+	}
+	if intra, ok := h264SliceIsIntra([]byte{sliceHeaderP}); !ok || intra {
+		t.Fatal("slice_type 0 must read as predicted")
+	}
+}
+func TestRandomAccess_RecoveryPointSEIParsing(t *testing.T) {
+	cases := map[string]struct {
+		payload []byte
+		want    bool
+	}{
+		"recovery_point alone":        {[]byte{0x06, 0x01, 0x84, 0x80}, true},
+		"pic_timing then recovery":    {[]byte{0x01, 0x02, 0x00, 0x00, 0x06, 0x01, 0x84, 0x80}, true},
+		"pic_timing only":             {[]byte{0x01, 0x02, 0x00, 0x00, 0x80}, false},
+		"user data only":              {[]byte{0x05, 0x03, 0xAA, 0xBB, 0xCC, 0x80}, false},
+		"payload runs past capture":   {[]byte{0x05, 0x40, 0xAA, 0xBB}, false},
+		"extended type past recovery": {[]byte{0xFF, 0x01, 0x02, 0x00, 0x00, 0x80}, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := seiHasRecoveryPoint(tc.payload); got != tc.want {
+				t.Fatalf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/backend/internal/stream/ingest/ring/randomaccess_fuzz_test.go
+++ b/backend/internal/stream/ingest/ring/randomaccess_fuzz_test.go
@@ -6,62 +6,6 @@ package ring
 
 import "testing"
 
-// These parsers read bit-packed fields out of a broadcast the receiver hands over
-// unverified. A truncated PES, a scrambled payload misread as clear, or a NAL cut
-// short by a lost packet all arrive here as arbitrary bytes, so the property that
-// matters is that no input crashes the ingest and none of them opens the attach
-// gate by accident.
-
-func FuzzH264SliceIsIntra(f *testing.F) {
-	f.Add([]byte{sliceHeaderI})
-	f.Add([]byte{sliceHeaderP})
-	f.Add([]byte{})
-	f.Add([]byte{0x00})
-	f.Add([]byte{0x00, 0x00, 0x03, 0x88})       // emulation prevention
-	f.Add([]byte{0x00, 0x00, 0x00, 0x00, 0x00}) // long zero run, no terminator
-	f.Add([]byte{0x01, 0x88, 0xFF, 0xFF, 0xFF, 0xFF})
-
-	f.Fuzz(func(t *testing.T, data []byte) {
-		isIntra, ok := h264SliceIsIntra(data)
-		// An unreadable header must never be reported as intra: that is what keeps a
-		// truncated capture from admitting a predicted picture as an entry point.
-		if !ok && isIntra {
-			t.Fatalf("unreadable slice header reported as intra: %x", data)
-		}
-	})
-}
-
-func FuzzSEIHasRecoveryPoint(f *testing.F) {
-	f.Add(seiRecoveryPoint)
-	f.Add([]byte{})
-	f.Add([]byte{0x80})
-	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF})             // payload type run with no terminator
-	f.Add([]byte{0x01, 0xFF, 0xFF, 0xFF})             // payload size run with no terminator
-	f.Add([]byte{0x01, 0x7F, 0x00})                   // payload size larger than the bytes present
-	f.Add([]byte{0x00, 0x00, 0x06, 0x01, 0x84, 0x80}) // recovery point behind another message
-
-	f.Fuzz(func(t *testing.T, data []byte) {
-		// The contract is termination without panic; the walk advances at least two
-		// bytes per message, so a malformed payload cannot loop forever.
-		_ = seiHasRecoveryPoint(data)
-	})
-}
-
-func FuzzHasAudioDescriptor(f *testing.F) {
-	f.Add([]byte{})
-	f.Add([]byte{descriptorAC3, 0x00})
-	f.Add([]byte{descriptorAudioReg, 0x04, 'A', 'C', '-', '3'})
-	f.Add([]byte{descriptorAudioReg, 0x02, 'A', 'C'}) // registration shorter than a format id
-	f.Add([]byte{0x0A, 0xFF, 0x01})                   // length running past the buffer
-
-	f.Fuzz(func(t *testing.T, data []byte) {
-		_ = hasAudioDescriptor(data)
-	})
-}
-
-// The ring is what actually meets the receiver's bytes, so it is fuzzed as a whole:
-// packets with a broken sync byte, an adaptation field longer than the packet, or a
-// PES header claiming more data than it carries must not take the process down.
 func FuzzMasterRingPush(f *testing.F) {
 	f.Add(make([]byte, TSPacketSize))
 	f.Add([]byte{0x47, 0x01, 0x00, 0x10})

--- a/backend/internal/stream/ingest/ring/randomaccess_test.go
+++ b/backend/internal/stream/ingest/ring/randomaccess_test.go
@@ -215,45 +215,6 @@ func TestRandomAccess_SliceHeaderSplitAcrossTSPackets(t *testing.T) {
 	}
 }
 
-// Emulation prevention bytes shift every field that follows them. A slice header
-// that reads as intra only after they are removed proves the removal happens.
-func TestRandomAccess_EmulationPreventionInSliceHeader(t *testing.T) {
-	// Raw bytes 00 00 03 88: with the 0x03 removed the header is 00 00 88.
-	// first_mb_in_slice then reads as a long Exp-Golomb value rather than 0, so this
-	// asserts the parse is attempted over the unescaped bytes and rejected cleanly
-	// rather than silently admitting the picture.
-	if _, ok := h264SliceIsIntra([]byte{0x00, 0x00, 0x03, 0x88}); ok {
-		t.Fatal("a header of leading zero bits must be reported unreadable, not intra")
-	}
-	if intra, ok := h264SliceIsIntra([]byte{sliceHeaderI}); !ok || !intra {
-		t.Fatal("slice_type 7 must read as intra")
-	}
-	if intra, ok := h264SliceIsIntra([]byte{sliceHeaderP}); !ok || intra {
-		t.Fatal("slice_type 0 must read as predicted")
-	}
-}
-
-func TestRandomAccess_RecoveryPointSEIParsing(t *testing.T) {
-	cases := map[string]struct {
-		payload []byte
-		want    bool
-	}{
-		"recovery_point alone":        {[]byte{0x06, 0x01, 0x84, 0x80}, true},
-		"pic_timing then recovery":    {[]byte{0x01, 0x02, 0x00, 0x00, 0x06, 0x01, 0x84, 0x80}, true},
-		"pic_timing only":             {[]byte{0x01, 0x02, 0x00, 0x00, 0x80}, false},
-		"user data only":              {[]byte{0x05, 0x03, 0xAA, 0xBB, 0xCC, 0x80}, false},
-		"payload runs past capture":   {[]byte{0x05, 0x40, 0xAA, 0xBB}, false},
-		"extended type past recovery": {[]byte{0xFF, 0x01, 0x02, 0x00, 0x00, 0x80}, false},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			if got := seiHasRecoveryPoint(tc.payload); got != tc.want {
-				t.Fatalf("want %v, got %v", tc.want, got)
-			}
-		})
-	}
-}
-
 // HEVC keeps IRAP detection and gains the rest of the IRAP range; the old
 // "trailing picture plus parameter sets" heuristic is gone.
 func TestRandomAccess_HEVC_IRAPRangeAndTrailingRejection(t *testing.T) {

--- a/backend/internal/stream/ingest/ring/reader.go
+++ b/backend/internal/stream/ingest/ring/reader.go
@@ -174,7 +174,7 @@ func (s *SubscriberReader) Read(p []byte) (int, error) {
 			//	                         decoder state to corrupt, so the tail is the
 			//	                         only entry point there is, and a legal one.
 			//	topology known, video  - only a random access point will do.
-			s.awaitingRandomAccess = !s.ring.hasPMTVersion || s.ring.videoPID != 0
+			s.awaitingRandomAccess = !s.ring.facts.HasPMT || s.ring.facts.VideoPID != 0
 		}
 
 		// The wait is a state, not a single pass. Without it the next push would

--- a/backend/internal/stream/ingest/ring/reader_resync_test.go
+++ b/backend/internal/stream/ingest/ring/reader_resync_test.go
@@ -395,8 +395,8 @@ func TestSubscriberReader_MPEG2OverrunResyncsToIFrame(t *testing.T) {
 	if _, err := r.Push(mpeg2PMTPacket(t, 100, 200)); err != nil {
 		t.Fatalf("push MPEG-2 PMT: %v", err)
 	}
-	if r.videoCodec != CodecMPEG2 {
-		t.Fatalf("test setup: expected CodecMPEG2, got %v", r.videoCodec)
+	if r.facts.VideoCodec != CodecMPEG2 {
+		t.Fatalf("test setup: expected CodecMPEG2, got %v", r.facts.VideoCodec)
 	}
 
 	reader := r.NewSubscriberReader(0)
@@ -479,8 +479,8 @@ func TestSubscriberReader_AudioOnlyServiceResumesAtTailWithoutWaiting(t *testing
 			t.Fatalf("push audio-only PMT: %v", err)
 		}
 	}
-	if r.videoPID != 0 {
-		t.Fatalf("test setup: expected no video PID, got %d", r.videoPID)
+	if r.facts.VideoPID != 0 {
+		t.Fatalf("test setup: expected no video PID, got %d", r.facts.VideoPID)
 	}
 
 	reader := r.NewSubscriberReader(0)

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -5,26 +5,14 @@
 package ring
 
 import (
-	"bytes"
 	"errors"
 	"sync"
 
-	"github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
-)
-
-const (
-	TSPacketSize = 188
-	SyncByte     = 0x47
-
-	// scrambledVerdictMinPackets is the number of scrambled video packets that must be observed,
-	// with zero clear ones, before the stream is declared scrambled. At broadcast video rates this
-	// threshold is crossed within a few tens of milliseconds.
-	scrambledVerdictMinPackets = 100
+	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
 )
 
 var (
 	ErrRingClosed        = errors.New("master ring buffer closed")
-	ErrInvalidPacketSize = errors.New("data slice is not 188-byte packet aligned")
 	ErrNoKeyframeFound   = errors.New("no keyframe index found in buffer")
 	ErrSubscriberOverrun = errors.New("subscriber was overtaken by master ring write head")
 	// ErrScrambledStream reports that the upstream video elementary stream carries a non-zero
@@ -33,189 +21,68 @@ var (
 	ErrScrambledStream = errors.New("upstream video elementary stream is scrambled; receiver descrambling unavailable")
 )
 
-// VideoCodec identifies the elementary video stream codec parsed from PMT.
-type VideoCodec string
-
+// Transport constants and the alignment error belong with the parser; they are
+// re-exported here because the whole repository already imports them by this name.
 const (
-	CodecUnknown VideoCodec = "unknown"
-	CodecH264    VideoCodec = "h264"
-	CodecH265    VideoCodec = "h265"
-	CodecMPEG2   VideoCodec = "mpeg2"
+	TSPacketSize = mediafacts.TSPacketSize
+	SyncByte     = mediafacts.SyncByte
 )
 
-var mpeg2CRCTable [256]uint32
+// ErrInvalidPacketSize reports data that is not 188-byte packet aligned.
+var ErrInvalidPacketSize = mediafacts.ErrInvalidPacketSize
 
-func init() {
-	// Counted as uint32 so the shift needs no narrowing conversion; the bound
-	// makes the two identical, but only one of them is checkable.
-	for i := uint32(0); i < 256; i++ {
-		crc := i << 24
-		for j := 0; j < 8; j++ {
-			if (crc & 0x80000000) != 0 {
-				crc = (crc << 1) ^ 0x04C11DB7
-			} else {
-				crc <<= 1
-			}
-		}
-		mpeg2CRCTable[i] = crc
-	}
-}
+// The interpretation of transport stream bytes lives in mediafacts. These aliases
+// keep the names consumers already import while the boundary is drawn: the ring
+// owns bytes, offsets and the generation; mediafacts owns what the bytes mean.
+type (
+	VideoCodec              = mediafacts.VideoCodec
+	AudioTrackInfo          = mediafacts.AudioTrackInfo
+	AudioChannelDeclaration = mediafacts.AudioChannelDeclaration
+	RandomAccessObservation = mediafacts.RandomAccessObservation
+	StreamScrambling        = mediafacts.StreamScrambling
+)
+
+const (
+	CodecUnknown = mediafacts.CodecUnknown
+	CodecH264    = mediafacts.CodecH264
+	CodecH265    = mediafacts.CodecH265
+	CodecMPEG2   = mediafacts.CodecMPEG2
+)
 
 // CalculateMPEG2CRC32 calculates the standard ISO/IEC 13818-1 32-bit CRC.
-func CalculateMPEG2CRC32(data []byte) uint32 {
-	crc := uint32(0xFFFFFFFF)
-	for _, b := range data {
-		crc = (crc << 8) ^ mpeg2CRCTable[byte(crc>>24)^b]
-	}
-	return crc
-}
-
-type psiStreamAssembler struct {
-	buf        []byte
-	sectionLen int
-	lastCC     uint8
-	hasCC      bool
-	lastPacket []byte
-	rawPackets [][]byte
-}
-
-func (s *psiStreamAssembler) reset() {
-	s.buf = s.buf[:0]
-	s.sectionLen = 0
-	s.hasCC = false
-	s.lastPacket = nil
-	s.rawPackets = s.rawPackets[:0]
-}
-
-type tableSectionTracker struct {
-	inFlightVersion uint8
-	hasInFlight     bool
-	lastSectionNum  uint8
-	sections        map[uint8][]byte
-	rawPackets      map[uint8][][]byte
-}
-
-func (t *tableSectionTracker) reset() {
-	t.hasInFlight = false
-	t.lastSectionNum = 0
-	t.sections = make(map[uint8][]byte)
-	t.rawPackets = make(map[uint8][][]byte)
-}
-
-func (t *tableSectionTracker) addSection(version uint8, sectionNum uint8, lastSectionNum uint8, sectionBytes []byte, packets [][]byte) bool {
-	if !t.hasInFlight || t.inFlightVersion != version || t.lastSectionNum != lastSectionNum {
-		t.inFlightVersion = version
-		t.hasInFlight = true
-		t.lastSectionNum = lastSectionNum
-		t.sections = make(map[uint8][]byte)
-		t.rawPackets = make(map[uint8][][]byte)
-	}
-
-	t.sections[sectionNum] = cloneSlice(sectionBytes)
-	t.rawPackets[sectionNum] = cloneSliceList(packets)
-
-	if len(t.sections) == int(lastSectionNum)+1 {
-		for i := uint8(0); i <= lastSectionNum; i++ {
-			if _, ok := t.sections[i]; !ok {
-				return false
-			}
-		}
-		return true
-	}
-	return false
-}
+func CalculateMPEG2CRC32(data []byte) uint32 { return mediafacts.CalculateMPEG2CRC32(data) }
 
 // MasterRing is a thread-safe, multi-reader circular FIFO buffer for MPEG-TS streams.
 // It maintains an in-band, stateful index of PAT, PMT, and PES/IDR Keyframe byte offsets.
+// MasterRing is a thread-safe, multi-reader circular FIFO buffer for MPEG-TS
+// streams. It owns the bytes, their monotonic offsets, the entry-point index and
+// the generation; what the bytes mean is read by a mediafacts.Core it holds.
 type MasterRing struct {
-	mu       sync.Mutex
-	notEmpty *sync.Cond
-	buf      []byte
-	capacity int
-	head     int64 // total bytes written monotonically
-	tail     int64 // oldest valid byte offset in buffer
-	isClosed bool
+	mu              sync.Mutex
+	notEmpty        *sync.Cond
+	buf             []byte
+	capacity        int
+	head            int64 // total bytes written monotonically
+	tail            int64 // oldest valid byte offset in buffer
+	isClosed        bool
+	keyframeOffsets []int64
+	maxKeyframes    int
+	generation      uint64
 
-	// PSI Table Assembly & Selection
-	targetProgramNumber uint16
-	patAssembler        psiStreamAssembler
-	pmtAssembler        psiStreamAssembler
-	patTracker          tableSectionTracker
-	pmtTracker          tableSectionTracker
-	rawPATPackets       [][]byte
-	rawPMTPackets       [][]byte
-	hasPATVersion       bool
-	patVersion          uint8
-	hasPMTVersion       bool
-	pmtVersion          uint8
-	pmtProgramNumber    uint16
-	pmtPID              uint16
-	videoPID            uint16
-	videoCodec          VideoCodec
+	// core reads what the transport stream says about itself. It is given byte
+	// chunks and the offset they start at, and answers with facts and ordered
+	// events; it never sees this struct.
+	core mediafacts.Core
 
-	// Stateful Video Parsing & Keyframe Indexing
-	currentPESOffset int64
-	pesHasKeyframe   bool
-	pesHasSPS        bool
-	pesHasPPS        bool
-	pesHasVPS        bool
-	annexBState      uint32 // 4-byte shift register for startcode scanning
-	expectingNALByte bool
-	keyframeOffsets  []int64
-	maxKeyframes     int
-	generation       uint64
+	// facts is the last answer the core gave, cached so an accessor never calls
+	// across the boundary while holding the ring lock. The facts only move when a
+	// chunk is ingested, so a cache cannot be stale between chunks.
+	facts mediafacts.Facts
 
-	// Random access classification for the access unit currently being assembled.
-	// Held per access unit because joinability is a property of all of its slices,
-	// which is only known once the next access unit begins.
-	auHasIRAP       bool
-	auHasRecoveryPt bool
-	auVCLCount      int
-	auIntraVCLCount int
-	// auScrambledPackets counts scrambled packets inside the access unit being
-	// assembled. An entry point whose own access unit was partly encrypted is not
-	// one a decoder can be started on.
-	auScrambledPackets int
-	cleanRAPCount      uint64
-	cleanAccessUnits   uint64
-	nalBuf             []byte
-	nalKind            nalCaptureKind
-	nalLeft            int
-	// nalSkip is the number of bytes of the NAL header still to pass over before
-	// the capture starts. H.264 has a one byte header, which is already consumed by
-	// the classification step; HEVC has two, and capturing from the first of the
-	// remaining bytes would read nuh_layer_id as if it were an SEI payload type.
-	nalSkip int
-	raObs   RandomAccessObservation
-
-	// Scrambling observation, kept per elementary stream rather than as one total.
-	// A service whose video descrambles while its audio does not is a different
-	// fault from one where neither does, and a single counter cannot tell them apart.
-	scrambledVideoPackets uint64
-	clearVideoPackets     uint64
-	scrambledAudioPackets uint64
-	clearAudioPackets     uint64
-	// videoClearRun counts consecutive clear video packets, reset by any scrambled
-	// one. Descrambling on this receiver was measured coming up intermittently -
-	// 733 scrambled packets interleaved with clear ones on one tune - so "a clear
-	// packet was seen" is not evidence that the stream is clear.
-	videoClearRun uint64
-	// audioClearRun is the same measure on the audio streams, kept separately so a
-	// service whose video is through but whose audio is not can be told apart.
-	audioClearRun uint64
-	// audioPIDs holds the elementary audio streams named by the active PMT.
-	audioPIDs   []uint16
-	audioTracks []AudioTrackInfo
-
-	// audioObservers follow the audio payload of the tracks whose codec this path
-	// can read, one per PID. They exist because the audio topology is not a
-	// property of the session start: a service moves between stereo and 5.1 on the
-	// same PID as programmes change, and a reading taken once at attach describes
-	// only whatever happened to be running then.
-	//
-	// Keyed by PID and rebuilt from scratch whenever the PMT changes, so an
-	// observation can never outlive the table that named the stream it came from.
-	audioObservers map[uint16]*esaudio.Observer
+	// activePSI is the raw PAT/PMT the core last parsed, kept because the
+	// subscriber delivers those packets ahead of an entry point. Interpretation is
+	// the core's; delivery is the ring's, and neither parses them twice.
+	activePSI mediafacts.ActivePSI
 }
 
 // NewMasterRing creates a new MasterRing with the specified capacity (aligned to 188 bytes).
@@ -231,16 +98,11 @@ func NewMasterRingWithProgram(capacityBytes int, targetProgram uint16) *MasterRi
 	}
 
 	r := &MasterRing{
-		buf:                 make([]byte, capacityBytes),
-		capacity:            capacityBytes,
-		targetProgramNumber: targetProgram,
-		videoCodec:          CodecUnknown,
-		currentPESOffset:    -1,
-		maxKeyframes:        64,
-		annexBState:         0xFFFFFFFF,
+		buf:          make([]byte, capacityBytes),
+		capacity:     capacityBytes,
+		maxKeyframes: 64,
+		core:         mediafacts.NewGoCore(targetProgram),
 	}
-	r.patTracker.reset()
-	r.pmtTracker.reset()
 	r.notEmpty = sync.NewCond(&r.mu)
 	return r
 }
@@ -251,18 +113,31 @@ func (r *MasterRing) SetTargetProgram(progNum uint16) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.targetProgramNumber != progNum {
-		r.targetProgramNumber = progNum
-		r.hasPATVersion = false
-		r.hasPMTVersion = false
-		r.pmtPID = 0
-		r.patAssembler.reset()
-		r.pmtAssembler.reset()
-		r.patTracker.reset()
-		r.pmtTracker.reset()
-		r.rawPATPackets = nil
-		r.invalidateVideoStateLocked()
+	r.applyLocked(r.core.SetTargetProgram(progNum))
+}
+
+// applyLocked takes what the core said about a chunk and acts on it.
+//
+// This is where the ownership split is executed. The core reported that the
+// program's identity changed and where the entry points are; the epoch those
+// belong to, and whether an entry point is still reachable, are decided here -
+// in order, because an entry point found before an identity change and one found
+// after it belong to different programs.
+func (r *MasterRing) applyLocked(res mediafacts.ParseResult) {
+	for _, ev := range res.Events {
+		switch ev.Kind {
+		case mediafacts.EventProgramIdentityChanged:
+			r.keyframeOffsets = r.keyframeOffsets[:0]
+			r.generation++
+		case mediafacts.EventRandomAccessPoint:
+			r.keyframeOffsets = append(r.keyframeOffsets, ev.Offset)
+			if len(r.keyframeOffsets) > r.maxKeyframes {
+				r.keyframeOffsets = r.keyframeOffsets[1:]
+			}
+		}
 	}
+	r.facts = res.Facts
+	r.activePSI = res.PSI
 }
 
 // Push writes a chunk of TS packets into the ring buffer and indexes PAT/PMT/IDR boundaries.
@@ -283,12 +158,14 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 		return 0, nil
 	}
 
-	// 1. Parse and index each 188-byte packet monotonically
-	for i := 0; i < n; i += TSPacketSize {
-		pkt := data[i : i+TSPacketSize]
-		pktOffset := r.head + int64(i)
-		r.indexPacketLocked(pkt, pktOffset)
+	// 1. Read what the chunk means before any of it becomes visible. The bytes are
+	//    committed below; a subscriber that could see them before the facts caught
+	//    up would be reading the new program with the old program's truth.
+	res, err := r.core.Ingest(r.head, data)
+	if err != nil {
+		return 0, err
 	}
+	r.applyLocked(res)
 
 	// 2. Write data into circular buffer safely, supporting len(data) > capacity without panic
 	remaining := data
@@ -320,809 +197,11 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	return n, nil
 }
 
-func (r *MasterRing) indexPacketLocked(pkt []byte, offset int64) {
-	if len(pkt) < TSPacketSize || pkt[0] != SyncByte {
-		return
-	}
-
-	pid := (uint16(pkt[1]&0x1F) << 8) | uint16(pkt[2])
-	pusi := (pkt[1] & 0x40) != 0
-	afc := (pkt[3] >> 4) & 0x03
-	hasPayload := (afc == 0x01 || afc == 0x03)
-	if !hasPayload {
-		return
-	}
-
-	payloadOffset := 4
-	if afc == 0x03 {
-		afLen := int(pkt[4])
-		payloadOffset = 5 + afLen
-		if payloadOffset >= TSPacketSize {
-			return
-		}
-	}
-	payload := pkt[payloadOffset:]
-
-	// 1. PAT (PID 0) Section Assembly
-	if pid == 0 {
-		r.feedPSIPacketLocked(true, pkt, pusi, payload)
-		return
-	}
-
-	// 2. PMT Section Assembly
-	if r.pmtPID > 0 && pid == r.pmtPID {
-		r.feedPSIPacketLocked(false, pkt, pusi, payload)
-		return
-	}
-
-	// 3. Video Elementary Stream Keyframe / IDR Indexing
-	if r.videoPID > 0 && pid == r.videoPID {
-		r.parseVideoPacketLocked(pkt, offset, pusi, payload)
-		return
-	}
-
-	// 4. Audio elementary streams. Whether the payload arrives clear decides
-	//    whether a channel is presentable, and for the codecs that carry their
-	//    channel layout in the frame header the payload is also the only place a
-	//    channel count above two can be read at all.
-	for _, apid := range r.audioPIDs {
-		if pid == apid {
-			if (pkt[3]>>6)&0x03 != 0 {
-				r.scrambledAudioPackets++
-				r.audioClearRun = 0
-				return
-			}
-			r.clearAudioPackets++
-			r.audioClearRun++
-			r.observeAudioPayloadLocked(apid, pusi, payload)
-			return
-		}
-	}
-}
-
-// observableAudioCodec reports whether the frame headers of a codec are read for
-// their channel layout. Everything else is left to the declaration and to
-// whatever the media path already does; a codec this parser cannot read produces
-// no observation rather than a guessed one.
-func observableAudioCodec(codec string) bool {
-	return codec == esaudio.CodecAC3 || codec == esaudio.CodecEAC3
-}
-
-// observeAudioPayloadLocked hands one clear audio packet's elementary stream
-// bytes to the observer for that PID.
-//
-// This is where transport ends. The observer is given elementary stream payload
-// and nothing else - no PID, no packet, no PMT - so what it reads is a property
-// of the audio rather than of how the audio arrived.
-func (r *MasterRing) observeAudioPayloadLocked(pid uint16, pusi bool, payload []byte) {
-	obs := r.audioObservers[pid]
-	if obs == nil {
-		return
-	}
-
-	es := payload
-	if pusi {
-		// A PES packet starts here, so the elementary stream does not: skip the
-		// header. Audio arrives either as an audio stream id or, for AC-3 in DVB,
-		// as private_stream_1.
-		if len(payload) < 9 || payload[0] != 0x00 || payload[1] != 0x00 || payload[2] != 0x01 {
-			return
-		}
-		if sid := payload[3]; sid != 0xBD && sid != 0xFD && (sid < 0xC0 || sid > 0xDF) {
-			return
-		}
-		esStart := 9 + int(payload[8])
-		if esStart >= len(payload) {
-			// The optional header ran past this packet. Rare, and not worth state of
-			// its own: the remainder is fed as if it were elementary stream, where it
-			// has to survive a syncword check and a run of agreeing frames before it
-			// could reach the observation.
-			return
-		}
-		es = payload[esStart:]
-	}
-	obs.Feed(es)
-}
-
-func (r *MasterRing) feedBytesToAssemblerLocked(isPAT bool, assembler *psiStreamAssembler, chunk []byte, pkt []byte) int {
-	if len(chunk) == 0 {
-		return 0
-	}
-
-	consumed := 0
-
-	// Phase 1: Complete 3-byte header if incomplete
-	if len(assembler.buf) < 3 {
-		needHeader := 3 - len(assembler.buf)
-		toTake := len(chunk)
-		if toTake > needHeader {
-			toTake = needHeader
-		}
-		assembler.buf = append(assembler.buf, chunk[:toTake]...)
-		assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
-		chunk = chunk[toTake:]
-		consumed += toTake
-
-		if len(assembler.buf) >= 3 {
-			secLen := int((uint16(assembler.buf[1]&0x0F) << 8) | uint16(assembler.buf[2]))
-			assembler.sectionLen = secLen + 3
-		} else {
-			return consumed
-		}
-	}
-
-	// Phase 2: Complete body up to sectionLen
-	if assembler.sectionLen > 0 && len(assembler.buf) < assembler.sectionLen {
-		needed := assembler.sectionLen - len(assembler.buf)
-		toTake := len(chunk)
-		if toTake > needed {
-			toTake = needed
-		}
-		assembler.buf = append(assembler.buf, chunk[:toTake]...)
-		if consumed == 0 { // Not added in Phase 1 for this packet
-			assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
-		}
-		consumed += toTake
-
-		if len(assembler.buf) >= assembler.sectionLen {
-			r.processCompletePSISectionLocked(isPAT, assembler.buf[:assembler.sectionLen], assembler.rawPackets)
-			assembler.buf = assembler.buf[:0]
-			assembler.sectionLen = 0
-			assembler.rawPackets = assembler.rawPackets[:0]
-		}
-	}
-
-	return consumed
-}
-
-func (r *MasterRing) feedPSIPacketLocked(isPAT bool, pkt []byte, pusi bool, payload []byte) {
-	var assembler *psiStreamAssembler
-	if isPAT {
-		assembler = &r.patAssembler
-	} else {
-		assembler = &r.pmtAssembler
-	}
-
-	cc := pkt[3] & 0x0F
-	if assembler.hasCC {
-		if cc == assembler.lastCC {
-			if bytes.Equal(pkt, assembler.lastPacket) {
-				// Exact byte-for-byte duplicate TS packet: silently ignore
-				return
-			}
-			// Same CC but different content: glitch / discontinuity!
-			assembler.reset()
-			if !pusi {
-				return
-			}
-		} else if cc != (assembler.lastCC+1)&0x0F {
-			// Continuity gap detected: abort corrupted in-flight assembly
-			assembler.reset()
-			if !pusi {
-				return
-			}
-		}
-	}
-	assembler.lastCC = cc
-	assembler.hasCC = true
-	assembler.lastPacket = cloneSlice(pkt)
-
-	offset := 0
-
-	if pusi {
-		if len(payload) < 1 {
-			return
-		}
-		pointerField := int(payload[0])
-
-		if pointerField > 0 {
-			// Case A: Bytes before pointer complete previous in-flight section
-			if len(assembler.buf) > 0 {
-				toTake := pointerField
-				if 1+toTake > len(payload) {
-					assembler.reset()
-					return
-				}
-				r.feedBytesToAssemblerLocked(isPAT, assembler, payload[1:1+toTake], pkt)
-				if len(assembler.buf) > 0 {
-					// Still incomplete after pointer field: missing data, discard
-					assembler.buf = assembler.buf[:0]
-					assembler.sectionLen = 0
-					assembler.rawPackets = assembler.rawPackets[:0]
-				}
-			}
-			offset = 1 + pointerField
-		} else {
-			// Case B: pointerField == 0. Discard any unfinished prior section
-			assembler.buf = assembler.buf[:0]
-			assembler.sectionLen = 0
-			assembler.rawPackets = assembler.rawPackets[:0]
-			offset = 1
-		}
-	} else {
-		// pusi == false: continue in-flight section
-		if len(assembler.buf) > 0 {
-			consumed := r.feedBytesToAssemblerLocked(isPAT, assembler, payload, pkt)
-			offset = consumed
-		} else {
-			return
-		}
-	}
-
-	// Parse subsequent sections in this payload (supporting multiple sections per packet)
-	for offset < len(payload) {
-		if payload[offset] == 0xFF {
-			// MPEG-TS PSI padding / stuffing bytes reached
-			break
-		}
-
-		avail := len(payload) - offset
-		if avail < 3 {
-			// Fragmented section header (1-2 bytes) spanning into next packet!
-			assembler.buf = append(assembler.buf, payload[offset:]...)
-			assembler.sectionLen = 0
-			assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
-			break
-		}
-
-		tableID := payload[offset]
-		expectedTableID := byte(0x00)
-		if !isPAT {
-			expectedTableID = 0x02
-		}
-		if tableID != expectedTableID {
-			break
-		}
-
-		secLen := int((uint16(payload[offset+1]&0x0F) << 8) | uint16(payload[offset+2]))
-		fullSecLen := secLen + 3
-
-		if avail >= fullSecLen {
-			// Complete section self-contained in this payload chunk!
-			sectionBytes := payload[offset : offset+fullSecLen]
-			r.processCompletePSISectionLocked(isPAT, sectionBytes, [][]byte{cloneSlice(pkt)})
-			offset += fullSecLen
-			continue
-		}
-
-		// Section spans across to next TS packet
-		assembler.buf = append(assembler.buf, payload[offset:]...)
-		assembler.sectionLen = fullSecLen
-		assembler.rawPackets = append(assembler.rawPackets, cloneSlice(pkt))
-		break
-	}
-}
-
-func (r *MasterRing) processCompletePSISectionLocked(isPAT bool, table []byte, rawPackets [][]byte) {
-	if len(table) < 12 {
-		return
-	}
-
-	// Validate MPEG-2 CRC32
-	if CalculateMPEG2CRC32(table) != 0 {
-		return
-	}
-
-	currentNext := table[5] & 0x01
-	if currentNext != 1 {
-		return
-	}
-
-	version := (table[5] >> 1) & 0x1F
-	sectionNum := table[6]
-	lastSectionNum := table[7]
-
-	if isPAT {
-		tableComplete := r.patTracker.addSection(version, sectionNum, lastSectionNum, table, rawPackets)
-		if !tableComplete {
-			return
-		}
-
-		// Full PAT Table Generation Complete: scan all sections for target program
-		matchedPID := uint16(0)
-		for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
-			sData := r.patTracker.sections[sIdx]
-			if len(sData) < 12 {
-				continue
-			}
-			programs := sData[8 : len(sData)-4]
-			for i := 0; i+4 <= len(programs); i += 4 {
-				progNum := (uint16(programs[i]) << 8) | uint16(programs[i+1])
-				progPID := ((uint16(programs[i+2]) & 0x1F) << 8) | uint16(programs[i+3])
-				if progNum == 0 {
-					continue
-				}
-
-				if r.targetProgramNumber > 0 {
-					if progNum == r.targetProgramNumber {
-						matchedPID = progPID
-						break
-					}
-				} else {
-					matchedPID = progPID
-					break
-				}
-			}
-			if matchedPID > 0 && r.targetProgramNumber > 0 {
-				break
-			}
-		}
-
-		if matchedPID > 0 {
-			if !r.hasPMTVersion || r.pmtPID != matchedPID || !r.hasPATVersion || r.patVersion != version {
-				if r.pmtPID != matchedPID {
-					r.pmtPID = matchedPID
-					r.pmtAssembler.reset()
-					r.pmtTracker.reset()
-					r.hasPMTVersion = false
-					r.invalidateVideoStateLocked()
-				}
-			}
-			r.hasPATVersion = true
-			r.patVersion = version
-
-			// Build deduplicated rawPATPackets from all sections 0..lastSectionNum
-			var allPATPackets [][]byte
-			for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
-				for _, pkt := range r.patTracker.rawPackets[sIdx] {
-					if !containsPacket(allPATPackets, pkt) {
-						allPATPackets = append(allPATPackets, cloneSlice(pkt))
-					}
-				}
-			}
-			r.rawPATPackets = allPATPackets
-		}
-	} else {
-		progNum := (uint16(table[3]) << 8) | uint16(table[4])
-		tableComplete := r.pmtTracker.addSection(version, sectionNum, lastSectionNum, table, rawPackets)
-		if !tableComplete {
-			return
-		}
-
-		// Full PMT Table Generation Complete
-		isChanged := !r.hasPMTVersion || version != r.pmtVersion || progNum != r.pmtProgramNumber
-		if isChanged {
-			r.hasPMTVersion = true
-			r.pmtVersion = version
-			r.pmtProgramNumber = progNum
-			r.invalidateVideoStateLocked()
-
-			// Scan elementary streams across all sections 0..lastSectionNum
-			for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
-				sData := r.pmtTracker.sections[sIdx]
-				if len(sData) < 12 {
-					continue
-				}
-				progInfoLen := int((uint16(sData[10]&0x0F) << 8) | uint16(sData[11]))
-				esStart := 12 + progInfoLen
-				esEnd := len(sData) - 4
-
-				for i := esStart; i+5 <= esEnd && i < len(sData); {
-					st := sData[i]
-					elemPID := ((uint16(sData[i+1]) & 0x1F) << 8) | uint16(sData[i+2])
-					esInfoLen := int((uint16(sData[i+3]&0x0F) << 8) | uint16(sData[i+4]))
-
-					switch st {
-					case 0x1B: // H.264 / AVC
-						if r.videoPID == 0 {
-							r.videoPID = elemPID
-							r.videoCodec = CodecH264
-						}
-					case 0x24, 0x27: // H.265 / HEVC
-						if r.videoPID == 0 {
-							r.videoPID = elemPID
-							r.videoCodec = CodecH265
-						}
-					case 0x02, 0x01: // MPEG-2 / MPEG-1 Video
-						if r.videoPID == 0 {
-							r.videoPID = elemPID
-							r.videoCodec = CodecMPEG2
-						}
-					default:
-						// The elementary stream loop is now walked to its end rather
-						// than stopped at the video entry: the audio streams that
-						// follow it are needed to tell "video descrambled, audio did
-						// not" apart from "nothing descrambled".
-						descriptors := []byte(nil)
-						if dStart := i + 5; dStart+esInfoLen <= len(sData) {
-							descriptors = sData[dStart : dStart+esInfoLen]
-						}
-						if isAudioStreamType(st, descriptors) {
-							r.audioPIDs = appendPID(r.audioPIDs, elemPID)
-							codec := AudioCodecFromStreamType(st, descriptors)
-							lang := LanguageFromDescriptors(descriptors)
-							declared := AudioChannelsFromDescriptors(descriptors)
-							r.audioTracks = appendAudioTrack(r.audioTracks, AudioTrackInfo{
-								PID:        elemPID,
-								StreamType: st,
-								Codec:      codec,
-								Language:   lang,
-								Declared:   declared,
-							})
-							if observableAudioCodec(codec) {
-								if r.audioObservers == nil {
-									r.audioObservers = make(map[uint16]*esaudio.Observer, 2)
-								}
-								r.audioObservers[elemPID] = esaudio.NewObserver()
-							}
-						}
-					}
-
-					i += 5 + esInfoLen
-				}
-			}
-		}
-
-		// Build deduplicated rawPMTPackets from all sections 0..lastSectionNum
-		var allPMTPackets [][]byte
-		for sIdx := uint8(0); sIdx <= lastSectionNum; sIdx++ {
-			for _, pkt := range r.pmtTracker.rawPackets[sIdx] {
-				if !containsPacket(allPMTPackets, pkt) {
-					allPMTPackets = append(allPMTPackets, cloneSlice(pkt))
-				}
-			}
-		}
-		r.rawPMTPackets = allPMTPackets
-	}
-}
-
-func containsPacket(list [][]byte, pkt []byte) bool {
-	for _, existing := range list {
-		if bytes.Equal(existing, pkt) {
-			return true
-		}
-	}
-	return false
-}
-
-func appendAudioTrack(list []AudioTrackInfo, track AudioTrackInfo) []AudioTrackInfo {
-	for i, existing := range list {
-		if existing.PID == track.PID {
-			list[i] = track
-			return list
-		}
-	}
-	return append(list, track)
-}
-
-func (r *MasterRing) invalidateVideoStateLocked() {
-	r.videoPID = 0
-	r.videoCodec = CodecUnknown
-	r.currentPESOffset = -1
-	r.pesHasKeyframe = false
-	r.pesHasSPS = false
-	r.pesHasPPS = false
-	r.pesHasVPS = false
-	r.annexBState = 0xFFFFFFFF
-	r.expectingNALByte = false
-	r.keyframeOffsets = r.keyframeOffsets[:0]
-	r.rawPMTPackets = nil
-	r.scrambledVideoPackets = 0
-	r.clearVideoPackets = 0
-	r.scrambledAudioPackets = 0
-	r.clearAudioPackets = 0
-	r.videoClearRun = 0
-	r.audioClearRun = 0
-	r.audioPIDs = nil
-	r.audioTracks = nil
-	// Observations do not survive the table that named their stream. The same PID
-	// can carry a different elementary stream after a PMT change, and carrying the
-	// old layout across would describe audio that is no longer there.
-	r.audioObservers = nil
-	r.raObs = RandomAccessObservation{}
-	r.cleanRAPCount = 0
-	r.cleanAccessUnits = 0
-	r.resetAccessUnitStateLocked()
-	r.generation++
-}
-
-func (r *MasterRing) parseVideoPacketLocked(pkt []byte, offset int64, pusi bool, payload []byte) {
-	// transport_scrambling_control != 0 means the payload is encrypted. Feeding it to the
-	// Annex-B scanner would index random bytes as NAL units, so it is never parsed. The
-	// observation is recorded instead, allowing attach to fail fast with ErrScrambledStream.
-	if (pkt[3]>>6)&0x03 != 0 {
-		r.scrambledVideoPackets++
-		r.auScrambledPackets++
-		r.videoClearRun = 0
-		return
-	}
-	r.clearVideoPackets++
-	r.videoClearRun++
-
-	esData := payload
-
-	if pusi {
-		// Video PES packet start: verify PES startcode prefix (00 00 01 E0..EF)
-		if len(payload) >= 9 && payload[0] == 0x00 && payload[1] == 0x00 && payload[2] == 0x01 && (payload[3] >= 0xE0 && payload[3] <= 0xEF) {
-			// Whether an access unit is joinable depends on every slice in it, which
-			// is only known once it ends - and it ends where the next one begins.
-			r.finalizeAccessUnitLocked()
-
-			r.currentPESOffset = offset
-			r.pesHasKeyframe = false
-			r.pesHasSPS = false
-			r.pesHasPPS = false
-			r.pesHasVPS = false
-			r.annexBState = 0xFFFFFFFF
-			r.expectingNALByte = false
-			r.resetAccessUnitStateLocked()
-
-			pesHeaderDataLen := int(payload[8])
-			esStart := 9 + pesHeaderDataLen
-			if esStart < len(payload) {
-				esData = payload[esStart:]
-			} else {
-				esData = nil
-			}
-		}
-	}
-
-	if len(esData) == 0 {
-		return
-	}
-
-	// Stateful Annex-B NAL unit parser across packet boundaries.
-	for _, b := range esData {
-		r.annexBState = (r.annexBState << 8) | uint32(b)
-
-		// Bytes immediately following a NAL header, held for slice-header and SEI
-		// parsing. Collected here because a NAL unit routinely spans TS packets and
-		// the fields that matter sit in its first bytes.
-		if r.nalLeft > 0 {
-			if r.nalSkip > 0 {
-				r.nalSkip--
-			} else {
-				r.nalBuf = append(r.nalBuf, b)
-				r.nalLeft--
-				if r.nalLeft == 0 {
-					r.consumeNALCaptureLocked()
-				}
-			}
-		}
-
-		if r.expectingNALByte {
-			r.expectingNALByte = false
-			// A start code inside a captured NAL means the capture budget outran the
-			// unit; read what was collected before moving on.
-			r.consumeNALCaptureLocked()
-
-			switch r.videoCodec {
-			case CodecH264:
-				r.classifyH264NALLocked(b & 0x1F)
-			case CodecH265:
-				r.classifyHEVCNALLocked((b >> 1) & 0x3F)
-			case CodecMPEG2:
-				r.classifyMPEG2StartCodeLocked(b)
-			}
-		}
-
-		// Check for 3-byte (00 00 01) or 4-byte (00 00 00 01) Annex-B startcode
-		if (r.annexBState & 0x00FFFFFF) == 0x00000001 {
-			r.expectingNALByte = true
-		}
-	}
-}
-
-// classifyMPEG2StartCodeLocked records what an MPEG-2 Video Elementary Stream start code
-// contributes to the current access unit and stream configuration.
-// ISO/IEC 13818-2:
-// - 0xB3: sequence_header_code (SPS equivalent / Codec Config)
-// - 0xB8: group_start_code (GOP Header / Entry Point)
-// - 0x00: picture_start_code (Picture Header -> contains picture_coding_type I/P/B)
-func (r *MasterRing) classifyMPEG2StartCodeLocked(startCode uint8) {
-	switch startCode {
-	case 0xB3: // Sequence Header
-		r.pesHasSPS = true
-	case 0xB8: // Group of Pictures Header
-		r.pesHasVPS = true
-	case 0x00: // Picture Header
-		r.auVCLCount++
-		r.beginNALCaptureLocked(captureMPEG2PictureHeader, mpeg2PictureHeaderCaptureBytes, 0)
-	}
-}
-
-// classifyH264NALLocked records what one H.264 NAL unit contributes to the access
-// unit being assembled, and starts a capture where the following bytes are needed.
-func (r *MasterRing) classifyH264NALLocked(nalType uint8) {
-	switch nalType {
-	case h264NALSliceIDR:
-		r.auHasIRAP = true
-		r.auVCLCount++
-		r.auIntraVCLCount++
-		// An IDR needs nothing else to be joinable, so it is indexed without waiting
-		// for the access unit to end. This keeps streams that do emit IDRs attaching
-		// exactly as fast as before.
-		r.indexRandomAccessPointLocked(true)
-	case h264NALSliceNonIDR, h264NALSlicePartA:
-		r.auVCLCount++
-		r.beginNALCaptureLocked(captureH264SliceHeader, sliceHeaderCaptureBytes, 0)
-	case h264NALSPS:
-		r.pesHasSPS = true
-	case h264NALPPS:
-		r.pesHasPPS = true
-	case h264NALSEI:
-		// The one byte H.264 NAL header has already been consumed, so the SEI
-		// payload starts with the very next byte.
-		r.beginNALCaptureLocked(captureSEI, seiCaptureBytes, 0)
-	}
-}
-
-// classifyHEVCNALLocked mirrors classifyH264NALLocked for HEVC.
-//
-// The whole IRAP range qualifies, not only IDR: a CRA or BLA picture is equally a
-// point a decoder can be started on. HEVC slice headers are not parsed for intra
-// coding - the fields needed sit behind the active parameter sets - so a stream that
-// never emits an IRAP is admitted on its recovery_point SEI instead, which is the
-// stream's own declaration of a random access point.
-func (r *MasterRing) classifyHEVCNALLocked(nalType uint8) {
-	switch {
-	case nalType >= hevcNALIRAPFirst && nalType <= hevcNALIRAPLast:
-		r.auHasIRAP = true
-		r.auVCLCount++
-		r.auIntraVCLCount++
-		r.indexRandomAccessPointLocked(true)
-	case nalType <= 9:
-		r.auVCLCount++
-	case nalType == hevcNALVPS:
-		r.pesHasVPS = true
-	case nalType == hevcNALSPS:
-		r.pesHasSPS = true
-	case nalType == hevcNALPPS:
-		r.pesHasPPS = true
-	case nalType == hevcNALPrefixSEI:
-		// The HEVC NAL header is two bytes. Only the first has been consumed by the
-		// classification above, so the second is passed over: reading it as the SEI
-		// payload type shifts every field that follows and hides the recovery point,
-		// which on a stream that emits no IRAP is the only signal there is.
-		r.beginNALCaptureLocked(captureSEI, seiCaptureBytes, 1)
-	}
-}
-
-func (r *MasterRing) beginNALCaptureLocked(kind nalCaptureKind, budget, skipHeaderBytes int) {
-	r.nalKind = kind
-	r.nalLeft = budget
-	r.nalSkip = skipHeaderBytes
-	r.nalBuf = r.nalBuf[:0]
-}
-
-// consumeNALCaptureLocked reads whatever was captured and clears the capture.
-func (r *MasterRing) consumeNALCaptureLocked() {
-	if r.nalKind == captureNone || len(r.nalBuf) == 0 {
-		r.nalKind = captureNone
-		r.nalLeft = 0
-		r.nalSkip = 0
-		return
-	}
-
-	switch r.nalKind {
-	case captureH264SliceHeader:
-		isIntra, ok := h264SliceIsIntra(r.nalBuf)
-		switch {
-		case !ok:
-			r.raObs.UnreadableSlices++
-		case isIntra:
-			r.auIntraVCLCount++
-		}
-	case captureSEI:
-		if seiHasRecoveryPoint(r.nalBuf) {
-			r.auHasRecoveryPt = true
-		}
-	case captureMPEG2PictureHeader:
-		isIntra, ok := mpeg2PictureIsIntra(r.nalBuf)
-		switch {
-		case !ok:
-			r.raObs.UnreadableSlices++
-		case isIntra:
-			r.auHasIRAP = true
-			r.auIntraVCLCount++
-			r.indexRandomAccessPointLocked(true)
-		}
-	}
-
-	r.nalKind = captureNone
-	r.nalLeft = 0
-	r.nalSkip = 0
-	r.nalBuf = r.nalBuf[:0]
-}
-
-// finalizeAccessUnitLocked decides whether the access unit that just ended was a
-// random access point, now that all of its slices have been seen.
-func (r *MasterRing) finalizeAccessUnitLocked() {
-	r.consumeNALCaptureLocked()
-
-	if r.currentPESOffset < 0 || r.auVCLCount == 0 {
-		return
-	}
-
-	// Descrambling is proven by any complete picture that arrived without an
-	// encrypted packet in it, not only by one a decoder could start on. Measured
-	// against the receiver, tying the two together made them true at the same
-	// millisecond in every zap, so the descrambling observation carried no
-	// information of its own. A clear predicted picture arrives up to a GOP before
-	// the next clear entry point does.
-	if r.auScrambledPackets == 0 {
-		r.cleanAccessUnits++
-	}
-
-	if r.pesHasKeyframe {
-		return
-	}
-
-	// An access unit with no parameter sets cannot configure a decoder that is
-	// starting cold, whatever its slices contain.
-	hasParameterSets := r.pesHasSPS && r.pesHasPPS
-	if r.videoCodec == CodecH265 {
-		hasParameterSets = hasParameterSets && r.pesHasVPS
-	}
-	if !hasParameterSets {
-		return
-	}
-
-	joinable := false
-	switch r.videoCodec {
-	case CodecH264:
-		// Every coded slice intra means the picture stands alone. One predicted
-		// slice is enough to disqualify it: the decoder would be missing exactly
-		// the references that slice names.
-		joinable = r.auIntraVCLCount == r.auVCLCount
-	case CodecH265:
-		joinable = r.auHasRecoveryPt
-	}
-
-	if !joinable {
-		if r.auHasRecoveryPt || r.auVCLCount > r.auIntraVCLCount {
-			r.raObs.PredictedRejected++
-		}
-		return
-	}
-
-	r.indexRandomAccessPointLocked(false)
-}
-
-// indexRandomAccessPointLocked records the current access unit as an attach point.
-func (r *MasterRing) indexRandomAccessPointLocked(irap bool) {
-	if r.pesHasKeyframe || r.currentPESOffset < 0 {
-		return
-	}
-	r.pesHasKeyframe = true
-
-	if irap {
-		r.raObs.IRAPPoints++
-	} else {
-		r.raObs.IntraPoints++
-	}
-	if r.auHasRecoveryPt {
-		r.raObs.RecoveryPointSEIs++
-	}
-	// An entry point whose own access unit carried scrambled packets is not one a
-	// decoder can be started on, however well it classified.
-	if r.auScrambledPackets == 0 {
-		r.cleanRAPCount++
-	}
-
-	r.keyframeOffsets = append(r.keyframeOffsets, r.currentPESOffset)
-	if len(r.keyframeOffsets) > r.maxKeyframes {
-		r.keyframeOffsets = r.keyframeOffsets[1:]
-	}
-}
-
-func (r *MasterRing) resetAccessUnitStateLocked() {
-	r.auHasIRAP = false
-	r.auHasRecoveryPt = false
-	r.auVCLCount = 0
-	r.auIntraVCLCount = 0
-	r.auScrambledPackets = 0
-	r.nalKind = captureNone
-	r.nalLeft = 0
-	r.nalSkip = 0
-	r.nalBuf = r.nalBuf[:0]
-}
-
 // RandomAccess returns how access units have been classified on this stream.
 func (r *MasterRing) RandomAccess() RandomAccessObservation {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.raObs
+	return r.facts.RandomAccess
 }
 
 func (r *MasterRing) pruneKeyframesLocked() {
@@ -1155,10 +234,10 @@ func (r *MasterRing) PrimedAttachPoint() PrimedAttachPoint {
 	defer r.mu.Unlock()
 
 	var preamble []byte
-	for _, pkt := range r.rawPATPackets {
+	for _, pkt := range r.activePSI.PAT {
 		preamble = append(preamble, pkt...)
 	}
-	for _, pkt := range r.rawPMTPackets {
+	for _, pkt := range r.activePSI.PMT {
 		preamble = append(preamble, pkt...)
 	}
 
@@ -1215,10 +294,10 @@ func (r *MasterRing) PATPMTPreamble() []byte {
 // holding r.mu. See latestKeyframeOffsetLocked for why the split exists.
 func (r *MasterRing) patpmtPreambleLocked() []byte {
 	var preamble []byte
-	for _, pkt := range r.rawPATPackets {
+	for _, pkt := range r.activePSI.PAT {
 		preamble = append(preamble, pkt...)
 	}
-	for _, pkt := range r.rawPMTPackets {
+	for _, pkt := range r.activePSI.PMT {
 		preamble = append(preamble, pkt...)
 	}
 	return preamble
@@ -1238,7 +317,7 @@ func (r *MasterRing) Generation() uint64 {
 func (r *MasterRing) VideoDetails() (uint16, VideoCodec) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.videoPID, r.videoCodec
+	return r.facts.VideoPID, r.facts.VideoCodec
 }
 
 // Head returns total bytes written monotonically.
@@ -1276,7 +355,7 @@ func (r *MasterRing) Close() {
 func (r *MasterRing) ScramblingObservation() (scrambled uint64, clear uint64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.scrambledVideoPackets, r.clearVideoPackets
+	return r.facts.Scrambling.VideoScrambled, r.facts.Scrambling.VideoClear
 }
 
 // StreamScrambling reports descrambling per elementary stream.
@@ -1284,58 +363,22 @@ func (r *MasterRing) ScramblingObservation() (scrambled uint64, clear uint64) {
 // Separate counters because the two faults they distinguish need different answers:
 // video clear with audio scrambled is a service the receiver is only half
 // descrambling, while neither clear is a service it is not descrambling at all.
-type StreamScrambling struct {
-	VideoScrambled uint64
-	VideoClear     uint64
-	AudioScrambled uint64
-	AudioClear     uint64
-	// VideoClearRun is the number of clear video packets since the last scrambled
-	// one. Descrambling was measured coming up intermittently on this receiver, so
-	// the run length - not the total - is what says the stream is clear now.
-	VideoClearRun uint64
-	// AudioClearRun is the same measure across the audio streams.
-	AudioClearRun uint64
-	// AudioPIDs are the audio elementary streams named by the active PMT.
-	AudioPIDs []uint16
-}
 
 // Scrambling returns the per-stream descrambling observation.
 func (r *MasterRing) Scrambling() StreamScrambling {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	pids := make([]uint16, len(r.audioPIDs))
-	copy(pids, r.audioPIDs)
+	pids := make([]uint16, len(r.facts.AudioPIDs))
+	copy(pids, r.facts.AudioPIDs)
 	return StreamScrambling{
-		VideoScrambled: r.scrambledVideoPackets,
-		VideoClear:     r.clearVideoPackets,
-		AudioScrambled: r.scrambledAudioPackets,
-		AudioClear:     r.clearAudioPackets,
-		VideoClearRun:  r.videoClearRun,
-		AudioClearRun:  r.audioClearRun,
+		VideoScrambled: r.facts.Scrambling.VideoScrambled,
+		VideoClear:     r.facts.Scrambling.VideoClear,
+		AudioScrambled: r.facts.Scrambling.AudioScrambled,
+		AudioClear:     r.facts.Scrambling.AudioClear,
+		VideoClearRun:  r.facts.Scrambling.VideoClearRun,
+		AudioClearRun:  r.facts.Scrambling.AudioClearRun,
 		AudioPIDs:      pids,
 	}
-}
-
-// scrambledVideoConfirmedLocked reports whether the video stream is conclusively scrambled.
-// It requires a minimum sample so that a handful of packets observed mid key-change cannot
-// trip the verdict, and demands that not one clear payload packet has been seen: a receiver
-// that descrambles clears transport_scrambling_control on every packet it emits.
-func (r *MasterRing) scrambledVideoConfirmedLocked() bool {
-	return r.clearVideoPackets == 0 && r.scrambledVideoPackets >= scrambledVerdictMinPackets
-}
-
-func cloneSlice(in []byte) []byte {
-	out := make([]byte, len(in))
-	copy(out, in)
-	return out
-}
-
-func cloneSliceList(in [][]byte) [][]byte {
-	out := make([][]byte, len(in))
-	for i, s := range in {
-		out[i] = cloneSlice(s)
-	}
-	return out
 }
 
 // KeyframeOffsets returns the currently indexed random access offsets.
@@ -1396,30 +439,10 @@ func (r *MasterRing) ReadinessFacts() ReadinessFacts {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	pids := make([]uint16, len(r.audioPIDs))
-	copy(pids, r.audioPIDs)
-
-	tracks := make([]AudioTrackInfo, len(r.audioTracks))
-	copy(tracks, r.audioTracks)
-	// The declaration is fixed by the PMT and only changes with it; the
-	// observation moves with the audio. Reading it here rather than storing it on
-	// the track is what makes a mid-programme change to 5.1 visible to the next
-	// snapshot instead of to the next PMT version.
-	for i := range tracks {
-		if obs := r.audioObservers[tracks[i].PID]; obs != nil {
-			tracks[i].Observed = obs.Current()
-		}
-	}
-
-	parameterSets := false
-	switch r.videoCodec {
-	case CodecMPEG2:
-		parameterSets = r.pesHasSPS // MPEG-2 Sequence Header (0xB3)
-	case CodecH265:
-		parameterSets = r.pesHasSPS && r.pesHasPPS && r.pesHasVPS
-	default:
-		parameterSets = r.pesHasSPS && r.pesHasPPS
-	}
+	// Everything the stream says about itself comes from the core. The two fields
+	// added here are the ones it cannot answer: which lifecycle epoch this is, and
+	// whether an entry point is still inside a buffer it cannot see.
+	f := r.facts
 
 	attach := false
 	if len(r.keyframeOffsets) > 0 {
@@ -1428,27 +451,25 @@ func (r *MasterRing) ReadinessFacts() ReadinessFacts {
 
 	return ReadinessFacts{
 		Generation:        r.generation,
-		HasPAT:            r.hasPATVersion,
-		HasPMT:            r.hasPMTVersion,
-		PMTVersion:        r.pmtVersion,
-		ProgramNumber:     r.pmtProgramNumber,
-		VideoPID:          r.videoPID,
-		VideoCodec:        r.videoCodec,
-		AudioPIDs:         pids,
-		AudioTracks:       tracks,
-		ParameterSetsSeen: parameterSets,
-		RandomAccess:      r.raObs,
-		Scrambling: StreamScrambling{
-			VideoScrambled: r.scrambledVideoPackets,
-			VideoClear:     r.clearVideoPackets,
-			AudioScrambled: r.scrambledAudioPackets,
-			AudioClear:     r.clearAudioPackets,
-			VideoClearRun:  r.videoClearRun,
-			AudioClearRun:  r.audioClearRun,
-			AudioPIDs:      pids,
-		},
-		CleanEntryPoints: r.cleanRAPCount,
-		CleanAccessUnits: r.cleanAccessUnits,
-		AttachAvailable:  attach,
+		HasPAT:            f.HasPAT,
+		HasPMT:            f.HasPMT,
+		PMTVersion:        f.PMTVersion,
+		ProgramNumber:     f.ProgramNumber,
+		VideoPID:          f.VideoPID,
+		VideoCodec:        f.VideoCodec,
+		AudioPIDs:         f.AudioPIDs,
+		AudioTracks:       f.AudioTracks,
+		ParameterSetsSeen: f.ParameterSetsSeen,
+		RandomAccess:      f.RandomAccess,
+		Scrambling:        f.Scrambling,
+		CleanEntryPoints:  f.CleanEntryPoints,
+		CleanAccessUnits:  f.CleanAccessUnits,
+		AttachAvailable:   attach,
 	}
+}
+
+// scrambledVideoConfirmedLocked asks the core's verdict. The reader goes through
+// the ring because the ring holds the lock, not because the ring decides.
+func (r *MasterRing) scrambledVideoConfirmedLocked() bool {
+	return r.facts.ScrambledVideoConfirmed
 }

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -31,6 +31,11 @@ const (
 // ErrInvalidPacketSize reports data that is not 188-byte packet aligned.
 var ErrInvalidPacketSize = mediafacts.ErrInvalidPacketSize
 
+// ErrCoreIncomplete reports a media core that interpreted less of a chunk than it
+// was given. The chunk is refused rather than committed, because bytes the ring
+// cannot explain are worse than bytes it does not have.
+var ErrCoreIncomplete = errors.New("media facts core did not interpret the whole chunk")
+
 // The interpretation of transport stream bytes lives in mediafacts. These aliases
 // keep the names consumers already import while the boundary is drawn: the ring
 // owns bytes, offsets and the generation; mediafacts owns what the bytes mean.
@@ -134,6 +139,12 @@ func (r *MasterRing) applyLocked(res mediafacts.ParseResult) {
 			if len(r.keyframeOffsets) > r.maxKeyframes {
 				r.keyframeOffsets = r.keyframeOffsets[1:]
 			}
+		default:
+			// EventUnknown, or a kind this build does not know. Both are refused
+			// rather than guessed at: across a wire boundary the zero value is what a
+			// truncated or mis-decoded event looks like, and the two things this
+			// switch can do - end an epoch, offer an attach point - are the two things
+			// that must never happen by accident.
 		}
 	}
 	r.facts = res.Facts
@@ -164,6 +175,13 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	res, err := r.core.Ingest(r.head, data)
 	if err != nil {
 		return 0, err
+	}
+	// A core that interpreted less than it was given leaves the ring with bytes it
+	// has no meaning for. Committing them anyway is exactly the failure this
+	// boundary exists to prevent, so the chunk is refused and nothing here moves:
+	// not the head, not the generation, not the index, not the facts.
+	if want := r.head + int64(len(data)); res.ProcessedThroughOffset != want {
+		return 0, ErrCoreIncomplete
 	}
 	r.applyLocked(res)
 
@@ -442,7 +460,14 @@ func (r *MasterRing) ReadinessFacts() ReadinessFacts {
 	// Everything the stream says about itself comes from the core. The two fields
 	// added here are the ones it cannot answer: which lifecycle epoch this is, and
 	// whether an entry point is still inside a buffer it cannot see.
+	// Copied on the way out. The cached facts are the ring's own state, and a
+	// consumer that received the backing arrays could write through a snapshot
+	// into the ring - or read them while a concurrent Push replaces what they
+	// describe. The pre-seam code copied these for the same reason.
 	f := r.facts
+	f.AudioPIDs = append([]uint16(nil), f.AudioPIDs...)
+	f.AudioTracks = append([]AudioTrackInfo(nil), f.AudioTracks...)
+	f.Scrambling.AudioPIDs = append([]uint16(nil), f.Scrambling.AudioPIDs...)
 
 	attach := false
 	if len(r.keyframeOffsets) > 0 {

--- a/backend/internal/stream/ingest/ring/ring_test.go
+++ b/backend/internal/stream/ingest/ring/ring_test.go
@@ -582,8 +582,8 @@ func TestMasterRing_SlowSubscriberOverrunIsolation(t *testing.T) {
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 0, false, false, 0, 1) {
 		_, _ = r.Push(pkt)
 	}
-	if r.videoPID != 0 {
-		t.Fatalf("test setup: expected an audio-only PMT, got video PID %d", r.videoPID)
+	if r.facts.VideoPID != 0 {
+		t.Fatalf("test setup: expected an audio-only PMT, got video PID %d", r.facts.VideoPID)
 	}
 
 	reader := r.NewSubscriberReader(0)
@@ -654,7 +654,7 @@ func TestMasterRing_CCDiscontinuity_AbortsCorruptedSection(t *testing.T) {
 	pkt2Corrupted[3] = (pkt2Corrupted[3] & 0xF0) | 0x05
 	_, _ = r.Push(pkt2Corrupted)
 
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("corrupted PAT section with CC gap was incorrectly accepted")
 	}
 
@@ -669,8 +669,8 @@ func TestMasterRing_CCDiscontinuity_AbortsCorruptedSection(t *testing.T) {
 	pkt2Valid[3] = (pkt2Valid[3] & 0xF0) | 0x07
 	_, _ = r.Push(pkt2Valid)
 
-	if r.pmtPID != pmtPID {
-		t.Fatalf("expected pmtPID=%d after clean retransmission, got %d", pmtPID, r.pmtPID)
+	if r.facts.PMTPID != pmtPID {
+		t.Fatalf("expected pmtPID=%d after clean retransmission, got %d", pmtPID, r.facts.PMTPID)
 	}
 }
 
@@ -684,7 +684,7 @@ func TestMasterRing_CurrentNextIndicator_InactiveTableIgnored(t *testing.T) {
 		_, _ = r.Push(pkt)
 	}
 
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("inactive PAT table (current_next=0) was incorrectly accepted")
 	}
 
@@ -692,8 +692,8 @@ func TestMasterRing_CurrentNextIndicator_InactiveTableIgnored(t *testing.T) {
 		_, _ = r.Push(pkt)
 	}
 
-	if r.pmtPID != pmtPID {
-		t.Fatalf("active PAT table was not accepted: got %d", r.pmtPID)
+	if r.facts.PMTPID != pmtPID {
+		t.Fatalf("active PAT table was not accepted: got %d", r.facts.PMTPID)
 	}
 }
 
@@ -787,15 +787,15 @@ func TestMasterRing_CRC32_CorruptedSectionRejected(t *testing.T) {
 	_, _ = r.Push(patPackets[0])
 	_, _ = r.Push(pkt2Corrupt)
 
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("PAT section with corrupted CRC32 was incorrectly accepted")
 	}
 
 	_, _ = r.Push(patPackets[0])
 	_, _ = r.Push(patPackets[1])
 
-	if r.pmtPID != pmtPID {
-		t.Fatalf("valid PAT section was not accepted: got %d", r.pmtPID)
+	if r.facts.PMTPID != pmtPID {
+		t.Fatalf("valid PAT section was not accepted: got %d", r.facts.PMTPID)
 	}
 }
 
@@ -806,16 +806,16 @@ func TestMasterRing_TargetProgramNumber_Selection(t *testing.T) {
 	defer r1.Close()
 	_, _ = r1.Push(multiPAT)
 
-	if r1.pmtPID != 100 {
-		t.Fatalf("expected default r1 to select PMT 100, got %d", r1.pmtPID)
+	if r1.facts.PMTPID != 100 {
+		t.Fatalf("expected default r1 to select PMT 100, got %d", r1.facts.PMTPID)
 	}
 
 	r2 := NewMasterRingWithProgram(100*TSPacketSize, 2)
 	defer r2.Close()
 	_, _ = r2.Push(multiPAT)
 
-	if r2.pmtPID != 200 {
-		t.Fatalf("expected r2 to select PMT 200 for program 2, got %d", r2.pmtPID)
+	if r2.facts.PMTPID != 200 {
+		t.Fatalf("expected r2 to select PMT 200 for program 2, got %d", r2.facts.PMTPID)
 	}
 }
 
@@ -863,8 +863,8 @@ func TestMasterRing_SetTargetProgram_InvalidatesOldProgramState(t *testing.T) {
 	defer r.Close()
 
 	_, _ = r.Push(multiPAT)
-	if r.pmtPID != 100 {
-		t.Fatalf("expected pmtPID=100 for program 1, got %d", r.pmtPID)
+	if r.facts.PMTPID != 100 {
+		t.Fatalf("expected pmtPID=100 for program 1, got %d", r.facts.PMTPID)
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 256, false, true, 0, 1) {
@@ -886,8 +886,8 @@ func TestMasterRing_SetTargetProgram_InvalidatesOldProgramState(t *testing.T) {
 	}
 
 	_, _ = r.Push(multiPAT)
-	if r.pmtPID != 200 {
-		t.Fatalf("expected pmtPID=200 after resolving program 2, got %d", r.pmtPID)
+	if r.facts.PMTPID != 200 {
+		t.Fatalf("expected pmtPID=200 after resolving program 2, got %d", r.facts.PMTPID)
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(200, 512, true, true, 0, 1) {
@@ -924,7 +924,7 @@ func TestMasterRing_PointerField_CompletesPreviousSectionAndStartsNew(t *testing
 	copy(pkt1[178:], sec1[:10])
 
 	_, _ = r.Push(pkt1)
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("section 1 should be incomplete")
 	}
 
@@ -946,8 +946,8 @@ func TestMasterRing_PointerField_CompletesPreviousSectionAndStartsNew(t *testing
 	_, _ = r.Push(pkt2)
 
 	// Section 2 was also parsed in the same packet and updated PMT PID to 200!
-	if r.pmtPID != 200 {
-		t.Fatalf("expected pmtPID=200 from Section 2 parsed in same packet, got %d", r.pmtPID)
+	if r.facts.PMTPID != 200 {
+		t.Fatalf("expected pmtPID=200 from Section 2 parsed in same packet, got %d", r.facts.PMTPID)
 	}
 }
 
@@ -975,8 +975,8 @@ func TestMasterRing_MultipleCompleteSectionsInSinglePacket(t *testing.T) {
 
 	_, _ = r.Push(pkt)
 
-	if r.pmtPID != 200 {
-		t.Fatalf("expected pmtPID=200 for target program 20 from multi-section packet, got %d", r.pmtPID)
+	if r.facts.PMTPID != 200 {
+		t.Fatalf("expected pmtPID=200 for target program 20 from multi-section packet, got %d", r.facts.PMTPID)
 	}
 }
 
@@ -1006,14 +1006,14 @@ func TestMasterRing_MultiSectionPAT_TargetOnlyInSection1(t *testing.T) {
 
 	// Push Section 0 (target 30 not in Section 0)
 	_, _ = r.Push(pkt0)
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("table should not be activated before section 1 arrives")
 	}
 
 	// Push Section 1
 	_, _ = r.Push(pkt1)
-	if r.pmtPID != 300 {
-		t.Fatalf("expected pmtPID=300 from Section 1, got %d", r.pmtPID)
+	if r.facts.PMTPID != 300 {
+		t.Fatalf("expected pmtPID=300 from Section 1, got %d", r.facts.PMTPID)
 	}
 
 	// Verify PAT preamble contains both Section 0 and Section 1 TS packets
@@ -1053,8 +1053,8 @@ func TestMasterRing_CarouselRepeatedSection0_PreservesMultiSectionPreamble(t *te
 	_, _ = r.Push(pkt0)
 	_, _ = r.Push(pkt1)
 
-	if r.pmtPID != 300 {
-		t.Fatalf("expected pmtPID=300, got %d", r.pmtPID)
+	if r.facts.PMTPID != 300 {
+		t.Fatalf("expected pmtPID=300, got %d", r.facts.PMTPID)
 	}
 
 	// Periodic DVB Carousel: Section 0 arrives again!
@@ -1064,8 +1064,8 @@ func TestMasterRing_CarouselRepeatedSection0_PreservesMultiSectionPreamble(t *te
 	_, _ = r.Push(pkt0Next)
 
 	// Target resolution must NOT be destroyed
-	if r.pmtPID != 300 {
-		t.Fatalf("expected pmtPID=300 preserved after carousel section 0, got %d", r.pmtPID)
+	if r.facts.PMTPID != 300 {
+		t.Fatalf("expected pmtPID=300 preserved after carousel section 0, got %d", r.facts.PMTPID)
 	}
 
 	// Preamble must STILL contain both sections
@@ -1091,8 +1091,8 @@ func TestMasterRing_MissingSection_PreventsTableActivation(t *testing.T) {
 	copy(pktInit[5:], secInit)
 	_, _ = r.Push(pktInit)
 
-	if r.pmtPID != 100 {
-		t.Fatalf("expected initial pmtPID=100, got %d", r.pmtPID)
+	if r.facts.PMTPID != 100 {
+		t.Fatalf("expected initial pmtPID=100, got %d", r.facts.PMTPID)
 	}
 
 	// New version v1 announces last_section_number = 1 (2 sections required)
@@ -1108,8 +1108,8 @@ func TestMasterRing_MissingSection_PreventsTableActivation(t *testing.T) {
 	_, _ = r.Push(pktV1_0)
 
 	// Because Section 1 of v1 is missing, table v1 is INCOMPLETE and must not activate!
-	if r.pmtPID != 100 {
-		t.Fatalf("incomplete table version must not activate: expected pmtPID=100, got %d", r.pmtPID)
+	if r.facts.PMTPID != 100 {
+		t.Fatalf("incomplete table version must not activate: expected pmtPID=100, got %d", r.facts.PMTPID)
 	}
 
 	// Push Section 1 of v1 (with program 30 -> PMT 300)
@@ -1124,8 +1124,8 @@ func TestMasterRing_MissingSection_PreventsTableActivation(t *testing.T) {
 	_, _ = r.Push(pktV1_1)
 
 	// Now table v1 is complete and activates!
-	if r.pmtPID != 300 {
-		t.Fatalf("expected pmtPID=300 after complete v1 assembly, got %d", r.pmtPID)
+	if r.facts.PMTPID != 300 {
+		t.Fatalf("expected pmtPID=300 after complete v1 assembly, got %d", r.facts.PMTPID)
 	}
 }
 
@@ -1147,8 +1147,8 @@ func TestMasterRing_DuplicateCC_IgnoredWithoutDiscontinuity(t *testing.T) {
 	_, _ = r.Push(patPackets[1])
 
 	// Assembly must have succeeded seamlessly
-	if r.pmtPID != pmtPID {
-		t.Fatalf("duplicate CC packet caused incorrect discontinuity reset: got pmtPID=%d", r.pmtPID)
+	if r.facts.PMTPID != pmtPID {
+		t.Fatalf("duplicate CC packet caused incorrect discontinuity reset: got pmtPID=%d", r.facts.PMTPID)
 	}
 }
 
@@ -1182,13 +1182,13 @@ func TestMasterRing_PSIHeaderSplitAcrossPackets(t *testing.T) {
 	copy(pkt2[4:], sec[2:])
 
 	_, _ = r.Push(pkt1)
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("table should not be resolved after 2 header bytes")
 	}
 
 	_, _ = r.Push(pkt2)
-	if r.pmtPID != pmtPID {
-		t.Fatalf("expected pmtPID=%d from section with split header across packets, got %d", pmtPID, r.pmtPID)
+	if r.facts.PMTPID != pmtPID {
+		t.Fatalf("expected pmtPID=%d from section with split header across packets, got %d", pmtPID, r.facts.PMTPID)
 	}
 }
 
@@ -1215,7 +1215,7 @@ func TestMasterRing_SameCCDifferentPayload_ResetsAssembly(t *testing.T) {
 	_, _ = r.Push(patPackets[1])
 
 	// Assembly must have been aborted by the glitch packet
-	if r.pmtPID != 0 {
+	if r.facts.PMTPID != 0 {
 		t.Fatalf("same CC with different payload failed to abort corrupted assembly")
 	}
 }
@@ -1242,8 +1242,8 @@ func TestMasterRing_MultipleSectionsSamePacket_PreambleDoesNotDuplicatePacket(t 
 
 	_, _ = r.Push(pkt)
 
-	if r.pmtPID != 200 {
-		t.Fatalf("expected pmtPID=200, got %d", r.pmtPID)
+	if r.facts.PMTPID != 200 {
+		t.Fatalf("expected pmtPID=200, got %d", r.facts.PMTPID)
 	}
 
 	// Preamble must contain the packet EXACTLY ONCE (188 bytes), not duplicated (376 bytes)
@@ -1299,8 +1299,8 @@ func TestMasterRing_MPEG2_SequenceHeaderAndIFrame(t *testing.T) {
 	}
 	_, _ = r.Push(pmtPkt)
 
-	if r.videoCodec != CodecMPEG2 {
-		t.Fatalf("expected CodecMPEG2, got %v", r.videoCodec)
+	if r.facts.VideoCodec != CodecMPEG2 {
+		t.Fatalf("expected CodecMPEG2, got %v", r.facts.VideoCodec)
 	}
 
 	// 3. MPEG-2 Video PES containing Sequence Header (00 00 01 B3) and I-Frame Picture Header (00 00 01 00 00 08)

--- a/backend/internal/stream/ingest/ring/scrambled_test.go
+++ b/backend/internal/stream/ingest/ring/scrambled_test.go
@@ -7,6 +7,8 @@ package ring
 import (
 	"errors"
 	"testing"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
 )
 
 // idrESPayload returns Annex-B elementary stream bytes containing an IDR slice NAL unit.
@@ -51,7 +53,7 @@ func TestMasterRing_ScrambledVideo_NotIndexedAndAttachIsTerminal(t *testing.T) {
 
 	pushClearPATPMT(t, r, pmtPID, videoPID)
 
-	for i := 0; i < scrambledVerdictMinPackets; i++ {
+	for i := 0; i < mediafacts.ScrambledVerdictMinPackets; i++ {
 		pkt := createVideoPESPacket(videoPID, true, uint8(i&0x0F), idrESPayload())
 		if _, err := r.Push(scrambleTSPacket(pkt)); err != nil {
 			t.Fatalf("push scrambled video packet %d failed: %v", i, err)
@@ -63,8 +65,8 @@ func TestMasterRing_ScrambledVideo_NotIndexedAndAttachIsTerminal(t *testing.T) {
 	}
 
 	scrambled, clear := r.ScramblingObservation()
-	if scrambled != scrambledVerdictMinPackets {
-		t.Fatalf("expected %d scrambled video packets observed, got %d", scrambledVerdictMinPackets, scrambled)
+	if scrambled != mediafacts.ScrambledVerdictMinPackets {
+		t.Fatalf("expected %d scrambled video packets observed, got %d", mediafacts.ScrambledVerdictMinPackets, scrambled)
 	}
 	if clear != 0 {
 		t.Fatalf("expected zero clear video packets, got %d", clear)
@@ -92,7 +94,7 @@ func TestMasterRing_ClearPayloadPresent_NotDeclaredScrambled(t *testing.T) {
 
 	pushClearPATPMT(t, r, pmtPID, videoPID)
 
-	for i := 0; i < scrambledVerdictMinPackets*2; i++ {
+	for i := 0; i < mediafacts.ScrambledVerdictMinPackets*2; i++ {
 		pkt := createVideoPESPacket(videoPID, true, uint8(i&0x0F), idrESPayload())
 		if _, err := r.Push(scrambleTSPacket(pkt)); err != nil {
 			t.Fatalf("push scrambled video packet %d failed: %v", i, err)
@@ -134,7 +136,7 @@ func TestMasterRing_ProgramChange_ResetsScramblingObservation(t *testing.T) {
 
 	pushClearPATPMT(t, r, pmtPID, videoPID)
 
-	for i := 0; i < scrambledVerdictMinPackets; i++ {
+	for i := 0; i < mediafacts.ScrambledVerdictMinPackets; i++ {
 		pkt := createVideoPESPacket(videoPID, true, uint8(i&0x0F), idrESPayload())
 		if _, err := r.Push(scrambleTSPacket(pkt)); err != nil {
 			t.Fatalf("push scrambled video packet %d failed: %v", i, err)

--- a/backend/internal/stream/ingest/ring/seam_test.go
+++ b/backend/internal/stream/ingest/ring/seam_test.go
@@ -5,6 +5,7 @@
 package ring
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
@@ -202,5 +203,177 @@ func TestSeam_EntryPointsBeforeAnIdentityChangeAreDropped(t *testing.T) {
 	got := r.KeyframeOffsets()
 	if len(got) != 1 || got[0] != 300 {
 		t.Errorf("KeyframeOffsets = %v, want only the entry point that arrived after the identity change", got)
+	}
+}
+
+// A snapshot the caller can write through is not a snapshot. The pre-seam code
+// copied these slices on the way out; the boundary made that easy to lose,
+// because the cached facts already look like a private copy - they are, of the
+// core's state, and shared with every caller of this one.
+func TestSeam_ReadinessFactsIsIndependentOfTheRing(t *testing.T) {
+	r := NewMasterRingWithProgram(400*TSPacketSize, 1)
+	defer r.Close()
+
+	pushAll(t, r, obsPAT(), obsPMT(0,
+		ac3Track(mtGerman, "deu", 0x85),
+		ac3Track(mtEnglish, "eng", 0x82),
+	))
+
+	first := r.ReadinessFacts()
+	if len(first.AudioPIDs) == 0 || len(first.AudioTracks) == 0 {
+		t.Fatal("fixture no longer produces audio tracks; this test would prove nothing")
+	}
+
+	wantPID := first.AudioPIDs[0]
+	wantCodec := first.AudioTracks[0].Codec
+	wantScramblingPID := first.Scrambling.AudioPIDs[0]
+
+	// A consumer doing what consumers do with a value they were handed.
+	first.AudioPIDs[0] = 0xBEEF
+	first.AudioTracks[0].Codec = "clobbered"
+	first.Scrambling.AudioPIDs[0] = 0xBEEF
+
+	second := r.ReadinessFacts()
+	if second.AudioPIDs[0] != wantPID {
+		t.Errorf("AudioPIDs[0] = %d after a caller wrote to an earlier snapshot, want %d", second.AudioPIDs[0], wantPID)
+	}
+	if second.AudioTracks[0].Codec != wantCodec {
+		t.Errorf("AudioTracks[0].Codec = %q, want %q", second.AudioTracks[0].Codec, wantCodec)
+	}
+	if second.Scrambling.AudioPIDs[0] != wantScramblingPID {
+		t.Errorf("Scrambling.AudioPIDs[0] = %d, want %d", second.Scrambling.AudioPIDs[0], wantScramblingPID)
+	}
+
+	// And the two snapshots must not share backing arrays with each other either.
+	second.AudioPIDs[0] = 0xF00D
+	if third := r.ReadinessFacts(); third.AudioPIDs[0] != wantPID {
+		t.Errorf("AudioPIDs[0] = %d, want %d - snapshots share a backing array", third.AudioPIDs[0], wantPID)
+	}
+}
+
+// shortCore interprets everything it is given and then understates how far it
+// got, which is what a truncated IPC response or a core that gave up mid-chunk
+// would look like from the ring's side.
+type shortCore struct {
+	mediafacts.Core
+	shortBy int64
+}
+
+func (c shortCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	res, err := c.Core.Ingest(startOffset, data)
+	res.ProcessedThroughOffset -= c.shortBy
+	// Events the ring must not act on, precisely because the chunk is short.
+	res.Events = append(res.Events, mediafacts.Event{Kind: mediafacts.EventProgramIdentityChanged})
+	return res, err
+}
+
+// Bytes the ring cannot explain are worse than bytes it does not have. A chunk
+// the core did not fully interpret is refused, and nothing moves with it.
+func TestSeam_AChunkTheCoreDidNotFinishIsNotCommitted(t *testing.T) {
+	const pmtPID = 100
+
+	r := NewMasterRingWithProgram(400*TSPacketSize, 1)
+	defer r.Close()
+	r.core = shortCore{Core: r.core, shortBy: TSPacketSize}
+
+	headBefore := r.Head()
+	tailBefore := r.Tail()
+	genBefore := r.Generation()
+	kfBefore := len(r.KeyframeOffsets())
+	factsBefore := r.ReadinessFacts()
+
+	data := createMultiPacketPAT(pmtPID)[0]
+	n, err := r.Push(data)
+
+	if !errors.Is(err, ErrCoreIncomplete) {
+		t.Fatalf("Push err = %v, want ErrCoreIncomplete", err)
+	}
+	if n != 0 {
+		t.Errorf("Push n = %d, want 0", n)
+	}
+	if got := r.Head(); got != headBefore {
+		t.Errorf("Head = %d, want %d - bytes were committed for a chunk that was refused", got, headBefore)
+	}
+	if got := r.Tail(); got != tailBefore {
+		t.Errorf("Tail = %d, want %d", got, tailBefore)
+	}
+	if got := r.Generation(); got != genBefore {
+		t.Errorf("Generation = %d, want %d - the refused chunk's events were applied", got, genBefore)
+	}
+	if got := len(r.KeyframeOffsets()); got != kfBefore {
+		t.Errorf("KeyframeOffsets len = %d, want %d", got, kfBefore)
+	}
+	if got := r.ReadinessFacts(); got.HasPAT != factsBefore.HasPAT || got.ProgramNumber != factsBefore.ProgramNumber {
+		t.Errorf("facts moved on a refused chunk: %+v", got)
+	}
+	if got := r.BufferedBytes(); got != 0 {
+		t.Errorf("BufferedBytes = %d, want 0 - refused bytes are readable", got)
+	}
+}
+
+// The zero value of an event is what a truncated frame or a failed decode
+// produces. It must mean nothing, not "a new programme began".
+func TestSeam_TheZeroEventIsNotALifecycleChange(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+
+	r.mu.Lock()
+	genBefore := r.generation
+	r.applyLocked(mediafacts.ParseResult{Events: []mediafacts.Event{
+		{},                                // zero value
+		{Kind: mediafacts.EventUnknown},   // named, still nothing
+		{Kind: mediafacts.EventKind(200)}, // a kind this build does not know
+		{Kind: mediafacts.EventKind(200), Offset: 4242},
+	}})
+	genAfter := r.generation
+	kf := len(r.keyframeOffsets)
+	r.mu.Unlock()
+
+	if genAfter != genBefore {
+		t.Errorf("Generation moved from %d to %d on events that say nothing", genBefore, genAfter)
+	}
+	if kf != 0 {
+		t.Errorf("KeyframeOffsets len = %d, want 0", kf)
+	}
+}
+
+// The PMT PID is what the PAT says, so it is a fact about the stream rather than
+// a helper for tests. It has to survive a remapping, and a remapping is an
+// identity change.
+func TestSeam_PMTPIDFollowsThePAT(t *testing.T) {
+	core := mediafacts.NewGoCore(1)
+
+	ingest := func(packets [][]byte) mediafacts.ParseResult {
+		t.Helper()
+		var last mediafacts.ParseResult
+		for _, pkt := range packets {
+			res, err := core.Ingest(0, pkt)
+			if err != nil {
+				t.Fatalf("ingest: %v", err)
+			}
+			last = res
+		}
+		return last
+	}
+
+	ingest(createMultiPacketPAT(100))
+	if got := core.Snapshot().PMTPID; got != 100 {
+		t.Fatalf("Facts.PMTPID = %d, want 100", got)
+	}
+
+	// The same program is remapped to a different PMT PID.
+	res := ingest(createMultiPacketPATWithVersion(200, 1, 1))
+	if got := core.Snapshot().PMTPID; got != 200 {
+		t.Errorf("Facts.PMTPID = %d after the PAT remapped the program, want 200", got)
+	}
+
+	identity := false
+	for _, ev := range res.Events {
+		if ev.Kind == mediafacts.EventProgramIdentityChanged {
+			identity = true
+		}
+	}
+	if !identity {
+		t.Error("a PAT that moved the program to another PMT PID reported no identity change")
 	}
 }

--- a/backend/internal/stream/ingest/ring/seam_test.go
+++ b/backend/internal/stream/ingest/ring/seam_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import (
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
+)
+
+// Three rules hold this boundary up, and each one is here because breaking it
+// would be silent:
+//
+//	the ring owns the bytes and their offsets
+//	the ring owns the generation
+//	the core owns what the bytes mean
+//
+// The third is enforced by the compiler - MasterRing has no parser state left to
+// reach for. The other two are enforced here.
+
+// streamWithEntryPoint returns PAT, PMT and one IDR access unit as raw transport,
+// which is the smallest input that makes a core report an entry point.
+func streamWithEntryPoint(videoPID uint16) []byte {
+	const pmtPID = 100
+
+	var out []byte
+	for _, pkt := range createMultiPacketPAT(pmtPID) {
+		out = append(out, pkt...)
+	}
+	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
+		out = append(out, pkt...)
+	}
+
+	es := append(startCode(), nalHdrSPS)
+	es = append(es, 0x01, 0x02)
+	es = append(es, startCode()...)
+	es = append(es, nalHdrPPS, 0x03)
+	es = append(es, nal(nalHdrIDR, sliceHeaderI)...)
+	return append(out, createVideoPESPacket(videoPID, true, 0, es)...)
+}
+
+func rapOffsets(events []mediafacts.Event) []int64 {
+	var out []int64
+	for _, ev := range events {
+		if ev.Kind == mediafacts.EventRandomAccessPoint {
+			out = append(out, ev.Offset)
+		}
+	}
+	return out
+}
+
+// An entry point is only useful if its offset means the same thing to the reader
+// that will seek to it. The core is told where the chunk starts and reports in
+// that system, so the same bytes ingested at a different base yield offsets that
+// differ by exactly the base - never an internal counter that happens to agree
+// while the ring starts at zero.
+func TestSeam_EntryPointOffsetsAreInTheCallersCoordinateSystem(t *testing.T) {
+	const videoPID = 256
+	const base = int64(64 * 1024 * 1024)
+
+	data := streamWithEntryPoint(videoPID)
+
+	atZero, err := mediafacts.NewGoCore(1).Ingest(0, data)
+	if err != nil {
+		t.Fatalf("ingest at 0: %v", err)
+	}
+	atBase, err := mediafacts.NewGoCore(1).Ingest(base, data)
+	if err != nil {
+		t.Fatalf("ingest at base: %v", err)
+	}
+
+	zeroRAPs, baseRAPs := rapOffsets(atZero.Events), rapOffsets(atBase.Events)
+	if len(zeroRAPs) == 0 {
+		t.Fatal("no entry point reported; the fixture no longer exercises this")
+	}
+	if len(zeroRAPs) != len(baseRAPs) {
+		t.Fatalf("got %d entry points at 0 and %d at base, want the same stream to read the same", len(zeroRAPs), len(baseRAPs))
+	}
+	for i := range zeroRAPs {
+		if got := baseRAPs[i] - zeroRAPs[i]; got != base {
+			t.Errorf("entry point %d moved by %d, want exactly the chunk's own start offset %d", i, got, base)
+		}
+	}
+
+	if atBase.ProcessedThroughOffset != base+int64(len(data)) {
+		t.Errorf("ProcessedThroughOffset = %d, want %d", atBase.ProcessedThroughOffset, base+int64(len(data)))
+	}
+}
+
+// The core reports that the program's identity changed. It does not decide that a
+// new lifecycle epoch has begun, and it cannot: nothing it returns is a
+// generation. The ring turns the event into one, which is what keeps subscriber
+// recovery, worker cuts and the entry-point index answering to a single owner.
+func TestSeam_TheCoreReportsIdentityAndTheRingDecidesTheEpoch(t *testing.T) {
+	const pmtPID = 100
+	const videoPID = 256
+
+	core := mediafacts.NewGoCore(1)
+
+	var identityEvents int
+	ingest := func(packets [][]byte) {
+		t.Helper()
+		for _, pkt := range packets {
+			res, err := core.Ingest(0, pkt)
+			if err != nil {
+				t.Fatalf("ingest: %v", err)
+			}
+			for _, ev := range res.Events {
+				if ev.Kind == mediafacts.EventProgramIdentityChanged {
+					identityEvents++
+				}
+			}
+		}
+	}
+
+	ingest(createMultiPacketPAT(pmtPID))
+	ingest(createMultiPacketPMT(pmtPID, videoPID, false))
+	afterFirst := identityEvents
+	if afterFirst == 0 {
+		t.Fatal("first PAT/PMT reported no identity change")
+	}
+
+	// The same table again is not a new identity.
+	ingest(createMultiPacketPMT(pmtPID, videoPID, false))
+	if identityEvents != afterFirst {
+		t.Errorf("a repeated PMT reported %d further identity changes, want 0", identityEvents-afterFirst)
+	}
+
+	// A new version is.
+	ingest(createMultiPacketPMTWithVersion(pmtPID, videoPID, false, true, 1, 1))
+	if identityEvents <= afterFirst {
+		t.Error("a new PMT version reported no identity change")
+	}
+}
+
+// The same run through the ring: every identity change becomes exactly one
+// generation, and it is the ring that counts them.
+func TestSeam_EveryIdentityChangeBecomesExactlyOneGeneration(t *testing.T) {
+	const pmtPID = 100
+	const videoPID = 256
+
+	r := NewMasterRingWithProgram(400*TSPacketSize, 1)
+	defer r.Close()
+
+	before := r.Generation()
+
+	for _, pkt := range createMultiPacketPAT(pmtPID) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PAT: %v", err)
+		}
+	}
+	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push PMT: %v", err)
+		}
+	}
+	afterFirst := r.Generation()
+	if afterFirst <= before {
+		t.Fatalf("Generation = %d after the first PAT/PMT, want it to have advanced from %d", afterFirst, before)
+	}
+
+	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push repeated PMT: %v", err)
+		}
+	}
+	if now := r.Generation(); now != afterFirst {
+		t.Errorf("Generation moved from %d to %d on a repeated PMT - the epoch tracks identity, not packets", afterFirst, now)
+	}
+
+	for _, pkt := range createMultiPacketPMTWithVersion(pmtPID, videoPID, false, true, 1, 1) {
+		if _, err := r.Push(pkt); err != nil {
+			t.Fatalf("push new PMT version: %v", err)
+		}
+	}
+	if now := r.Generation(); now <= afterFirst {
+		t.Errorf("Generation = %d after a new PMT version, want it past %d", now, afterFirst)
+	}
+}
+
+// An entry point found before an identity change belongs to the program that
+// ended. Replaying the events in order is what drops it; replaying them as two
+// independent lists would keep it and hand a subscriber an attach point into a
+// stream that no longer exists.
+func TestSeam_EntryPointsBeforeAnIdentityChangeAreDropped(t *testing.T) {
+	events := []mediafacts.Event{
+		{Kind: mediafacts.EventRandomAccessPoint, Offset: 100},
+		{Kind: mediafacts.EventRandomAccessPoint, Offset: 200},
+		{Kind: mediafacts.EventProgramIdentityChanged},
+		{Kind: mediafacts.EventRandomAccessPoint, Offset: 300},
+	}
+
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+
+	r.mu.Lock()
+	r.applyLocked(mediafacts.ParseResult{Events: events})
+	r.mu.Unlock()
+
+	got := r.KeyframeOffsets()
+	if len(got) != 1 || got[0] != 300 {
+		t.Errorf("KeyframeOffsets = %v, want only the entry point that arrived after the identity change", got)
+	}
+}


### PR DESCRIPTION
Step 0 of the media core migration. **No behaviour changes** — this draws the boundary that a Rust sidecar can later sit behind, and proves it is in the right place by leaving every existing test untouched.

## The split

`MasterRing` was one type with one mutex doing two unrelated jobs. What is left of it is ten fields:

```go
type MasterRing struct {
    mu, notEmpty, buf, capacity, head, tail, isClosed
    keyframeOffsets, maxKeyframes, generation

    core      mediafacts.Core   // reads what the bytes mean
    facts     mediafacts.Facts  // its last answer, cached
    activePSI mediafacts.ActivePSI
}
```

Everything else — TS packets, PSI assembly, PAT/PMT and descriptors, PES, NAL classification, SPS/SEI, access units, entry points, scrambling, the audio observers — moved to `internal/stream/ingest/mediafacts`.

```go
Core.Ingest(startOffset int64, data []byte) (ParseResult, error)
```

Chunk in, facts and ordered events out. One call per receiver read, not per 188-byte packet.

## Three ownership rules, each enforced by a test

**The ring owns the generation.** The core reports `EventProgramIdentityChanged` and stops there — nothing it returns *is* a generation. The ring turns that into an epoch, because the epoch is what subscriber recovery, worker cuts and the entry-point index all answer to.

This was the one real coupling: the parser used to do `r.generation++` itself, from inside a function named after video state.

**The ring owns byte offsets.** Every entry point comes back in the caller's own monotonic coordinate system, because the core was told where the chunk began. A wrong offset here is a seek into the wrong bytes and nothing would catch it — so the test ingests identical bytes at two different bases and requires the results to differ by exactly the base. It fails if the core reports chunk-relative offsets.

**Events are ordered and replayed in order.** An entry point found before an identity change belongs to the programme that ended. Two independent lists would keep it and hand a subscriber an attach point into a stream that no longer exists.

## Ordering

Parsing runs before the bytes are committed, exactly as before. A caller that commits first and learns afterwards that those bytes began a new programme has already handed a subscriber the old stream's truth.

## PSI is parsed once

The core interprets PAT/PMT and hands the raw packets back anyway via `ActivePSI`, because the subscriber preamble is a transport concern. The alternative is parsing those tables a second time, in a second place, with a second answer.

## What did not move

Buffer, head/tail, entry-point index, generation, `SubscriberReader`, `PrimedAttach`, lease and worker lifecycle. That half works and was expensive to stabilise.

## Proof

**Every existing test passes unchanged.** The ~4,000 lines of parser tests, five real captures and four fuzzers were not modified except to follow the two files that changed package. Consumers are untouched — `ring` re-exports the moved names as type aliases.

Four new tests pin the ownership rules; each was verified to fail when the rule it names is removed (offsets made chunk-relative → coordinate test fails; identity events replayed out of order → stale entry point survives).

## Gates

`go build ./...` · `go test ./...` · `make test-race-pr` · `make lint` — all green locally.

## Next

The `mediafacts.Core` interface is what a Rust sidecar implements. `GoCore` becomes the differential reference, not the thing being replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)