### PR TITLE
Give the media core a deadline, a failure taxonomy and a rule

### DIFF
--- a/backend/internal/stream/ingest/ingeststats/sampler_test.go
+++ b/backend/internal/stream/ingest/ingeststats/sampler_test.go
@@ -5,6 +5,7 @@
 package ingeststats
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -83,7 +84,7 @@ func overrunSubscriber(t *testing.T) (*ring.SubscriberReader, ring.SubscriberSta
 		if end > len(capture) {
 			end = len(capture)
 		}
-		if _, err := r.Push(capture[i:end]); err != nil {
+		if _, err := r.Push(context.Background(), capture[i:end]); err != nil {
 			t.Fatalf("push capture: %v", err)
 		}
 	}

--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -6,9 +6,98 @@ package mediafacts
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"time"
 
 	"github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
 )
+
+// DefaultIngestDeadline bounds how long one chunk may be interpreted.
+//
+// It is a stall detector, not a budget meant to be spent. The in-process core
+// finishes a 64 KiB chunk in microseconds and a core on a local socket should
+// answer in milliseconds, so anything approaching this value means the core has
+// stopped answering rather than that it is working hard.
+//
+// The number is derived from two measurements rather than chosen. Measured on
+// the repository's own DVB captures, GoCore interprets a chunk in:
+//
+//	 64 KiB   p50 ~230us   p99 ~350us
+//	256 KiB   p50 ~1.0ms   p99 ~1.05ms
+//	  1 MiB   p50 ~3.7ms   p99 ~4.1ms
+//	  4 MiB           ~14.9ms
+//
+// 4 MiB is the ceiling: the normalizer's sink is handed its staging buffer, which
+// defaults to that size. So the worst realistic chunk costs about 15 ms in
+// process, and a core across a local socket adds a transfer and a round trip to
+// that, not an order of magnitude.
+//
+// The upper bound comes from the viewer. A zap fails when transport readiness is
+// not reached within the pipeline's ReadyTimeout, 8s by default. A hung core
+// costs that budget exactly one deadline and no more - the caller retires it, and
+// every later chunk fails immediately - so the deadline can afford headroom
+// without putting the zap at risk.
+//
+// 500ms is roughly 33x the slowest measured chunk and an eighth of the smallest
+// viewer-facing budget. A test in the pipeline package holds the two against each
+// other, because a deadline that quietly grew past the zap budget would turn a
+// hung core into a hung zap instead of a failed one.
+const DefaultIngestDeadline = 500 * time.Millisecond
+
+// Ways a core fails. They are separate because a caller may want to tell them
+// apart in a log or a metric - but not in its handling, which is identical for
+// all of them and stated on Core.Ingest.
+var (
+	// ErrCoreTimeout means the core did not answer within the deadline. It says
+	// nothing about whether the core is alive; a core that answers later has still
+	// missed the chunk, and its state has moved on without the caller.
+	ErrCoreTimeout = errors.New("media facts core did not answer within the deadline")
+
+	// ErrCoreGone means the core ended the conversation - a closed pipe, an EOF,
+	// a process that is no longer there.
+	ErrCoreGone = errors.New("media facts core is gone")
+
+	// ErrCoreCrashed means the core terminated abnormally.
+	ErrCoreCrashed = errors.New("media facts core crashed")
+
+	// ErrCoreInvalidResponse means the core answered with something that is not a
+	// result: a truncated frame, a field that cannot be, a decode failure.
+	ErrCoreInvalidResponse = errors.New("media facts core returned an invalid response")
+
+	// ErrCoreProtocolVersion means the core speaks a version of this contract that
+	// this build does not. It is fatal on purpose: a partially understood protocol
+	// is how a caller ends up acting on fields that mean something else.
+	ErrCoreProtocolVersion = errors.New("media facts core protocol version mismatch")
+)
+
+// IsCoreFailure reports whether an error means the core can no longer be trusted
+// with the next chunk.
+//
+// Every failure of a core is one of these, and every one of them has the same
+// consequence: the chunk is refused and the core is retired. The classification
+// exists so that consequence is applied by asking one question rather than by
+// listing errors at each call site - a list that would eventually miss one.
+func IsCoreFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, context.Canceled),
+		errors.Is(err, ErrCoreTimeout),
+		errors.Is(err, ErrCoreGone),
+		errors.Is(err, ErrCoreCrashed),
+		errors.Is(err, ErrCoreInvalidResponse),
+		errors.Is(err, ErrCoreProtocolVersion),
+		errors.Is(err, ErrInvalidPacketSize):
+		return true
+	}
+	// An unrecognised error from a core is still an error from a core. Treating
+	// only known failures as failures is how an unknown one becomes a silent
+	// success.
+	return true
+}
 
 // Core reads transport stream bytes and reports what they say.
 //
@@ -33,20 +122,34 @@ type Core interface {
 	// Ingest consumes one chunk of transport stream. startOffset is the chunk's
 	// position in the caller's own monotonic byte coordinate system, and every
 	// offset in the result is expressed in that same system.
-	Ingest(startOffset int64, data []byte) (ParseResult, error)
-
-	// Snapshot returns what the core currently knows. Facts only move when a chunk
-	// is ingested, so a caller that keeps the facts from the last Ingest never
-	// needs to call this on a hot path.
-	Snapshot() Facts
+	//
+	// The context bounds the call. An implementation that reaches another process
+	// must stop waiting when it expires and must not answer afterwards - a late
+	// answer describes a chunk the caller has already refused.
+	//
+	// Any error, of any kind, means the same thing to the caller and is not
+	// negotiable: no facts, no events, no PSI, no bytes committed, and this core
+	// is never asked again. That includes a result that is well-formed but
+	// incomplete, because a core that consumed less than it was given has moved
+	// past bytes the caller is about to throw away.
+	Ingest(ctx context.Context, startOffset int64, data []byte) (ParseResult, error)
 
 	// SetTargetProgram selects which program of a multi-program transport is
 	// followed. Changing it discards everything read about the previous one.
-	SetTargetProgram(programNumber uint16) ParseResult
-
-	// Reset discards all parser state.
-	Reset() ParseResult
+	//
+	// Bounded and fallible for the same reason Ingest is: it is the only other
+	// call that reaches the core, and an implementation behind a socket can hang
+	// here just as easily. Its failures carry the same consequence.
+	SetTargetProgram(ctx context.Context, programNumber uint16) (ParseResult, error)
 }
+
+// Deliberately absent from this interface: Snapshot and Reset.
+//
+// Neither is called on a Core anywhere in production - the caller keeps the facts
+// from the last Ingest, and nothing resets a core it is about to retire. Leaving
+// them in would mean a later wire protocol has to carry two messages that exist
+// only because an interface once listed them. GoCore keeps both as its own
+// methods, where they are used internally and by tests.
 
 // EventKind names something the core saw that the caller has to act on. Facts
 // describe a state; events describe a moment in the byte stream, and their order
@@ -257,20 +360,44 @@ func NewGoCore(targetProgramNumber uint16) *GoCore {
 }
 
 // Ingest interprets one chunk of transport stream.
-func (c *GoCore) Ingest(startOffset int64, data []byte) (ParseResult, error) {
+func (c *GoCore) Ingest(ctx context.Context, startOffset int64, data []byte) (ParseResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseResult{}, err
+	}
 	if len(data)%TSPacketSize != 0 {
 		return ParseResult{}, ErrInvalidPacketSize
 	}
 
 	c.events = c.events[:0]
 	for i := 0; i < len(data); i += TSPacketSize {
+		// Checked during the chunk, not only before it. The largest chunk this
+		// path sees is the normalizer's staging buffer, and a caller that gave up
+		// half way through one should not wait for the rest.
+		//
+		// Returning here leaves the parser part way through a chunk the caller
+		// will refuse. That is not a leak: the caller retires a core whose Ingest
+		// returned an error, so this state is never read again.
+		if i%(ctxCheckPackets*TSPacketSize) == 0 {
+			if err := ctx.Err(); err != nil {
+				return ParseResult{}, err
+			}
+		}
 		c.indexPacketLocked(data[i:i+TSPacketSize], startOffset+int64(i))
 	}
 	return c.result(startOffset + int64(len(data))), nil
 }
 
+// ctxCheckPackets is how often the context is re-read while a chunk is being
+// interpreted. At the measured throughput this is a few milliseconds apart -
+// often enough that cancellation is not delayed noticeably, rare enough that the
+// check does not show up beside the parsing.
+const ctxCheckPackets = 4096
+
 // SetTargetProgram selects the program to follow.
-func (c *GoCore) SetTargetProgram(programNumber uint16) ParseResult {
+func (c *GoCore) SetTargetProgram(ctx context.Context, programNumber uint16) (ParseResult, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseResult{}, err
+	}
 	c.events = c.events[:0]
 	if c.targetProgramNumber != programNumber {
 		c.targetProgramNumber = programNumber
@@ -284,7 +411,7 @@ func (c *GoCore) SetTargetProgram(programNumber uint16) ParseResult {
 		c.rawPATPackets = nil
 		c.resetProgramStateLocked()
 	}
-	return c.result(0)
+	return c.result(0), nil
 }
 
 // Reset discards everything read so far.

--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -39,8 +39,8 @@ import (
 // every later chunk fails immediately - so the deadline can afford headroom
 // without putting the zap at risk.
 //
-// 500ms is roughly 33x the slowest measured chunk and an eighth of the smallest
-// viewer-facing budget. A test in the pipeline package holds the two against each
+// 500ms is roughly 33x the slowest measured chunk and a sixteenth of the
+// smallest viewer-facing budget. A test in the pipeline package holds the two against each
 // other, because a deadline that quietly grew past the zap budget would turn a
 // hung core into a hung zap instead of a failed one.
 const DefaultIngestDeadline = 500 * time.Millisecond

--- a/backend/internal/stream/ingest/mediafacts/deadline_test.go
+++ b/backend/internal/stream/ingest/mediafacts/deadline_test.go
@@ -1,0 +1,67 @@
+package mediafacts
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
+)
+
+func capture(t *testing.T, name string) []byte {
+	t.Helper()
+	_, self, _, _ := runtime.Caller(0)
+	root := filepath.Join(filepath.Dir(self), "..", "..", "..", "..", "testdata", "segments")
+	b, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		t.Skipf("capture %s unavailable: %v", name, err)
+	}
+	return b
+}
+
+// The deadline is a number with a derivation, and a derivation stops being true
+// when the thing it was derived from changes. This keeps the two attached: if the
+// parser ever slows down enough that a worst-case chunk eats a meaningful part of
+// DefaultIngestDeadline, the headroom the number was chosen for is gone and this
+// says so before a stalled core starts looking like a slow one.
+func TestIngestStaysFarInsideItsDeadline(t *testing.T) {
+	for _, name := range []string{"test_hevc_stream.ts", "verify_aac.ts", "verify_seg.ts"} {
+		data := capture(t, name)
+		data = data[:len(data)/TSPacketSize*TSPacketSize]
+
+		for _, chunk := range []int{64 * 1024, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024} {
+			chunk = chunk / TSPacketSize * TSPacketSize
+			if len(data) < chunk {
+				continue
+			}
+			c := NewGoCore(1)
+			var samples []time.Duration
+			for off := 0; off+chunk <= len(data); off += chunk {
+				start := time.Now()
+				if _, err := c.Ingest(context.Background(), int64(off), data[off:off+chunk]); err != nil {
+					t.Fatalf("ingest: %v", err)
+				}
+				samples = append(samples, time.Since(start))
+			}
+			if len(samples) == 0 {
+				continue
+			}
+			sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+			p50 := samples[len(samples)*50/100]
+			p99 := samples[len(samples)*99/100]
+			max := samples[len(samples)-1]
+			t.Logf("%-22s chunk=%4dKiB n=%3d  p50=%-10v p99=%-10v max=%v",
+				name, chunk/1024, len(samples), p50, p99, max)
+
+			// A tenth of the deadline. Chosen so the assertion fires on a real
+			// regression rather than on a loaded machine: the measured worst case
+			// is around 3% of it.
+			if budget := DefaultIngestDeadline / 10; max > budget {
+				t.Errorf("%s at %d KiB took %v, more than %v - the deadline no longer has the headroom it was derived from",
+					name, chunk/1024, max, budget)
+			}
+		}
+	}
+}

