### PR TITLE
Put CGO_ENABLED where the go build can see it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,8 +98,12 @@ COPY --from=webui-builder /apps/webui/dist /app/backend/internal/control/http/di
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
+# The environment has to be on the command it is meant for. As a prefix to the
+# whole line it applied to `cd` and nothing else, so `go build` ran with cgo
+# enabled and the image has been shipping a dynamically linked daemon.
+WORKDIR /app/backend
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    cd /app/backend && go build -buildvcs=false -ldflags="-s -w -X github.com/ManuGH/xg2g/internal/version.Version=${BUILD_VERSION} -X github.com/ManuGH/xg2g/internal/version.Commit=${BUILD_COMMIT} -X github.com/ManuGH/xg2g/internal/version.Date=${BUILD_DATE}" -o /xg2g ./cmd/daemon
+    go build -buildvcs=false -ldflags="-s -w -X github.com/ManuGH/xg2g/internal/version.Version=${BUILD_VERSION} -X github.com/ManuGH/xg2g/internal/version.Commit=${BUILD_COMMIT} -X github.com/ManuGH/xg2g/internal/version.Date=${BUILD_DATE}" -o /xg2g ./cmd/daemon
 
 # Stage 4: Final runtime image.
 # By default this inherits the internal FFmpeg base stage.


### PR DESCRIPTION
The daemon has never been built the way the Dockerfile says it is.

```dockerfile
RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
    cd /app/backend && go build ...
```

An environment prefix applies to **one** command, and that command was `cd`. The `go build` after the `&&` ran in a fresh environment with cgo at its default. Every image published from this Dockerfile carries a dynamically linked daemon that needs libc at runtime — the flag has been inert, and the shape of the line made it look deliberate.

```
FOO=1 cd /tmp && echo $FOO   →  (empty)
```

## How it surfaced

An image assertion written for an unrelated branch — a gate that checks the Go binary stays static while a Rust artifact is added beside it — failed on `main`'s own artifact. The gate was right; the assumption was wrong.

## Evidence

Measured on the real deployment host (Linux LXC, amd64), by pulling the binary out of the built image:

| | before | after |
|---|---|---|
| `file` | `dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2` | `statically linked` |
| `ldd` | `libc.so.6`, `ld-linux-x86-64.so.2` | `not a dynamic executable` |
| `_cgo_` symbols | **26** | **0** |
| size | 34 631 945 | 34 504 866 |

Nothing had to change but where the words sit. The dependency set already compiled without cgo — SQLite here is `modernc.org`'s pure-Go implementation.

## The runtime change, tested rather than assumed

A pure-Go binary resolves DNS with Go's resolver instead of libc's. That is the one difference that shows up in production and not in a unit test, so the image was started against the real receiver.

**Differential, same env, same hostnames, old image vs new:**

```
xg2g-verify (dynamic/cgo)      xg2g-cgo-fix (static)
  vuuno4k.local  -> no such host  |  vuuno4k.local  -> no such host
  10.10.55.64    -> status 200    |  10.10.55.64    -> status 200
```

Identical. The container's resolver is Tailscale MagicDNS at `100.100.100.100`, which has never held those names — the failure is NXDOMAIN from a working resolver, in both builds. The deployment addresses the receiver by IP (`XG2G_E2_HOST=http://10.10.55.64`), so DNS is not on that path at all.

**Full runtime check of the fixed image:**

- container reaches `healthy`
- `xg2g healthcheck ready` → `Healthcheck successful (ready, metrics=false)`, exit 0
- OpenWebIF reachable: `/api/about` and `/api/epgservice` both 200 against the live VU+
- runs as uid 10001
- FFmpeg 8.1.2 present
- version reports `v3.10.0`

The running deployment was not touched — the test built and ran in a scratch directory with its own data volume and no published ports, and all four production containers were still up and healthy afterwards.

## Scope

Dockerfile only. No Go source, no Rust files. [#890](https://github.com/ManuGH/xg2g/pull/890) rebases onto this and keeps its `statically linked` assertion sharp.

## Test environment

```
macOS:            no  — Docker daemon not running there; nothing derived from it
Linux LXC amd64:  yes — image built and run, binary inspected, VU+ reached
Docker amd64:     yes — real build, real start, real healthcheck
Docker arm64:     not tested — no binfmt on the LXC; CI covers the build
real VU+:         yes — OpenWebIF 200s from inside the fixed image
```

**Untested production paths:** arm64 runtime; live transcode and streaming under the static binary (the daemon started and reached the receiver, but no playback session was driven); long-running behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)