### PR TITLE
Let BuildKit say which platform the daemon is built for

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,14 @@ COPY . /app
 # Copy built WebUI assets to the correct location for Go embedding
 COPY --from=webui-builder /apps/webui/dist /app/backend/internal/control/http/dist
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+# Declared without values on purpose. BuildKit fills these in from the platform
+# being built; giving them defaults replaces that with the default, so a
+# --platform=linux/arm64 build compiled the daemon for amd64 and put it in an
+# arm64 image. That stayed invisible while CGO_ENABLED and GOARCH were being
+# dropped by the shell - Go then built for whatever the emulated builder was,
+# which happened to be right.
+ARG TARGETOS
+ARG TARGETARCH
 # The environment has to be on the command it is meant for. As a prefix to the
 # whole line it applied to `cd` and nothing else, so `go build` ran with cgo
 # enabled and the image has been shipping a dynamically linked daemon.


### PR DESCRIPTION
```dockerfile
ARG TARGETOS=linux
ARG TARGETARCH=amd64
```

BuildKit populates these from the platform being built — but only where they are declared **without** a value. Giving them defaults replaces the real platform with the default, so a `--platform=linux/arm64` build compiles the daemon for **amd64** and puts that binary in an arm64 image.

## Why it was invisible until now

While the environment prefix was being swallowed by the shell ([#891](https://github.com/ManuGH/xg2g/pull/891)), `GOARCH` never reached `go build` at all, and Go compiled for whatever the emulated builder was — under QEMU for an arm64 build, that was arm64. The value was wrong *and* unused. Fixing the shell bug made the wrong value load-bearing.

Two bugs that cancelled each other out, in the same three lines.

## Evidence

The image gate on [#890](https://github.com/ManuGH/xg2g/pull/890) pulls both binaries out of the built image and checks each is built for the platform it claims. On `linux/arm64`:

```
./xg2g.bin:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
./media-core.bin: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV)
```

The Rust stage was right for a reason worth noting: it has no `ARG` default to shadow, and builds natively for whatever platform the stage runs on.

## Blast radius

**Nothing published is affected.** `docker.yml` builds `linux/amd64` only, where the default happened to match the real platform. What was broken is every multi-arch build anyone might have made — the resulting arm64 image would fail to exec its own entrypoint.

## Scope

Dockerfile only, three lines. [#890](https://github.com/ManuGH/xg2g/pull/890) rebases onto this; its arm64 image gate then has a chance of passing, and stays sharp.

## Test environment

```
macOS:            no  — no Docker daemon
Linux LXC amd64:  partially — confirmed that an ARG without a default receives
                  arm64 from BuildKit, and that one with a default does not
Docker amd64:     unchanged by this PR (the default already matched)
Docker arm64:     proven by #890's image gate once rebased — that gate is what
                  found this
real VU+:         n/a — build-time only
```

**Untested production paths:** arm64 runtime. This makes the arm64 image contain an arm64 daemon; whether that daemon then behaves correctly on real arm64 hardware is a separate question and is not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)