--- a/backend/internal/stream/ingest/mediafacts/deadline_test.go
+++ b/backend/internal/stream/ingest/mediafacts/deadline_test.go
@@ -27,6 +27,21 @@ func capture(t *testing.T, name string) []byte {
 // DefaultIngestDeadline, the headroom the number was chosen for is gone and this
 // says so before a stalled core starts looking like a slow one.
 func TestIngestStaysFarInsideItsDeadline(t *testing.T) {
+	// A wall-clock guard measures the parser. Under coverage it measures the
+	// counters coverage inserted into the parser, which is a different thing and
+	// not one DefaultIngestDeadline was derived from - atomic counters on every
+	// block turn the 4 MiB chunk from ~15ms into ~54ms without the parser having
+	// changed at all.
+	//
+	// Skipping here is not a loosened gate. The property is still checked on every
+	// ordinary run and on the race job; what is dropped is a timing claim from the
+	// one run that cannot make it honestly. The alternative - raising the limit
+	// until instrumented timings fit under it - would fit the contract to the
+	// measuring instrument and leave the real headroom unguarded.
+	if testing.CoverMode() != "" {
+		t.Skip("wall-clock ingest headroom is not meaningful under coverage instrumentation")
+	}
+
 	for _, name := range []string{"test_hevc_stream.ts", "verify_aac.ts", "verify_seg.ts"} {
 		data := capture(t, name)
 		data = data[:len(data)/TSPacketSize*TSPacketSize]

--- a/backend/internal/stream/ingest/normalizer/normalizer_test.go
+++ b/backend/internal/stream/ingest/normalizer/normalizer_test.go
@@ -572,7 +572,7 @@ func TestNormalizer_RealBroadcast_EndToEnd(t *testing.T) {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		_, pushErr := master.Push(chunk)
+		_, pushErr := master.Push(context.Background(), chunk)
 		return pushErr
 	})
 	if err != nil {

--- a/backend/internal/stream/ingest/pipeline/core_deadline_test.go
+++ b/backend/internal/stream/ingest/pipeline/core_deadline_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
+)
+
+// The core's deadline and the viewer's patience are set in different packages for
+// different reasons, and neither knows about the other. This is where they are
+// held together.
+//
+// A zap fails when transport readiness is not reached within ReadyTimeout, and
+// reaching readiness takes many chunks. A core that stops answering costs that
+// budget exactly one deadline - the ring retires it and every later chunk fails
+// at once - so what matters is not that the deadline is small, but that it stays
+// a fraction of the budget it is spent from. If someone raises the deadline to
+// something comfortable for a slow socket, a hung core stops being a failed chunk
+// and becomes a failed zap, and nothing else in the tree would notice.
+func TestIngestDeadlineStaysWellInsideTheZapBudget(t *testing.T) {
+	ready := DefaultPreparationConfig().ReadyTimeout
+	deadline := mediafacts.DefaultIngestDeadline
+
+	if ready <= 0 {
+		t.Fatalf("ReadyTimeout = %v; the budget this is measured against is gone", ready)
+	}
+
+	// Four is not a magic number, it is the smallest ratio at which a hung core
+	// still leaves the majority of a zap for the work that follows it.
+	const minRatio = 4
+	if deadline*minRatio > ready {
+		t.Errorf("ingest deadline %v is more than a quarter of the zap budget %v; a hung core would take most of a viewer's wait with it",
+			deadline, ready)
+	}
+	t.Logf("ingest deadline %v against a zap budget of %v (ratio %.1f)", deadline, ready, float64(ready)/float64(deadline))
+}

--- a/backend/internal/stream/ingest/pipeline/pipeline.go
+++ b/backend/internal/stream/ingest/pipeline/pipeline.go
@@ -53,10 +53,9 @@ func NewSessionPipeline(normCfg normalizer.Config, ringCapacity int, targetProgr
 	master := ring.NewMasterRingWithProgram(ringCapacity, targetProgram)
 
 	norm, err := normalizer.NewStreamNormalizer(normCfg, func(ctx context.Context, chunk []byte) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		_, pushErr := master.Push(chunk)
+		// The pipeline's own context now reaches the core, so a chunk is bounded
+		// rather than only refused before it starts.
+		_, pushErr := master.Push(ctx, chunk)
 		return pushErr
 	})
 	if err != nil {

--- a/backend/internal/stream/ingest/pipeline/pipeline_test.go
+++ b/backend/internal/stream/ingest/pipeline/pipeline_test.go
@@ -343,7 +343,7 @@ func TestPipeline_PrimedAttachSnapshotAndReaderAreAtomic(t *testing.T) {
 	defer master.Close()
 
 	// Past the 733-packet threshold, with room to spare rather than on the edge of it
-	_, err = master.Push(data[:800*ring.TSPacketSize])
+	_, err = master.Push(context.Background(), data[:800*ring.TSPacketSize])
 	if err != nil {
 		t.Fatalf("push failed: %v", err)
 	}

--- a/backend/internal/stream/ingest/pipeline/scrambled_test.go
+++ b/backend/internal/stream/ingest/pipeline/scrambled_test.go
@@ -51,7 +51,7 @@ func videoPIDOf(t *testing.T, data []byte) uint16 {
 	t.Helper()
 	probe := ring.NewMasterRing(len(data) + ring.TSPacketSize)
 	defer probe.Close()
-	if _, err := probe.Push(data); err != nil {
+	if _, err := probe.Push(context.Background(), data); err != nil {
 		t.Fatalf("probe push failed: %v", err)
 	}
 	pid, _ := probe.VideoDetails()

--- a/backend/internal/stream/ingest/pipeline/variant_lifetime_test.go
+++ b/backend/internal/stream/ingest/pipeline/variant_lifetime_test.go
@@ -56,7 +56,7 @@ func feedRingDirectly(t *testing.T, master *ring.MasterRing) {
 					return
 				default:
 				}
-				if _, err := master.Push(capture[i : i+chunk]); err != nil {
+				if _, err := master.Push(context.Background(), capture[i:i+chunk]); err != nil {
 					return
 				}
 				time.Sleep(time.Millisecond)

--- a/backend/internal/stream/ingest/ring/audio_observation_test.go
+++ b/backend/internal/stream/ingest/ring/audio_observation_test.go
@@ -5,6 +5,7 @@
 package ring
 
 import (
+	"context"
 	"encoding/binary"
 	"testing"
 )
@@ -175,7 +176,7 @@ func obsAC3Run(byte6 byte, n int) []byte {
 func pushAll(t *testing.T, r *MasterRing, packets ...[]byte) {
 	t.Helper()
 	for _, pkt := range packets {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push: %v", err)
 		}
 	}

--- a/backend/internal/stream/ingest/ring/contract_test.go
+++ b/backend/internal/stream/ingest/ring/contract_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
+)
+
+// The contract a remote core will have to keep. Every case here is written
+// against the in-process core, on purpose: if the rules only hold once a socket
+// is involved, they are not rules, they are behaviour of one implementation.
+
+// scriptedCore fails on demand and counts how often it was entered.
+type scriptedCore struct {
+	mediafacts.Core
+	err    error
+	delay  time.Duration
+	visits atomic.Int32
+}
+
+func (c *scriptedCore) Ingest(ctx context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	c.visits.Add(1)
+	if c.delay > 0 {
+		select {
+		case <-time.After(c.delay):
+		case <-ctx.Done():
+			return mediafacts.ParseResult{}, ctx.Err()
+		}
+	}
+	if c.err != nil {
+		return mediafacts.ParseResult{}, c.err
+	}
+	return c.Core.Ingest(ctx, startOffset, data)
+}
+
+// A caller that gave up before the core was entered has not damaged anything.
+// Nothing was interpreted, so the core and the ring still describe the same
+// stream, and retiring it here would throw away a working core over a caller's
+// timeout.
+func TestContract_CancellationBeforeTheCoreLeavesItUsable(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := &scriptedCore{Core: r.core}
+	r.core = core
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := r.Push(ctx, onePacket()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Push err = %v, want context.Canceled", err)
+	}
+	if got := core.visits.Load(); got != 0 {
+		t.Errorf("core entered %d times for a chunk that was refused before it, want 0", got)
+	}
+
+	// The core survived, so the next chunk goes through.
+	if _, err := r.Push(context.Background(), onePacket()); err != nil {
+		t.Errorf("second Push err = %v, want nil - the core was never damaged", err)
+	}
+	if got := r.Head(); got != TSPacketSize {
+		t.Errorf("Head = %d, want %d", got, TSPacketSize)
+	}
+}
+
+// Once the core has been entered, it has consumed something the ring is about to
+// throw away - and it makes no difference whether the caller gave up or the core
+// went quiet. Both leave the two out of step.
+func TestContract_CancellationInsideTheCoreRetiresIt(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := &scriptedCore{Core: r.core, delay: 5 * time.Second}
+	r.core = core
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	headBefore := r.Head()
+	_, err := r.Push(ctx, onePacket())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Push err = %v, want context.Canceled", err)
+	}
+	if got := r.Head(); got != headBefore {
+		t.Errorf("Head = %d, want %d - a cancelled chunk was committed", got, headBefore)
+	}
+
+	entered := core.visits.Load()
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+	}
+	if got := core.visits.Load(); got != entered {
+		t.Errorf("core entered %d more times after it diverged, want 0", got-entered)
+	}
+}
+
+// The ring's own deadline is not the caller's. When it is what expired, the
+// caller is told the core went quiet rather than that its own context did.
+func TestContract_TheRingsDeadlineIsReportedAsACoreTimeout(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	r.ingestDeadline = 40 * time.Millisecond
+	core := &scriptedCore{Core: r.core, delay: 5 * time.Second}
+	r.core = core
+
+	_, err := r.Push(context.Background(), onePacket())
+	if !errors.Is(err, mediafacts.ErrCoreTimeout) {
+		t.Fatalf("Push err = %v, want ErrCoreTimeout", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Push err = %v, want it to still carry the deadline it came from", err)
+	}
+	if got := r.Head(); got != 0 {
+		t.Errorf("Head = %d, want 0", got)
+	}
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+	}
+}
+
+// However a core dies, the consequence is the same. This is the rule the sidecar
+// will be held to, written as a table so a new failure mode has an obvious place
+// to be added - and no place to be handled differently.
+func TestContract_EveryCoreFailureRetiresTheCore(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"the core went quiet", mediafacts.ErrCoreTimeout},
+		{"the core is gone", mediafacts.ErrCoreGone},
+		{"the core crashed", mediafacts.ErrCoreCrashed},
+		{"the core answered with nonsense", mediafacts.ErrCoreInvalidResponse},
+		{"the core speaks another protocol", mediafacts.ErrCoreProtocolVersion},
+		{"something nobody has named yet", errors.New("unclassified")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewMasterRing(400 * TSPacketSize)
+			defer r.Close()
+			core := &scriptedCore{Core: r.core, err: tc.err}
+			r.core = core
+
+			gen, head := r.Generation(), r.Head()
+
+			if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, tc.err) {
+				t.Fatalf("Push err = %v, want %v", err, tc.err)
+			}
+			if got := r.Head(); got != head {
+				t.Errorf("Head = %d, want %d", got, head)
+			}
+			if got := r.Generation(); got != gen {
+				t.Errorf("Generation = %d, want %d", got, gen)
+			}
+			if got := r.BufferedBytes(); got != 0 {
+				t.Errorf("BufferedBytes = %d, want 0", got)
+			}
+
+			entered := core.visits.Load()
+			if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+				t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+			}
+			if got := core.visits.Load(); got != entered {
+				t.Errorf("core entered %d more times, want 0", got-entered)
+			}
+		})
+	}
+}
+
+// SetTargetProgram reaches the core too, and an implementation behind a socket
+// can hang there just as easily. It is bounded and it retires the core the same
+// way - discovered here rather than during process integration.
+func TestContract_SetTargetProgramIsBoundedAndRetiresTheCore(t *testing.T) {
+	t.Run("cancelled before the core is entered", func(t *testing.T) {
+		r := NewMasterRing(400 * TSPacketSize)
+		defer r.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		if err := r.SetTargetProgram(ctx, 2); !errors.Is(err, context.Canceled) {
+			t.Fatalf("SetTargetProgram err = %v, want context.Canceled", err)
+		}
+		if _, err := r.Push(context.Background(), onePacket()); err != nil {
+			t.Errorf("Push err = %v, want nil - nothing was damaged", err)
+		}
+	})
+
+	t.Run("the core fails inside it", func(t *testing.T) {
+		r := NewMasterRing(400 * TSPacketSize)
+		defer r.Close()
+		r.core = &failingTargetCore{Core: r.core}
+
+		if err := r.SetTargetProgram(context.Background(), 2); !errors.Is(err, mediafacts.ErrCoreGone) {
+			t.Fatalf("SetTargetProgram err = %v, want ErrCoreGone", err)
+		}
+		if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+			t.Errorf("Push err = %v, want ErrCoreUnusable", err)
+		}
+	})
+}
+
+type failingTargetCore struct{ mediafacts.Core }
+
+func (c *failingTargetCore) SetTargetProgram(context.Context, uint16) (mediafacts.ParseResult, error) {
+	return mediafacts.ParseResult{}, mediafacts.ErrCoreGone
+}

--- a/backend/internal/stream/ingest/ring/contract_test.go
+++ b/backend/internal/stream/ingest/ring/contract_test.go
@@ -336,3 +336,92 @@ func TestContract_SetTargetProgramIgnoresAnAnswerAfterCancellation(t *testing.T)
 		t.Errorf("Push err = %v, want ErrCoreUnusable", err)
 	}
 }
+
+// gatedCore is entered, waits to be let go, answers successfully, and says when
+// it has done so. It ignores its context throughout.
+type gatedCore struct {
+	mediafacts.Core
+	entered  chan struct{}
+	proceed  chan struct{}
+	returned chan struct{}
+	onceIn   sync.Once
+	onceOut  sync.Once
+	visits   atomic.Int32
+}
+
+func newGatedCore(inner mediafacts.Core) *gatedCore {
+	return &gatedCore{
+		Core:     inner,
+		entered:  make(chan struct{}),
+		proceed:  make(chan struct{}),
+		returned: make(chan struct{}),
+	}
+}
+
+func (c *gatedCore) Ingest(_ context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	c.visits.Add(1)
+	c.onceIn.Do(func() { close(c.entered) })
+	<-c.proceed
+	res, err := c.Core.Ingest(context.Background(), startOffset, data)
+	c.onceOut.Do(func() { close(c.returned) })
+	return res, err
+}
+
+// The last window. Between reading the context after the core returns and
+// actually committing, the caller waits for the ring lock - and that wait is as
+// long as whatever reader is holding it. A chunk that stopped being wanted during
+// that wait must not be published on the other side of it.
+//
+// The lock is taken by the test only once the core is already inside, because
+// Push takes it briefly beforehand to read the head; holding it from the start
+// would stop the chunk before it ever reached the core and prove nothing.
+func TestContract_CancellationWhileWaitingForTheCommitLockIsNotCommitted(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := newGatedCore(r.core)
+	r.core = core
+
+	headBefore, genBefore := r.Head(), r.Generation()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := r.Push(ctx, onePacket())
+		errCh <- err
+	}()
+
+	// The core is inside and past the point where Push needed the lock.
+	<-core.entered
+
+	// A reader now holds it, so the commit has to queue.
+	r.mu.Lock()
+	close(core.proceed)
+	<-core.returned
+
+	// The caller is queued for the lock this test holds.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	r.mu.Unlock()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Push err = %v, want context.Canceled", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("Push never returned")
+	}
+
+	if got := r.Head(); got != headBefore {
+		t.Errorf("Head = %d, want %d - the chunk was committed after the caller gave up", got, headBefore)
+	}
+	if got := r.Generation(); got != genBefore {
+		t.Errorf("Generation = %d, want %d", got, genBefore)
+	}
+	if got := r.BufferedBytes(); got != 0 {
+		t.Errorf("BufferedBytes = %d, want 0", got)
+	}
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+	}
+}

