### PR TITLE
Run the media core outside the lock its readers hold

### DIFF
--- a/backend/internal/stream/ingest/ring/isolation_test.go
+++ b/backend/internal/stream/ingest/ring/isolation_test.go
@@ -46,6 +46,7 @@ type blockingCore struct {
 	entered chan struct{}
 	release chan struct{}
 	once    sync.Once
+	calls   atomic.Int32
 }
 
 func newBlockingCore(inner mediafacts.Core) *blockingCore {
@@ -53,6 +54,7 @@ func newBlockingCore(inner mediafacts.Core) *blockingCore {
 }
 
 func (c *blockingCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	c.calls.Add(1)
 	c.once.Do(func() { close(c.entered) })
 	<-c.release
 	return c.Core.Ingest(startOffset, data)
@@ -321,5 +323,16 @@ func TestIsolation_ARingThatMovedUnderTheChunkRefusesTheCommit(t *testing.T) {
 
 	if got := r.Head(); got != TSPacketSize {
 		t.Errorf("Head = %d, want %d - the chunk was committed at the wrong offset", got, TSPacketSize)
+	}
+
+	// The core interpreted that chunk and the ring threw it away, which is the
+	// same divergence an error or a short result leaves behind. Asking it again
+	// would be asking about a stream nobody is holding.
+	entered := core.calls.Load()
+	if _, err := r.Push(onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+	}
+	if got := core.calls.Load(); got != entered {
+		t.Errorf("the core was entered %d more times after it diverged from the ring, want 0", got-entered)
 	}
 }

--- a/backend/internal/stream/ingest/ring/isolation_test.go
+++ b/backend/internal/stream/ingest/ring/isolation_test.go
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
+)
+
+// The core is about to become a process on the other end of a socket. These tests
+// are about what happens to the ring when that process is slow, wrong, or gone,
+// and they are written against the in-process core because the answer must not
+// depend on which implementation is behind the boundary.
+
+const isolationWait = 2 * time.Second
+
+// mustReturnWithin fails the test if f is still running after d. Every call it
+// guards is one that has to stay reachable while a core is working.
+func mustReturnWithin(t *testing.T, what string, f func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(isolationWait):
+		t.Fatalf("%s did not return within %v while a core was running", what, isolationWait)
+	}
+}
+
+// blockingCore stops inside Ingest until it is released, which is what a hung
+// socket looks like from the ring's side.
+type blockingCore struct {
+	mediafacts.Core
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingCore(inner mediafacts.Core) *blockingCore {
+	return &blockingCore{Core: inner, entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (c *blockingCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	c.once.Do(func() { close(c.entered) })
+	<-c.release
+	return c.Core.Ingest(startOffset, data)
+}
+
+func onePacket() []byte {
+	pkt := make([]byte, TSPacketSize)
+	pkt[0] = SyncByte
+	pkt[1] = 0x1F
+	pkt[2] = 0xFF
+	pkt[3] = 0x10
+	return pkt
+}
+
+// 1. A core that never returns must cost the stream its facts, not its readers.
+// Before the boundary moved, Ingest ran under the lock every reader takes, so a
+// hung core would have taken subscribers, readiness and Close down with it.
+func TestIsolation_ASlowCoreDoesNotBlockReadersOrClose(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	core := newBlockingCore(r.core)
+	r.core = core
+
+	pushErr := make(chan error, 1)
+	go func() { _, err := r.Push(onePacket()); pushErr <- err }()
+
+	<-core.entered
+
+	mustReturnWithin(t, "ReadinessFacts", func() { _ = r.ReadinessFacts() })
+	mustReturnWithin(t, "Head", func() { _ = r.Head() })
+	mustReturnWithin(t, "Tail", func() { _ = r.Tail() })
+	mustReturnWithin(t, "BufferedBytes", func() { _ = r.BufferedBytes() })
+	mustReturnWithin(t, "Generation", func() { _ = r.Generation() })
+	mustReturnWithin(t, "KeyframeOffsets", func() { _ = r.KeyframeOffsets() })
+	mustReturnWithin(t, "Close", r.Close)
+
+	close(core.release)
+
+	select {
+	case err := <-pushErr:
+		if !errors.Is(err, ErrRingClosed) {
+			t.Errorf("Push err = %v, want ErrRingClosed - the ring closed while the chunk was in the core", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("Push never returned after the core was released")
+	}
+}
+
+// countingCore records how many callers are inside Ingest at once and the offset
+// each of them was given.
+type countingCore struct {
+	mediafacts.Core
+
+	inFlight    atomic.Int32
+	maxInFlight atomic.Int32
+
+	mu      sync.Mutex
+	offsets []int64
+}
+
+func (c *countingCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	now := c.inFlight.Add(1)
+	for {
+		max := c.maxInFlight.Load()
+		if now <= max || c.maxInFlight.CompareAndSwap(max, now) {
+			break
+		}
+	}
+	defer c.inFlight.Add(-1)
+
+	// Long enough that genuinely concurrent callers would overlap here.
+	time.Sleep(time.Millisecond)
+
+	c.mu.Lock()
+	c.offsets = append(c.offsets, startOffset)
+	c.mu.Unlock()
+
+	return c.Core.Ingest(startOffset, data)
+}
+
+// 2. The core is single-threaded by contract, and the bytes have to land in the
+// order they were interpreted. Both come from the same lock: whoever holds it
+// reads the head, interprets against it, and commits at it before the next
+// writer sees anything.
+func TestIsolation_WritersAreSerialisedAndKeepTheirOrder(t *testing.T) {
+	const writers = 8
+
+	r := NewMasterRing(4000 * TSPacketSize)
+	defer r.Close()
+	core := &countingCore{Core: r.core}
+	r.core = core
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := r.Push(onePacket()); err != nil {
+				t.Errorf("Push: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := core.maxInFlight.Load(); got != 1 {
+		t.Errorf("%d callers were inside the core at once, want 1 - the core is single-threaded by contract", got)
+	}
+
+	core.mu.Lock()
+	offsets := append([]int64(nil), core.offsets...)
+	core.mu.Unlock()
+
+	if len(offsets) != writers {
+		t.Fatalf("core saw %d chunks, want %d", len(offsets), writers)
+	}
+
+	// Every chunk was measured against the head the previous one left behind: the
+	// offsets are the whole sequence, once each, with no gap and no overlap.
+	seen := make(map[int64]bool, writers)
+	for _, off := range offsets {
+		if off%int64(TSPacketSize) != 0 || off < 0 || off >= int64(writers*TSPacketSize) {
+			t.Errorf("chunk offset %d is not one of the %d packet positions", off, writers)
+		}
+		if seen[off] {
+			t.Errorf("two chunks were both interpreted at offset %d", off)
+		}
+		seen[off] = true
+	}
+	if got := r.Head(); got != int64(writers*TSPacketSize) {
+		t.Errorf("Head = %d, want %d - a chunk was committed at the wrong offset", got, writers*TSPacketSize)
+	}
+}
+
+// erroringCore fails the way a dead socket would.
+type erroringCore struct {
+	mediafacts.Core
+	err   error
+	calls atomic.Int32
+}
+
+func (c *erroringCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	c.calls.Add(1)
+	return mediafacts.ParseResult{}, c.err
+}
+
+var errCoreExploded = errors.New("core exploded")
+
+// 3. A core that failed once has consumed bytes the ring then threw away, so its
+// state and the ring's have parted company. Asking it again would be asking a
+// stream nobody is holding.
+func TestIsolation_AFailedCoreIsNotReused(t *testing.T) {
+	tests := []struct {
+		name    string
+		core    func(inner mediafacts.Core) mediafacts.Core
+		wantErr error
+	}{
+		{
+			name:    "the core errored",
+			core:    func(inner mediafacts.Core) mediafacts.Core { return &erroringCore{Core: inner, err: errCoreExploded} },
+			wantErr: errCoreExploded,
+		},
+		{
+			name:    "the core came back short",
+			core:    func(inner mediafacts.Core) mediafacts.Core { return shortCore{Core: inner, shortBy: TSPacketSize} },
+			wantErr: ErrCoreIncomplete,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewMasterRing(400 * TSPacketSize)
+			defer r.Close()
+			r.core = tc.core(r.core)
+
+			headBefore, genBefore := r.Head(), r.Generation()
+
+			if _, err := r.Push(onePacket()); !errors.Is(err, tc.wantErr) {
+				t.Fatalf("first Push err = %v, want %v", err, tc.wantErr)
+			}
+			if got := r.Head(); got != headBefore {
+				t.Errorf("Head = %d, want %d", got, headBefore)
+			}
+			if got := r.Generation(); got != genBefore {
+				t.Errorf("Generation = %d, want %d", got, genBefore)
+			}
+			if got := r.BufferedBytes(); got != 0 {
+				t.Errorf("BufferedBytes = %d, want 0", got)
+			}
+
+			// The second attempt must not reach the core at all.
+			if _, err := r.Push(onePacket()); !errors.Is(err, ErrCoreUnusable) {
+				t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+			}
+			if got := r.Head(); got != headBefore {
+				t.Errorf("Head = %d after the refused second chunk, want %d", got, headBefore)
+			}
+		})
+	}
+}
+
+// 4a. Close during an ingest. The chunk comes back to a ring that is no longer
+// accepting anything, and publishing into it would hand bytes to a stream that
+// has already been torn down.
+func TestIsolation_CloseDuringIngestPreventsAStaleCommit(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	core := newBlockingCore(r.core)
+	r.core = core
+
+	headBefore, genBefore := r.Head(), r.Generation()
+
+	pushErr := make(chan error, 1)
+	go func() { _, err := r.Push(onePacket()); pushErr <- err }()
+
+	<-core.entered
+	r.Close()
+	close(core.release)
+
+	select {
+	case err := <-pushErr:
+		if !errors.Is(err, ErrRingClosed) {
+			t.Fatalf("Push err = %v, want ErrRingClosed", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("Push never returned")
+	}
+
+	if got := r.Head(); got != headBefore {
+		t.Errorf("Head = %d, want %d - the chunk was committed after Close", got, headBefore)
+	}
+	if got := r.Generation(); got != genBefore {
+		t.Errorf("Generation = %d, want %d", got, genBefore)
+	}
+	if got := r.BufferedBytes(); got != 0 {
+		t.Errorf("BufferedBytes = %d, want 0", got)
+	}
+}
+
+// 4b. The same rule for the other thing that can change under a chunk: the ring
+// moving on. What the core read describes bytes at one offset, and committing it
+// at another is a plausible, silent lie.
+func TestIsolation_ARingThatMovedUnderTheChunkRefusesTheCommit(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := newBlockingCore(r.core)
+	r.core = core
+
+	pushErr := make(chan error, 1)
+	go func() { _, err := r.Push(onePacket()); pushErr <- err }()
+
+	<-core.entered
+
+	// Something else advanced the ring while the chunk was being read.
+	r.mu.Lock()
+	r.head += TSPacketSize
+	r.mu.Unlock()
+
+	close(core.release)
+
+	select {
+	case err := <-pushErr:
+		if !errors.Is(err, ErrRingAdvanced) {
+			t.Fatalf("Push err = %v, want ErrRingAdvanced", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("Push never returned")
+	}
+
+	if got := r.Head(); got != TSPacketSize {
+		t.Errorf("Head = %d, want %d - the chunk was committed at the wrong offset", got, TSPacketSize)
+	}
+}

--- a/backend/internal/stream/ingest/ring/isolation_test.go
+++ b/backend/internal/stream/ingest/ring/isolation_test.go
@@ -336,3 +336,60 @@ func TestIsolation_ARingThatMovedUnderTheChunkRefusesTheCommit(t *testing.T) {
 		t.Errorf("the core was entered %d more times after it diverged from the ring, want 0", got-entered)
 	}
 }
+
+// An empty chunk is still a write, and a closed ring refuses writes. Moving the
+// core out of the reader lock moved the zero-length shortcut above the state
+// checks with it, which quietly turned "the ring is closed" into "nothing to do".
+func TestPush_EmptyChunkPreservesClosedSemantics(t *testing.T) {
+	t.Run("a closed ring refuses an empty chunk", func(t *testing.T) {
+		r := NewMasterRing(400 * TSPacketSize)
+		core := &countingCore{Core: r.core}
+		r.core = core
+
+		r.Close()
+
+		for _, data := range [][]byte{nil, {}} {
+			if _, err := r.Push(data); !errors.Is(err, ErrRingClosed) {
+				t.Errorf("Push(%v) err = %v, want ErrRingClosed", data, err)
+			}
+		}
+
+		core.mu.Lock()
+		defer core.mu.Unlock()
+		if len(core.offsets) != 0 {
+			t.Errorf("the core was entered %d times for an empty chunk, want 0", len(core.offsets))
+		}
+	})
+
+	t.Run("an open ring accepts an empty chunk and does nothing", func(t *testing.T) {
+		r := NewMasterRing(400 * TSPacketSize)
+		defer r.Close()
+		core := &countingCore{Core: r.core}
+		r.core = core
+
+		headBefore, tailBefore, genBefore := r.Head(), r.Tail(), r.Generation()
+
+		n, err := r.Push(nil)
+		if err != nil {
+			t.Fatalf("Push(nil) err = %v, want nil", err)
+		}
+		if n != 0 {
+			t.Errorf("Push(nil) n = %d, want 0", n)
+		}
+		if got := r.Head(); got != headBefore {
+			t.Errorf("Head = %d, want %d", got, headBefore)
+		}
+		if got := r.Tail(); got != tailBefore {
+			t.Errorf("Tail = %d, want %d", got, tailBefore)
+		}
+		if got := r.Generation(); got != genBefore {
+			t.Errorf("Generation = %d, want %d", got, genBefore)
+		}
+
+		core.mu.Lock()
+		defer core.mu.Unlock()
+		if len(core.offsets) != 0 {
+			t.Errorf("the core was entered %d times for an empty chunk, want 0", len(core.offsets))
+		}
+	})
+}

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -197,9 +197,6 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	}
 
 	n := len(data)
-	if n == 0 {
-		return 0, nil
-	}
 
 	// One writer at a time, and the core belongs to whoever holds this. Taken
 	// before r.mu and released after it, never the other way round.
@@ -219,6 +216,14 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	}
 	startOffset := r.head
 	r.mu.Unlock()
+
+	// An empty chunk has nothing to interpret and nothing to commit, so the core
+	// is never entered for one. It is answered here rather than at the top of the
+	// function: whether the ring is still accepting writes is a question about the
+	// ring, and an empty chunk does not exempt a caller from the answer.
+	if n == 0 {
+		return 0, nil
+	}
 
 	// 2. Interpret the chunk with no ring lock held. This is the call that may sit
 	//    on a socket, and it is the reason the lock above was released.

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -246,10 +246,18 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	// describe the ring it was read against. Committing after a Close would
 	// publish into a stream nobody is holding; committing at a moved head would
 	// publish at the wrong offset. Both are refused rather than reconciled.
+	//
+	// Both also leave the core holding a chunk the ring does not have, which is
+	// the same divergence an error or a short result produces - the reason for it
+	// differs, the consequence does not. Every path that returns after Ingest
+	// without committing retires the core, so no later path can be added that
+	// forgets to. ingestMu is still held, which is what guards the flag.
 	if r.isClosed {
+		r.coreUnusable = true
 		return 0, ErrRingClosed
 	}
 	if r.head != startOffset {
+		r.coreUnusable = true
 		return 0, ErrRingAdvanced
 	}
 

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -36,6 +36,17 @@ var ErrInvalidPacketSize = mediafacts.ErrInvalidPacketSize
 // cannot explain are worse than bytes it does not have.
 var ErrCoreIncomplete = errors.New("media facts core did not interpret the whole chunk")
 
+// ErrCoreUnusable reports a core that has already failed once. A core that
+// errored or came back short may have consumed bytes the ring then refused, so
+// its state and the ring's have diverged and no later answer from it can be
+// trusted. Recovery is a new core, not another attempt at this one.
+var ErrCoreUnusable = errors.New("media facts core is unusable after an earlier failure")
+
+// ErrRingAdvanced reports that the ring moved while a chunk was being
+// interpreted, so what the core read no longer describes where the bytes would
+// land. The chunk is refused rather than committed at the wrong offset.
+var ErrRingAdvanced = errors.New("ring advanced while the chunk was being interpreted")
+
 // The interpretation of transport stream bytes lives in mediafacts. These aliases
 // keep the names consumers already import while the boundary is drawn: the ring
 // owns bytes, offsets and the generation; mediafacts owns what the bytes mean.
@@ -74,9 +85,23 @@ type MasterRing struct {
 	maxKeyframes    int
 	generation      uint64
 
+	// ingestMu serialises writers and owns the core for the length of a call. It
+	// exists so the core can run without r.mu: a core behind a socket may hang,
+	// and a hung core must not take subscribers, readiness and Close with it.
+	//
+	// Lock order is always ingestMu before mu, never the reverse. Close and every
+	// reader take mu alone, which is what keeps them reachable while a core runs.
+	ingestMu sync.Mutex
+
+	// coreUnusable marks a core that answered with an error or an incomplete
+	// result. Such a core may already have advanced past bytes the ring refused,
+	// so its next answer would describe a stream nobody is holding. Guarded by
+	// ingestMu, because it is a property of the core rather than of the ring.
+	coreUnusable bool
+
 	// core reads what the transport stream says about itself. It is given byte
 	// chunks and the offset they start at, and answers with facts and ordered
-	// events; it never sees this struct.
+	// events; it never sees this struct. Guarded by ingestMu.
 	core mediafacts.Core
 
 	// facts is the last answer the core gave, cached so an accessor never calls
@@ -115,10 +140,24 @@ func NewMasterRingWithProgram(capacityBytes int, targetProgram uint16) *MasterRi
 // SetTargetProgram configures the desired program number for PMT resolution,
 // immediately invalidating existing PSI and decoder states if the target changed.
 func (r *MasterRing) SetTargetProgram(progNum uint16) {
+	// The core is single-threaded by contract, so this cannot run beside an
+	// Ingest. It waits behind a slow core, which is the right trade: this is
+	// control plane, and the calls that must never wait are Close and the readers.
+	r.ingestMu.Lock()
+	defer r.ingestMu.Unlock()
+
+	if r.coreUnusable {
+		return
+	}
+	res := r.core.SetTargetProgram(progNum)
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.applyLocked(r.core.SetTargetProgram(progNum))
+	if r.isClosed {
+		return
+	}
+	r.applyLocked(res)
 }
 
 // applyLocked takes what the core said about a chunk and acts on it.
@@ -157,35 +196,66 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 		return 0, ErrInvalidPacketSize
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if r.isClosed {
-		return 0, ErrRingClosed
-	}
-
 	n := len(data)
 	if n == 0 {
 		return 0, nil
 	}
 
-	// 1. Read what the chunk means before any of it becomes visible. The bytes are
-	//    committed below; a subscriber that could see them before the facts caught
-	//    up would be reading the new program with the old program's truth.
-	res, err := r.core.Ingest(r.head, data)
+	// One writer at a time, and the core belongs to whoever holds this. Taken
+	// before r.mu and released after it, never the other way round.
+	r.ingestMu.Lock()
+	defer r.ingestMu.Unlock()
+
+	if r.coreUnusable {
+		return 0, ErrCoreUnusable
+	}
+
+	// 1. Read the ring's position, then let go of it. Everything a reader needs -
+	//    subscribers, readiness, Close - stays reachable while the core works.
+	r.mu.Lock()
+	if r.isClosed {
+		r.mu.Unlock()
+		return 0, ErrRingClosed
+	}
+	startOffset := r.head
+	r.mu.Unlock()
+
+	// 2. Interpret the chunk with no ring lock held. This is the call that may sit
+	//    on a socket, and it is the reason the lock above was released.
+	res, err := r.core.Ingest(startOffset, data)
 	if err != nil {
+		r.coreUnusable = true
 		return 0, err
 	}
 	// A core that interpreted less than it was given leaves the ring with bytes it
 	// has no meaning for. Committing them anyway is exactly the failure this
-	// boundary exists to prevent, so the chunk is refused and nothing here moves:
-	// not the head, not the generation, not the index, not the facts.
-	if want := r.head + int64(len(data)); res.ProcessedThroughOffset != want {
+	// boundary exists to prevent, so the chunk is refused and nothing moves: not
+	// the head, not the generation, not the index, not the facts. The core is
+	// finished either way - it consumed what the ring is about to throw away.
+	if want := startOffset + int64(n); res.ProcessedThroughOffset != want {
+		r.coreUnusable = true
 		return 0, ErrCoreIncomplete
 	}
+
+	// 3. Commit. Facts, events, PSI and bytes become visible together, under one
+	//    hold of the lock, or none of them do.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// The ring was unlocked while the core ran, so what it read may no longer
+	// describe the ring it was read against. Committing after a Close would
+	// publish into a stream nobody is holding; committing at a moved head would
+	// publish at the wrong offset. Both are refused rather than reconciled.
+	if r.isClosed {
+		return 0, ErrRingClosed
+	}
+	if r.head != startOffset {
+		return 0, ErrRingAdvanced
+	}
+
 	r.applyLocked(res)
 
-	// 2. Write data into circular buffer safely, supporting len(data) > capacity without panic
+	// 4. Write data into circular buffer safely, supporting len(data) > capacity without panic
 	remaining := data
 	for len(remaining) > 0 {
 		chunk := remaining
@@ -361,6 +431,9 @@ func (r *MasterRing) BufferedBytes() int {
 
 // Close closes the master ring buffer, waking all blocked subscriber readers.
 func (r *MasterRing) Close() {
+	// Deliberately does not take ingestMu. Close has to work while a core is
+	// running, including one that will never return; a chunk in flight sees the
+	// closed flag when it comes back to commit and is refused there.
 	r.mu.Lock()
 	defer r.mu.Unlock()
 


### PR DESCRIPTION
The half [#887](https://github.com/ManuGH/xg2g/pull/887) named but did not build. It drew the semantic boundary and said so explicitly: `Push` still held the reader-facing ring lock across `core.Ingest`, so a core behind a socket that hung would take subscribers, readiness and `Close` with it — and `Close` is precisely the call that has to work when a core is wedged.

## Two locks, one order

```
ingestMu   one writer at a time, and it owns the core
mu         the ring: buffer, head, tail, index, generation, facts
```

Always `ingestMu` before `mu`, never the reverse.

```
ingestMu ─┬─ mu: read head, release
          │
          ├─ core.Ingest(startOffset, data)      ← no ring lock held
          │     ├─ error / short  → poison core, commit nothing
          │     └─ complete
          │
          └─ mu: re-check state, then commit
                 events + facts + PSI + bytes + head/tail   ← one hold
```

`Close` and every reader take `mu` alone. That is what keeps them reachable while a core works.

## Letting go of the lock means re-checking, not trusting

The ring can change under a chunk now, so the commit verifies what the chunk was read against:

| condition | outcome | why |
|---|---|---|
| closed meanwhile | `ErrRingClosed` | publishing into a torn-down stream hands bytes to nobody |
| head moved | `ErrRingAdvanced` | the core read bytes at one offset; committing at another is a plausible, silent lie |

Nothing partial is ever visible: all four kinds of state move under that one hold of `mu`, or none of them do.

## A failed core is not asked again

A core that errored or came back short consumed bytes the ring then threw away — its state and the ring's have parted company, and its next answer would describe a stream nobody is holding. `ErrCoreUnusable` fails the following `Push` before it reaches the core. Recovery is a new core, not another attempt at this one.

With `GoCore` this path is dormant: it neither errors nor comes back short. That is exactly why it is cheap to define now and expensive to retrofit once a socket can produce both.

`SetTargetProgram` takes `ingestMu` too — it is the only other caller into the core, which is single-threaded by contract. It therefore waits behind a slow core. That is the right trade: it is control plane, and the calls that must never wait are `Close` and the readers.

## The four invariants

Each has a test, and each test fails when the property it names is removed:

1. **A blocked core delays no reader.** `ReadinessFacts`, `Head`, `Tail`, `BufferedBytes`, `Generation`, `KeyframeOffsets`, `Close` — all must return within 2s while a core sits inside `Ingest`. Restoring the old single lock hangs the first of them for the full timeout.
2. **Writers are serialised and keep their order.** Eight concurrent pushes; the core records max concurrency and every offset it was handed. Without `ingestMu`: *8 callers were inside the core at once* and `Head = 188, want 1504` — every chunk committed over the last.
3. **A failed core commits nothing and is refused afterwards.** Both variants — hard error and short result — leave head, generation and buffered bytes untouched, and the next `Push` returns `ErrCoreUnusable`.
4. **Close, or the ring advancing, during an ingest prevents the stale commit.** Without the re-check both return `nil` and commit.

## Gates

`go build ./...` · `go test ./...` · `make test-race-pr` · `make lint`, plus `go test -race -count=3` on the ring package — all green locally.

No behaviour changes for a working core. Still no Rust, still no sidecar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)