### PR TITLE
iOS CI: pre-boot the simulator, and prove the compile step is really redundant

### DIFF
--- a/.github/workflows/architecture-convergence.yml
+++ b/.github/workflows/architecture-convergence.yml
@@ -92,25 +92,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+      - name: Resolve and Pre-boot iOS Simulator
+        id: simulator
+        run: |
+          set -euo pipefail
+          SIM_NAME="iPhone 16 Pro"
+          SIM_UDID=$(xcrun simctl list devices "${SIM_NAME}" available | grep -E -m1 "${SIM_NAME}.*\([0-9A-Fa-f-]+\)" | sed -E 's/.*\(([0-9A-Fa-f-]+)\).*/\1/' || true)
+          if [ -z "${SIM_UDID}" ]; then
+            echo "iPhone 16 Pro not found, falling back to first available iPhone"
+            SIM_UDID=$(xcrun simctl list devices available | grep -E -m1 "iPhone.*\([0-9A-Fa-f-]+\)" | sed -E 's/.*\(([0-9A-Fa-f-]+)\).*/\1/')
+          fi
+          echo "Selected Simulator UDID: ${SIM_UDID}"
+          echo "udid=${SIM_UDID}" >> "$GITHUB_OUTPUT"
+          echo "Pre-booting simulator ${SIM_UDID} in background..."
+          xcrun simctl boot "${SIM_UDID}" 2>/dev/null || true
+
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version-file: backend/go.mod
           cache: false
 
-      - name: Compile iOS application
-        working-directory: ios
-        run: |
-          set -euo pipefail
-          xcodebuild \
-            -project Xg2g.xcodeproj \
-            -scheme Xg2g \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO \
-            build
-
       - name: Exercise generated iOS contracts against the Go router
-        run: ./ios/scripts/run-contract-tests.sh 'iPhone 16 Pro'
+        run: ./ios/scripts/run-contract-tests.sh "${{ steps.simulator.outputs.udid }}"
 
   merge-gate:
     name: Architecture Convergence / Merge Gate

--- a/ios/scripts/run-contract-tests.sh
+++ b/ios/scripts/run-contract-tests.sh
@@ -61,6 +61,12 @@ fi
 #
 # Running the same package with a test filter that matches nothing does that
 # work up front, through `go test` so the build flags stay identical.