--- a/backend/internal/stream/ingest/ring/contract_test.go
+++ b/backend/internal/stream/ingest/ring/contract_test.go
@@ -358,6 +358,15 @@ func newGatedCore(inner mediafacts.Core) *gatedCore {
 	}
 }
 
+func (c *gatedCore) SetTargetProgram(_ context.Context, n uint16) (mediafacts.ParseResult, error) {
+	c.visits.Add(1)
+	c.onceIn.Do(func() { close(c.entered) })
+	<-c.proceed
+	res, err := c.Core.SetTargetProgram(context.Background(), n)
+	c.onceOut.Do(func() { close(c.returned) })
+	return res, err
+}
+
 func (c *gatedCore) Ingest(_ context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
 	c.visits.Add(1)
 	c.onceIn.Do(func() { close(c.entered) })
@@ -423,5 +432,98 @@ func TestContract_CancellationWhileWaitingForTheCommitLockIsNotCommitted(t *test
 	}
 	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
 		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+	}
+}
+
+// Cancellation during the wait for the ring lock that Push takes to read the
+// head. The core has still not been entered at that point, so this belongs on the
+// usable side of the rule - and without a check there it would land on the other
+// one, which is an edge nobody would find until a socket made the wait long.
+//
+// The lock is held from the start here, which is exactly what makes the wait
+// happen: Push needs it before it reaches the core.
+func TestContract_CancellationWaitingForTheHeadLockLeavesTheCoreUsable(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := newGatedCore(r.core)
+	close(core.proceed) // never reached; the point is that it is not
+	r.core = core
+
+	r.mu.Lock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := r.Push(ctx, onePacket())
+		errCh <- err
+	}()
+
+	// Push now holds ingestMu and is queued for the lock this test holds.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	r.mu.Unlock()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Push err = %v, want context.Canceled", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("Push never returned")
+	}
+
+	if got := core.visits.Load(); got != 0 {
+		t.Errorf("core entered %d times before the caller gave up, want 0", got)
+	}
+	if got := r.Head(); got != 0 {
+		t.Errorf("Head = %d, want 0", got)
+	}
+
+	// The core was never entered, so it was never damaged.
+	if _, err := r.Push(context.Background(), onePacket()); err != nil {
+		t.Errorf("second Push err = %v, want nil - the core should still be usable", err)
+	}
+}
+
+// The same commit-lock guard as Push has, on the other call into the core.
+// SetTargetProgram is a separate implementation, and separate implementations of
+// the same rule are how one of them ends up without it.
+func TestContract_SetTargetProgramCancellationAtTheCommitLockIsNotApplied(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := newGatedCore(r.core)
+	r.core = core
+
+	genBefore := r.Generation()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- r.SetTargetProgram(ctx, 2) }()
+
+	<-core.entered
+	// SetTargetProgram does not take the ring lock before the core, so it can be
+	// held from here: the call will queue for it on the way to applying.
+	r.mu.Lock()
+	close(core.proceed)
+	<-core.returned
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	r.mu.Unlock()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("SetTargetProgram err = %v, want context.Canceled", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("SetTargetProgram never returned")
+	}
+
+	if got := r.Generation(); got != genBefore {
+		t.Errorf("Generation = %d, want %d - the result was applied after the caller gave up", got, genBefore)
+	}
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("Push err = %v, want ErrCoreUnusable", err)
 	}
 }

--- a/backend/internal/stream/ingest/ring/contract_test.go
+++ b/backend/internal/stream/ingest/ring/contract_test.go
@@ -7,6 +7,7 @@ package ring
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -211,4 +212,127 @@ type failingTargetCore struct{ mediafacts.Core }
 
 func (c *failingTargetCore) SetTargetProgram(context.Context, uint16) (mediafacts.ParseResult, error) {
 	return mediafacts.ParseResult{}, mediafacts.ErrCoreGone
+}
+
+// uncooperativeCore is the core the contract has to survive: it ignores its
+// context entirely, works until it is done, and returns a complete, well-formed
+// result for a chunk the caller stopped waiting for.
+//
+// Not a strawman. A process on the other end of a socket learns that its caller
+// gave up only when it next touches the socket, and a core that finished parsing
+// just before that will answer with a perfectly good result to nobody.
+type uncooperativeCore struct {
+	mediafacts.Core
+	entered chan struct{}
+	proceed chan struct{}
+	once    sync.Once
+	visits  atomic.Int32
+}
+
+func newUncooperativeCore(inner mediafacts.Core) *uncooperativeCore {
+	return &uncooperativeCore{Core: inner, entered: make(chan struct{}), proceed: make(chan struct{})}
+}
+
+func (c *uncooperativeCore) Ingest(_ context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	c.visits.Add(1)
+	c.once.Do(func() { close(c.entered) })
+	<-c.proceed
+	// context.Background() on purpose: this core does not honour cancellation.
+	return c.Core.Ingest(context.Background(), startOffset, data)
+}
+
+func (c *uncooperativeCore) SetTargetProgram(_ context.Context, n uint16) (mediafacts.ParseResult, error) {
+	c.visits.Add(1)
+	c.once.Do(func() { close(c.entered) })
+	<-c.proceed
+	return c.Core.SetTargetProgram(context.Background(), n)
+}
+
+// A result that arrives after the caller gave up is not a result. Committing it
+// would publish bytes past the point the caller stopped waiting, which is exactly
+// what the deadline exists to prevent - and a core cannot be trusted to decline
+// on its own.
+func TestContract_ASuccessfulAnswerAfterCancellationIsNotCommitted(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := newUncooperativeCore(r.core)
+	r.core = core
+
+	headBefore, genBefore := r.Head(), r.Generation()
+	factsBefore := r.ReadinessFacts()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := r.Push(ctx, onePacket())
+		errCh <- err
+	}()
+
+	<-core.entered
+	cancel()
+	close(core.proceed)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Push err = %v, want context.Canceled", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("Push never returned")
+	}
+
+	if got := r.Head(); got != headBefore {
+		t.Errorf("Head = %d, want %d - a result nobody was waiting for was committed", got, headBefore)
+	}
+	if got := r.Generation(); got != genBefore {
+		t.Errorf("Generation = %d, want %d", got, genBefore)
+	}
+	if got := r.BufferedBytes(); got != 0 {
+		t.Errorf("BufferedBytes = %d, want 0", got)
+	}
+	if got := r.ReadinessFacts(); got.HasPAT != factsBefore.HasPAT || got.ProgramNumber != factsBefore.ProgramNumber {
+		t.Errorf("facts moved on a chunk that was refused: %+v", got)
+	}
+
+	entered := core.visits.Load()
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
+	}
+	if got := core.visits.Load(); got != entered {
+		t.Errorf("core entered %d more times after it answered too late, want 0", got-entered)
+	}
+}
+
+// The same for the other call into the core.
+func TestContract_SetTargetProgramIgnoresAnAnswerAfterCancellation(t *testing.T) {
+	r := NewMasterRing(400 * TSPacketSize)
+	defer r.Close()
+	core := newUncooperativeCore(r.core)
+	r.core = core
+
+	genBefore := r.Generation()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- r.SetTargetProgram(ctx, 2) }()
+
+	<-core.entered
+	cancel()
+	close(core.proceed)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("SetTargetProgram err = %v, want context.Canceled", err)
+		}
+	case <-time.After(isolationWait):
+		t.Fatal("SetTargetProgram never returned")
+	}
+
+	if got := r.Generation(); got != genBefore {
+		t.Errorf("Generation = %d, want %d - the refused result was applied", got, genBefore)
+	}
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
+		t.Errorf("Push err = %v, want ErrCoreUnusable", err)
+	}
 }

--- a/backend/internal/stream/ingest/ring/isolation_test.go
+++ b/backend/internal/stream/ingest/ring/isolation_test.go
@@ -5,6 +5,7 @@
 package ring
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -53,11 +54,11 @@ func newBlockingCore(inner mediafacts.Core) *blockingCore {
 	return &blockingCore{Core: inner, entered: make(chan struct{}), release: make(chan struct{})}
 }
 