+# Guarantee that the entire test target compiles cleanly before anything else.
+# -only-testing must never hide compilation errors in other test suites, and a
+# Swift break has no reason to wait for a Go build and a fixture server first -
+# it cannot be caused by either, and it fails the job regardless.
+"${REPO_ROOT}/ios/scripts/verify-ios-build.sh" "${SIMULATOR}"
+
 echo "==> building the contract fixture"
 (
   cd "${REPO_ROOT}/backend"
@@ -109,10 +115,6 @@ if [[ -z "${READY:-}" ]]; then
   report_fixture_log
   exit 1
 fi
-
-# Guarantee that the entire test target compiles cleanly before running.
-# -only-testing must never hide compilation errors in other test suites.
-"${REPO_ROOT}/ios/scripts/verify-ios-build.sh" "${SIMULATOR}"
 
 if [[ "${SIMULATOR}" =~ ^[0-9A-Fa-f-]+$ ]]; then
   DESTINATION="platform=iOS Simulator,id=${SIMULATOR}"

--- a/ios/scripts/run-contract-tests.sh
+++ b/ios/scripts/run-contract-tests.sh
@@ -114,7 +114,15 @@ fi
 # -only-testing must never hide compilation errors in other test suites.
 "${REPO_ROOT}/ios/scripts/verify-ios-build.sh" "${SIMULATOR}"
 
-echo "==> running iOS contract suite against ${BASE_URL}"
+if [[ "${SIMULATOR}" =~ ^[0-9A-Fa-f-]+$ ]]; then
+  DESTINATION="platform=iOS Simulator,id=${SIMULATOR}"
+  echo "==> Ensuring simulator ${SIMULATOR} is fully booted..."
+  xcrun simctl bootstatus "${SIMULATOR}" -b
+else
+  DESTINATION="platform=iOS Simulator,name=${SIMULATOR}"
+fi
+
+echo "==> running iOS contract suite against ${BASE_URL} on ${DESTINATION}"
 cd "${REPO_ROOT}/ios"
 
 # The address lives in the scheme's test environment, not on this command line:
@@ -125,7 +133,7 @@ set +e
 xcodebuild test \
   -project Xg2g.xcodeproj \
   -scheme Xg2g \
-  -destination "platform=iOS Simulator,name=${SIMULATOR}" \
+  -destination "${DESTINATION}" \
   -only-testing:Xg2gTests/BackendContractTests \
   2>&1 | tee "${OUTPUT}"
 STATUS="${PIPESTATUS[0]}"

--- a/ios/scripts/verify-ios-build.sh
+++ b/ios/scripts/verify-ios-build.sh
@@ -18,11 +18,17 @@ if ! command -v xcodebuild >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "==> Verifying iOS build-for-testing on ${SIMULATOR}..."
+if [[ "${SIMULATOR}" =~ ^[0-9A-Fa-f-]+$ ]]; then
+  DESTINATION="platform=iOS Simulator,id=${SIMULATOR}"
+else
+  DESTINATION="platform=iOS Simulator,name=${SIMULATOR}"
+fi
+
+echo "==> Verifying iOS build-for-testing on ${DESTINATION}..."
 xcodebuild build-for-testing \
   -project "${REPO_ROOT}/ios/Xg2g.xcodeproj" \
   -scheme Xg2g \
-  -destination "platform=iOS Simulator,name=${SIMULATOR}" \
+  -destination "${DESTINATION}" \
   -quiet
 
 echo "✅ iOS build-for-testing passed (entire Xg2gTests target compiles cleanly)"

--- a/ios/scripts/verify-ios-build.sh
+++ b/ios/scripts/verify-ios-build.sh
@@ -18,11 +18,11 @@ if ! command -v xcodebuild >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ "${SIMULATOR}" =~ ^[0-9A-Fa-f-]+$ ]]; then
-  DESTINATION="platform=iOS Simulator,id=${SIMULATOR}"
-else
-  DESTINATION="platform=iOS Simulator,name=${SIMULATOR}"
-fi
+# Compiling needs a platform, not a device. The step this replaced used the
+# generic destination for exactly that reason, and keeping it means a simulator
+# that failed to resolve or boot cannot take the only compile coverage with it.
+# The concrete device is picked later, by the run that actually needs one.
+DESTINATION="generic/platform=iOS Simulator"
 
 echo "==> Verifying iOS build-for-testing on ${DESTINATION}..."
 xcodebuild build-for-testing \


### PR DESCRIPTION
Lifted out of [#890](https://github.com/ManuGH/xg2g/pull/890), where it did not belong — that PR is Rust build foundation only, and this is a CI coverage change. The commit is unchanged (`ci(ios): pre-boot simulator in background and eliminate duplicate build`, authored by ManuGH).

**Draft on purpose.** The simulator pre-boot is uncontroversial; the deletion of the separate `Compile iOS application` step is not, and it is not proven yet.

## What review flagged

The workflow previously ran a fast, device-independent compile:

```
xcodebuild ... -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
```

After the deletion, the only remaining Swift compile coverage comes from `verify-ios-build.sh` (`build-for-testing`, no `CODE_SIGNING_ALLOWED=NO`), invoked from inside `run-contract-tests.sh` — after `go test` has built the package tree and the fixture server is up, and dependent on the new simulator UDID resolution and boot succeeding.

So a plain Swift compile break now surfaces later, less clearly, and only if the simulator came up.

## What has to be proven before this leaves draft

1. `verify-ios-build.sh` compiles the app **and** the full test target, not just one of them.
2. A deliberately injected Swift compile error turns the new workflow red, reliably.
3. A simulator resolution or boot failure does not needlessly take the only compile coverage with it, where that is avoidable.
4. The existing skip-detection for contract tests still behaves.
5. Three CI runs before and after, median compared — the change is a speed optimisation, so the speed claim needs a number.

If the separate step does come out, the PR title and description say so explicitly:

> Compile coverage is not removed; it is consolidated into build-for-testing.

Later, the cleaner shape is `build-for-testing` → `test-without-building` sharing one `DerivedDataPath` and one simulator UDID.

## Test environment

```
macOS:            not yet — no runs made for this PR
Linux LXC amd64:  n/a — iOS CI runs on macOS runners
Docker amd64:     n/a
Docker arm64:     n/a
real VU+:         n/a
```

**Untested:** everything above. This PR exists so the claim can be tested somewhere other than inside a Rust PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)