-func (c *blockingCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+func (c *blockingCore) Ingest(ctx context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
 	c.calls.Add(1)
 	c.once.Do(func() { close(c.entered) })
 	<-c.release
-	return c.Core.Ingest(startOffset, data)
+	return c.Core.Ingest(ctx, startOffset, data)
 }
 
 func onePacket() []byte {
@@ -78,7 +79,7 @@ func TestIsolation_ASlowCoreDoesNotBlockReadersOrClose(t *testing.T) {
 	r.core = core
 
 	pushErr := make(chan error, 1)
-	go func() { _, err := r.Push(onePacket()); pushErr <- err }()
+	go func() { _, err := r.Push(context.Background(), onePacket()); pushErr <- err }()
 
 	<-core.entered
 
@@ -114,7 +115,7 @@ type countingCore struct {
 	offsets []int64
 }
 
-func (c *countingCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+func (c *countingCore) Ingest(ctx context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
 	now := c.inFlight.Add(1)
 	for {
 		max := c.maxInFlight.Load()
@@ -131,7 +132,7 @@ func (c *countingCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseR
 	c.offsets = append(c.offsets, startOffset)
 	c.mu.Unlock()
 
-	return c.Core.Ingest(startOffset, data)
+	return c.Core.Ingest(ctx, startOffset, data)
 }
 
 // 2. The core is single-threaded by contract, and the bytes have to land in the
@@ -151,7 +152,7 @@ func TestIsolation_WritersAreSerialisedAndKeepTheirOrder(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, err := r.Push(onePacket()); err != nil {
+			if _, err := r.Push(context.Background(), onePacket()); err != nil {
 				t.Errorf("Push: %v", err)
 			}
 		}()
@@ -194,7 +195,7 @@ type erroringCore struct {
 	calls atomic.Int32
 }
 
-func (c *erroringCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+func (c *erroringCore) Ingest(ctx context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
 	c.calls.Add(1)
 	return mediafacts.ParseResult{}, c.err
 }
@@ -230,7 +231,7 @@ func TestIsolation_AFailedCoreIsNotReused(t *testing.T) {
 
 			headBefore, genBefore := r.Head(), r.Generation()
 
-			if _, err := r.Push(onePacket()); !errors.Is(err, tc.wantErr) {
+			if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, tc.wantErr) {
 				t.Fatalf("first Push err = %v, want %v", err, tc.wantErr)
 			}
 			if got := r.Head(); got != headBefore {
@@ -244,7 +245,7 @@ func TestIsolation_AFailedCoreIsNotReused(t *testing.T) {
 			}
 
 			// The second attempt must not reach the core at all.
-			if _, err := r.Push(onePacket()); !errors.Is(err, ErrCoreUnusable) {
+			if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
 				t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
 			}
 			if got := r.Head(); got != headBefore {
@@ -265,7 +266,7 @@ func TestIsolation_CloseDuringIngestPreventsAStaleCommit(t *testing.T) {
 	headBefore, genBefore := r.Head(), r.Generation()
 
 	pushErr := make(chan error, 1)
-	go func() { _, err := r.Push(onePacket()); pushErr <- err }()
+	go func() { _, err := r.Push(context.Background(), onePacket()); pushErr <- err }()
 
 	<-core.entered
 	r.Close()
@@ -301,7 +302,7 @@ func TestIsolation_ARingThatMovedUnderTheChunkRefusesTheCommit(t *testing.T) {
 	r.core = core
 
 	pushErr := make(chan error, 1)
-	go func() { _, err := r.Push(onePacket()); pushErr <- err }()
+	go func() { _, err := r.Push(context.Background(), onePacket()); pushErr <- err }()
 
 	<-core.entered
 
@@ -329,7 +330,7 @@ func TestIsolation_ARingThatMovedUnderTheChunkRefusesTheCommit(t *testing.T) {
 	// same divergence an error or a short result leaves behind. Asking it again
 	// would be asking about a stream nobody is holding.
 	entered := core.calls.Load()
-	if _, err := r.Push(onePacket()); !errors.Is(err, ErrCoreUnusable) {
+	if _, err := r.Push(context.Background(), onePacket()); !errors.Is(err, ErrCoreUnusable) {
 		t.Errorf("second Push err = %v, want ErrCoreUnusable", err)
 	}
 	if got := core.calls.Load(); got != entered {
@@ -349,7 +350,7 @@ func TestPush_EmptyChunkPreservesClosedSemantics(t *testing.T) {
 		r.Close()
 
 		for _, data := range [][]byte{nil, {}} {
-			if _, err := r.Push(data); !errors.Is(err, ErrRingClosed) {
+			if _, err := r.Push(context.Background(), data); !errors.Is(err, ErrRingClosed) {
 				t.Errorf("Push(%v) err = %v, want ErrRingClosed", data, err)
 			}
 		}
@@ -369,7 +370,7 @@ func TestPush_EmptyChunkPreservesClosedSemantics(t *testing.T) {
 
 		headBefore, tailBefore, genBefore := r.Head(), r.Tail(), r.Generation()
 
-		n, err := r.Push(nil)
+		n, err := r.Push(context.Background(), nil)
 		if err != nil {
 			t.Fatalf("Push(nil) err = %v, want nil", err)
 		}

--- a/backend/internal/stream/ingest/ring/lockorder_test.go
+++ b/backend/internal/stream/ingest/ring/lockorder_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package ring
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Two locks with an order between them is a deadlock waiting for a third caller.
+// The order is ingestMu before mu, always, and it is written in comments where it
+// matters - but a comment does not fail a build. This reads the package instead.
+//
+// Deliberately a source check rather than a lock abstraction. There are two
+// mutexes and a handful of functions that take them; wrapping that in a type with
+// an enforced ordering would be a larger thing than the problem, and would itself
+// need to be trusted.
+func TestLockOrder_IngestMuIsAlwaysTakenBeforeMu(t *testing.T) {
+	fset := token.NewFileSet()
+	pkg, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	checked := 0
+	for _, p := range pkg {
+		for name, file := range p.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				fn, ok := n.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					return true
+				}
+
+				// The order the two locks are taken in, in source order.
+				var order []string
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok || sel.Sel.Name != "Lock" {
+						return true
+					}
+					inner, ok := sel.X.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					switch inner.Sel.Name {
+					case "mu", "ingestMu":
+						order = append(order, inner.Sel.Name)
+					}
+					return true
+				})
+
+				if len(order) < 2 {
+					return true
+				}
+				checked++
+
+				seenMu := false
+				for _, l := range order {
+					if l == "mu" {
+						seenMu = true
+						continue
+					}
+					if l == "ingestMu" && seenMu {
+						t.Errorf("%s: %s takes mu before ingestMu (%v); the order is ingestMu first, always",
+							filepath.Base(fset.Position(fn.Pos()).Filename), fn.Name.Name, order)
+					}
+				}
+				_ = name
+				return true
+			})
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no function was found taking both locks; this check has stopped checking anything")
+	}
+	t.Logf("%d functions take both locks, all in the order ingestMu -> mu", checked)
+}

--- a/backend/internal/stream/ingest/ring/randomaccess_fuzz_test.go
+++ b/backend/internal/stream/ingest/ring/randomaccess_fuzz_test.go
@@ -4,7 +4,10 @@
 
 package ring
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func FuzzMasterRingPush(f *testing.F) {
 	f.Add(make([]byte, TSPacketSize))
@@ -14,7 +17,7 @@ func FuzzMasterRingPush(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		r := NewMasterRing(64 * TSPacketSize)
 		defer r.Close()
-		_, _ = r.Push(data)
+		_, _ = r.Push(context.Background(), data)
 		_, _ = r.LatestKeyframeOffset()
 		_ = r.RandomAccess()
 		_, _ = r.VideoDetails()

--- a/backend/internal/stream/ingest/ring/randomaccess_test.go
+++ b/backend/internal/stream/ingest/ring/randomaccess_test.go
@@ -6,6 +6,7 @@ package ring
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,12 +51,12 @@ func h264Ring(t *testing.T, videoPID uint16) (*MasterRing, uint16) {
 	t.Cleanup(r.Close)
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PAT: %v", err)
 		}
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PMT: %v", err)
 		}
 	}
@@ -69,7 +70,7 @@ func h264Ring(t *testing.T, videoPID uint16) (*MasterRing, uint16) {
 func pushAU(t *testing.T, r *MasterRing, videoPID uint16, cc uint8, es []byte) int64 {
 	t.Helper()
 	offset := r.Head()
-	if _, err := r.Push(createVideoPESPacket(videoPID, true, cc, es)); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(videoPID, true, cc, es)); err != nil {
 		t.Fatalf("push access unit: %v", err)
 	}
 	return offset
@@ -201,10 +202,10 @@ func TestRandomAccess_SliceHeaderSplitAcrossTSPackets(t *testing.T) {
 	}
 
 	want := r.Head()
-	if _, err := r.Push(createVideoPESPacket(vpid, true, 0, head)); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(vpid, true, 0, head)); err != nil {
 		t.Fatalf("push head: %v", err)
 	}
-	if _, err := r.Push(createVideoPESPacket(vpid, false, 1, []byte{sliceHeaderI, 0x00, 0x00})); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(vpid, false, 1, []byte{sliceHeaderI, 0x00, 0x00})); err != nil {
 		t.Fatalf("push tail: %v", err)
 	}
 	pushAU(t, r, vpid, 2, nal(nalHdrNonIDR, sliceHeaderP))
@@ -226,10 +227,10 @@ func TestRandomAccess_HEVC_IRAPRangeAndTrailingRejection(t *testing.T) {
 		r := NewMasterRing(400 * TSPacketSize)
 		t.Cleanup(r.Close)
 		for _, pkt := range createMultiPacketPAT(pmtPID) {
-			_, _ = r.Push(pkt)
+			_, _ = r.Push(context.Background(), pkt)
 		}
 		for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, true) {
-			_, _ = r.Push(pkt)
+			_, _ = r.Push(context.Background(), pkt)
 		}
 		return r
 	}
@@ -299,7 +300,7 @@ func TestScrambling_PerStreamCountersAndClearRun(t *testing.T) {
 	scrambled[3] |= 0xC0 // transport_scrambling_control = odd key
 
 	for i := 0; i < 3; i++ {
-		if _, err := r.Push(clear); err != nil {
+		if _, err := r.Push(context.Background(), clear); err != nil {
 			t.Fatalf("push clear: %v", err)
 		}
 	}
@@ -307,7 +308,7 @@ func TestScrambling_PerStreamCountersAndClearRun(t *testing.T) {
 		t.Fatalf("after three clear packets: %+v", got)
 	}
 
-	if _, err := r.Push(scrambled); err != nil {
+	if _, err := r.Push(context.Background(), scrambled); err != nil {
 		t.Fatalf("push scrambled: %v", err)
 	}
 	got := r.Scrambling()
@@ -350,7 +351,7 @@ func TestRandomAccess_RealCapture_ClassificationIsStable(t *testing.T) {
 
 			r := NewMasterRing(len(data) + TSPacketSize)
 			defer r.Close()
-			if _, err := r.Push(data); err != nil {
+			if _, err := r.Push(context.Background(), data); err != nil {
 				t.Fatalf("push capture: %v", err)
 			}
 

--- a/backend/internal/stream/ingest/ring/randomaccess_test.go
+++ b/backend/internal/stream/ingest/ring/randomaccess_test.go
@@ -351,8 +351,25 @@ func TestRandomAccess_RealCapture_ClassificationIsStable(t *testing.T) {
 
 			r := NewMasterRing(len(data) + TSPacketSize)
 			defer r.Close()
-			if _, err := r.Push(context.Background(), data); err != nil {
-				t.Fatalf("push capture: %v", err)
+
+			// Fed the way the normalizer feeds it. Its sink is handed the staging
+			// buffer, 4 MiB by default, so that is the largest chunk the ring ever
+			// sees in production - and the size the core's deadline was derived
+			// for. A single 7.6 MiB push tested a call that cannot happen and, once
+			// the deadline existed, failed for that reason alone.
+			//
+			// Chunking also makes this a stronger test than it was: the numbers
+			// below now have to survive real chunk boundaries falling anywhere in
+			// the stream, not just one push that contains everything.
+			const maxChunk = 4 * 1024 * 1024 / TSPacketSize * TSPacketSize
+			for off := 0; off < len(data); off += maxChunk {
+				end := off + maxChunk
+				if end > len(data) {
+					end = len(data)
+				}
+				if _, err := r.Push(context.Background(), data[off:end]); err != nil {
+					t.Fatalf("push at %d: %v", off, err)
+				}
 			}
 
 			if _, codec := r.VideoDetails(); codec != tc.codec {

--- a/backend/internal/stream/ingest/ring/reader_resync_test.go
+++ b/backend/internal/stream/ingest/ring/reader_resync_test.go
@@ -6,6 +6,7 @@ package ring
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"sync"
 	"testing"
@@ -28,12 +29,12 @@ func newH264Ring(t *testing.T, capacityPackets int) (*MasterRing, *SubscriberRea
 	t.Cleanup(r.Close)
 
 	for _, pkt := range createMultiPacketPAT(100) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PAT: %v", err)
 		}
 	}
 	for _, pkt := range createMultiPacketPMT(100, 256, false) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PMT: %v", err)
 		}
 	}
@@ -48,7 +49,7 @@ func newH264Ring(t *testing.T, capacityPackets int) (*MasterRing, *SubscriberRea
 func pushFiller(t *testing.T, r *MasterRing, count int) {
 	t.Helper()
 	for i := 0; i < count; i++ {
-		if _, err := r.Push(createBasicPacket(85, false, uint8(i%16))); err != nil {
+		if _, err := r.Push(context.Background(), createBasicPacket(85, false, uint8(i%16))); err != nil {
 			t.Fatalf("push filler %d: %v", i, err)
 		}
 	}
@@ -59,10 +60,10 @@ func pushFiller(t *testing.T, r *MasterRing, count int) {
 func pushKeyframe(t *testing.T, r *MasterRing, pid uint16, es []byte, cc uint8) int64 {
 	t.Helper()
 	offset := r.Head()
-	if _, err := r.Push(createVideoPESPacket(pid, true, cc, es)); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(pid, true, cc, es)); err != nil {
 		t.Fatalf("push keyframe: %v", err)
 	}
-	if _, err := r.Push(createVideoPESPacket(pid, true, cc+1, []byte{0x00, 0x00, 0x01, 0x41})); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(pid, true, cc+1, []byte{0x00, 0x00, 0x01, 0x41})); err != nil {
 		t.Fatalf("finalise access unit: %v", err)
 	}
 	return offset
@@ -212,7 +213,7 @@ func TestSubscriberReader_PMTChangeDuringWaitDeliversNewGenerationPreamble(t *te
 
 	// New generation: video moves to PID 512 and to HEVC.
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 512, true, true, 1, 1) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PMT v1: %v", err)
 		}
 	}
@@ -388,11 +389,11 @@ func TestSubscriberReader_MPEG2OverrunResyncsToIFrame(t *testing.T) {
 	defer r.Close()
 
 	for _, pkt := range createMultiPacketPAT(100) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PAT: %v", err)
 		}
 	}
-	if _, err := r.Push(mpeg2PMTPacket(t, 100, 200)); err != nil {
+	if _, err := r.Push(context.Background(), mpeg2PMTPacket(t, 100, 200)); err != nil {
 		t.Fatalf("push MPEG-2 PMT: %v", err)
 	}
 	if r.facts.VideoCodec != CodecMPEG2 {
@@ -410,10 +411,10 @@ func TestSubscriberReader_MPEG2OverrunResyncsToIFrame(t *testing.T) {
 		0x00, 0x00, 0x01, 0x00, 0x00, 0x08, 0x00, 0x00, // picture header, I-frame
 	}
 	keyframe := r.Head()
-	if _, err := r.Push(createVideoPESPacket(200, true, 0, mpeg2IFrame)); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(200, true, 0, mpeg2IFrame)); err != nil {
 		t.Fatalf("push I-frame: %v", err)
 	}
-	if _, err := r.Push(createVideoPESPacket(200, true, 1, []byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x10})); err != nil {
+	if _, err := r.Push(context.Background(), createVideoPESPacket(200, true, 1, []byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x10})); err != nil {
 		t.Fatalf("finalise access unit: %v", err)
 	}
 
@@ -470,12 +471,12 @@ func TestSubscriberReader_AudioOnlyServiceResumesAtTailWithoutWaiting(t *testing
 	defer r.Close()
 
 	for _, pkt := range createMultiPacketPAT(100) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PAT: %v", err)
 		}
 	}
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 0, false, false, 0, 1) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push audio-only PMT: %v", err)
 		}
 	}
@@ -526,7 +527,7 @@ func TestSubscriberReader_UnknownTopologyWaitsRatherThanResumingAtTail(t *testin
 
 	// No PAT, no PMT: nothing here says what this stream is.
 	for i := 0; i < 30; i++ {
-		if _, err := r.Push(createBasicPacket(256, false, uint8(i%16))); err != nil {
+		if _, err := r.Push(context.Background(), createBasicPacket(256, false, uint8(i%16))); err != nil {
 			t.Fatalf("push %d: %v", i, err)
 		}
 	}
@@ -585,7 +586,7 @@ func TestSubscriberReader_PartialPreambleIsDiscardedOnGenerationChange(t *testin
 
 	// The stream moves on while the rest is still queued.
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 512, true, true, 1, 1) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PMT v1: %v", err)
 		}
 	}

--- a/backend/internal/stream/ingest/ring/real_capture_test.go
+++ b/backend/internal/stream/ingest/ring/real_capture_test.go
@@ -6,6 +6,7 @@ package ring
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"os/exec"
@@ -82,7 +83,7 @@ func TestMasterRing_RealCapture_H264_DecodingVerification(t *testing.T) {
 			end = i + ((end-i)/TSPacketSize)*TSPacketSize
 		}
 		if end > i {
-			if _, err := r.Push(data[i:end]); err != nil {
+			if _, err := r.Push(context.Background(), data[i:end]); err != nil {
 				t.Fatalf("push failed at %d: %v", i, err)
 			}
 		}
@@ -172,7 +173,7 @@ func TestMasterRing_RemuxedHEVC_TS_DecodingVerification(t *testing.T) {
 			end = i + ((end-i)/TSPacketSize)*TSPacketSize
 		}
 		if end > i {
-			if _, err := r.Push(data[i:end]); err != nil {
+			if _, err := r.Push(context.Background(), data[i:end]); err != nil {
 				t.Fatalf("push failed at %d: %v", i, err)
 			}
 		}
@@ -247,7 +248,7 @@ func TestMasterRing_RealCapture_AllSegments_Sanity(t *testing.T) {
 			defer r.Close()
 
 			n, err := io.Copy(writerFunc(func(p []byte) (int, error) {
-				return r.Push(p)
+				return r.Push(context.Background(), p)
 			}), bytes.NewReader(data))
 
 			if err != nil || n == 0 {

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -187,6 +187,14 @@ func (r *MasterRing) SetTargetProgram(ctx context.Context, progNum uint16) error
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Last read of the context, on the far side of the lock wait, for the same
+	// reason as in Push.
+	if err := ctx.Err(); err != nil {
+		return r.retireCore(ctx, err)
+	}
+	if err := callCtx.Err(); err != nil {
+		return r.retireCore(ctx, err)
+	}
 	if r.isClosed {
 		r.coreUnusable = true
 		return ErrRingClosed
@@ -344,6 +352,18 @@ func (r *MasterRing) Push(ctx context.Context, data []byte) (int, error) {
 	// differs, the consequence does not. Every path that returns after Ingest
 	// without committing retires the core, so no later path can be added that
 	// forgets to. ingestMu is still held, which is what guards the flag.
+	//
+	// The context is read once more here, and this is the last place it can be:
+	// waiting for this lock takes as long as the reader holding it, and a chunk
+	// that stopped being wanted during that wait must not be published on the
+	// other side of it. Checked after the lock rather than before, so there is no
+	// window left between the check and the commit.
+	if err := ctx.Err(); err != nil {
+		return 0, r.retireCore(ctx, err)
+	}
+	if err := ingestCtx.Err(); err != nil {
+		return 0, r.retireCore(ctx, err)
+	}
 	if r.isClosed {
 		return 0, r.retireCore(ctx, ErrRingClosed)
 	}

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -175,6 +175,15 @@ func (r *MasterRing) SetTargetProgram(ctx context.Context, progNum uint16) error
 		return r.retireCore(ctx, err)
 	}
 
+	// Same reasoning as in Push: a core that answered after the call stopped being
+	// wanted has still answered, and its result is not applied.
+	if err := ctx.Err(); err != nil {
+		return r.retireCore(ctx, err)
+	}
+	if err := callCtx.Err(); err != nil {
+		return r.retireCore(ctx, err)
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -293,6 +302,22 @@ func (r *MasterRing) Push(ctx context.Context, data []byte) (int, error) {
 	if err != nil {
 		// Past this point the core has been entered, so every way out that does
 		// not commit retires it - the caller's own cancellation included.
+		return 0, r.retireCore(ctx, err)
+	}
+
+	// A successful return is not the same as a return that is still wanted. A core
+	// that ignores its context - which a remote one may do by accident, or by
+	// being a process that finished its work before noticing the socket closed -
+	// can hand back a complete, well-formed result for a chunk nobody is waiting
+	// for any more. Committing it would publish bytes past the point the caller
+	// gave up, which is the one thing the deadline exists to prevent.
+	//
+	// The contract cannot assume cooperation. It has to hold for a core that does
+	// the wrong thing, because that is the core it will eventually meet.
+	if err := ctx.Err(); err != nil {
+		return 0, r.retireCore(ctx, err)
+	}
+	if err := ingestCtx.Err(); err != nil {
 		return 0, r.retireCore(ctx, err)
 	}
 	// A core that interpreted less than it was given leaves the ring with bytes it

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -5,8 +5,10 @@
 package ring
 
 import (
+	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/ManuGH/xg2g/internal/stream/ingest/mediafacts"
 )
@@ -99,6 +101,10 @@ type MasterRing struct {
 	// ingestMu, because it is a property of the core rather than of the ring.
 	coreUnusable bool
 
+	// ingestDeadline bounds a single call into the core. It is not a budget to be
+	// spent - it is how long a core may go quiet before it is treated as gone.
+	ingestDeadline time.Duration
+
 	// core reads what the transport stream says about itself. It is given byte
 	// chunks and the offset they start at, and answers with facts and ordered
 	// events; it never sees this struct. Guarded by ingestMu.
@@ -128,10 +134,11 @@ func NewMasterRingWithProgram(capacityBytes int, targetProgram uint16) *MasterRi
 	}
 
 	r := &MasterRing{
-		buf:          make([]byte, capacityBytes),
-		capacity:     capacityBytes,
-		maxKeyframes: 64,
-		core:         mediafacts.NewGoCore(targetProgram),
+		buf:            make([]byte, capacityBytes),
+		capacity:       capacityBytes,
+		maxKeyframes:   64,
+		ingestDeadline: mediafacts.DefaultIngestDeadline,
+		core:           mediafacts.NewGoCore(targetProgram),
 	}
 	r.notEmpty = sync.NewCond(&r.mu)
 	return r
@@ -139,7 +146,14 @@ func NewMasterRingWithProgram(capacityBytes int, targetProgram uint16) *MasterRi
 
 // SetTargetProgram configures the desired program number for PMT resolution,
 // immediately invalidating existing PSI and decoder states if the target changed.
-func (r *MasterRing) SetTargetProgram(progNum uint16) {
+func (r *MasterRing) SetTargetProgram(ctx context.Context, progNum uint16) error {
+	// Before the core is entered, a caller that gave up means the call never
+	// happened. Nothing was interpreted, so nothing diverged, and the core is
+	// still good for the next chunk.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// The core is single-threaded by contract, so this cannot run beside an
 	// Ingest. It waits behind a slow core, which is the right trade: this is
 	// control plane, and the calls that must never wait are Close and the readers.
@@ -147,17 +161,45 @@ func (r *MasterRing) SetTargetProgram(progNum uint16) {
 	defer r.ingestMu.Unlock()
 
 	if r.coreUnusable {
-		return
+		return ErrCoreUnusable
 	}
-	res := r.core.SetTargetProgram(progNum)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, r.ingestDeadline)
+	defer cancel()
+
+	res, err := r.core.SetTargetProgram(callCtx, progNum)
+	if err != nil {
+		return r.retireCore(ctx, err)
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.isClosed {
-		return
+		r.coreUnusable = true
+		return ErrRingClosed
 	}
 	r.applyLocked(res)
+	return nil
+}
+
+// retireCore records that the core can no longer be trusted and names why.
+//
+// Every failure after the core has been entered lands here, because every one of
+// them leaves the same wreckage: the core consumed something the ring is about to
+// throw away, so the two no longer describe the same stream. The distinction the
+// caller may care about - did it time out, or did the caller give up - is kept in
+// the returned error, not in whether the core survives.
+func (r *MasterRing) retireCore(callerCtx context.Context, err error) error {
+	r.coreUnusable = true
+	if callerCtx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+		// Our own deadline, not the caller's. The core went quiet.
+		return errors.Join(mediafacts.ErrCoreTimeout, err)
+	}
+	return err
 }
 
 // applyLocked takes what the core said about a chunk and acts on it.
@@ -191,12 +233,20 @@ func (r *MasterRing) applyLocked(res mediafacts.ParseResult) {
 }
 
 // Push writes a chunk of TS packets into the ring buffer and indexes PAT/PMT/IDR boundaries.
-func (r *MasterRing) Push(data []byte) (int, error) {
+func (r *MasterRing) Push(ctx context.Context, data []byte) (int, error) {
 	if len(data)%TSPacketSize != 0 {
 		return 0, ErrInvalidPacketSize
 	}
 
 	n := len(data)
+
+	// Cancellation before the core is entered is not a core failure. Nothing was
+	// interpreted, so the core and the ring still agree and it stays usable. That
+	// is the whole distinction: not that the context expired, but whether the core
+	// had already consumed something by the time it did.
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 
 	// One writer at a time, and the core belongs to whoever holds this. Taken
 	// before r.mu and released after it, never the other way round.
@@ -205,6 +255,13 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 
 	if r.coreUnusable {
 		return 0, ErrCoreUnusable
+	}
+
+	// Re-checked: waiting for the writer lock can take as long as the core call
+	// ahead of it, and a caller that gave up during that wait is in the same
+	// position as one that gave up before it.
+	if err := ctx.Err(); err != nil {
+		return 0, err
 	}
 
 	// 1. Read the ring's position, then let go of it. Everything a reader needs -
@@ -227,10 +284,16 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 
 	// 2. Interpret the chunk with no ring lock held. This is the call that may sit
 	//    on a socket, and it is the reason the lock above was released.
-	res, err := r.core.Ingest(startOffset, data)
+	// The core runs under a deadline of its own, derived from the caller's context
+	// rather than replacing it: whichever expires first ends the call.
+	ingestCtx, cancel := context.WithTimeout(ctx, r.ingestDeadline)
+	defer cancel()
+
+	res, err := r.core.Ingest(ingestCtx, startOffset, data)
 	if err != nil {
-		r.coreUnusable = true
-		return 0, err
+		// Past this point the core has been entered, so every way out that does
+		// not commit retires it - the caller's own cancellation included.
+		return 0, r.retireCore(ctx, err)
 	}
 	// A core that interpreted less than it was given leaves the ring with bytes it
 	// has no meaning for. Committing them anyway is exactly the failure this
@@ -238,8 +301,7 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	// the head, not the generation, not the index, not the facts. The core is
 	// finished either way - it consumed what the ring is about to throw away.
 	if want := startOffset + int64(n); res.ProcessedThroughOffset != want {
-		r.coreUnusable = true
-		return 0, ErrCoreIncomplete
+		return 0, r.retireCore(ctx, ErrCoreIncomplete)
 	}
 
 	// 3. Commit. Facts, events, PSI and bytes become visible together, under one
@@ -258,12 +320,10 @@ func (r *MasterRing) Push(data []byte) (int, error) {
 	// without committing retires the core, so no later path can be added that
 	// forgets to. ingestMu is still held, which is what guards the flag.
 	if r.isClosed {
-		r.coreUnusable = true
-		return 0, ErrRingClosed
+		return 0, r.retireCore(ctx, ErrRingClosed)
 	}
 	if r.head != startOffset {
-		r.coreUnusable = true
-		return 0, ErrRingAdvanced
+		return 0, r.retireCore(ctx, ErrRingAdvanced)
 	}
 
 	r.applyLocked(res)

--- a/backend/internal/stream/ingest/ring/ring.go
+++ b/backend/internal/stream/ingest/ring/ring.go
@@ -187,8 +187,8 @@ func (r *MasterRing) SetTargetProgram(ctx context.Context, progNum uint16) error
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Last read of the context, on the far side of the lock wait, for the same
-	// reason as in Push.
+	// Last read of the context, on the far side of the lock wait. Same
+	// linearization point as in Push, and the same reason for it.
 	if err := ctx.Err(); err != nil {
 		return r.retireCore(ctx, err)
 	}
@@ -291,6 +291,19 @@ func (r *MasterRing) Push(ctx context.Context, data []byte) (int, error) {
 	startOffset := r.head
 	r.mu.Unlock()
 
+	// Waiting for that lock is a wait like any other, and a caller can give up
+	// during it. The core has still not been entered, so this is the same
+	// situation as a cancellation before the call: nothing was interpreted,
+	// nothing diverged, and the core is not retired.
+	//
+	// Without this the rule would quietly read "cancelled before some of the
+	// pre-core locks leaves the core usable, cancelled while waiting for this one
+	// retires it" - an edge that is invisible here and would be discovered across
+	// a socket.
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	// An empty chunk has nothing to interpret and nothing to commit, so the core
 	// is never entered for one. It is answered here rather than at the top of the
 	// function: whether the ring is still accepting writes is a question about the
@@ -353,11 +366,15 @@ func (r *MasterRing) Push(ctx context.Context, data []byte) (int, error) {
 	// without committing retires the core, so no later path can be added that
 	// forgets to. ingestMu is still held, which is what guards the flag.
 	//
-	// The context is read once more here, and this is the last place it can be:
-	// waiting for this lock takes as long as the reader holding it, and a chunk
-	// that stopped being wanted during that wait must not be published on the
-	// other side of it. Checked after the lock rather than before, so there is no
-	// window left between the check and the commit.
+	// The context is read once more here, under the lock, and that read is the
+	// commit's linearization point: a cancellation visible by then wins, and one
+	// that becomes visible after it does not.
+	//
+	// Stated that way on purpose. Cancellation is asynchronous, so "no commit may
+	// happen after the caller gives up" is not implementable - there is always a
+	// last instruction. What is implementable, and what a remote core can be held
+	// to, is a single point where the question is asked for the last time, with
+	// nothing between it and the commit that could wait.
 	if err := ctx.Err(); err != nil {
 		return 0, r.retireCore(ctx, err)
 	}

--- a/backend/internal/stream/ingest/ring/ring_test.go
+++ b/backend/internal/stream/ingest/ring/ring_test.go
@@ -6,6 +6,7 @@ package ring
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"sync"
 	"testing"
@@ -219,14 +220,14 @@ func TestMasterRing_MultiPacketPATPMT_Assembly(t *testing.T) {
 
 	patPackets := createMultiPacketPAT(pmtPID)
 	for _, pkt := range patPackets {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push pat failed: %v", err)
 		}
 	}
 
 	pmtPackets := createMultiPacketPMT(pmtPID, videoPID, false)
 	for _, pkt := range pmtPackets {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push pmt failed: %v", err)
 		}
 	}
@@ -256,10 +257,10 @@ func TestMasterRing_StatefulAnnexBSplitAcrossTSPackets(t *testing.T) {
 	const videoPID = 256
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	frameStartOffset := r.Head()
@@ -275,10 +276,10 @@ func TestMasterRing_StatefulAnnexBSplitAcrossTSPackets(t *testing.T) {
 	pkt2 := createBasicPacket(videoPID, false, 1)
 	copy(pkt2[4:], es2)
 
-	if _, err := r.Push(pkt1); err != nil {
+	if _, err := r.Push(context.Background(), pkt1); err != nil {
 		t.Fatalf("push pkt1 failed: %v", err)
 	}
-	if _, err := r.Push(pkt2); err != nil {
+	if _, err := r.Push(context.Background(), pkt2); err != nil {
 		t.Fatalf("push pkt2 failed: %v", err)
 	}
 
@@ -299,10 +300,10 @@ func TestMasterRing_SPSWithoutIDR_NotIndexed(t *testing.T) {
 	const videoPID = 256
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	// Standalone SPS parameter update (NAL 7) without PPS or slice
@@ -310,7 +311,7 @@ func TestMasterRing_SPSWithoutIDR_NotIndexed(t *testing.T) {
 		0x00, 0x00, 0x00, 0x01, 0x07, 0x42, 0x00, 0x1E,
 	}
 	pkt := createVideoPESPacket(videoPID, true, 0, es)
-	if _, err := r.Push(pkt); err != nil {
+	if _, err := r.Push(context.Background(), pkt); err != nil {
 		t.Fatalf("push failed: %v", err)
 	}
 
@@ -328,10 +329,10 @@ func TestMasterRing_NonVideoPID_RandomAccessIndicatorIgnored(t *testing.T) {
 	const audioPID = 85
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	audioPkt := make([]byte, TSPacketSize)
@@ -342,7 +343,7 @@ func TestMasterRing_NonVideoPID_RandomAccessIndicatorIgnored(t *testing.T) {
 	audioPkt[4] = 5
 	audioPkt[5] = 0x40
 
-	if _, err := r.Push(audioPkt); err != nil {
+	if _, err := r.Push(context.Background(), audioPkt); err != nil {
 		t.Fatalf("push failed: %v", err)
 	}
 
@@ -359,10 +360,10 @@ func TestMasterRing_HEVC_KeyframeDetection(t *testing.T) {
 	const videoPID = 256
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, true) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	vPID, vCodec := r.VideoDetails()
@@ -379,7 +380,7 @@ func TestMasterRing_HEVC_KeyframeDetection(t *testing.T) {
 		0x00, 0x00, 0x00, 0x01, 0x26, 0x01,
 	}
 	pkt := createVideoPESPacket(videoPID, true, 0, es)
-	if _, err := r.Push(pkt); err != nil {
+	if _, err := r.Push(context.Background(), pkt); err != nil {
 		t.Fatalf("push failed: %v", err)
 	}
 
@@ -399,7 +400,7 @@ func TestMasterRing_PushLargerThanRingCapacity(t *testing.T) {
 		copy(largeData[i*TSPacketSize:], pkt)
 	}
 
-	n, err := r.Push(largeData)
+	n, err := r.Push(context.Background(), largeData)
 	if err != nil || n != len(largeData) {
 		t.Fatalf("large push failed: n=%d err=%v", n, err)
 	}
@@ -423,21 +424,21 @@ func TestMasterRing_KeyframePruneAllOlderThanTail(t *testing.T) {
 	const videoPID = 256
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	es := []byte{0x00, 0x00, 0x01, 0x05}
-	_, _ = r.Push(createVideoPESPacket(videoPID, true, 0, es))
+	_, _ = r.Push(context.Background(), createVideoPESPacket(videoPID, true, 0, es))
 
 	if _, ok := r.LatestKeyframeOffset(); !ok {
 		t.Fatalf("expected initial keyframe indexed")
 	}
 
 	for i := 0; i < 30; i++ {
-		_, _ = r.Push(createBasicPacket(videoPID, false, uint8(i%16)))
+		_, _ = r.Push(context.Background(), createBasicPacket(videoPID, false, uint8(i%16)))
 	}
 
 	if _, ok := r.LatestKeyframeOffset(); ok {
@@ -467,7 +468,7 @@ func TestSubscriberReader_ConcurrentReadSeekClose_NoDeadlock(t *testing.T) {
 			default:
 				pkt := createBasicPacket(256, false, cc)
 				cc++
-				_, _ = r.Push(pkt)
+				_, _ = r.Push(context.Background(), pkt)
 				time.Sleep(500 * time.Microsecond)
 			}
 		}
@@ -549,7 +550,7 @@ func TestMasterRing_MultiReaderConcurrency(t *testing.T) {
 			if end > len(allData) {
 				end = len(allData)
 			}
-			_, _ = r.Push(allData[i:end])
+			_, _ = r.Push(context.Background(), allData[i:end])
 			time.Sleep(1 * time.Millisecond)
 		}
 		r.Close()
@@ -577,10 +578,10 @@ func TestMasterRing_SlowSubscriberOverrunIsolation(t *testing.T) {
 	defer r.Close()
 
 	for _, pkt := range createMultiPacketPAT(100) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 0, false, false, 0, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	if r.facts.VideoPID != 0 {
 		t.Fatalf("test setup: expected an audio-only PMT, got video PID %d", r.facts.VideoPID)
@@ -591,7 +592,7 @@ func TestMasterRing_SlowSubscriberOverrunIsolation(t *testing.T) {
 
 	baseline := r.Tail()
 	for i := 0; i < 30; i++ {
-		_, _ = r.Push(createBasicPacket(256, false, uint8(i%16)))
+		_, _ = r.Push(context.Background(), createBasicPacket(256, false, uint8(i%16)))
 	}
 
 	buf := make([]byte, TSPacketSize)
@@ -646,13 +647,13 @@ func TestMasterRing_CCDiscontinuity_AbortsCorruptedSection(t *testing.T) {
 	pkt1 := make([]byte, TSPacketSize)
 	copy(pkt1, patPackets[0])
 	pkt1[3] = (pkt1[3] & 0xF0) | 0x00
-	_, _ = r.Push(pkt1)
+	_, _ = r.Push(context.Background(), pkt1)
 
 	// 2. Send corrupted second packet with CC=5 (gap!)
 	pkt2Corrupted := make([]byte, TSPacketSize)
 	copy(pkt2Corrupted, patPackets[1])
 	pkt2Corrupted[3] = (pkt2Corrupted[3] & 0xF0) | 0x05
-	_, _ = r.Push(pkt2Corrupted)
+	_, _ = r.Push(context.Background(), pkt2Corrupted)
 
 	if r.facts.PMTPID != 0 {
 		t.Fatalf("corrupted PAT section with CC gap was incorrectly accepted")
@@ -662,12 +663,12 @@ func TestMasterRing_CCDiscontinuity_AbortsCorruptedSection(t *testing.T) {
 	pkt1Valid := make([]byte, TSPacketSize)
 	copy(pkt1Valid, patPackets[0])
 	pkt1Valid[3] = (pkt1Valid[3] & 0xF0) | 0x06
-	_, _ = r.Push(pkt1Valid)
+	_, _ = r.Push(context.Background(), pkt1Valid)
 
 	pkt2Valid := make([]byte, TSPacketSize)
 	copy(pkt2Valid, patPackets[1])
 	pkt2Valid[3] = (pkt2Valid[3] & 0xF0) | 0x07
-	_, _ = r.Push(pkt2Valid)
+	_, _ = r.Push(context.Background(), pkt2Valid)
 
 	if r.facts.PMTPID != pmtPID {
 		t.Fatalf("expected pmtPID=%d after clean retransmission, got %d", pmtPID, r.facts.PMTPID)
@@ -681,7 +682,7 @@ func TestMasterRing_CurrentNextIndicator_InactiveTableIgnored(t *testing.T) {
 	const pmtPID = 100
 	patPacketsInactive := createMultiPacketPATWithVersion(pmtPID, 0, 0)
 	for _, pkt := range patPacketsInactive {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	if r.facts.PMTPID != 0 {
@@ -689,7 +690,7 @@ func TestMasterRing_CurrentNextIndicator_InactiveTableIgnored(t *testing.T) {
 	}
 
 	for _, pkt := range createMultiPacketPATWithVersion(pmtPID, 0, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	if r.facts.PMTPID != pmtPID {
@@ -703,11 +704,11 @@ func TestMasterRing_PMTVersionChange_PurgesStaleKeyframes(t *testing.T) {
 
 	const pmtPID = 100
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(pmtPID, 256, false, true, 0, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	vPID1, vCodec1 := r.VideoDetails()
@@ -716,7 +717,7 @@ func TestMasterRing_PMTVersionChange_PurgesStaleKeyframes(t *testing.T) {
 	}
 
 	es1 := []byte{0x00, 0x00, 0x01, 0x05}
-	_, _ = r.Push(createVideoPESPacket(256, true, 0, es1))
+	_, _ = r.Push(context.Background(), createVideoPESPacket(256, true, 0, es1))
 
 	if _, ok := r.LatestKeyframeOffset(); !ok {
 		t.Fatalf("expected keyframe on PID 256 indexed")
@@ -724,7 +725,7 @@ func TestMasterRing_PMTVersionChange_PurgesStaleKeyframes(t *testing.T) {
 
 	pmtV2 := createMultiPacketPMTWithVersion(pmtPID, 512, true, true, 1, 1)
 	for _, pkt := range pmtV2 {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	vPID2, vCodec2 := r.VideoDetails()
@@ -738,7 +739,7 @@ func TestMasterRing_PMTVersionChange_PurgesStaleKeyframes(t *testing.T) {
 
 	frameStart := r.Head()
 	es2 := []byte{0x00, 0x00, 0x00, 0x01, 0x26, 0x01}
-	_, _ = r.Push(createVideoPESPacket(512, true, 0, es2))
+	_, _ = r.Push(context.Background(), createVideoPESPacket(512, true, 0, es2))
 
 	newOffset, ok := r.LatestKeyframeOffset()
 	if !ok || newOffset != frameStart {
@@ -752,11 +753,11 @@ func TestMasterRing_PMTVersionChange_NoVideoStream_LeavesPIDZero(t *testing.T) {
 
 	const pmtPID = 100
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(pmtPID, 256, false, true, 0, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	if vPID, _ := r.VideoDetails(); vPID != 256 {
@@ -764,7 +765,7 @@ func TestMasterRing_PMTVersionChange_NoVideoStream_LeavesPIDZero(t *testing.T) {
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(pmtPID, 0, false, false, 1, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	vPID, vCodec := r.VideoDetails()
@@ -784,15 +785,15 @@ func TestMasterRing_CRC32_CorruptedSectionRejected(t *testing.T) {
 	copy(pkt2Corrupt, patPackets[1])
 	pkt2Corrupt[6] ^= 0xFF
 
-	_, _ = r.Push(patPackets[0])
-	_, _ = r.Push(pkt2Corrupt)
+	_, _ = r.Push(context.Background(), patPackets[0])
+	_, _ = r.Push(context.Background(), pkt2Corrupt)
 
 	if r.facts.PMTPID != 0 {
 		t.Fatalf("PAT section with corrupted CRC32 was incorrectly accepted")
 	}
 
-	_, _ = r.Push(patPackets[0])
-	_, _ = r.Push(patPackets[1])
+	_, _ = r.Push(context.Background(), patPackets[0])
+	_, _ = r.Push(context.Background(), patPackets[1])
 
 	if r.facts.PMTPID != pmtPID {
 		t.Fatalf("valid PAT section was not accepted: got %d", r.facts.PMTPID)
@@ -804,7 +805,7 @@ func TestMasterRing_TargetProgramNumber_Selection(t *testing.T) {
 
 	r1 := NewMasterRing(100 * TSPacketSize)
 	defer r1.Close()
-	_, _ = r1.Push(multiPAT)
+	_, _ = r1.Push(context.Background(), multiPAT)
 
 	if r1.facts.PMTPID != 100 {
 		t.Fatalf("expected default r1 to select PMT 100, got %d", r1.facts.PMTPID)
@@ -812,7 +813,7 @@ func TestMasterRing_TargetProgramNumber_Selection(t *testing.T) {
 
 	r2 := NewMasterRingWithProgram(100*TSPacketSize, 2)
 	defer r2.Close()
-	_, _ = r2.Push(multiPAT)
+	_, _ = r2.Push(context.Background(), multiPAT)
 
 	if r2.facts.PMTPID != 200 {
 		t.Fatalf("expected r2 to select PMT 200 for program 2, got %d", r2.facts.PMTPID)
@@ -827,16 +828,16 @@ func TestMasterRing_RepeatedSamePMT_DoesNotPurgeKeyframes(t *testing.T) {
 	const videoPID = 256
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 	pmtV0 := createMultiPacketPMTWithVersion(pmtPID, videoPID, false, true, 0, 1)
 	for _, pkt := range pmtV0 {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	frameStart := r.Head()
 	es := []byte{0x00, 0x00, 0x01, 0x05}
-	_, _ = r.Push(createVideoPESPacket(videoPID, true, 0, es))
+	_, _ = r.Push(context.Background(), createVideoPESPacket(videoPID, true, 0, es))
 
 	offset1, ok := r.LatestKeyframeOffset()
 	if !ok || offset1 != frameStart {
@@ -844,7 +845,7 @@ func TestMasterRing_RepeatedSamePMT_DoesNotPurgeKeyframes(t *testing.T) {
 	}
 
 	for _, pkt := range pmtV0 {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	offset2, ok := r.LatestKeyframeOffset()
@@ -862,21 +863,21 @@ func TestMasterRing_SetTargetProgram_InvalidatesOldProgramState(t *testing.T) {
 	r := NewMasterRingWithProgram(100*TSPacketSize, 1)
 	defer r.Close()
 
-	_, _ = r.Push(multiPAT)
+	_, _ = r.Push(context.Background(), multiPAT)
 	if r.facts.PMTPID != 100 {
 		t.Fatalf("expected pmtPID=100 for program 1, got %d", r.facts.PMTPID)
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(100, 256, false, true, 0, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
-	_, _ = r.Push(createVideoPESPacket(256, true, 0, []byte{0x00, 0x00, 0x01, 0x05}))
+	_, _ = r.Push(context.Background(), createVideoPESPacket(256, true, 0, []byte{0x00, 0x00, 0x01, 0x05}))
 	if _, ok := r.LatestKeyframeOffset(); !ok {
 		t.Fatalf("expected initial keyframe indexed")
 	}
 
-	r.SetTargetProgram(2)
+	r.SetTargetProgram(context.Background(), 2)
 
 	if vPID, _ := r.VideoDetails(); vPID != 0 {
 		t.Fatalf("expected vPID=0 immediately after SetTargetProgram, got %d", vPID)
@@ -885,13 +886,13 @@ func TestMasterRing_SetTargetProgram_InvalidatesOldProgramState(t *testing.T) {
 		t.Fatalf("expected keyframe purged immediately after SetTargetProgram")
 	}
 
-	_, _ = r.Push(multiPAT)
+	_, _ = r.Push(context.Background(), multiPAT)
 	if r.facts.PMTPID != 200 {
 		t.Fatalf("expected pmtPID=200 after resolving program 2, got %d", r.facts.PMTPID)
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(200, 512, true, true, 0, 1) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	vPID2, vCodec2 := r.VideoDetails()
@@ -923,7 +924,7 @@ func TestMasterRing_PointerField_CompletesPreviousSectionAndStartsNew(t *testing
 	pkt1[177] = 0x00 // pointer_field = 0
 	copy(pkt1[178:], sec1[:10])
 
-	_, _ = r.Push(pkt1)
+	_, _ = r.Push(context.Background(), pkt1)
 	if r.facts.PMTPID != 0 {
 		t.Fatalf("section 1 should be incomplete")
 	}
@@ -943,7 +944,7 @@ func TestMasterRing_PointerField_CompletesPreviousSectionAndStartsNew(t *testing
 		pkt2[i] = 0xFF // Stuffing
 	}
 
-	_, _ = r.Push(pkt2)
+	_, _ = r.Push(context.Background(), pkt2)
 
 	// Section 2 was also parsed in the same packet and updated PMT PID to 200!
 	if r.facts.PMTPID != 200 {
@@ -973,7 +974,7 @@ func TestMasterRing_MultipleCompleteSectionsInSinglePacket(t *testing.T) {
 		pkt[i] = 0xFF // Stuffing
 	}
 
-	_, _ = r.Push(pkt)
+	_, _ = r.Push(context.Background(), pkt)
 
 	if r.facts.PMTPID != 200 {
 		t.Fatalf("expected pmtPID=200 for target program 20 from multi-section packet, got %d", r.facts.PMTPID)
@@ -1005,13 +1006,13 @@ func TestMasterRing_MultiSectionPAT_TargetOnlyInSection1(t *testing.T) {
 	copy(pkt1[5:], sec1)
 
 	// Push Section 0 (target 30 not in Section 0)
-	_, _ = r.Push(pkt0)
+	_, _ = r.Push(context.Background(), pkt0)
 	if r.facts.PMTPID != 0 {
 		t.Fatalf("table should not be activated before section 1 arrives")
 	}
 
 	// Push Section 1
-	_, _ = r.Push(pkt1)
+	_, _ = r.Push(context.Background(), pkt1)
 	if r.facts.PMTPID != 300 {
 		t.Fatalf("expected pmtPID=300 from Section 1, got %d", r.facts.PMTPID)
 	}
@@ -1050,8 +1051,8 @@ func TestMasterRing_CarouselRepeatedSection0_PreservesMultiSectionPreamble(t *te
 	pkt1[4] = 0x00
 	copy(pkt1[5:], sec1)
 
-	_, _ = r.Push(pkt0)
-	_, _ = r.Push(pkt1)
+	_, _ = r.Push(context.Background(), pkt0)
+	_, _ = r.Push(context.Background(), pkt1)
 
 	if r.facts.PMTPID != 300 {
 		t.Fatalf("expected pmtPID=300, got %d", r.facts.PMTPID)
@@ -1061,7 +1062,7 @@ func TestMasterRing_CarouselRepeatedSection0_PreservesMultiSectionPreamble(t *te
 	pkt0Next := make([]byte, TSPacketSize)
 	copy(pkt0Next, pkt0)
 	pkt0Next[3] = 0x12 // CC=2
-	_, _ = r.Push(pkt0Next)
+	_, _ = r.Push(context.Background(), pkt0Next)
 
 	// Target resolution must NOT be destroyed
 	if r.facts.PMTPID != 300 {
@@ -1089,7 +1090,7 @@ func TestMasterRing_MissingSection_PreventsTableActivation(t *testing.T) {
 	pktInit[3] = 0x10
 	pktInit[4] = 0x00
 	copy(pktInit[5:], secInit)
-	_, _ = r.Push(pktInit)
+	_, _ = r.Push(context.Background(), pktInit)
 
 	if r.facts.PMTPID != 100 {
 		t.Fatalf("expected initial pmtPID=100, got %d", r.facts.PMTPID)
@@ -1105,7 +1106,7 @@ func TestMasterRing_MissingSection_PreventsTableActivation(t *testing.T) {
 	pktV1_0[3] = 0x11
 	pktV1_0[4] = 0x00
 	copy(pktV1_0[5:], secV1_0)
-	_, _ = r.Push(pktV1_0)
+	_, _ = r.Push(context.Background(), pktV1_0)
 
 	// Because Section 1 of v1 is missing, table v1 is INCOMPLETE and must not activate!
 	if r.facts.PMTPID != 100 {
@@ -1121,7 +1122,7 @@ func TestMasterRing_MissingSection_PreventsTableActivation(t *testing.T) {
 	pktV1_1[3] = 0x12
 	pktV1_1[4] = 0x00
 	copy(pktV1_1[5:], secV1_1)
-	_, _ = r.Push(pktV1_1)
+	_, _ = r.Push(context.Background(), pktV1_1)
 
 	// Now table v1 is complete and activates!
 	if r.facts.PMTPID != 300 {
@@ -1138,13 +1139,13 @@ func TestMasterRing_DuplicateCC_IgnoredWithoutDiscontinuity(t *testing.T) {
 	patPackets := createMultiPacketPAT(pmtPID)
 
 	// 1. Push Packet 1 with CC=0
-	_, _ = r.Push(patPackets[0])
+	_, _ = r.Push(context.Background(), patPackets[0])
 
 	// 2. Push exact duplicate of Packet 1 with same CC=0 (DVB retransmission)
-	_, _ = r.Push(patPackets[0])
+	_, _ = r.Push(context.Background(), patPackets[0])
 
 	// 3. Push Packet 2 with CC=1
-	_, _ = r.Push(patPackets[1])
+	_, _ = r.Push(context.Background(), patPackets[1])
 
 	// Assembly must have succeeded seamlessly
 	if r.facts.PMTPID != pmtPID {
@@ -1181,12 +1182,12 @@ func TestMasterRing_PSIHeaderSplitAcrossPackets(t *testing.T) {
 	pkt2[3] = 0x11 // CC=1
 	copy(pkt2[4:], sec[2:])
 
-	_, _ = r.Push(pkt1)
+	_, _ = r.Push(context.Background(), pkt1)
 	if r.facts.PMTPID != 0 {
 		t.Fatalf("table should not be resolved after 2 header bytes")
 	}
 
-	_, _ = r.Push(pkt2)
+	_, _ = r.Push(context.Background(), pkt2)
 	if r.facts.PMTPID != pmtPID {
 		t.Fatalf("expected pmtPID=%d from section with split header across packets, got %d", pmtPID, r.facts.PMTPID)
 	}
@@ -1201,7 +1202,7 @@ func TestMasterRing_SameCCDifferentPayload_ResetsAssembly(t *testing.T) {
 	patPackets := createMultiPacketPAT(pmtPID)
 
 	// 1. Push Packet 1 (PUSI=1, CC=0)
-	_, _ = r.Push(patPackets[0])
+	_, _ = r.Push(context.Background(), patPackets[0])
 
 	// 2. Push glitch continuation packet with SAME CC=0 but PUSI=0 and different payload
 	corruptedPkt := make([]byte, TSPacketSize)
@@ -1209,10 +1210,10 @@ func TestMasterRing_SameCCDifferentPayload_ResetsAssembly(t *testing.T) {
 	corruptedPkt[1] = 0x00 // PUSI=0
 	corruptedPkt[2] = 0x00
 	corruptedPkt[3] = 0x10 // CC=0 (same CC as pkt 1, but completely different packet!)
-	_, _ = r.Push(corruptedPkt)
+	_, _ = r.Push(context.Background(), corruptedPkt)
 
 	// 3. Push Packet 2 (PUSI=0, CC=1)
-	_, _ = r.Push(patPackets[1])
+	_, _ = r.Push(context.Background(), patPackets[1])
 
 	// Assembly must have been aborted by the glitch packet
 	if r.facts.PMTPID != 0 {
@@ -1240,7 +1241,7 @@ func TestMasterRing_MultipleSectionsSamePacket_PreambleDoesNotDuplicatePacket(t 
 		pkt[i] = 0xFF // Stuffing
 	}
 
-	_, _ = r.Push(pkt)
+	_, _ = r.Push(context.Background(), pkt)
 
 	if r.facts.PMTPID != 200 {
 		t.Fatalf("expected pmtPID=200, got %d", r.facts.PMTPID)
@@ -1259,7 +1260,7 @@ func TestMasterRing_MPEG2_SequenceHeaderAndIFrame(t *testing.T) {
 
 	// 1. PAT with prog 1 -> PMT PID 100
 	for _, pkt := range createMultiPacketPAT(100) {
-		_, _ = r.Push(pkt)
+		_, _ = r.Push(context.Background(), pkt)
 	}
 
 	// 2. PMT with video stream_type=0x02 (MPEG-2 Video) on PID 200
@@ -1297,7 +1298,7 @@ func TestMasterRing_MPEG2_SequenceHeaderAndIFrame(t *testing.T) {
 	for i := 5 + len(pmtSection); i < TSPacketSize; i++ {
 		pmtPkt[i] = 0xFF
 	}
-	_, _ = r.Push(pmtPkt)
+	_, _ = r.Push(context.Background(), pmtPkt)
 
 	if r.facts.VideoCodec != CodecMPEG2 {
 		t.Fatalf("expected CodecMPEG2, got %v", r.facts.VideoCodec)
@@ -1312,11 +1313,11 @@ func TestMasterRing_MPEG2_SequenceHeaderAndIFrame(t *testing.T) {
 	}
 
 	videoPkt := createVideoPESPacket(200, true, 0, mpeg2ES)
-	_, _ = r.Push(videoPkt)
+	_, _ = r.Push(context.Background(), videoPkt)
 
 	// Finalize the access unit with another packet
 	nextAUPkt := createVideoPESPacket(200, true, 1, []byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x10}) // P-Frame
-	_, _ = r.Push(nextAUPkt)
+	_, _ = r.Push(context.Background(), nextAUPkt)
 
 	kf, ok := r.LatestKeyframeOffset()
 	if !ok {

--- a/backend/internal/stream/ingest/ring/scrambled_test.go
+++ b/backend/internal/stream/ingest/ring/scrambled_test.go
@@ -5,6 +5,7 @@
 package ring
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -29,12 +30,12 @@ func scrambleTSPacket(pkt []byte) []byte {
 func pushClearPATPMT(t *testing.T, r *MasterRing, pmtPID, videoPID uint16) {
 	t.Helper()
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PAT failed: %v", err)
 		}
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PMT failed: %v", err)
 		}
 	}
@@ -55,7 +56,7 @@ func TestMasterRing_ScrambledVideo_NotIndexedAndAttachIsTerminal(t *testing.T) {
 
 	for i := 0; i < mediafacts.ScrambledVerdictMinPackets; i++ {
 		pkt := createVideoPESPacket(videoPID, true, uint8(i&0x0F), idrESPayload())
-		if _, err := r.Push(scrambleTSPacket(pkt)); err != nil {
+		if _, err := r.Push(context.Background(), scrambleTSPacket(pkt)); err != nil {
 			t.Fatalf("push scrambled video packet %d failed: %v", i, err)
 		}
 	}
@@ -96,14 +97,14 @@ func TestMasterRing_ClearPayloadPresent_NotDeclaredScrambled(t *testing.T) {
 
 	for i := 0; i < mediafacts.ScrambledVerdictMinPackets*2; i++ {
 		pkt := createVideoPESPacket(videoPID, true, uint8(i&0x0F), idrESPayload())
-		if _, err := r.Push(scrambleTSPacket(pkt)); err != nil {
+		if _, err := r.Push(context.Background(), scrambleTSPacket(pkt)); err != nil {
 			t.Fatalf("push scrambled video packet %d failed: %v", i, err)
 		}
 	}
 
 	// A clear non-VCL slice: parsed, but not a random access point.
 	clearPkt := createVideoPESPacket(videoPID, true, 0x0F, []byte{0x00, 0x00, 0x01, 0x01, 0x11, 0x22})
-	if _, err := r.Push(clearPkt); err != nil {
+	if _, err := r.Push(context.Background(), clearPkt); err != nil {
 		t.Fatalf("push clear video packet failed: %v", err)
 	}
 
@@ -138,7 +139,7 @@ func TestMasterRing_ProgramChange_ResetsScramblingObservation(t *testing.T) {
 
 	for i := 0; i < mediafacts.ScrambledVerdictMinPackets; i++ {
 		pkt := createVideoPESPacket(videoPID, true, uint8(i&0x0F), idrESPayload())
-		if _, err := r.Push(scrambleTSPacket(pkt)); err != nil {
+		if _, err := r.Push(context.Background(), scrambleTSPacket(pkt)); err != nil {
 			t.Fatalf("push scrambled video packet %d failed: %v", i, err)
 		}
 	}
@@ -147,7 +148,7 @@ func TestMasterRing_ProgramChange_ResetsScramblingObservation(t *testing.T) {
 		t.Fatalf("precondition failed: expected scrambled packets to be observed before program change")
 	}
 
-	r.SetTargetProgram(2)
+	r.SetTargetProgram(context.Background(), 2)
 
 	scrambled, clear := r.ScramblingObservation()
 	if scrambled != 0 || clear != 0 {

--- a/backend/internal/stream/ingest/ring/seam_test.go
+++ b/backend/internal/stream/ingest/ring/seam_test.go
@@ -5,6 +5,7 @@
 package ring
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -63,11 +64,11 @@ func TestSeam_EntryPointOffsetsAreInTheCallersCoordinateSystem(t *testing.T) {
 
 	data := streamWithEntryPoint(videoPID)
 
-	atZero, err := mediafacts.NewGoCore(1).Ingest(0, data)
+	atZero, err := mediafacts.NewGoCore(1).Ingest(context.Background(), 0, data)
 	if err != nil {
 		t.Fatalf("ingest at 0: %v", err)
 	}
-	atBase, err := mediafacts.NewGoCore(1).Ingest(base, data)
+	atBase, err := mediafacts.NewGoCore(1).Ingest(context.Background(), base, data)
 	if err != nil {
 		t.Fatalf("ingest at base: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestSeam_TheCoreReportsIdentityAndTheRingDecidesTheEpoch(t *testing.T) {
 	ingest := func(packets [][]byte) {
 		t.Helper()
 		for _, pkt := range packets {
-			res, err := core.Ingest(0, pkt)
+			res, err := core.Ingest(context.Background(), 0, pkt)
 			if err != nil {
 				t.Fatalf("ingest: %v", err)
 			}
@@ -148,12 +149,12 @@ func TestSeam_EveryIdentityChangeBecomesExactlyOneGeneration(t *testing.T) {
 	before := r.Generation()
 
 	for _, pkt := range createMultiPacketPAT(pmtPID) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PAT: %v", err)
 		}
 	}
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push PMT: %v", err)
 		}
 	}
@@ -163,7 +164,7 @@ func TestSeam_EveryIdentityChangeBecomesExactlyOneGeneration(t *testing.T) {
 	}
 
 	for _, pkt := range createMultiPacketPMT(pmtPID, videoPID, false) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push repeated PMT: %v", err)
 		}
 	}
@@ -172,7 +173,7 @@ func TestSeam_EveryIdentityChangeBecomesExactlyOneGeneration(t *testing.T) {
 	}
 
 	for _, pkt := range createMultiPacketPMTWithVersion(pmtPID, videoPID, false, true, 1, 1) {
-		if _, err := r.Push(pkt); err != nil {
+		if _, err := r.Push(context.Background(), pkt); err != nil {
 			t.Fatalf("push new PMT version: %v", err)
 		}
 	}
@@ -259,8 +260,8 @@ type shortCore struct {
 	shortBy int64
 }
 
-func (c shortCore) Ingest(startOffset int64, data []byte) (mediafacts.ParseResult, error) {
-	res, err := c.Core.Ingest(startOffset, data)
+func (c shortCore) Ingest(ctx context.Context, startOffset int64, data []byte) (mediafacts.ParseResult, error) {
+	res, err := c.Core.Ingest(ctx, startOffset, data)
 	res.ProcessedThroughOffset -= c.shortBy
 	// Events the ring must not act on, precisely because the chunk is short.
 	res.Events = append(res.Events, mediafacts.Event{Kind: mediafacts.EventProgramIdentityChanged})
@@ -283,7 +284,7 @@ func TestSeam_AChunkTheCoreDidNotFinishIsNotCommitted(t *testing.T) {
 	factsBefore := r.ReadinessFacts()
 
 	data := createMultiPacketPAT(pmtPID)[0]
-	n, err := r.Push(data)
+	n, err := r.Push(context.Background(), data)
 
 	if !errors.Is(err, ErrCoreIncomplete) {
 		t.Fatalf("Push err = %v, want ErrCoreIncomplete", err)
@@ -347,7 +348,7 @@ func TestSeam_PMTPIDFollowsThePAT(t *testing.T) {
 		t.Helper()
 		var last mediafacts.ParseResult
 		for _, pkt := range packets {
-			res, err := core.Ingest(0, pkt)
+			res, err := core.Ingest(context.Background(), 0, pkt)
 			if err != nil {
 				t.Fatalf("ingest: %v", err)
 			}

--- a/backend/internal/stream/ingest/variant/variant_test.go
+++ b/backend/internal/stream/ingest/variant/variant_test.go
@@ -212,7 +212,7 @@ func TestAudioVariantWorker_RealCapture_TranscodeAndAttach(t *testing.T) {
 					end = i + ((end-i)/ring.TSPacketSize)*ring.TSPacketSize
 				}
 				if end > i {
-					if _, perr := masterRing.Push(data[i:end]); perr != nil {
+					if _, perr := masterRing.Push(context.Background(), data[i:end]); perr != nil {
 						return
 					}
 				}

--- a/backend/internal/stream/ingest/variant/worker.go
+++ b/backend/internal/stream/ingest/variant/worker.go
@@ -450,7 +450,10 @@ func (w *AudioVariantWorker) run(ctx context.Context) error {
 					// a non-packet-sized push, which pushLen has just ruled out, and
 					// a closed ring, which means this worker is being torn down and
 					// the read loop below is about to end anyway.
-					_, _ = w.variantRing.Push(chunk[:pushLen])
+					//
+					// The worker's own context bounds the call, so a core that stops
+					// answering ends this worker rather than pinning it.
+					_, _ = w.variantRing.Push(ctx, chunk[:pushLen])
 				}
 				rem := len(chunk) - pushLen
 				if rem > 0 {

--- a/backend/internal/stream/ingest/variant/worker_attach_test.go
+++ b/backend/internal/stream/ingest/variant/worker_attach_test.go
@@ -116,10 +116,10 @@ func newPrimedRing(t *testing.T, capacityPackets int) *ring.MasterRing {
 	r := ring.NewMasterRing(capacityPackets * ring.TSPacketSize)
 	t.Cleanup(r.Close)
 
-	if _, err := r.Push(tsPATPacket(t, 100, 0)); err != nil {
+	if _, err := r.Push(context.Background(), tsPATPacket(t, 100, 0)); err != nil {
 		t.Fatalf("push PAT: %v", err)
 	}
-	if _, err := r.Push(tsPMTPacket(t, 100, 256, false, 0)); err != nil {
+	if _, err := r.Push(context.Background(), tsPMTPacket(t, 100, 256, false, 0)); err != nil {
 		t.Fatalf("push PMT: %v", err)
 	}
 	return r
@@ -133,17 +133,17 @@ func TestAttachPrimedMaster_AttachesAtKeyframeNotTail(t *testing.T) {
 
 	// Filler ahead of the keyframe, so tail != keyframe offset.
 	for i := 0; i < 20; i++ {
-		if _, err := r.Push(tsVideoPacket(t, 85, uint8(i), []byte{0xAA})); err != nil {
+		if _, err := r.Push(context.Background(), tsVideoPacket(t, 85, uint8(i), []byte{0xAA})); err != nil {
 			t.Fatalf("push filler: %v", err)
 		}
 	}
 
 	keyframeOffset := r.Head()
-	if _, err := r.Push(tsVideoPacket(t, 256, 0, h264IDR)); err != nil {
+	if _, err := r.Push(context.Background(), tsVideoPacket(t, 256, 0, h264IDR)); err != nil {
 		t.Fatalf("push keyframe: %v", err)
 	}
 	for i := 0; i < 5; i++ {
-		if _, err := r.Push(tsVideoPacket(t, 256, uint8(i+1), []byte{0xBB})); err != nil {
+		if _, err := r.Push(context.Background(), tsVideoPacket(t, 256, uint8(i+1), []byte{0xBB})); err != nil {
 			t.Fatalf("push trailing video: %v", err)
 		}
 	}
@@ -179,7 +179,7 @@ func TestAttachPrimedMaster_RefusesTailWhenNoKeyframe(t *testing.T) {
 
 	// Audio only: nothing here is a video random access point.
 	for i := 0; i < 30; i++ {
-		if _, err := r.Push(tsVideoPacket(t, 85, uint8(i), []byte{0xAA})); err != nil {
+		if _, err := r.Push(context.Background(), tsVideoPacket(t, 85, uint8(i), []byte{0xAA})); err != nil {
 			t.Fatalf("push audio: %v", err)
 		}
 	}
@@ -207,7 +207,7 @@ func TestAttachPrimedMaster_RefusesTailWhenNoKeyframe(t *testing.T) {
 func TestAttachPrimedMaster_PMTChangeInvalidatesRatherThanFallsBackToTail(t *testing.T) {
 	r := newPrimedRing(t, 200)
 
-	if _, err := r.Push(tsVideoPacket(t, 256, 0, h264IDR)); err != nil {
+	if _, err := r.Push(context.Background(), tsVideoPacket(t, 256, 0, h264IDR)); err != nil {
 		t.Fatalf("push first keyframe: %v", err)
 	}
 
@@ -219,7 +219,7 @@ func TestAttachPrimedMaster_PMTChangeInvalidatesRatherThanFallsBackToTail(t *tes
 
 	// PMT v1 moves video to another PID and codec. The ring invalidates the video
 	// state, drops the keyframe index and bumps the generation.
-	if _, err := r.Push(tsPMTPacket(t, 100, 512, true, 1)); err != nil {
+	if _, err := r.Push(context.Background(), tsPMTPacket(t, 100, 512, true, 1)); err != nil {
 		t.Fatalf("push PMT v1: %v", err)
 	}
 	if _, ok := r.LatestKeyframeOffset(); ok {
@@ -235,7 +235,7 @@ func TestAttachPrimedMaster_PMTChangeInvalidatesRatherThanFallsBackToTail(t *tes
 
 	// The new generation produces its own random access point.
 	newKeyframe := r.Head()
-	if _, err := r.Push(tsVideoPacket(t, 512, 0, hevcIRAP)); err != nil {
+	if _, err := r.Push(context.Background(), tsVideoPacket(t, 512, 0, hevcIRAP)); err != nil {
 		t.Fatalf("push second keyframe: %v", err)
 	}
 
@@ -300,10 +300,10 @@ func TestAttachPrimedMaster_ConcurrentGenerationChurnNeverMixesSnapshot(t *testi
 				videoPID = 512
 				es = hevcIRAP
 			}
-			_, _ = r.Push(tsPMTPacket(t, 100, videoPID, hevc, version))
-			_, _ = r.Push(tsVideoPacket(t, videoPID, 0, es))
+			_, _ = r.Push(context.Background(), tsPMTPacket(t, 100, videoPID, hevc, version))
+			_, _ = r.Push(context.Background(), tsVideoPacket(t, videoPID, 0, es))
 			for i := 0; i < 8; i++ {
-				_, _ = r.Push(tsVideoPacket(t, videoPID, uint8(i+1), []byte{0xCC}))
+				_, _ = r.Push(context.Background(), tsVideoPacket(t, videoPID, uint8(i+1), []byte{0xCC}))
 			}
 			time.Sleep(2 * time.Millisecond)
 		}

--- a/backend/internal/stream/ingest/variant/worker_generation_test.go
+++ b/backend/internal/stream/ingest/variant/worker_generation_test.go
@@ -36,7 +36,7 @@ func runGenerationCut(t *testing.T, firstCapture, secondCapture string, key Audi
 			if end > len(data) {
 				end = len(data)
 			}
-			if _, err := masterRing.Push(data[i:end]); err != nil {
+			if _, err := masterRing.Push(context.Background(), data[i:end]); err != nil {
 				return
 			}
 			time.Sleep(time.Millisecond)
@@ -154,7 +154,7 @@ func TestAudioVariant_GenerationCut_ClientReattachesToNewWorker(t *testing.T) {
 			if end > len(data) {
 				end = len(data)
 			}
-			if _, err := masterRing.Push(data[i:end]); err != nil {
+			if _, err := masterRing.Push(context.Background(), data[i:end]); err != nil {
 				return
 			}
 			time.Sleep(time.Millisecond)

--- a/backend/internal/stream/ingest/variant/worker_ownership_test.go
+++ b/backend/internal/stream/ingest/variant/worker_ownership_test.go
@@ -51,7 +51,7 @@ func feedCapture(t *testing.T, r *ring.MasterRing) {
 			if end > len(data) {
 				end = len(data)
 			}
-			if _, err := r.Push(data[i:end]); err != nil {
+			if _, err := r.Push(context.Background(), data[i:end]); err != nil {
 				return false
 			}
 			time.Sleep(time.Millisecond)


### PR DESCRIPTION
Step 2 of the media core migration. The seam made a remote core possible; nothing yet said what happens when one misbehaves. This writes that down as code, entirely inside the Go model — **before a socket exists to discover it through**.

## The contract

```go
Ingest(ctx, startOffset, data) (ParseResult, error)
SetTargetProgram(ctx, programNumber) (ParseResult, error)
```

Both calls into the core are bounded, because both can hang once the core is a process. `SetTargetProgram` is the one that would have been found late: control plane, rarely exercised, and holding the same lock `Ingest` does.

## The deadline is derived, not chosen

Measured on this repository's own DVB captures:

| chunk | p50 | p99 | max |
|---|---|---|---|
| 64 KiB | ~230 µs | ~350 µs | 350 µs |
| 256 KiB | ~1.0 ms | ~1.05 ms | 1.05 ms |
| 1 MiB | ~3.7 ms | ~4.1 ms | 4.1 ms |
| **4 MiB** | | | **14.9 ms** |

4 MiB is the ceiling — the normalizer hands its sink the staging buffer, which defaults to that size. (The 64 KiB read buffer is upstream of it; the chunk reaching `Push` can be far larger.)

The upper bound comes from the viewer: a zap fails when readiness is not reached within the pipeline's `ReadyTimeout`, **8 s**. **500 ms** sits ~33× above the slowest chunk and a **sixteenth** of the smallest viewer-facing budget — and a hung core costs that budget *exactly one* deadline, because the caller then retires it.

Both ends are held mechanically:

- `pipeline`: a test fails if the deadline ever exceeds a quarter of `ReadyTimeout` (currently 16:1)
- `mediafacts`: a test fails if the parser slows enough to eat the headroom the number was derived from

`ReadyTimeout = 8 s` is the product limit, **not** the RPC latency assumption. Conflating the two is how a shared ingest ends up owned by one viewer's timeout.

## The rule, and the one distinction inside it

It holds for a core that does **not** cooperate. Both calls re-read the context after a successful return, before anything is applied: a core that ignores cancellation, finishes its work and hands back a complete, valid result gets that result discarded and is retired. A process on the other end of a socket learns its caller gave up only when it next touches the socket — one that finished parsing just before that will answer perfectly well to nobody.


```
cancelled before the core was entered
  → nothing was interpreted, nothing diverged, the core stays usable

anything at all once the core has been entered
  → no facts, no events, no PSI, no bytes, core retired, never asked again
```

The second case now includes **the caller's own cancellation**, which it did not before. A core that consumed half a chunk the ring then threw away is out of step with the ring whatever the reason — and the reason is kept in the error, not in whether the core survives.

## Named failures, identical handling

`ErrCoreTimeout` · `ErrCoreGone` · `ErrCoreCrashed` · `ErrCoreInvalidResponse` · `ErrCoreProtocolVersion`

Named so a log or a metric can tell them apart. Nothing else may. An **unrecognised** error is treated as a failure too — the alternative is that an unknown one becomes a silent success.

## The interface got smaller

`Snapshot` and `Reset` are gone from `Core`. Neither is called on a `Core` anywhere in production, and every method left in an interface is a message a wire protocol will eventually have to carry. `GoCore` keeps both.

## The lock order stopped being a comment

A test parses the package and fails if any function takes `mu` before `ingestMu`. Verified by mutation:

```
ring.go: Push takes mu before ingestMu ([mu ingestMu mu mu])
```

Deliberately a source check, not a lock abstraction — there are two mutexes and two functions that take them; wrapping that in an enforced-ordering type would be larger than the problem and would itself need to be trusted.

## Tests

Cancellation before the core → core still usable, next chunk succeeds. Cancellation inside → retired, core not entered again. The ring's own deadline reported as `ErrCoreTimeout` while still carrying `context.DeadlineExceeded`. Every failure class, including an unnamed one, in a table. `SetTargetProgram` in both positions. All #888 invariants unchanged.

No context-free escape hatch: both production callers pass their real lifecycle context (pipeline's and the variant worker's), and ~150 test call sites were migrated rather than shimmed.

## Out of scope, per plan

No process, no socket, no IPC, no handshake, no supervisor, no parser migration. Those implement this contract; they do not get to define it.

## Test environment

```
macOS:            yes — go build, go test ./..., race gate, lint, measurements
Linux LXC amd64:  no  — nothing runtime-facing changed; no Docker/sidecar claim
Docker:           n/a
real VU+:         n/a
```

**Untested production paths:** none new — this changes no runtime behaviour for a working core. The first behaviour that needs the LXC is step 3, when a real process is on the other end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
