### PR TITLE
feat(mediafacts): the audio shadow's latency cannot reach the authoritative ingest path (4b.2a)

### DIFF
--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -202,12 +202,21 @@ type audioShadowRunner struct {
 	errors     atomic.Uint64
 
 	// retired is read on the capture path for every audio packet of every chunk,
-	// which is the other reason none of this is behind the mutex.
+	// which is why it is an atomic and not something the lock below has to be
+	// taken for.
 	retired atomic.Bool
-	// retireOnce guards the one state transition there is. Whoever reaches it
-	// first decides what the end was - a failure, a full queue, or a Close - and
-	// everyone after it adds nothing.
-	retireOnce sync.Once
+
+	// lifecycle pairs the two things that must be one decision: putting work in
+	// the queue, and ending the comparison. Checking a flag and then sending are
+	// two moments, and a producer that passed the check before a retirement would
+	// otherwise land a chunk's audio in a channel nobody will read again.
+	//
+	// It is worth naming for what it is not. It is never held across ObserveAudio,
+	// a comparison, or a mismatch being recorded, and it never nests with mu. The
+	// longest a producer can wait on it is one channel send and at most
+	// audioShadowQueueDepth non-blocking receives - local instructions, never the
+	// speed of the shadow.
+	lifecycle sync.Mutex
 
 	mu     sync.Mutex
 	recent []AudioShadowMismatch
@@ -252,10 +261,12 @@ func (r *audioShadowRunner) Close() {
 	// Through the same door as a retirement, so a shutdown does not also get
 	// counted as a failure - and so a shadow erroring out on its way to the exit
 	// does not add one either. Whatever ended it first is what the report says.
-	r.retireOnce.Do(func() {
-		r.retired.Store(true)
-		r.cancel()
-	})
+	r.lifecycle.Lock()
+	r.retireLocked(false)
+	r.lifecycle.Unlock()
+	// Waited for with the lock released. The worker takes it to retire itself,
+	// and a Close holding it while waiting for that worker to finish would be
+	// waiting for something it had made impossible.
 	<-r.done
 }
 
@@ -283,7 +294,19 @@ func (r *audioShadowRunner) run(ctx context.Context) {
 // are stateful, so a missing batch makes every later one a comparison against a
 // stream the shadow never saw - agreement and disagreement would both stop
 // meaning anything. So the queue filling up ends the comparison instead.
+//
+// The send is under the lifecycle lock, and so is every retirement it can race
+// with. An unlocked check followed by an unlocked send is two moments: a
+// producer can pass "not retired yet", a worker can retire and empty the queue
+// in between, and the send then lands in a channel that will never be read -
+// one chunk's owned audio, held for as long as the core holds the runner.
 func (r *audioShadowRunner) offer(work audioShadowWork) {
+	if r.retired.Load() {
+		return
+	}
+	r.lifecycle.Lock()
+	defer r.lifecycle.Unlock()
+	// Again, now that the answer cannot change underneath the send.
 	if r.retired.Load() {
 		return
 	}
@@ -291,27 +314,57 @@ func (r *audioShadowRunner) offer(work audioShadowWork) {
 	case r.queue <- work:
 		r.batches.Add(uint64(len(work.batches)))
 	default:
-		r.retire()
+		// Still holding the lock. The retirement a failed send causes has to be
+		// the same moment as the send, or the queue it empties could be refilled
+		// by the offer immediately behind it.
+		r.retireLocked(true)
 	}
 }
 
 // retire ends the comparison for good, once, whichever side noticed first.
+func (r *audioShadowRunner) retire() {
+	r.lifecycle.Lock()
+	defer r.lifecycle.Unlock()
+	r.retireLocked(true)
+}
+
+// retireLocked is the one state transition there is, and the only place the
+// queue is emptied. The caller holds lifecycle.
 //
 // Once, because Errors is not "how many things went wrong" but "the comparison
 // stopped, and this is the reason": a shadow that failed while the queue behind
-// it filled up is one retirement. The error is counted before the flag is
-// raised, so anything that sees the comparison stopped also sees why.
+// it filled up is one retirement. counted is false for a Close, which ends the
+// comparison without anything having gone wrong. The error is counted before the
+// flag is raised, so anything that sees the comparison stopped also sees why.
 //
-// And it cancels. A retirement decided on the producer side - a full queue -
-// must reach a worker that is already inside a call, or the comparison would be
-// over while the goroutine ran on. Cancelling is how it reaches it, and
-// cancelling never blocks, which is why this is safe to call from Ingest.
-func (r *audioShadowRunner) retire() {
-	r.retireOnce.Do(func() {
+// It cancels. A retirement decided on the producer side - a full queue - must
+// reach a worker that is already inside a call, or the comparison would be over
+// while the goroutine ran on. Cancelling is how it reaches it, and cancelling
+// never blocks, which is why this is safe to reach from Ingest.
+//
+// And it empties the queue, which is not the same thing as dropping a batch. A
+// dropped batch would be a hole in a stateful comparison that carries on either
+// side of it; this is the comparison ending, after which those work items have
+// no future at all. Nothing will ever hold them against a reference. Left in the
+// channel they would keep several chunks of copied audio reachable for as long
+// as the core keeps the runner - so the worse the shadow behaved, the more
+// memory its corpse would hold.
+func (r *audioShadowRunner) retireLocked(counted bool) {
+	if r.retired.Load() {
+		return
+	}
+	if counted {
 		r.errors.Add(1)
-		r.retired.Store(true)
-		r.cancel()
-	})
+	}
+	r.retired.Store(true)
+	r.cancel()
+	for {
+		select {
+		case <-r.queue:
+		default:
+			return
+		}
+	}
 }
 
 func (r *audioShadowRunner) snapshot() AudioShadowReport {
@@ -402,8 +455,9 @@ func (c *GoCore) SetAudioShadow(shadow AudioShadow) {
 
 // CloseAudioShadow ends the comparison and the goroutine behind it.
 //
-// Bounded: it does not wait for the shadow to come back. See
-// (*audioShadowRunner).Close.
+// It waits for the worker to have terminated, and is bounded by the AudioShadow
+// cancellation contract and by nothing else: it never waits for a shadow to
+// finish work it has not been cancelled out of. See (*audioShadowRunner).Close.
 func (c *GoCore) CloseAudioShadow() {
 	if c.shadowRunner != nil {
 		c.shadowRunner.Close()

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -6,6 +6,8 @@ package mediafacts
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
 )
@@ -18,8 +20,9 @@ import (
 // call and skips frame payload that ran past the end of one, so the same bytes
 // concatenated would be a different input and agreement on it would prove less.
 //
-// The slices point into the chunk the core was handed. They are valid for the
-// duration of the call that produced them and must not be retained past it.
+// The bytes a shadow receives are the shadow's own. They are copied out of the
+// core's chunk before the batch leaves the ingest call, because the chunk does
+// not outlive that call and the shadow may run long after it.
 type AudioShadowBatch struct {
 	PID   uint16
 	Epoch uint64
@@ -37,12 +40,13 @@ type AudioShadowObservation struct {
 //
 // It is given every batch from one chunk, in the order they happened, and
 // answers what it made of them. It is asked, never obeyed: nothing it returns
-// reaches a fact, an event or the control flow of the core. What it is for is
-// the comparison.
+// reaches a fact, an event or the control flow of the core.
+//
+// It is also never waited for. Calls arrive on a worker of the core's own, one
+// chunk at a time and never concurrently, and however long one takes is the
+// worker's problem alone - the ingest that produced the batches has long
+// returned.
 type AudioShadow interface {
-	// ObserveAudio is called once per chunk that produced any audio, after the
-	// chunk has been interpreted. An error retires the shadow for the lifetime of
-	// the core - see (*GoCore).runAudioShadow for why there is no second chance.
 	ObserveAudio(ctx context.Context, batches []AudioShadowBatch) ([]AudioShadowObservation, error)
 }
 
@@ -61,7 +65,9 @@ type AudioShadowMismatch struct {
 // per comparison is not something anyone reads, and a count that stops rising is
 // something a dashboard can see.
 type AudioShadowReport struct {
-	// Batches is how many stream-and-epoch runs have been handed over.
+	// Batches is how many stream-and-epoch runs have been accepted for
+	// comparison. Accepted, not handed over: a chunk that arrived at a full queue
+	// is not in here, and is the last thing that happens before Disabled.
 	Batches uint64
 	// Compared is how many observations were held against the core's own answer.
 	// Every batch has one, including a batch from an epoch that ended inside the
@@ -70,53 +76,265 @@ type AudioShadowReport struct {
 	Compared uint64
 	// Mismatches counts comparisons that disagreed about anything.
 	Mismatches uint64
-	// Errors counts failures of the shadow itself.
+	// Errors counts why the comparison stopped, and stops at one. A shadow that
+	// failed and a queue that filled up behind it are one retirement, not two.
 	Errors uint64
 	// Disabled reports that the shadow has been retired and will not be called
 	// again.
 	Disabled bool
-	// Recent holds the last few mismatches, oldest first, for whoever is looking
-	// at why the counter moved.
+	// Recent holds the last few mismatches, oldest first.
 	Recent []AudioShadowMismatch
-}
-
-// pendingAudioShadowBatch is a batch and the core's own answer to it.
-//
-// The reference is frozen here rather than read back later, because "later" may
-// be after the observer that produced it has been thrown away: a PMT change can
-// end an epoch half way through a chunk, and the batch from before it is exactly
-// the one a PID-reuse bug would show up in. Comparing only what is still alive at
-// the end of the chunk would skip it - and a shadow that gets the ended epoch
-// wrong and the current one right would report no disagreement at all.
-//
-// The reference never leaves this process. A shadow is asked what it made of the
-// bytes, not asked to agree with an answer it was given.
-type pendingAudioShadowBatch struct {
-	Batch     AudioShadowBatch
-	Reference esaudio.Observation
 }
 
 // recentMismatches is how many disagreements are kept. Enough to see a pattern,
 // few enough that a stream disagreeing about every chunk cannot grow memory.
 const recentMismatches = 8
 
-// SetAudioShadow attaches a second observer to this core.
+// audioShadowQueueDepth is how many chunks may be waiting for the shadow.
+//
+// Small on purpose. A shadow that is a few chunks behind is a shadow that will
+// not catch up - chunks arrive for as long as the session runs - and a deep
+// queue would only delay noticing that, while holding a copy of every chunk's
+// audio in the meantime.
+const audioShadowQueueDepth = 4
+
+// pendingAudioShadowBatch is a batch and the core's own answer to it.
+//
+// The reference is frozen here rather than read back later, because "later" may
+// be after the observer that produced it has been thrown away: a PMT change can
+// end an epoch half way through a chunk, and the batch from before it is exactly
+// the one a PID-reuse bug would show up in.
+//
+// The reference never leaves this process. It travels with the work item to the
+// worker; a shadow is asked what it made of the bytes, not asked to agree with
+// an answer it was given.
+type pendingAudioShadowBatch struct {
+	Batch     AudioShadowBatch
+	Reference esaudio.Observation
+}
+
+// audioShadowWork is one chunk's worth of comparison, owning its bytes.
+type audioShadowWork struct {
+	batches    []AudioShadowBatch
+	references []esaudio.Observation
+}
+
+// audioShadowRunner is the shadow, its queue and the one goroutine that drives
+// it.
+//
+// The whole point of this type is that nothing in it is on the authoritative
+// path. Ingest copies the audio it captured, offers it to the queue without
+// waiting, and returns; whether the shadow is fast, slow, hung or broken can
+// change how much of the comparison happens, and nothing else.
+//
+// Which is why the counters are atomics rather than fields of a report behind
+// the mutex. The mutex is held while the worker records a disagreement, and an
+// ingest that waits on it - however briefly - has the worker's speed back inside
+// its own duration. What is left under the mutex is the mismatch ring alone,
+// which the ingest path never touches.
+type audioShadowRunner struct {
+	shadow AudioShadow
+	queue  chan audioShadowWork
+
+	batches    atomic.Uint64
+	compared   atomic.Uint64
+	mismatches atomic.Uint64
+	errors     atomic.Uint64
+
+	// retired is read on the capture path for every audio packet of every chunk,
+	// which is the other reason none of this is behind the mutex.
+	retired    atomic.Bool
+	retireOnce sync.Once
+
+	mu     sync.Mutex
+	recent []AudioShadowMismatch
+
+	cancel   context.CancelFunc
+	stopOnce sync.Once
+	stop     chan struct{}
+	// done is closed when the worker goroutine has actually ended, which is not
+	// the moment Close returns: a shadow that ignores the context it was given
+	// holds the goroutine until it comes back. Nothing on the ingest path waits
+	// for this - it is how a test can tell "the caller was let go" apart from
+	// "the goroutine ended".
+	done chan struct{}
+}
+
+func newAudioShadowRunner(shadow AudioShadow) *audioShadowRunner {
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &audioShadowRunner{
+		shadow: shadow,
+		queue:  make(chan audioShadowWork, audioShadowQueueDepth),
+		cancel: cancel,
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	go r.run(ctx)
+	return r
+}
+
+// Close stops the runner without waiting for it.
+//
+// Bounded by construction: it signals and returns. A shadow that respects the
+// context it was given comes back at once and the goroutine ends; one that
+// ignores it ends the goroutine whenever it finally returns - and until then it
+// is a goroutine sitting in somebody else's code, not a caller being held up.
+func (r *audioShadowRunner) Close() {
+	r.stopOnce.Do(func() {
+		r.cancel()
+		close(r.stop)
+	})
+}
+
+func (r *audioShadowRunner) run(ctx context.Context) {
+	defer close(r.done)
+	for {
+		select {
+		case <-r.stop:
+			return
+		case work := <-r.queue:
+			r.process(ctx, work)
+		}
+	}
+}
+
+// offer hands one chunk's work to the queue without ever waiting for room.
+//
+// A full queue is not a batch to drop and carry on from. The shadow's observers
+// are stateful, so a missing batch makes every later one a comparison against a
+// stream the shadow never saw - agreement and disagreement would both stop
+// meaning anything. So the queue filling up ends the comparison instead.
+func (r *audioShadowRunner) offer(work audioShadowWork) {
+	if r.retired.Load() {
+		return
+	}
+	select {
+	case r.queue <- work:
+		r.batches.Add(uint64(len(work.batches)))
+	default:
+		r.retire()
+	}
+}
+
+// retire ends the comparison for good, once, whichever side noticed first.
+//
+// Once, because Errors is not "how many things went wrong" but "the comparison
+// stopped, and this is the reason": a shadow that failed while the queue behind
+// it filled up is one retirement. The error is counted before the flag is
+// raised, so anything that sees the comparison stopped also sees why.
+func (r *audioShadowRunner) retire() {
+	r.retireOnce.Do(func() {
+		r.errors.Add(1)
+		r.retired.Store(true)
+	})
+}
+
+func (r *audioShadowRunner) snapshot() AudioShadowReport {
+	out := AudioShadowReport{
+		Batches:    r.batches.Load(),
+		Compared:   r.compared.Load(),
+		Mismatches: r.mismatches.Load(),
+		Errors:     r.errors.Load(),
+		Disabled:   r.retired.Load(),
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out.Recent = append([]AudioShadowMismatch(nil), r.recent...)
+	return out
+}
+
+// process runs one chunk's comparison.
+func (r *audioShadowRunner) process(ctx context.Context, work audioShadowWork) {
+	if r.retired.Load() {
+		return
+	}
+	observations, err := r.shadow.ObserveAudio(ctx, work.batches)
+	if err != nil {
+		r.retire()
+		return
+	}
+
+	// The answer is checked before any of it is believed. An answer that is
+	// missing, extra, reordered or labelled with somebody else's stream is not a
+	// smaller comparison - it is a shadow that has lost track of what it was
+	// asked, and every remaining number it produces is about an unknown stream.
+	if len(observations) != len(work.batches) {
+		r.retire()
+		return
+	}
+	for i := range observations {
+		if observations[i].PID != work.batches[i].PID || observations[i].Epoch != work.batches[i].Epoch {
+			r.retire()
+			return
+		}
+	}
+
+	for i, o := range observations {
+		reference := work.references[i]
+		r.compared.Add(1)
+		fields := esaudio.Compare(reference, o.Observation)
+		if len(fields) == 0 {
+			continue
+		}
+		r.mismatches.Add(1)
+		r.recordMismatch(AudioShadowMismatch{
+			PID:       o.PID,
+			Epoch:     o.Epoch,
+			Fields:    fields,
+			Reference: reference,
+			Shadow:    o.Observation,
+		})
+	}
+}
+
+func (r *audioShadowRunner) recordMismatch(m AudioShadowMismatch) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recent = append(r.recent, m)
+	if len(r.recent) > recentMismatches {
+		r.recent = r.recent[len(r.recent)-recentMismatches:]
+	}
+}
+
+// SetAudioShadow attaches a second observer to this core, replacing any before
+// it.
 //
 // Deliberately not part of the Core interface and not on the constructor: a
 // shadow is something an operator turns on for a migration, not part of what a
 // core is. A core without one behaves exactly as it did before this existed,
 // down to not capturing the feeds.
+//
+// It starts a goroutine, so whoever attaches a shadow owns ending it:
+// CloseAudioShadow, or another SetAudioShadow, or SetAudioShadow(nil).
 func (c *GoCore) SetAudioShadow(shadow AudioShadow) {
-	c.shadow = shadow
-	c.shadowBatches = nil
-	c.shadowReport = AudioShadowReport{}
+	c.CloseAudioShadow()
+	c.clearAudioShadowBatches()
+	if shadow == nil {
+		return
+	}
+	c.shadowRunner = newAudioShadowRunner(shadow)
+}
+
+// CloseAudioShadow ends the comparison and the goroutine behind it.
+//
+// Bounded: it does not wait for the shadow to come back. See
+// (*audioShadowRunner).Close.
+func (c *GoCore) CloseAudioShadow() {
+	if c.shadowRunner != nil {
+		c.shadowRunner.Close()
+		c.shadowRunner = nil
+	}
 }
 
 // AudioShadowReport returns what the shadow has been doing so far.
+//
+// Safe to call while the worker is running: the counters are the worker's and
+// this is a copy of them.
 func (c *GoCore) AudioShadowReport() AudioShadowReport {
-	out := c.shadowReport
-	out.Recent = append([]AudioShadowMismatch(nil), c.shadowReport.Recent...)
-	return out
+	if c.shadowRunner == nil {
+		return AudioShadowReport{}
+	}
+	return c.shadowRunner.snapshot()
 }
 
 // captureAudioShadowFeedLocked records one feed exactly as the core's own
@@ -127,7 +345,7 @@ func (c *GoCore) AudioShadowReport() AudioShadowReport {
 // side of it belong to different elementary streams that merely share a number.
 // Folding them together would hand the shadow a stream that never existed.
 func (c *GoCore) captureAudioShadowFeedLocked(pid uint16, es []byte, observer *esaudio.Observer) {
-	if c.shadow == nil || c.shadowReport.Disabled || len(es) == 0 {
+	if c.shadowRunner == nil || c.shadowRunner.retired.Load() || len(es) == 0 {
 		return
 	}
 	for i := len(c.shadowBatches) - 1; i >= 0; i-- {
@@ -168,84 +386,47 @@ func (c *GoCore) clearAudioShadowBatches() {
 	c.shadowBatches = c.shadowBatches[:0]
 }
 
-// runAudioShadow hands the chunk's batches over and compares what comes back.
+// handOffAudioShadow copies the chunk's audio and offers it to the worker.
 //
-// Everything in here is best effort in one direction only: it reads the core's
-// state and writes nothing back to it. A shadow that fails, hangs past its
-// caller's deadline, or answers nonsense changes no fact, no event and no error
-// this core returns - the only thing it can change is whether it is asked again.
+// This is the only part of the comparison that is still on the authoritative
+// path, and it is the part that has to be: the captured feeds point into the
+// chunk, and the chunk is gone the moment Ingest returns. So the bytes are
+// copied here, once, into a single buffer per chunk - the feed boundaries are
+// preserved as offsets into it, because those boundaries are the input.
 //
-// And it is not asked again. A shadow that failed once is a second
-// implementation that is now in an unknown state, and the useful thing to
-// report from that point on is "the comparison stopped", not a stream of
-// disagreements between a working observer and a broken one. Reviving it would
-// also be the transparent restart the process contract already refuses.
-func (c *GoCore) runAudioShadow(ctx context.Context) {
-	// Not cleared here. Ingest clears on every way out, including the ones that
-	// never reach this function, and dropping the length early would hide the
-	// elements that still have to be zeroed from that cleanup.
-	pending := c.shadowBatches
-
-	if c.shadow == nil || c.shadowReport.Disabled || len(pending) == 0 {
-		return
-	}
-	c.shadowReport.Batches += uint64(len(pending))
-
-	batches := make([]AudioShadowBatch, len(pending))
-	for i := range pending {
-		batches[i] = pending[i].Batch
-	}
-
-	observations, err := c.shadow.ObserveAudio(ctx, batches)
-	if err != nil {
-		c.retireAudioShadow()
+// Every feed is capped at its own end. A shadow that appends to one of them gets
+// a copy rather than the next feed's first bytes, which is the kind of thing
+// that would otherwise show up as the other implementation disagreeing.
+//
+// Then the work is offered without waiting. Nothing after this line is allowed
+// to affect how long this call takes.
+func (c *GoCore) handOffAudioShadow() {
+	if c.shadowRunner == nil || c.shadowRunner.retired.Load() || len(c.shadowBatches) == 0 {
 		return
 	}
 
-	// The answer is checked before any of it is believed. An answer that is
-	// missing, extra, reordered or labelled with somebody else's stream is not a
-	// smaller comparison - it is a shadow that has lost track of what it was
-	// asked, and every remaining number it produces is about an unknown stream.
-	if len(observations) != len(batches) {
-		c.retireAudioShadow()
-		return
-	}
-	for i := range observations {
-		if observations[i].PID != batches[i].PID || observations[i].Epoch != batches[i].Epoch {
-			c.retireAudioShadow()
-			return
+	total := 0
+	for i := range c.shadowBatches {
+		for _, f := range c.shadowBatches[i].Batch.Feeds {
+			total += len(f)
 		}
 	}
+	owned := make([]byte, 0, total)
 
-	for i, o := range observations {
-		reference := pending[i].Reference
-		c.shadowReport.Compared++
-		fields := esaudio.Compare(reference, o.Observation)
-		if len(fields) == 0 {
-			continue
-		}
-		c.shadowReport.Mismatches++
-		c.shadowReport.Recent = append(c.shadowReport.Recent, AudioShadowMismatch{
-			PID:       o.PID,
-			Epoch:     o.Epoch,
-			Fields:    fields,
-			Reference: reference,
-			Shadow:    o.Observation,
-		})
-		if len(c.shadowReport.Recent) > recentMismatches {
-			c.shadowReport.Recent = c.shadowReport.Recent[len(c.shadowReport.Recent)-recentMismatches:]
-		}
+	work := audioShadowWork{
+		batches:    make([]AudioShadowBatch, len(c.shadowBatches)),
+		references: make([]esaudio.Observation, len(c.shadowBatches)),
 	}
-}
-
-// retireAudioShadow ends the comparison for the lifetime of this core.
-//
-// A shadow that failed once is a second implementation in an unknown state, and
-// the useful thing to report from here on is "the comparison stopped", not a
-// stream of disagreements between a working observer and a broken one. Reviving
-// it would also be the transparent restart the process contract already refuses.
-func (c *GoCore) retireAudioShadow() {
-	c.shadowReport.Errors++
-	// One flag, read everywhere: the report is the state, not a copy of it.
-	c.shadowReport.Disabled = true
+	for i := range c.shadowBatches {
+		src := c.shadowBatches[i].Batch
+		feeds := make([][]byte, len(src.Feeds))
+		for j, f := range src.Feeds {
+			start := len(owned)
+			owned = append(owned, f...)
+			feeds[j] = owned[start:len(owned):len(owned)]
+		}
+		work.batches[i] = AudioShadowBatch{PID: src.PID, Epoch: src.Epoch, Feeds: feeds}
+		work.references[i] = c.shadowBatches[i].Reference
+	}
+	c.shadowRunner.offer(work)
 }

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -85,6 +85,9 @@ type AudioShadowReport struct {
 	// Batches is how many stream-and-epoch runs have been accepted for
 	// comparison. Accepted, not handed over: a chunk that arrived at a full queue
 	// is not in here, and is the last thing that happens before Disabled.
+	//
+	// Counted before the work carrying it is put where the worker can reach it,
+	// which is what keeps Compared from ever running ahead of it.
 	Batches uint64
 	// Compared is how many observations were held against the core's own answer.
 	// Every batch has one, including a batch from an epoch that ended inside the
@@ -302,6 +305,11 @@ func (r *audioShadowRunner) run(ctx context.Context) {
 // producer can pass "not retired yet", a worker can retire and empty the queue
 // in between, and the send then lands in a channel that will never be read -
 // one chunk's owned audio, held for as long as the core holds the runner.
+//
+// Room is looked for rather than found out about, which is what a send inside a
+// select cannot do: there is no point between choosing the send and performing
+// it where the count could be published, and a count published after the work is
+// a count the worker's own can already have run past.
 func (r *audioShadowRunner) offer(work audioShadowWork) {
 	if r.retired.Load() {
 		return
@@ -312,15 +320,35 @@ func (r *audioShadowRunner) offer(work audioShadowWork) {
 	if r.retired.Load() {
 		return
 	}
-	select {
-	case r.queue <- work:
-		r.batches.Add(uint64(len(work.batches)))
-	default:
-		// Still holding the lock. The retirement a failed send causes has to be
-		// the same moment as the send, or the queue it empties could be refilled
+	// The room seen here is still there below. Offers are the only senders and
+	// this lock serialises them; the one thing that empties the queue behind a
+	// producer's back is a retirement, and that is under this lock too. What is
+	// left is a worker that only ever receives - so between the check and the
+	// send the queue can grow emptier, never fuller, and the send cannot block.
+	if len(r.queue) == cap(r.queue) {
+		// Still holding the lock. The retirement a full queue causes has to be
+		// the same moment as the check, or the queue it empties could be refilled
 		// by the offer immediately behind it.
 		r.retireLocked(true)
+		return
 	}
+	r.publishLocked(work)
+}
+
+// publishLocked counts the work and then hands it over, in that order.
+//
+// The order is the whole of it, which is why it is a function and not two
+// statements at the end of offer. Batches is what the report says was accepted,
+// and the worker starts raising Compared the moment it can reach the work - so a
+// count published after the send is a count that a comparison of the very work
+// it has not counted yet can already be ahead of, and the report would say more
+// comparisons happened than there was work to compare.
+//
+// The caller holds lifecycle and has established that the queue has room. The
+// send is unconditional and must not be reached without that.
+func (r *audioShadowRunner) publishLocked(work audioShadowWork) {
+	r.batches.Add(uint64(len(work.batches)))
+	r.queue <- work
 }
 
 // retire ends the comparison for good, once, whichever side noticed first.

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -42,10 +42,27 @@ type AudioShadowObservation struct {
 // answers what it made of them. It is asked, never obeyed: nothing it returns
 // reaches a fact, an event or the control flow of the core.
 //
-// It is also never waited for. Calls arrive on a worker of the core's own, one
-// chunk at a time and never concurrently, and however long one takes is the
-// worker's problem alone - the ingest that produced the batches has long
-// returned.
+// It is also never waited for by the ingest path. Calls arrive on a worker of
+// the core's own, one chunk at a time and never concurrently, and however long
+// one takes is the worker's problem alone - the ingest that produced the batches
+// has long returned.
+//
+// One thing is required rather than tolerated:
+//
+//	ObserveAudio MUST return when ctx is cancelled.
+//
+// This is the only lever anything has over a call in progress. Go cannot end a
+// goroutine sitting inside an interface method from the outside, so an
+// implementation that ignores its context cannot be shut down at all - not
+// bounded, not eventually, not by anyone. Everything below that says "the worker
+// ends" says it on the strength of this line.
+//
+// An implementation that reaches another process owns enforcing it locally, and
+// may not assume the peer cooperates: a sidecar that never replies, or that
+// ignores a cancellation of its own, must still not keep ObserveAudio from
+// returning. That is a socket deadline and a connection this side can tear down,
+// not a request the far end is trusted to honour. The RemoteAudioShadow of 4b.2b
+// is where that has to be proven; nothing here can prove it for it.
 type AudioShadow interface {
 	ObserveAudio(ctx context.Context, batches []AudioShadowBatch) ([]AudioShadowObservation, error)
 }
@@ -96,6 +113,24 @@ const recentMismatches = 8
 // not catch up - chunks arrive for as long as the session runs - and a deep
 // queue would only delay noticing that, while holding a copy of every chunk's
 // audio in the meantime.
+//
+// What that costs, exactly, because "bounded" on its own is not a number:
+//
+//	live work items       = audioShadowQueueDepth + 1 in the worker's hand = 5
+//	largest chunk C       = the normalizer's staging capacity, 4 MiB by default;
+//	                        it is what one egress tick can hand the ring
+//	worst-case bytes/item = every packet of the chunk carrying audio payload:
+//	                        184/188*C copied + a 24 byte slice header per feed
+//	                        (one feed per packet, 24/188*C) = 208/188*C = 1.106*C
+//	                        plus 64 bytes per stream-and-epoch in the chunk,
+//	                        which the PMT bounds and rounding already covers
+//	worst-case per core    = 5 * 1.106 * 4 MiB = 22.1 MiB
+//
+// Retained, not allocated: the allocation volume of a run is larger and is a
+// different question. This is what a core with a shadow attached can be holding
+// at one instant, and it is reached only by a stream that is audio and nothing
+// else with the worker fully stalled - at which point the next chunk retires the
+// comparison and it all becomes garbage.
 const audioShadowQueueDepth = 4
 
 // pendingAudioShadowBatch is a batch and the core's own answer to it.
@@ -132,6 +167,11 @@ type audioShadowWork struct {
 // ingest that waits on it - however briefly - has the worker's speed back inside
 // its own duration. What is left under the mutex is the mismatch ring alone,
 // which the ingest path never touches.
+//
+// The runner owns a context for the shadow's whole lifetime, and every end of
+// the comparison cancels it. That is what lets the producer side finish a
+// retirement without waiting for anything: cancelling is not a handshake, and
+// the worker is woken by its own context rather than by anybody watching it.
 type audioShadowRunner struct {
 	shadow AudioShadow
 	queue  chan audioShadowWork
@@ -143,20 +183,21 @@ type audioShadowRunner struct {
 
 	// retired is read on the capture path for every audio packet of every chunk,
 	// which is the other reason none of this is behind the mutex.
-	retired    atomic.Bool
+	retired atomic.Bool
+	// retireOnce guards the one state transition there is. Whoever reaches it
+	// first decides what the end was - a failure, a full queue, or a Close - and
+	// everyone after it adds nothing.
 	retireOnce sync.Once
 
 	mu     sync.Mutex
 	recent []AudioShadowMismatch
 
-	cancel   context.CancelFunc
-	stopOnce sync.Once
-	stop     chan struct{}
-	// done is closed when the worker goroutine has actually ended, which is not
-	// the moment Close returns: a shadow that ignores the context it was given
-	// holds the goroutine until it comes back. Nothing on the ingest path waits
-	// for this - it is how a test can tell "the caller was let go" apart from
-	// "the goroutine ended".
+	// cancel ends the shadow's context. Non-blocking, callable from anywhere, and
+	// the only thing that can reach a call already in progress.
+	cancel context.CancelFunc
+	// done is closed when the worker goroutine has ended. Close waits on it, so
+	// that "the comparison is over" and "the goroutine is gone" are the same
+	// moment for every shadow that keeps the contract above.
 	done chan struct{}
 }
 
@@ -166,31 +207,49 @@ func newAudioShadowRunner(shadow AudioShadow) *audioShadowRunner {
 		shadow: shadow,
 		queue:  make(chan audioShadowWork, audioShadowQueueDepth),
 		cancel: cancel,
-		stop:   make(chan struct{}),
 		done:   make(chan struct{}),
 	}
 	go r.run(ctx)
 	return r
 }
 
-// Close stops the runner without waiting for it.
+// Close ends the comparison and does not come back until the worker is gone.
 //
-// Bounded by construction: it signals and returns. A shadow that respects the
-// context it was given comes back at once and the goroutine ends; one that
-// ignores it ends the goroutine whenever it finally returns - and until then it
-// is a goroutine sitting in somebody else's code, not a caller being held up.
+// Cancel, then wait. The wait is what makes this a shutdown rather than an
+// announcement: without it Close would return while a goroutine of ours was
+// still inside somebody else's code, and "no leaked workers" would be a hope
+// instead of a postcondition.
+//
+// Bounded for every shadow that keeps the AudioShadow contract, and for no
+// other. One that never returns from a cancelled ObserveAudio hangs this call -
+// deliberately, because the alternative is to walk away from a goroutine that
+// cannot be accounted for and call it clean. The hang names the shadow that
+// broke the contract; the walk-away would name nothing.
+//
+// It is not on the ingest path and never becomes one: retiring the comparison
+// from a full queue cancels, and does not wait.
 func (r *audioShadowRunner) Close() {
-	r.stopOnce.Do(func() {
+	// Through the same door as a retirement, so a shutdown does not also get
+	// counted as a failure - and so a shadow erroring out on its way to the exit
+	// does not add one either. Whatever ended it first is what the report says.
+	r.retireOnce.Do(func() {
+		r.retired.Store(true)
 		r.cancel()
-		close(r.stop)
 	})
+	<-r.done
 }
 
 func (r *audioShadowRunner) run(ctx context.Context) {
 	defer close(r.done)
 	for {
+		// Checked before the select rather than left to it: once the comparison is
+		// over, what is still queued is work whose answer nobody may believe, and
+		// draining it would be a race against ctx.Done for no reason.
+		if r.retired.Load() {
+			return
+		}
 		select {
-		case <-r.stop:
+		case <-ctx.Done():
 			return
 		case work := <-r.queue:
 			r.process(ctx, work)
@@ -222,10 +281,16 @@ func (r *audioShadowRunner) offer(work audioShadowWork) {
 // stopped, and this is the reason": a shadow that failed while the queue behind
 // it filled up is one retirement. The error is counted before the flag is
 // raised, so anything that sees the comparison stopped also sees why.
+//
+// And it cancels. A retirement decided on the producer side - a full queue -
+// must reach a worker that is already inside a call, or the comparison would be
+// over while the goroutine ran on. Cancelling is how it reaches it, and
+// cancelling never blocks, which is why this is safe to call from Ingest.
 func (r *audioShadowRunner) retire() {
 	r.retireOnce.Do(func() {
 		r.errors.Add(1)
 		r.retired.Store(true)
+		r.cancel()
 	})
 }
 

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -273,9 +273,11 @@ func (r *audioShadowRunner) Close() {
 func (r *audioShadowRunner) run(ctx context.Context) {
 	defer close(r.done)
 	for {
-		// Checked before the select rather than left to it: once the comparison is
-		// over, what is still queued is work whose answer nobody may believe, and
-		// draining it would be a race against ctx.Done for no reason.
+		// Checked before the select rather than left to it. Draining is not this
+		// loop's job: the retirement path empties the queue under lifecycle, and no
+		// later offer can refill it. So by the time this is visible, nothing queued
+		// has a semantic future and nothing is left to collect - the worker's only
+		// remaining job is to stop being a goroutine.
 		if r.retired.Load() {
 			return
 		}

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -369,18 +369,43 @@ func (r *audioShadowRunner) retireLocked(counted bool) {
 	}
 }
 
+// snapshot reads the counters in the reverse of the order the worker writes
+// them, which is the difference between a report that lags and one that lies.
+//
+// The worker writes batches, then compared, then mismatches, then the ring; and
+// errors, then the retired flag. Reading in that same order lets a snapshot
+// catch the second write of a pair without the first: Disabled true beside
+// Errors zero, which the retirement comment says cannot happen, or a mismatch
+// counted with an empty ring beside it. Reading backwards inverts that. Seeing
+// the later write now implies seeing the earlier one, so a field can only be
+// behind, never ahead of, the fields written before it.
+//
+// The statements are separate on purpose. As a struct literal the order is real
+// but invisible, and the next edit would reorder the fields for tidiness and
+// quietly take the guarantee away.
+//
+// What this does not do is make any two fields consistent for a reader that
+// wants them to be: a caller polling one field and asserting on another still
+// has to ask for both in the same snapshot. See awaitShadow in the tests.
 func (r *audioShadowRunner) snapshot() AudioShadowReport {
-	out := AudioShadowReport{
-		Batches:    r.batches.Load(),
-		Compared:   r.compared.Load(),
-		Mismatches: r.mismatches.Load(),
-		Errors:     r.errors.Load(),
-		Disabled:   r.retired.Load(),
-	}
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	out.Recent = append([]AudioShadowMismatch(nil), r.recent...)
-	return out
+	recent := append([]AudioShadowMismatch(nil), r.recent...)
+	r.mu.Unlock()
+
+	disabled := r.retired.Load()
+	mismatches := r.mismatches.Load()
+	compared := r.compared.Load()
+	batches := r.batches.Load()
+	errors := r.errors.Load()
+
+	return AudioShadowReport{
+		Batches:    batches,
+		Compared:   compared,
+		Mismatches: mismatches,
+		Errors:     errors,
+		Disabled:   disabled,
+		Recent:     recent,
+	}
 }
 
 // process runs one chunk's comparison.

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -114,23 +114,43 @@ const recentMismatches = 8
 // queue would only delay noticing that, while holding a copy of every chunk's
 // audio in the meantime.
 //
-// What that costs, exactly, because "bounded" on its own is not a number:
+// What that costs, exactly, because "bounded" on its own is not a number.
 //
-//	live work items       = audioShadowQueueDepth + 1 in the worker's hand = 5
-//	largest chunk C       = the normalizer's staging capacity, 4 MiB by default;
-//	                        it is what one egress tick can hand the ring
-//	worst-case bytes/item = every packet of the chunk carrying audio payload:
-//	                        184/188*C copied + a 24 byte slice header per feed
-//	                        (one feed per packet, 24/188*C) = 208/188*C = 1.106*C
-//	                        plus 64 bytes per stream-and-epoch in the chunk,
-//	                        which the PMT bounds and rounding already covers
-//	worst-case per core    = 5 * 1.106 * 4 MiB = 22.1 MiB
+// A logical payload-and-metadata upper bound, and deliberately not called a heap
+// or RSS ceiling: every term below is a structure this code builds, and none of
+// them accounts for what the allocator rounds a size class up to, or for the
+// capacity an append leaves behind where a builder does not pre-size exactly.
+//
+//	largest chunk C = the normalizer's staging capacity, 4 MiB by default;
+//	                  it is what one egress tick can hand the ring
+//	max feeds      <= C/188, one per transport packet
+//	max batches    <= C/188 as well, because every batch needs at least one feed:
+//	                  a chunk alternating between streams is the worst case, and
+//	                  the per-batch term is not a rounding error against the
+//	                  payload the way a per-PMT bound would be
+//
+//	per work item, worst case:
+//	  ES bytes copied    184/188 * C
+//	  feed headers        24/188 * C   (24 bytes per []byte)
+//	  batch + reference   64/188 * C   (40 + 24 bytes per stream-and-epoch)
+//	                    ------------
+//	                    272/188 * C  = 1.447 * C = 5.79 MiB at C = 4 MiB
+//
+//	live work items:
+//	  retained by the runner  5 = audioShadowQueueDepth + one in the worker's
+//	                              hand                       = 28.9 MiB
+//	  peak                    6 = the above plus the one the producer is
+//	                              assembling before the offer = 34.7 MiB
+//
+// Beside that, and only for the duration of one Ingest, the capture side holds
+// c.shadowBatches: 64 bytes per batch and 24 per feed, up to 88/188 * C of
+// metadata again - and no payload, because those feeds point into the caller's
+// chunk instead of copying it.
 //
 // Retained, not allocated: the allocation volume of a run is larger and is a
-// different question. This is what a core with a shadow attached can be holding
-// at one instant, and it is reached only by a stream that is audio and nothing
-// else with the worker fully stalled - at which point the next chunk retires the
-// comparison and it all becomes garbage.
+// different question. And reaching any of this needs a stream that is audio and
+// nothing else with the worker fully stalled - at which point the next chunk
+// retires the comparison and all of it becomes garbage.
 const audioShadowQueueDepth = 4
 
 // pendingAudioShadowBatch is a batch and the core's own answer to it.

--- a/backend/internal/stream/ingest/mediafacts/audioshadow.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow.go
@@ -185,11 +185,11 @@ type audioShadowWork struct {
 // waiting, and returns; whether the shadow is fast, slow, hung or broken can
 // change how much of the comparison happens, and nothing else.
 //
-// Which is why the counters are atomics rather than fields of a report behind
-// the mutex. The mutex is held while the worker records a disagreement, and an
-// ingest that waits on it - however briefly - has the worker's speed back inside
-// its own duration. What is left under the mutex is the mismatch ring alone,
-// which the ingest path never touches.
+// Which is why nothing on the ingest path is behind the report's mutex. That
+// mutex is held while the worker records a disagreement, and an ingest that
+// waited on it - however briefly - would have the worker's speed back inside its
+// own duration. What an ingest takes is lifecycle, for the length of one send,
+// and nothing else.
 //
 // The runner owns a context for the shadow's whole lifetime, and every end of
 // the comparison cancels it. That is what lets the producer side finish a
@@ -199,10 +199,12 @@ type audioShadowRunner struct {
 	shadow AudioShadow
 	queue  chan audioShadowWork
 
-	batches    atomic.Uint64
-	compared   atomic.Uint64
-	mismatches atomic.Uint64
-	errors     atomic.Uint64
+	// batches is the producer's and is published before the work it counts can be
+	// reached by anyone; compared and errors are the worker's. Atomics, so that
+	// reading the report never puts the reader inside an ingest or a comparison.
+	batches  atomic.Uint64
+	compared atomic.Uint64
+	errors   atomic.Uint64
 
 	// retired is read on the capture path for every audio packet of every chunk,
 	// which is why it is an atomic and not something the lock below has to be
@@ -221,8 +223,13 @@ type audioShadowRunner struct {
 	// speed of the shadow.
 	lifecycle sync.Mutex
 
-	mu     sync.Mutex
-	recent []AudioShadowMismatch
+	// mu guards a pair, not a ring. A disagreement that has been counted but not
+	// yet kept is a report that names a mismatch and cannot show it, so the count
+	// and the ring it counts are written under one lock and read under the same
+	// one. The ingest path never takes this.
+	mu         sync.Mutex
+	mismatches uint64
+	recent     []AudioShadowMismatch
 
 	// cancel ends the shadow's context. Non-blocking, callable from anywhere, and
 	// the only thing that can reach a call already in progress.
@@ -397,31 +404,49 @@ func (r *audioShadowRunner) retireLocked(counted bool) {
 	}
 }
 
-// snapshot reads the counters in the reverse of the order the worker writes
-// them, which is the difference between a report that lags and one that lies.
+// snapshot is one reading of what the shadow has been doing.
 //
-// The worker writes batches, then compared, then mismatches, then the ring; and
-// errors, then the retired flag. Reading in that same order lets a snapshot
-// catch the second write of a pair without the first: Disabled true beside
-// Errors zero, which the retirement comment says cannot happen, or a mismatch
-// counted with an empty ring beside it. Reading backwards inverts that. Seeing
-// the later write now implies seeing the earlier one, so a field can only be
-// behind, never ahead of, the fields written before it.
+// It may lag. What it may not do is contradict itself, and reading in the
+// reverse of the order things are written is what keeps it from doing so: seeing
+// a later write implies seeing the earlier ones, so a field can only be behind,
+// never ahead of, the fields written before it.
+//
+// Reading backwards is not on its own enough to make every pair of fields agree,
+// and claiming it is would be claiming more than this type provides. What holds
+// is exactly this, and each line is a property of how the field is written, not
+// of the order it is read in alone:
+//
+//   - Compared never exceeds Batches. A batch is counted before the work
+//     carrying it is put where the worker can reach it, so anything compared was
+//     counted first; compared is read before batches, and the later load cannot
+//     have missed what the earlier one implies.
+//   - Mismatches and Recent are one pair. They are written under mu together and
+//     read under mu together, so a counted disagreement is one the report can
+//     show. The ring is bounded and forgets, so it may hold fewer entries than
+//     the count says, but never none while the count is not zero.
+//   - Mismatches never exceeds Compared, for the same reason as the first: a
+//     comparison is counted before the disagreement it found.
+//   - A retirement that was counted shows its reason. Errors is written before
+//     the retired flag and read after Disabled.
+//
+// And what it does not say. Disabled beside Errors at zero is not a
+// contradiction and never was: a Close ends the comparison without anything
+// having gone wrong, and that is precisely what it looks like. Nor does any of
+// this make two separate calls agree - a caller polling one field and asserting
+// on another still has to ask for both in the same snapshot. See awaitShadow in
+// the tests.
 //
 // The statements are separate on purpose. As a struct literal the order is real
 // but invisible, and the next edit would reorder the fields for tidiness and
 // quietly take the guarantee away.
-//
-// What this does not do is make any two fields consistent for a reader that
-// wants them to be: a caller polling one field and asserting on another still
-// has to ask for both in the same snapshot. See awaitShadow in the tests.
 func (r *audioShadowRunner) snapshot() AudioShadowReport {
+	disabled := r.retired.Load()
+
 	r.mu.Lock()
+	mismatches := r.mismatches
 	recent := append([]AudioShadowMismatch(nil), r.recent...)
 	r.mu.Unlock()
 
-	disabled := r.retired.Load()
-	mismatches := r.mismatches.Load()
 	compared := r.compared.Load()
 	batches := r.batches.Load()
 	errors := r.errors.Load()
@@ -469,7 +494,6 @@ func (r *audioShadowRunner) process(ctx context.Context, work audioShadowWork) {
 		if len(fields) == 0 {
 			continue
 		}
-		r.mismatches.Add(1)
 		r.recordMismatch(AudioShadowMismatch{
 			PID:       o.PID,
 			Epoch:     o.Epoch,
@@ -480,9 +504,18 @@ func (r *audioShadowRunner) process(ctx context.Context, work audioShadowWork) {
 	}
 }
 
+// recordMismatch counts a disagreement and keeps it, in one moment.
+//
+// One moment because a report that has been told a mismatch happened and cannot
+// show it is a report nobody can act on: the count and the ring are what a reader
+// holds against each other, and raising the count outside this lock would leave
+// them disagreeing for as long as the worker took to get here. The ring can be
+// behind the count - it keeps the last few and forgets the rest - but it is never
+// empty while the count is not.
 func (r *audioShadowRunner) recordMismatch(m AudioShadowMismatch) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.mismatches++
 	r.recent = append(r.recent, m)
 	if len(r.recent) > recentMismatches {
 		r.recent = r.recent[len(r.recent)-recentMismatches:]

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -288,6 +288,14 @@ func awaitEntered(t *testing.T, s *replayShadow, want int) {
 //
 // The comparison is off the ingest path now, so "after Ingest returned" is no
 // longer "after the shadow answered". Polling a counter is what that costs.
+//
+// The predicate has to name everything the assertions afterwards depend on, and
+// not a field written earlier than them. The report is a snapshot of counters
+// the worker writes one after another: it can lag, but the fields in it never
+// contradict each other - so asking for all of them at once is a real question,
+// while asking for one and then asserting on another is a race the test would
+// lose only occasionally. The returned report is the very snapshot that
+// satisfied the predicate, with no re-read in between.
 func awaitShadow(t *testing.T, core *GoCore, what string, done func(AudioShadowReport) bool) AudioShadowReport {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -461,8 +469,12 @@ func TestAudioShadow_ADisagreementAboutTheEndedEpochIsStillFound(t *testing.T) {
 		t.Fatalf("Ingest: %v", err)
 	}
 
-	report := awaitShadow(t, core, "both epochs to be compared", func(r AudioShadowReport) bool {
-		return r.Compared >= 2 || r.Disabled
+	// Both comparisons and the disagreement in one snapshot: the mismatch is
+	// counted after the comparison it came from and recorded after that again, so
+	// a predicate that only asked about Compared would be satisfied before there
+	// was anything in Recent to look at.
+	report := awaitShadow(t, core, "both epochs compared and the disagreement recorded", func(r AudioShadowReport) bool {
+		return (r.Compared >= 2 && r.Mismatches >= 1 && len(r.Recent) >= 1) || r.Disabled
 	})
 	if report.Compared != 2 {
 		t.Fatalf("compared %d of 2 batches: %+v", report.Compared, report)
@@ -607,8 +619,11 @@ func TestAudioShadow_AMismatchNamesTheFieldsAndLeavesTheFactsAlone(t *testing.T)
 		t.Fatalf("the shadow's opinion reached the facts: %+v", got)
 	}
 
+	// Recorded, not merely compared. Compared rises before esaudio.Compare has
+	// even run, so a test that waited on it would be asserting about a mismatch
+	// the worker had not got to yet.
 	report := awaitShadow(t, core, "the mismatch to be recorded", func(r AudioShadowReport) bool {
-		return r.Compared > 0 || r.Disabled
+		return (r.Mismatches >= 1 && len(r.Recent) >= 1) || r.Disabled
 	})
 	if report.Mismatches != 1 || len(report.Recent) != 1 {
 		t.Fatalf("mismatch not recorded: %+v", report)

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -887,21 +887,195 @@ func TestAudioShadow_AFullQueueRetiresRatherThanSkippingAChunk(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("the worker outlived the retirement; a retirement decided on the producer side never reached it")
 	}
+	// Nothing that was queued behind the retirement was carried on with. Not
+	// compared, not answered, not seen.
 	if got := blocked.enteredCount(); got != 1 {
-		t.Errorf("the shadow was reached %d times; everything queued behind the retirement was carried on with", got)
+		t.Errorf("the shadow was reached %d times after a retirement that ended the comparison", got)
 	}
-	// What was still queued is abandoned rather than caught up on. It is a run
-	// with a hole in front of it, and comparing across that hole is the thing this
-	// design refuses to do.
-	if len(runner.queue) == 0 {
-		t.Error("the queue was drained after the retirement; those batches were compared or dropped, and either would be a lie")
+	if got := core.AudioShadowReport(); got.Compared != 0 {
+		t.Errorf("%d comparisons happened after the retirement: %+v", got.Compared, got)
+	}
+	// And it was let go rather than kept. Those work items have no future - the
+	// comparison is over, nothing will ever hold them against a reference - so
+	// leaving them in the channel would be keeping several chunks of copied audio
+	// alive for as long as the core keeps the runner.
+	if n := len(runner.queue); n != 0 {
+		t.Errorf("%d work items still queued once the worker had ended; that is %d chunks of audio nothing will ever read",
+			n, n)
 	}
 	close(blocked.block)
 
-	// And a chunk after all that reaches nothing at all.
+	// And a chunk after all that reaches nothing, and puts nothing back.
 	ingest(audioShadowQueueDepth + 2)
 	if got := core.AudioShadowReport(); got.Errors != 1 || got.Batches != uint64(audioShadowQueueDepth+1) {
 		t.Errorf("work was accepted after the retirement: %+v", got)
+	}
+	if n := len(runner.queue); n != 0 {
+		t.Errorf("an offer after the retirement left %d work items in a queue nobody reads", n)
+	}
+}
+
+// The same postcondition, reached from the other side: the worker retires itself
+// while chunks are already waiting behind it.
+//
+// The queue here is not full - this is not the queue-full path. It is the
+// ordinary case of a shadow that fails once with a backlog behind it, and the
+// backlog has exactly as little future as it does after a full queue.
+func TestAudioShadow_AWorkerThatFailsWithABacklogLetsTheBacklogGo(t *testing.T) {
+	chunk := shadowChunk()
+
+	core := NewGoCore(1)
+	failing := newReplayShadow()
+	failing.block = make(chan struct{})
+	failing.err = errors.New("the shadow fell over")
+	core.SetAudioShadow(failing)
+	runner := core.shadowRunner
+	defer core.CloseAudioShadow()
+
+	// The first chunk is in the shadow's hands and stuck there.
+	if _, err := core.Ingest(context.Background(), 0, chunk); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	awaitEntered(t, failing, 1)
+
+	// Three more wait behind it, which is a backlog and not a full queue.
+	for i := 1; i < audioShadowQueueDepth; i++ {
+		if _, err := core.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk); err != nil {
+			t.Fatalf("Ingest %d: %v", i, err)
+		}
+	}
+	if got := core.AudioShadowReport(); got.Disabled {
+		t.Fatalf("retired before the shadow had failed: %+v", got)
+	}
+
+	// Now let the first call answer, with an error.
+	close(failing.block)
+
+	select {
+	case <-runner.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the worker outlived its own retirement")
+	}
+	if n := len(runner.queue); n != 0 {
+		t.Errorf("%d work items outlived the worker that was supposed to be the only reader of them", n)
+	}
+	if got := failing.enteredCount(); got != 1 {
+		t.Errorf("the shadow was reached %d times; the backlog was worked through after it had failed", got)
+	}
+	report := core.AudioShadowReport()
+	if !report.Disabled || report.Errors != 1 {
+		t.Errorf("a failure with a backlog behind it did not retire cleanly: %+v", report)
+	}
+	if report.Compared != 0 {
+		t.Errorf("%d comparisons survived the failure: %+v", report.Compared, report)
+	}
+}
+
+// fakeWork is a work item with nothing interesting in it, for the tests that are
+// about the queue rather than about audio.
+func fakeWork(epoch uint64) audioShadowWork {
+	owned := make([]byte, 64)
+	return audioShadowWork{
+		batches:    []AudioShadowBatch{{PID: shadowAudioPID, Epoch: epoch, Feeds: [][]byte{owned}}},
+		references: []esaudio.Observation{{}},
+	}
+}
+
+// The same invariant, pinned deterministically rather than raced for.
+//
+// The test below this one is the property; this one is the mechanism that
+// currently provides it, and it is bound to the lifecycle lock on purpose. If
+// the pairing of enqueue and retirement is ever replaced - by an atomic
+// protocol, by an in-flight-offer count - this test has to be rewritten against
+// that, not deleted. What it pins is the reason the cleanup can be trusted at
+// all: while a retirement is in progress, no offer can complete.
+func TestAudioShadow_AnOfferCannotLandWhileARetirementIsInProgress(t *testing.T) {
+	r := newAudioShadowRunner(echoShadow{})
+	defer r.Close()
+
+	// Stand exactly where a retirement stands: inside the critical section, with
+	// the flag not yet raised and the queue not yet emptied.
+	r.lifecycle.Lock()
+
+	landed := make(chan struct{})
+	go func() {
+		r.offer(fakeWork(1))
+		close(landed)
+	}()
+
+	// Generous by four orders of magnitude: an offer that is not excluded here
+	// would be done in microseconds.
+	var landedDuring bool
+	select {
+	case <-landed:
+		landedDuring = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	queuedDuring := len(r.queue)
+
+	// Finish the retirement and get out of the critical section before reporting
+	// anything. A failure raised while still holding this would deadlock the Close
+	// in the defer, and a test that hangs where it should fail says nothing.
+	r.retireLocked(true)
+	r.lifecycle.Unlock()
+	<-landed
+
+	if landedDuring {
+		t.Fatal("an offer ran to completion while a retirement was in progress - " +
+			"the check and the send are two moments, and the cleanup cannot cover what lands between them")
+	}
+	if queuedDuring != 0 {
+		t.Fatalf("%d work items landed during a retirement", queuedDuring)
+	}
+	// And the offer that was waiting found the door shut rather than a queue
+	// nobody reads.
+	if n := len(r.queue); n != 0 {
+		t.Fatalf("an offer that had been waiting for the retirement landed %d work items after it", n)
+	}
+}
+
+// A retirement decided while a producer is mid-offer must not leave that
+// producer's work behind.
+//
+// The window is real: reading the flag and sending are not one instruction, so a
+// producer can pass the check, a worker can retire and empty the queue in
+// between, and the send can land after the cleanup that was supposed to have
+// covered it. The invariant is not about who gets there first. It is about what
+// is true once both sides have finished: the queue holds nothing, and no offer
+// after the retirement can change that.
+func TestAudioShadow_NoWorkOutlivesARetirementRacedWithAnOffer(t *testing.T) {
+	const rounds = 200
+	for round := 0; round < rounds; round++ {
+		r := newAudioShadowRunner(echoShadow{})
+
+		var offers sync.WaitGroup
+		for p := 0; p < 8; p++ {
+			offers.Add(1)
+			go func() {
+				defer offers.Done()
+				for i := 0; i < audioShadowQueueDepth*2; i++ {
+					r.offer(fakeWork(uint64(i)))
+				}
+			}()
+		}
+
+		r.retire()
+		offers.Wait()
+		<-r.done
+
+		if n := len(r.queue); n != 0 {
+			t.Fatalf("round %d: %d work items survived a retirement raced with an offer", round, n)
+		}
+		// And the door stays shut. Batches is the count of what was accepted, so
+		// it standing still is the same statement as the queue being empty.
+		batches := r.batches.Load()
+		r.offer(fakeWork(9999))
+		if got := r.batches.Load(); got != batches {
+			t.Fatalf("round %d: an offer after the retirement was accepted (%d then %d)", round, batches, got)
+		}
+		if n := len(r.queue); n != 0 {
+			t.Fatalf("round %d: an offer after the retirement left %d work items behind", round, n)
+		}
 	}
 }
 

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -1094,6 +1094,56 @@ func TestAudioShadow_NoWorkOutlivesARetirementRacedWithAnOffer(t *testing.T) {
 	}
 }
 
+// --- the report never contradicts itself -----------------------------------
+
+// Work is counted before anybody can reach it.
+//
+// The mechanism behind "Compared never exceeds Batches", pinned where the two
+// sides meet. Everything a worker does begins with the receive, so the moment
+// the work is in the channel is the moment Compared can start moving - and if
+// the count is published after that, a report read in between says fewer batches
+// were accepted than have already been compared.
+//
+// Deliberately without a worker and without a buffer. Both would take the moment
+// away: a buffered send returns immediately and the producer would be past
+// everything after it before anything could look, and a worker would take the
+// work rather than leave it where the test can ask about it. Here the producer
+// is parked in the send itself - exactly where a worker would have the work in
+// its hands - and what the report says at that instant is the whole question.
+func TestAudioShadow_WorkIsCountedBeforeAnythingCanReachIt(t *testing.T) {
+	r := &audioShadowRunner{queue: make(chan audioShadowWork)}
+
+	published := make(chan struct{})
+	go func() {
+		defer close(published)
+		// The contract publishLocked is written against. Held across a send that
+		// cannot complete here, which is a thing only this test does: in the runner
+		// the room check above it is what makes the send unable to block.
+		r.lifecycle.Lock()
+		defer r.lifecycle.Unlock()
+		r.publishLocked(fakeWork(1))
+	}()
+
+	// Generous by six orders of magnitude: reaching a send takes nanoseconds, and
+	// this one has nothing to complete against until the receive below.
+	time.Sleep(100 * time.Millisecond)
+
+	if got := r.batches.Load(); got != 1 {
+		t.Fatalf("work is reachable with %d batches counted, want 1 - a worker taking it "+
+			"now would raise Compared past Batches, and the report would claim more "+
+			"comparisons than there was work to compare", got)
+	}
+
+	work := <-r.queue
+	<-published
+	if got := len(work.batches); got != 1 {
+		t.Fatalf("the work that was handed over carries %d batches, want 1", got)
+	}
+	if got := r.batches.Load(); got != 1 {
+		t.Fatalf("batches = %d after the hand-off, want 1 - counted once, at the hand-off", got)
+	}
+}
+
 // The hand-off owns its bytes. The chunk is the caller's and is gone the moment
 // Ingest returns, so the copy is made before that - and this is the test that
 // the copy is a copy.

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -470,9 +471,9 @@ func TestAudioShadow_ADisagreementAboutTheEndedEpochIsStillFound(t *testing.T) {
 	}
 
 	// Both comparisons and the disagreement in one snapshot: the mismatch is
-	// counted after the comparison it came from and recorded after that again, so
-	// a predicate that only asked about Compared would be satisfied before there
-	// was anything in Recent to look at.
+	// counted and kept after the comparison it came from, so a predicate that
+	// only asked about Compared would be satisfied before there was anything in
+	// Recent to look at.
 	report := awaitShadow(t, core, "both epochs compared and the disagreement recorded", func(r AudioShadowReport) bool {
 		return (r.Compared >= 2 && r.Mismatches >= 1 && len(r.Recent) >= 1) || r.Disabled
 	})
@@ -1141,6 +1142,152 @@ func TestAudioShadow_WorkIsCountedBeforeAnythingCanReachIt(t *testing.T) {
 	}
 	if got := r.batches.Load(); got != 1 {
 		t.Fatalf("batches = %d after the hand-off, want 1 - counted once, at the hand-off", got)
+	}
+}
+
+// A counted disagreement is never one nobody can look at.
+//
+// The mechanism behind the second half of the pair, pinned the same way: the
+// count and the ring are written under one lock, so there is no moment at which
+// Mismatches has moved and Recent has not. The test stands in that lock and
+// holds the door, which turns "there is no such moment" into "and here is the
+// worker, waiting outside it, having changed nothing".
+//
+// Nothing is asserted while the lock is held. A failure raised in there would
+// deadlock the CloseAudioShadow in the defer against a worker that can never
+// finish, and a test that hangs where it should fail says nothing.
+func TestAudioShadow_ACountedMismatchIsNeverOneNobodyCanSee(t *testing.T) {
+	core := NewGoCore(1)
+	shadow := newReplayShadow()
+	// Wrong about everything, so the first chunk is a disagreement.
+	shadow.distort = func(o AudioShadowObservation) AudioShadowObservation {
+		o.Observation.Channels++
+		return o
+	}
+	core.SetAudioShadow(shadow)
+	defer core.CloseAudioShadow()
+	runner := core.shadowRunner
+
+	// Stand exactly where a disagreement is written, before the worker gets here.
+	runner.mu.Lock()
+
+	if _, err := core.Ingest(context.Background(), 0, shadowChunk()); err != nil {
+		runner.mu.Unlock()
+		t.Fatalf("Ingest: %v", err)
+	}
+	// Reached the shadow, so the comparison it answers is the next thing it does.
+	awaitEntered(t, shadow, 1)
+	// And then generously longer than comparing one batch and asking for this
+	// lock can take.
+	time.Sleep(100 * time.Millisecond)
+
+	mismatches, kept := runner.mismatches, len(runner.recent)
+	runner.mu.Unlock()
+
+	if mismatches != 0 || kept != 0 {
+		t.Fatalf("%d mismatches counted with %d kept while the ring was held shut - "+
+			"a report read at that moment names a disagreement it cannot show",
+			mismatches, kept)
+	}
+
+	// And on the other side of the lock the pair arrives together.
+	report := awaitShadow(t, core, "the disagreement to be counted and kept", func(r AudioShadowReport) bool {
+		return r.Mismatches >= 1 || r.Disabled
+	})
+	if report.Mismatches != 1 || len(report.Recent) != 1 {
+		t.Fatalf("the pair did not arrive together: %+v", report)
+	}
+}
+
+// reportViolation is one snapshot that said two things that cannot both be true.
+type reportViolation struct {
+	what   string
+	report AudioShadowReport
+}
+
+// The property the two tests above are the mechanism for, hunted for rather than
+// pinned: a reader looking at any moment of a live comparison never sees a report
+// contradicting itself.
+//
+// A snapshot is allowed to be behind. It is not allowed to have caught the second
+// write of a pair without the first, and every pair here is one the ingest path
+// and the worker write from different goroutines while this reads them.
+func TestAudioShadow_AReportNeverContradictsItself(t *testing.T) {
+	const chunks = 300
+
+	core := NewGoCore(1)
+	shadow := newReplayShadow()
+	shadow.distort = func(o AudioShadowObservation) AudioShadowObservation {
+		o.Observation.Channels++
+		return o
+	}
+	core.SetAudioShadow(shadow)
+	defer core.CloseAudioShadow()
+
+	violations := make(chan reportViolation, 1)
+	stop := make(chan struct{})
+	var sentinel sync.WaitGroup
+	sentinel.Add(1)
+	go func() {
+		defer sentinel.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			r := core.AudioShadowReport()
+			var what string
+			switch {
+			case r.Compared > r.Batches:
+				what = "more comparisons than accepted batches"
+			case r.Mismatches > r.Compared:
+				what = "more disagreements than comparisons"
+			case r.Mismatches > 0 && len(r.Recent) == 0:
+				what = "a disagreement counted with nothing kept to look at"
+			}
+			if what != "" {
+				violations <- reportViolation{what: what, report: r}
+				return
+			}
+			runtime.Gosched()
+		}
+	}()
+
+	chunk := shadowChunk()
+	for i := 0; i < chunks; i++ {
+		// Paced to keep a slot free, so this stays a test about the counters
+		// rather than one about a queue filling up and ending the comparison
+		// after four chunks. Written so it cannot underflow if the very invariant
+		// under test breaks.
+		awaitShadow(t, core, "room in the queue", func(r AudioShadowReport) bool {
+			return r.Compared+audioShadowQueueDepth > r.Batches || r.Disabled
+		})
+		if _, err := core.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk); err != nil {
+			t.Fatalf("Ingest %d: %v", i, err)
+		}
+	}
+	report := awaitShadow(t, core, "every chunk to be compared", func(r AudioShadowReport) bool {
+		return r.Compared >= chunks || r.Disabled
+	})
+
+	close(stop)
+	sentinel.Wait()
+	select {
+	case v := <-violations:
+		t.Fatalf("a snapshot said %s: %+v", v.what, v.report)
+	default:
+	}
+
+	if report.Disabled {
+		t.Fatalf("the comparison was retired during the run, so most of it was never watched: %+v", report)
+	}
+	if report.Compared != chunks || report.Mismatches != chunks {
+		t.Fatalf("compared %d and disagreed %d times over %d chunks: %+v",
+			report.Compared, report.Mismatches, chunks, report)
+	}
+	if len(report.Recent) != recentMismatches {
+		t.Fatalf("the ring holds %d of the last %d disagreements", len(report.Recent), recentMismatches)
 	}
 }
 

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -9,8 +9,12 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/ManuGH/xg2g/internal/stream/ingest/esaudio"
 )
@@ -150,9 +154,25 @@ const (
 // valid after the call, which is exactly the contract a wire implementation has
 // to respect too.
 type replayShadow struct {
+	mu        sync.Mutex
 	observers map[[2]uint64]*esaudio.Observer
 	seen      []AudioShadowBatch
 	calls     int
+
+	// entries counts calls that have been reached, as opposed to calls that have
+	// answered. A shadow held in the block below has been reached and has not
+	// answered, and which of the two a test waits for is the difference between
+	// watching the worker and watching the comparison.
+	entries atomic.Int64
+
+	// block, when set, holds ObserveAudio until it is closed. The worker is the
+	// only thing waiting on it, which is the property most of these tests are
+	// about.
+	block chan struct{}
+	// ignoreCtx makes it the badly behaved kind: one that sits in the block and
+	// never looks at the context it was handed. Cancelling cannot get it back,
+	// which is exactly the case Close has to be bounded for.
+	ignoreCtx bool
 
 	err     error
 	distort func(AudioShadowObservation) AudioShadowObservation
@@ -165,7 +185,21 @@ func newReplayShadow() *replayShadow {
 	return &replayShadow{observers: map[[2]uint64]*esaudio.Observer{}}
 }
 
-func (s *replayShadow) ObserveAudio(_ context.Context, batches []AudioShadowBatch) ([]AudioShadowObservation, error) {
+func (s *replayShadow) ObserveAudio(ctx context.Context, batches []AudioShadowBatch) ([]AudioShadowObservation, error) {
+	s.entries.Add(1)
+	if s.block != nil {
+		if s.ignoreCtx {
+			<-s.block
+		} else {
+			select {
+			case <-s.block:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.calls++
 	if s.err != nil {
 		return nil, s.err
@@ -201,6 +235,8 @@ func (s *replayShadow) ObserveAudio(_ context.Context, batches []AudioShadowBatc
 
 // batchesFor is every batch the shadow was handed for one stream, in order.
 func (s *replayShadow) batchesFor(pid uint16) []AudioShadowBatch {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	var out []AudioShadowBatch
 	for _, b := range s.seen {
 		if b.PID == pid {
@@ -227,6 +263,48 @@ func assertFeeds(t *testing.T, batches []AudioShadowBatch, want [][]byte) {
 			t.Fatalf("feed %d differs (%d bytes captured, %d expected)\n captured %x…\n expected %x…",
 				i, len(got[i]), len(want[i]), got[i][:min(12, len(got[i]))], want[i][:min(12, len(want[i]))])
 		}
+	}
+}
+
+func (s *replayShadow) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// enteredCount is how many calls have been reached, answered or not.
+func (s *replayShadow) enteredCount() int {
+	return int(s.entries.Load())
+}
+
+// awaitEntered waits for the worker to be inside the shadow.
+func awaitEntered(t *testing.T, s *replayShadow, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for s.enteredCount() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("the worker reached the shadow %d times, want %d", s.enteredCount(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// awaitShadow waits for the worker to get where the test needs it.
+//
+// The comparison is off the ingest path now, so "after Ingest returned" is no
+// longer "after the shadow answered". Polling a counter is what that costs.
+func awaitShadow(t *testing.T, core *GoCore, what string, done func(AudioShadowReport) bool) AudioShadowReport {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		report := core.AudioShadowReport()
+		if done(report) {
+			return report
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s; report = %+v", what, report)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -261,19 +339,17 @@ func TestAudioShadow_ReplayingTheCapturedFeedsReproducesTheCoresOwnObservation(t
 		t.Fatalf("Ingest: %v", err)
 	}
 
-	// Byte for byte and boundary for boundary, not merely "close enough to reach
-	// the same answer". A capture one PES header too early reaches the same answer
-	// too, and would be a different input the day a parser disagrees about it.
-	assertFeeds(t, shadow.batchesFor(shadowAudioPID), wantFeeds)
-
 	want := observedTrack(t, res.Facts, shadowAudioPID)
 	if !want.Known() {
 		t.Fatalf("the core established nothing to compare against: %+v", want)
 	}
-	report := core.AudioShadowReport()
-	if report.Compared == 0 {
-		t.Fatal("nothing was compared")
-	}
+	report := awaitShadow(t, core, "the first comparison", func(r AudioShadowReport) bool {
+		return r.Compared > 0 || r.Disabled
+	})
+	// Byte for byte and boundary for boundary, not merely "close enough to reach
+	// the same answer". A capture one PES header too early reaches the same answer
+	// too, and would be a different input the day a parser disagrees about it.
+	assertFeeds(t, shadow.batchesFor(shadowAudioPID), wantFeeds)
 	if report.Mismatches != 0 {
 		t.Fatalf("the replayed feeds disagreed with the core: %+v", report.Recent)
 	}
@@ -305,6 +381,9 @@ func TestAudioShadow_AnEpochChangeInsideOneChunkSplitsTheBatches(t *testing.T) {
 		t.Fatalf("Ingest: %v", err)
 	}
 
+	awaitShadow(t, core, "both epochs to be compared", func(r AudioShadowReport) bool {
+		return r.Compared >= 2 || r.Disabled
+	})
 	batches := shadow.batchesFor(shadowAudioPID)
 	if len(batches) != 2 {
 		t.Fatalf("got %d batches for PID %d, want 2 - the feeds either side of the reset are not one stream",
@@ -340,7 +419,9 @@ func TestAudioShadow_AnEpochChangeInsideOneChunkSplitsTheBatches(t *testing.T) {
 			replayed.Current().Frames)
 	}
 
-	report := core.AudioShadowReport()
+	report := awaitShadow(t, core, "both epochs to be compared", func(r AudioShadowReport) bool {
+		return r.Compared >= 2 || r.Disabled
+	})
 	if report.Batches != 2 || report.Compared != 2 {
 		t.Fatalf("report = %+v; both epochs are handed over and both have a reference to be held against - "+
 			"comparing only the one whose observer is still alive is how a shadow that gets the ended epoch "+
@@ -385,7 +466,9 @@ func TestAudioShadow_ADisagreementAboutTheEndedEpochIsStillFound(t *testing.T) {
 		t.Fatalf("Ingest: %v", err)
 	}
 
-	report := core.AudioShadowReport()
+	report := awaitShadow(t, core, "both epochs to be compared", func(r AudioShadowReport) bool {
+		return r.Compared >= 2 || r.Disabled
+	})
 	if report.Compared != 2 {
 		t.Fatalf("compared %d of 2 batches: %+v", report.Compared, report)
 	}
@@ -446,9 +529,11 @@ func TestAudioShadow_AnAnswerThatDoesNotLineUpRetiresTheShadow(t *testing.T) {
 			if !reflect.DeepEqual(plainResult, got) {
 				t.Fatalf("a shadow that lost track changed the authoritative result")
 			}
-			report := core.AudioShadowReport()
-			if !report.Disabled || report.Errors != 1 {
-				t.Fatalf("the shadow was not retired: %+v", report)
+			report := awaitShadow(t, core, "the shadow to be retired", func(r AudioShadowReport) bool {
+				return r.Disabled
+			})
+			if report.Errors != 1 {
+				t.Fatalf("the shadow was not retired cleanly: %+v", report)
 			}
 			if report.Compared != 0 || report.Mismatches != 0 {
 				t.Errorf("an answer that does not line up was believed in part: %+v", report)
@@ -485,9 +570,11 @@ func TestAudioShadow_AFailingShadowChangesNothingAndIsNotAskedAgain(t *testing.T
 			plainResult, shadowedResult)
 	}
 
-	report := shadowed.AudioShadowReport()
-	if !report.Disabled || report.Errors != 1 {
-		t.Fatalf("a failed shadow was not retired: %+v", report)
+	report := awaitShadow(t, shadowed, "the shadow to be retired", func(r AudioShadowReport) bool {
+		return r.Disabled
+	})
+	if report.Errors != 1 {
+		t.Fatalf("a failed shadow was not retired cleanly: %+v", report)
 	}
 
 	// A second chunk must not reach it. A shadow that failed once is a second
@@ -496,8 +583,8 @@ func TestAudioShadow_AFailingShadowChangesNothingAndIsNotAskedAgain(t *testing.T
 	if _, err := shadowed.Ingest(context.Background(), int64(len(chunk)), chunk); err != nil {
 		t.Fatalf("second Ingest: %v", err)
 	}
-	if failing.calls != 1 {
-		t.Errorf("the shadow was called %d times after failing once", failing.calls)
+	if failing.callCount() != 1 {
+		t.Errorf("the shadow was called %d times after failing once", failing.callCount())
 	}
 }
 
@@ -525,7 +612,9 @@ func TestAudioShadow_AMismatchNamesTheFieldsAndLeavesTheFactsAlone(t *testing.T)
 		t.Fatalf("the shadow's opinion reached the facts: %+v", got)
 	}
 
-	report := core.AudioShadowReport()
+	report := awaitShadow(t, core, "the mismatch to be recorded", func(r AudioShadowReport) bool {
+		return r.Compared > 0 || r.Disabled
+	})
 	if report.Mismatches != 1 || len(report.Recent) != 1 {
 		t.Fatalf("mismatch not recorded: %+v", report)
 	}
@@ -638,4 +727,371 @@ func TestAudioShadow_AnAbandonedChunkLeavesNoFeedsBehind(t *testing.T) {
 		t.Fatal("the shadow was run for a chunk the caller gave up on")
 	}
 	assertNoCapturedFeeds(t, core)
+}
+
+// --- the shadow is not on the authoritative path ---------------------------
+
+// shadowChunk is what these tests hand over: a program, one AC-3 stream, and
+// enough frames for there to be an observation to disagree about.
+func shadowChunk() []byte {
+	chunk := append([]byte(nil), shadowPAT()...)
+	chunk = append(chunk, shadowPMT(0, shadowAudioPID)...)
+	audio, _ := shadowAudioPackets(shadowAudioPID, shadowAC3Run(shadowByte6Surround, 5))
+	return append(chunk, audio...)
+}
+
+// withinDeadline runs f and fails the test if it has not come back in time.
+//
+// A blocked hand-off would not be a slow test, it would be a hung one, and a
+// hung test says "timeout after 10 minutes" without saying where. This says
+// where.
+func withinDeadline(t *testing.T, d time.Duration, what string, f func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("%s did not come back within %s", what, d)
+	}
+}
+
+// The invariant the whole step is for: a shadow that never answers cannot slow
+// down, fail or change a single authoritative ingest.
+//
+// Both cores are given the same chunks in the same order and their results are
+// held against each other on every one of them - not just at the end, because a
+// shadow that perturbed the middle of the run and was right again by the end
+// would pass that.
+func TestAudioShadow_AHangingShadowNeverHoldsUpIngest(t *testing.T) {
+	const chunks = 100
+	chunk := shadowChunk()
+
+	plain := NewGoCore(1)
+	shadowed := NewGoCore(1)
+	hanging := newReplayShadow()
+	hanging.block = make(chan struct{})
+	shadowed.SetAudioShadow(hanging)
+	defer shadowed.CloseAudioShadow()
+	defer close(hanging.block)
+
+	results := make([]ParseResult, 0, chunks)
+	first, err := shadowed.Ingest(context.Background(), 0, chunk)
+	if err != nil {
+		t.Fatalf("shadowed Ingest 0: %v", err)
+	}
+	results = append(results, first)
+	// Waited for on purpose. The interesting run is the one where the worker is
+	// already inside a call that will never return, not the one where the
+	// scheduler never got round to starting it.
+	awaitEntered(t, hanging, 1)
+
+	withinDeadline(t, 30*time.Second, fmt.Sprintf("%d ingests behind a shadow that never answers", chunks-1), func() {
+		for i := 1; i < chunks; i++ {
+			got, err := shadowed.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk)
+			if err != nil {
+				t.Errorf("shadowed Ingest %d: %v", i, err)
+				return
+			}
+			results = append(results, got)
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	for i := 0; i < chunks; i++ {
+		want, err := plain.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk)
+		if err != nil {
+			t.Fatalf("plain Ingest %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(want, results[i]) {
+			t.Fatalf("chunk %d: a shadow that never answered changed the authoritative result", i)
+		}
+	}
+
+	// And the shadow is still in there. What kept the ingests going is the
+	// hand-off never waiting, not the shadow having quietly finished.
+	if got, answered := hanging.enteredCount(), hanging.callCount(); got != 1 || answered != 0 {
+		t.Errorf("the shadow was reached %d times and answered %d; the test never let the first call return",
+			got, answered)
+	}
+}
+
+// A queue that fills up ends the comparison. It does not drop a chunk and carry
+// on: the shadow's observers are stateful, so the batch after a missing one is a
+// comparison against a stream it never saw.
+func TestAudioShadow_AFullQueueRetiresRatherThanSkippingAChunk(t *testing.T) {
+	chunk := shadowChunk()
+
+	core := NewGoCore(1)
+	blocked := newReplayShadow()
+	blocked.block = make(chan struct{})
+	core.SetAudioShadow(blocked)
+	runner := core.shadowRunner
+	defer core.CloseAudioShadow()
+
+	plain := NewGoCore(1)
+
+	ingest := func(i int) {
+		t.Helper()
+		want, err := plain.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk)
+		if err != nil {
+			t.Fatalf("plain Ingest %d: %v", i, err)
+		}
+		var got ParseResult
+		withinDeadline(t, 10*time.Second, fmt.Sprintf("Ingest %d", i), func() {
+			var err error
+			got, err = core.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk)
+			if err != nil {
+				t.Errorf("Ingest %d: %v", i, err)
+			}
+		})
+		if t.Failed() {
+			t.FailNow()
+		}
+		if !reflect.DeepEqual(want, got) {
+			t.Fatalf("chunk %d: the result differs from a core with no shadow attached", i)
+		}
+	}
+
+	// The first one leaves the queue and is stuck inside the shadow. Waiting for
+	// that is what makes the count below the queue's and not a race with it.
+	ingest(0)
+	awaitEntered(t, blocked, 1)
+
+	// Now fill the queue exactly, and then hand over one more.
+	for i := 1; i <= audioShadowQueueDepth; i++ {
+		ingest(i)
+		if report := core.AudioShadowReport(); report.Disabled {
+			t.Fatalf("retired at chunk %d, before the queue was full: %+v", i, report)
+		}
+	}
+	ingest(audioShadowQueueDepth + 1)
+
+	report := core.AudioShadowReport()
+	if !report.Disabled || report.Errors != 1 {
+		t.Fatalf("a full queue did not retire the shadow exactly once: %+v", report)
+	}
+	// One batch per chunk, and only the ones that were taken.
+	if report.Batches != uint64(audioShadowQueueDepth+1) {
+		t.Errorf("Batches = %d, want %d - the chunk that found the queue full is not an accepted batch",
+			report.Batches, audioShadowQueueDepth+1)
+	}
+
+	// Letting the shadow go must not restart it. What is still in the queue is a
+	// run with a hole after it, and comparing across that hole is the thing this
+	// design refuses to do.
+	close(blocked.block)
+	deadline := time.Now().Add(5 * time.Second)
+	for len(runner.queue) > 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the worker never drained the queue")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := blocked.enteredCount(); got != 1 {
+		t.Errorf("the shadow was reached %d times; everything queued behind the retirement was carried on with", got)
+	}
+
+	// And a chunk after all that reaches nothing at all.
+	ingest(audioShadowQueueDepth + 2)
+	if got := core.AudioShadowReport(); got.Errors != 1 || got.Batches != uint64(audioShadowQueueDepth+1) {
+		t.Errorf("work was accepted after the retirement: %+v", got)
+	}
+}
+
+// The hand-off owns its bytes. The chunk is the caller's and is gone the moment
+// Ingest returns, so the copy is made before that - and this is the test that
+// the copy is a copy.
+func TestAudioShadow_TheWorkOwnsItsBytesOnceIngestHasReturned(t *testing.T) {
+	head := append([]byte(nil), shadowPAT()...)
+	head = append(head, shadowPMT(0, shadowAudioPID)...)
+	audio, wantFeeds := shadowAudioPackets(shadowAudioPID, shadowAC3Run(shadowByte6Surround, 5))
+	chunk := append(head, audio...)
+
+	core := NewGoCore(1)
+	// Blocked, so the shadow is guaranteed to still be waiting when the chunk it
+	// was given is overwritten underneath it.
+	shadow := newReplayShadow()
+	shadow.block = make(chan struct{})
+	core.SetAudioShadow(shadow)
+	defer core.CloseAudioShadow()
+
+	res, err := core.Ingest(context.Background(), 0, chunk)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	want := observedTrack(t, res.Facts, shadowAudioPID)
+	if !want.Known() {
+		t.Fatalf("the core established nothing to compare against: %+v", want)
+	}
+
+	// The caller reuses its buffer, which is what a caller with a staging buffer
+	// does between chunks.
+	for i := range chunk {
+		chunk[i] = 0xAA
+	}
+	close(shadow.block)
+
+	report := awaitShadow(t, core, "the comparison to happen after the chunk was overwritten", func(r AudioShadowReport) bool {
+		return r.Compared > 0 || r.Disabled
+	})
+	if report.Disabled {
+		t.Fatalf("the shadow was retired: %+v", report)
+	}
+	assertFeeds(t, shadow.batchesFor(shadowAudioPID), wantFeeds)
+	if report.Mismatches != 0 {
+		t.Fatalf("the shadow read the overwritten chunk: %+v", report.Recent)
+	}
+}
+
+// Close is bounded whatever the shadow is doing, and the goroutine behind it
+// ends - at the latest when the shadow finally comes back.
+func TestAudioShadow_CloseComesBackWhileTheShadowIsStillInThere(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ignoreCtx bool
+	}{
+		{"a shadow that watches its context", false},
+		{"a shadow that ignores it", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk := shadowChunk()
+			core := NewGoCore(1)
+			stuck := newReplayShadow()
+			stuck.block = make(chan struct{})
+			stuck.ignoreCtx = tc.ignoreCtx
+			core.SetAudioShadow(stuck)
+			runner := core.shadowRunner
+
+			if _, err := core.Ingest(context.Background(), 0, chunk); err != nil {
+				t.Fatalf("Ingest: %v", err)
+			}
+			awaitEntered(t, stuck, 1)
+
+			withinDeadline(t, 2*time.Second, "CloseAudioShadow with the shadow still inside", core.CloseAudioShadow)
+
+			if tc.ignoreCtx {
+				// Nothing can get it back, so the goroutine is still in there - and
+				// the caller is not.
+				select {
+				case <-runner.done:
+					t.Fatal("the worker ended while the shadow it called had not returned")
+				case <-time.After(50 * time.Millisecond):
+				}
+				close(stuck.block)
+			}
+
+			select {
+			case <-runner.done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("the worker goroutine outlived the shadow's return")
+			}
+			if !tc.ignoreCtx {
+				close(stuck.block)
+			}
+		})
+	}
+}
+
+// --- what the isolation costs the ingest path ------------------------------
+
+// echoShadow answers the question it was asked and does nothing else.
+//
+// A benchmark of the hand-off wants the cheapest shadow that still counts as
+// one: what is being measured is the capture, the copy and the offer, not how
+// long somebody else's parser takes.
+type echoShadow struct{}
+
+func (echoShadow) ObserveAudio(_ context.Context, batches []AudioShadowBatch) ([]AudioShadowObservation, error) {
+	out := make([]AudioShadowObservation, len(batches))
+	for i, b := range batches {
+		out[i] = AudioShadowObservation{PID: b.PID, Epoch: b.Epoch}
+	}
+	return out, nil
+}
+
+// benchChunk builds about size bytes of transport, audioPercent of it audio and
+// the rest null packets.
+//
+// Null padding rather than video, so that the difference between the two arms is
+// the audio path and nothing else. It also makes the baseline cheaper than a
+// real chunk, so the relative overhead measured here is an upper bound on what a
+// stream with video in it would see.
+func benchChunk(size int, audioPercent int) []byte {
+	packets := size / TSPacketSize
+	audioPackets := packets * audioPercent / 100
+	// 184 payload bytes per packet, 128 per AC-3 frame, and the first packet of
+	// the run loses 9 of them to the PES header.
+	frames := (audioPackets*184 - 9) / 128
+	if frames < 1 {
+		frames = 1
+	}
+	audio, _ := shadowAudioPackets(shadowAudioPID, shadowAC3Run(shadowByte6Surround, frames))
+
+	null := make([]byte, TSPacketSize)
+	null[0], null[1], null[2], null[3] = SyncByte, 0x1F, 0xFF, 0x10
+
+	out := append([]byte(nil), shadowPAT()...)
+	out = append(out, shadowPMT(0, shadowAudioPID)...)
+	sent := 0
+	for i := 0; i < packets; i++ {
+		if sent*TSPacketSize < len(audio) && i*audioPercent/100 >= sent {
+			out = append(out, audio[sent*TSPacketSize:(sent+1)*TSPacketSize]...)
+			sent++
+			continue
+		}
+		out = append(out, null...)
+	}
+	return out
+}
+
+// BenchmarkIngestAudioShadow is the price of the isolation.
+//
+// Not a threshold and deliberately not tied to any deadline: what is bounded by
+// design is that the shadow's own speed is not in here at all. What is left is a
+// copy of the chunk's audio and a channel send, and this is how big that is.
+func BenchmarkIngestAudioShadow(b *testing.B) {
+	const chunkSize = 4 << 20
+	for _, share := range []int{10, 100} {
+		chunk := benchChunk(chunkSize, share)
+
+		b.Run(fmt.Sprintf("audio=%d%%/no-shadow", share), func(b *testing.B) {
+			core := NewGoCore(1)
+			b.SetBytes(int64(len(chunk)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := core.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("audio=%d%%/async-shadow", share), func(b *testing.B) {
+			core := NewGoCore(1)
+			core.SetAudioShadow(echoShadow{})
+			defer core.CloseAudioShadow()
+			b.SetBytes(int64(len(chunk)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := core.Ingest(context.Background(), int64(i)*int64(len(chunk)), chunk); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.StopTimer()
+			// Without this the fast run is the one where the shadow was retired
+			// early and the core stopped capturing - which is the unshadowed path
+			// wearing the shadowed arm's name.
+			if report := core.AudioShadowReport(); report.Disabled {
+				b.Fatalf("the shadow was retired during the measurement: %+v", report)
+			}
+		})
+	}
 }

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -999,6 +999,51 @@ func TestAudioShadow_CloseComesBackWhileTheShadowIsStillInThere(t *testing.T) {
 	}
 }
 
+// Reset discards the stream, not the comparison. The worker is nobody else's to
+// stop, and the epoch is the shadow's key for per-stream state - restarting it
+// at zero would hand a stateful shadow a stream it thinks it already knows.
+func TestAudioShadow_ResetKeepsTheShadowAndNeverReusesAnEpoch(t *testing.T) {
+	chunk := shadowChunk()
+	core := NewGoCore(1)
+	shadow := newReplayShadow()
+	core.SetAudioShadow(shadow)
+	defer core.CloseAudioShadow()
+
+	if _, err := core.Ingest(context.Background(), 0, chunk); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	awaitShadow(t, core, "the first chunk to be compared", func(r AudioShadowReport) bool {
+		return r.Compared > 0 || r.Disabled
+	})
+
+	core.Reset()
+	if core.shadowRunner == nil {
+		t.Fatal("Reset dropped the shadow's worker, which nothing else can stop")
+	}
+
+	if _, err := core.Ingest(context.Background(), int64(len(chunk)), chunk); err != nil {
+		t.Fatalf("Ingest after Reset: %v", err)
+	}
+	report := awaitShadow(t, core, "the chunk after the reset to be compared", func(r AudioShadowReport) bool {
+		return r.Compared > 1 || r.Disabled
+	})
+	if report.Disabled {
+		t.Fatalf("the shadow was retired across a reset: %+v", report)
+	}
+	if report.Mismatches != 0 {
+		t.Fatalf("mismatches across a reset: %+v", report.Recent)
+	}
+
+	batches := shadow.batchesFor(shadowAudioPID)
+	if len(batches) != 2 {
+		t.Fatalf("got %d batches, want one per chunk", len(batches))
+	}
+	if batches[1].Epoch <= batches[0].Epoch {
+		t.Fatalf("epoch %d then %d: a reset handed the shadow a key it had already used for a stream that is gone",
+			batches[0].Epoch, batches[1].Epoch)
+	}
+}
+
 // --- what the isolation costs the ingest path ------------------------------
 
 // echoShadow answers the question it was asked and does nothing else.

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -1267,8 +1267,16 @@ func TestAudioShadow_AReportNeverContradictsItself(t *testing.T) {
 			t.Fatalf("Ingest %d: %v", i, err)
 		}
 	}
-	report := awaitShadow(t, core, "every chunk to be compared", func(r AudioShadowReport) bool {
-		return r.Compared >= chunks || r.Disabled
+	// Mismatches, not Compared. Every chunk here disagrees, and a disagreement is
+	// counted after the comparison that found it - so a predicate that stops at
+	// Compared stops one write short of what the assertions below read, and the
+	// last chunk's disagreement would be missing from the report often enough to
+	// matter. What the snapshot guarantees does the rest: Mismatches never exceeds
+	// Compared, which never exceeds Batches, and the ring is written under the
+	// same lock as the count - so asking for the last of them has asked for all
+	// of them.
+	report := awaitShadow(t, core, "every chunk to be compared and every disagreement kept", func(r AudioShadowReport) bool {
+		return r.Mismatches >= chunks || r.Disabled
 	})
 
 	close(stop)

--- a/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
+++ b/backend/internal/stream/ingest/mediafacts/audioshadow_test.go
@@ -169,10 +169,6 @@ type replayShadow struct {
 	// only thing waiting on it, which is the property most of these tests are
 	// about.
 	block chan struct{}
-	// ignoreCtx makes it the badly behaved kind: one that sits in the block and
-	// never looks at the context it was handed. Cancelling cannot get it back,
-	// which is exactly the case Close has to be bounded for.
-	ignoreCtx bool
 
 	err     error
 	distort func(AudioShadowObservation) AudioShadowObservation
@@ -187,15 +183,14 @@ func newReplayShadow() *replayShadow {
 
 func (s *replayShadow) ObserveAudio(ctx context.Context, batches []AudioShadowBatch) ([]AudioShadowObservation, error) {
 	s.entries.Add(1)
+	// Held here until the test lets go - or until the context is cancelled, which
+	// is the AudioShadow contract and the only reason anything downstream of this
+	// can promise that a worker ends.
 	if s.block != nil {
-		if s.ignoreCtx {
-			<-s.block
-		} else {
-			select {
-			case <-s.block:
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
+		select {
+		case <-s.block:
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	s.mu.Lock()
@@ -813,8 +808,10 @@ func TestAudioShadow_AHangingShadowNeverHoldsUpIngest(t *testing.T) {
 		}
 	}
 
-	// And the shadow is still in there. What kept the ingests going is the
-	// hand-off never waiting, not the shadow having quietly finished.
+	// The shadow was reached once and never answered: the test never let go of it,
+	// and what ended the call in the end was the retirement cancelling it. What
+	// kept the ingests going was the hand-off never waiting - not the shadow
+	// quietly finishing, and not the queue quietly draining.
 	if got, answered := hanging.enteredCount(), hanging.callCount(); got != 1 || answered != 0 {
 		t.Errorf("the shadow was reached %d times and answered %d; the test never let the first call return",
 			got, answered)
@@ -882,21 +879,24 @@ func TestAudioShadow_AFullQueueRetiresRatherThanSkippingAChunk(t *testing.T) {
 			report.Batches, audioShadowQueueDepth+1)
 	}
 
-	// Letting the shadow go must not restart it. What is still in the queue is a
-	// run with a hole after it, and comparing across that hole is the thing this
-	// design refuses to do.
-	close(blocked.block)
-	deadline := time.Now().Add(5 * time.Second)
-	for len(runner.queue) > 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("the worker never drained the queue")
-		}
-		time.Sleep(time.Millisecond)
+	// And the retirement reaches the call that is already in progress. Nobody
+	// closes the block and nobody calls Close: the cancellation the retirement
+	// carries is the whole reason the worker can end here at all.
+	select {
+	case <-runner.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the worker outlived the retirement; a retirement decided on the producer side never reached it")
 	}
-	time.Sleep(20 * time.Millisecond)
 	if got := blocked.enteredCount(); got != 1 {
 		t.Errorf("the shadow was reached %d times; everything queued behind the retirement was carried on with", got)
 	}
+	// What was still queued is abandoned rather than caught up on. It is a run
+	// with a hole in front of it, and comparing across that hole is the thing this
+	// design refuses to do.
+	if len(runner.queue) == 0 {
+		t.Error("the queue was drained after the retirement; those batches were compared or dropped, and either would be a lie")
+	}
+	close(blocked.block)
 
 	// And a chunk after all that reaches nothing at all.
 	ingest(audioShadowQueueDepth + 2)
@@ -950,52 +950,46 @@ func TestAudioShadow_TheWorkOwnsItsBytesOnceIngestHasReturned(t *testing.T) {
 	}
 }
 
-// Close is bounded whatever the shadow is doing, and the goroutine behind it
-// ends - at the latest when the shadow finally comes back.
-func TestAudioShadow_CloseComesBackWhileTheShadowIsStillInThere(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		ignoreCtx bool
-	}{
-		{"a shadow that watches its context", false},
-		{"a shadow that ignores it", true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			chunk := shadowChunk()
-			core := NewGoCore(1)
-			stuck := newReplayShadow()
-			stuck.block = make(chan struct{})
-			stuck.ignoreCtx = tc.ignoreCtx
-			core.SetAudioShadow(stuck)
-			runner := core.shadowRunner
+// Close cancels whatever the worker is inside and does not come back until the
+// goroutine is gone.
+//
+// There is no companion case for a shadow that ignores its context, because
+// there is nothing to assert about one. Go cannot end a goroutine parked in an
+// interface method from the outside, so bounded shutdown and an accounted-for
+// worker cannot both be had against arbitrary code - which is why cancellation
+// is a contract in the AudioShadow doc rather than a hope in this file. Proving
+// a real implementation keeps it against a peer that never replies belongs to
+// the RemoteAudioShadow in 4b.2b, and cannot be proven here.
+func TestAudioShadow_CloseCancelsTheShadowAndWaitsForTheWorker(t *testing.T) {
+	chunk := shadowChunk()
+	core := NewGoCore(1)
+	stuck := newReplayShadow()
+	stuck.block = make(chan struct{})
+	defer close(stuck.block)
+	core.SetAudioShadow(stuck)
+	runner := core.shadowRunner
 
-			if _, err := core.Ingest(context.Background(), 0, chunk); err != nil {
-				t.Fatalf("Ingest: %v", err)
-			}
-			awaitEntered(t, stuck, 1)
+	if _, err := core.Ingest(context.Background(), 0, chunk); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	awaitEntered(t, stuck, 1)
 
-			withinDeadline(t, 2*time.Second, "CloseAudioShadow with the shadow still inside", core.CloseAudioShadow)
+	// Nothing else can end that call: the block is still shut, and only the
+	// cancellation Close carries can get the shadow out of it.
+	withinDeadline(t, 5*time.Second, "CloseAudioShadow with the shadow still waiting", core.CloseAudioShadow)
 
-			if tc.ignoreCtx {
-				// Nothing can get it back, so the goroutine is still in there - and
-				// the caller is not.
-				select {
-				case <-runner.done:
-					t.Fatal("the worker ended while the shadow it called had not returned")
-				case <-time.After(50 * time.Millisecond):
-				}
-				close(stuck.block)
-			}
+	// Not "eventually, probably". Close having returned is the goroutine having
+	// ended, or the wait in it was decoration.
+	select {
+	case <-runner.done:
+	default:
+		t.Fatal("Close returned with the worker still running")
+	}
 
-			select {
-			case <-runner.done:
-			case <-time.After(5 * time.Second):
-				t.Fatal("the worker goroutine outlived the shadow's return")
-			}
-			if !tc.ignoreCtx {
-				close(stuck.block)
-			}
-		})
+	// A shutdown is not a failure. A report that called it one would say the
+	// comparison stopped for a reason that never happened.
+	if got := runner.snapshot(); got.Errors != 0 {
+		t.Errorf("a clean Close was reported as %d errors: %+v", got.Errors, got)
 	}
 }
 

--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -449,7 +449,19 @@ func (c *GoCore) SetTargetProgram(ctx context.Context, programNumber uint16) (Pa
 // Reset discards everything read so far.
 func (c *GoCore) Reset() ParseResult {
 	target := c.targetProgramNumber
+	// The shadow is not stream state and does not die here. It belongs to whoever
+	// attached it, and a core that dropped it would leave the worker running with
+	// nothing left that could stop it.
+	//
+	// Its epoch does not go back to zero either. The epoch is the shadow's key for
+	// per-stream state, and a counter that restarts hands it a (PID, epoch) it has
+	// already seen - for a stream that no longer exists. So it carries across and
+	// turns once, which is what a reset is: everything on this core's PIDs from
+	// here on is a different elementary stream.
+	runner, epoch := c.shadowRunner, c.shadowEpoch
 	*c = *NewGoCore(target)
+	c.shadowRunner = runner
+	c.shadowEpoch = epoch + 1
 	c.events = append(c.events, Event{Kind: EventProgramIdentityChanged})
 	return c.result(0)
 }

--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -362,10 +362,9 @@ type GoCore struct {
 	// shadow is a second observer of the same elementary stream bytes, attached
 	// for a migration and never for a decision. Everything about it is in
 	// audioshadow.go.
-	shadow        AudioShadow
+	shadowRunner  *audioShadowRunner
 	shadowEpoch   uint64
 	shadowBatches []pendingAudioShadowBatch
-	shadowReport  AudioShadowReport
 
 	// events accumulates what the chunk being ingested meant, in order.
 	events []Event
@@ -392,8 +391,8 @@ func (c *GoCore) Ingest(ctx context.Context, startOffset int64, data []byte) (Pa
 	c.events = c.events[:0]
 	// The feeds captured below point into data. They are valid for this call and
 	// no longer, so every way out of it has to drop them - the cancelled chunk
-	// half way through the loop included, which never reaches runAudioShadow at
-	// all. Cleared on the way in as well, because an earlier call that returned
+	// half way through the loop included, which never reaches handOffAudioShadow
+	// at all. Cleared on the way in as well, because an earlier call that returned
 	// through such a path is exactly what would leave something here.
 	c.clearAudioShadowBatches()
 	defer c.clearAudioShadowBatches()
@@ -413,9 +412,10 @@ func (c *GoCore) Ingest(ctx context.Context, startOffset int64, data []byte) (Pa
 		c.indexPacketLocked(data[i:i+TSPacketSize], startOffset+int64(i))
 	}
 	// After the chunk is interpreted and before the result is built, so that the
-	// feeds still point into a chunk that exists and nothing the shadow does can
-	// reach the result. It cannot fail this call: see runAudioShadow.
-	c.runAudioShadow(ctx)
+	// feeds still point into a chunk that exists. What happens here is a copy and
+	// a non-blocking offer; the comparison itself is somebody else's goroutine,
+	// and nothing about it can reach this call's duration or its result.
+	c.handOffAudioShadow()
 	return c.result(startOffset + int64(len(data))), nil
 }
 


### PR DESCRIPTION
# Pull Request

> **Status:** the runner was reviewed and approved on `4c65ae7c`. What came after
> that is the report's own coherence, which the approval did not cover:
> `snapshot()` reads the counters in the reverse of the order they are written
> (`3ce7ad7b`), `Batches` is published before the work it counts can be reached
> (`d905a407`), and a disagreement is counted where it is kept, under one lock
> (`7bcff07a`). The last of it was a guard that stopped one write too early and
> went red 3 times in 40 local runs (`02b8da7e`); the runner is unchanged by that
> one. Both orderings are pinned by mutation-tested guards.
>
> The OpenWebIF/ReceiverTopology polling commit that had been pushed onto this
> branch has been removed and lives on `fix/openwebif-polling-tiers`, with the two
> review findings against it. This PR is again exactly three `mediafacts` files.
>
> Merge is gated on CI being fully green on the current head, with `main`
> unchanged at `3f48fc47`.

## Summary

Step 4b.2a of the audio-parser migration: make it true, and provable, that the
shadow observer cannot affect the authoritative ingest path. No wire, no
`MsgObserveAudioBatch`, no `RemoteCore` change — that is 4b.2b.

The seam from #901 called the shadow synchronously from inside `Ingest`. Any
budget given to it that way is still part of `Ingest`'s own duration, so a
caller whose deadline is nearly spent could lose the ring commit to a slow
second implementation. There is no budget now. What stays synchronous is a
capture, one owning copy, and a non-blocking send:

```
GoCore.Ingest
  ├─ authoritative Go parsing
  ├─ capture shadow batches + frozen references
  ├─ own the bytes (single buffer per chunk, feeds capped at their own end)
  ├─ non-blocking enqueue
  └─ return ParseResult          → ring commit

single ordered worker (per core)
  └─ ObserveAudio → compare against the frozen Go reference
```

## Change Contract

### Fixed

- `Reset()` replaced the whole core and with it the field holding the shadow's
  worker, leaving a goroutine nothing else could stop, and restarted the epoch
  counter at zero — handing a stateful observer a `(PID, epoch)` it had already
  seen, for an elementary stream that no longer exists. That is the PID-reuse
  confusion this differential exists to find, manufactured by the thing looking
  for it. The runner and a monotonic epoch now survive a reset.
- The hand-off's feed slices had capacity running into the next feed's bytes, so
  a shadow appending to one could read across the boundary it was given.
- The documented queue bound was too small and mis-stated (see below).
- A retirement stopped the worker but left the queue alone. Those work items have
  no future — nothing will ever hold them against a reference — yet they stayed
  reachable from the runner, and the runner from the core, so a retired shadow on
  a long session could sit on its whole queue until the session ended: up to
  23.2 MiB of copied audio, with the worst-behaved shadow holding the most.
- `offer` read the retired flag and sent as two separate moments. A producer
  could pass the check, a worker could retire and empty the queue in between, and
  the send would then land in a channel with no reader left — the exact item the
  cleanup was meant to cover.
- `CloseAudioShadow`'s comment still said it does not wait, while the runner's
  `Close` waits for the worker.

### Improved

- The counters are atomics; the runner's mutex covers only the mismatch ring,
  which the ingest path never touches. Previously the enqueue took the same
  mutex the worker holds while tallying a comparison, which put the worker's
  speed back inside `Ingest`'s duration.
- Ending the comparison is one state transition — flag, cancel, and emptying the
  queue — and putting work in the queue is the same decision, both under a
  `lifecycle` mutex. A shadow that fails while the queue behind it fills up is
  one retirement with one reason, not two errors. That mutex is never held across
  `ObserveAudio`, a comparison, or a mismatch being recorded, and never nests
  with the mismatch ring's own lock: the longest a producer waits on it is one
  channel send and at most four non-blocking receives. The invariant is not
  "`Ingest` takes no lock" — it is that no lock `Ingest` takes is ever held by
  slow shadow work.

### New

- `audioShadowRunner`: bounded queue (4), one ordered worker per core, no
  parallel calls, `(epoch, PID, feeds)` order preserved exactly.
- `CloseAudioShadow()` — attaching a shadow starts a goroutine, so the attacher
  owns ending it.
- Adversarial tests and `BenchmarkIngestAudioShadow`.

### Removed

- The synchronous `runAudioShadow` path.
- An adversary that asserted bounded `Close` **and** a leak-free shutdown
  against a shadow that ignores its context. Those two cannot both hold: Go
  cannot end a goroutine parked inside an interface method from the outside, so
  that test was describing the leak, not excluding it.

### Explicitly Unchanged

- Every authoritative result. The tests hold a shadowed core's `ParseResult`
  against an unshadowed one per chunk, not just at the end of a run.
- No wire, no `MsgObserveAudioBatch`, no `RemoteCore` diff, no protocol change.
- A core with no shadow attached behaves exactly as before, down to not
  capturing the feeds.

### Risks

- **A shadow that breaks the cancellation contract hangs `Close`.** Deliberate:
  the alternative is walking away from a goroutine that cannot be accounted for
  and calling it clean. The hang names the shadow that broke the contract.
- **A full queue ends the comparison permanently.** Also deliberate: the
  observers are stateful, so a skipped batch makes every later comparison one
  against a stream the shadow never saw. Dropping and continuing would make
  agreement and disagreement equally meaningless.
- Synchronous cost grows with the audio bytes in a chunk — measured below.

### Acceptance Criteria

- [x] Neither the behaviour nor the speed of the shadow consumer can change the
      duration or the outcome of the authoritative ingest/commit path; only the
      locally bounded copy/enqueue stays synchronous.
- [x] Enqueue never blocks; the queue is bounded; a full queue retires rather
      than drops.
- [x] The work item owns its bytes: no `[]byte` into the ingest chunk survives
      `Ingest`'s return.
- [x] Frozen Go references travel with the work item and never reach the shadow.
- [x] A worker error retires without retry, and the authoritative path is
      untouched.
- [x] `Close` is bounded for every contract-compliant shadow and leaves no
      worker behind.
- [x] Once the worker's `done` channel is closed: the queue holds nothing, the
      runner retains no owning audio or reference, no later offer is accepted,
      and `Batches` cannot rise again.

### Migration Exit Condition

The shadow is a migration scaffold. It leaves when the Rust observer is
authoritative for audio and the Go observer is removed, or when the comparison
is abandoned. Next action is 4b.2b: `MsgObserveAudioBatch` and a
`RemoteAudioShadow`, which must satisfy the cancellation contract **even against
a Rust peer that ignores cancellation or never replies** — a socket deadline and
a teardown on this side, not a request the far end is trusted to honour. That
requirement is recorded on the `AudioShadow` interface.

### Deviations From the Agreed Scope

- None.

## Scope

- In scope: latency and lifetime isolation of the audio shadow inside
  `internal/stream/ingest/mediafacts`.
- Out of scope: IPC, the Rust side, production performance tuning, and reusing
  the copy buffer across chunks (a known lever, left alone because it
  reintroduces ownership between the two sides).

## Risk and Rollout

- Risk level: low. Off by default and unreachable in production: nothing calls
  `SetAudioShadow` outside tests, and a core without one does not even capture.
- Rollout: none required.
- Fallback: revert the branch; the seam returns to #901's synchronous form.

## Verification

```bash
# macOS, darwin/arm64, go1.26.5
go test -count=1 ./internal/stream/ingest/mediafacts/
go test -race -count=1 -skip TestIngestStaysFarInsideItsDeadline ./internal/stream/ingest/mediafacts/
go test -count=1 ./internal/stream/ingest/...
go vet ./internal/stream/...

# LXC 110, linux/amd64, Intel Core Ultra 9 285HX, go1.26.5
go test -count=1 ./internal/stream/ingest/mediafacts/                            # ok 0.176s
go test -race -count=1 -skip TestIngestStaysFarInsideItsDeadline ./…mediafacts/  # ok 1.143s
go test -race -count=5 -run 'TestAudioShadow_(NoWorkOutlives|AnOfferCannotLand|AFullQueue|AWorkerThatFails|CloseCancels)' \
    ./internal/stream/ingest/mediafacts/                                        # ok 1.559s
```

All green on both. `TestIngestStaysFarInsideItsDeadline` fails under `-race`
only (121 ms against a 50 ms bound at a 4 MiB chunk) and does so on `main` as
well — pre-existing, not from this branch, verified against a clean tree.

### The lifetime claims were mutation-tested, not assumed

| Mutation | Result |
| --- | --- |
| queue cleanup removed from the retirement | **3/3 red**, in three tests at once |
| `offer`'s pairing with the retirement removed | racing test: 2/5 red without `-race`, 5/5 with — **not good enough on its own** |
| the same mutation, against the deterministic linearization test | **5/5 red**, with a plain-language message |

The mutation run also found a defect in the first version of the deterministic
test itself: it called `t.Fatal` while still holding the lifecycle lock, so its
own failure path deadlocked in the deferred `Close` instead of reporting. It now
captures the finding, leaves the critical section, and reports after.

### The adversaries

| Test | What it pins |
| --- | --- |
| `AHangingShadowNeverHoldsUpIngest` | worker demonstrably parked inside `ObserveAudio`, then 99 further ingests; every result `DeepEqual` to an unshadowed core, per chunk |
| `AFullQueueRetiresRatherThanSkippingAChunk` | queue filled exactly, next chunk retires; the worker then ends **with nobody calling `Close` and the shadow still blocked** — the retirement's cancellation is what reaches it. Afterwards: queue empty, shadow reached exactly once, nothing compared, and a later chunk puts nothing back |
| `AWorkerThatFailsWithABacklogLetsTheBacklogGo` | the other direction: a worker that fails itself with three chunks waiting behind it (queue *not* full). After `done`: queue empty, the backlog never reached the shadow, one error |
| `NoWorkOutlivesARetirementRacedWithAnOffer` | 200 rounds × 8 producers offering into a concurrent `retire()`; once both sides have finished, the queue is empty and no further offer is accepted |
| `AnOfferCannotLandWhileARetirementIsInProgress` | the deterministic companion: an offer attempted from inside the retirement's critical section cannot complete, and finds the door shut once it is let through |
| `TheWorkOwnsItsBytesOnceIngestHasReturned` | chunk overwritten with `0xAA` after `Ingest` returns, *then* the shadow released: feeds byte-identical, zero mismatches |
| `CloseCancelsTheShadowAndWaitsForTheWorker` | `Close` returns bounded, the worker is already gone when it does, and a clean shutdown is not counted as an error |
| `ResetKeepsTheShadowAndNeverReusesAnEpoch` | runner survives, epoch strictly increases across a reset |
| `AnAnswerThatDoesNotLineUpRetiresTheShadow` | missing/extra/reordered/mislabelled answers retire rather than compare a smaller set |

### What the isolation costs

`BenchmarkIngestAudioShadow`, 4 MiB chunk, `-benchtime 10x -count 6`, no
`-race`, median (range). Padding is null packets, so the delta is the audio path
and nothing else — which also makes the baseline cheaper than a real chunk, so
the *relative* figures are an upper bound. The two machines are reported
separately and no ratio is taken across them.

**macOS, Apple M4, `GOMAXPROCS=10`**

| audio share | baseline | async shadow | Δ |
| --- | --- | --- | --- |
| 10 % | 256 µs (235–364) | 321 µs (310–339) | **+65 µs** |
| 100 % | 1094 µs (1091–1100) | 2030 µs (1921–2083) | **+936 µs** |

**LXC 110, linux/amd64, Intel Core Ultra 9 285HX, `GOMAXPROCS=12`**

| audio share | baseline | async shadow | Δ |
| --- | --- | --- | --- |
| 10 % | 189 µs (171–195) | 373 µs (328–388) | **+184 µs** |
| 100 % | 1232 µs (1102–1250) | 2780 µs (2550–2883) | **+1547 µs** |

Incremental slope from the difference of the two arms (fixed costs cancel):
**≈ 236 µs per MiB of copied audio on the M4, ≈ 369 µs/MiB on amd64.**
Allocation volume is machine-independent, as expected: 1052 B/10 allocs
baseline, 634 KB/30 at 10 %, 6.93 MB/38 at 100 %. The cost is allocation and
first-touch page faults, not IPC — there is no IPC in this branch.

### The queue's bound

Documented at `audioShadowQueueDepth` as a **logical payload-and-metadata upper
bound** — not a heap or RSS ceiling, since it accounts for neither allocator
size classes nor capacity left behind by an append:

```
largest chunk C = normalizer staging capacity, 4 MiB by default
max feeds      <= C/188      max batches <= C/188   (a batch needs >= 1 feed)

per work item:  184/188*C payload + 24/188*C feed headers
                + 64/188*C batch+reference  =  272/188*C = 1.447*C = 5.79 MiB

live items:     5 retained by the runner (queue + worker)      = 28.9 MiB
                6 at peak, incl. the one the producer is building = 34.7 MiB
```

## Checklist

- [x] Tests added/updated for changed behavior
- [x] Documentation updated & rendered (no doc templates touched)
- [x] No secrets or credentials introduced
- [x] Backward compatibility considered — `AudioShadow` gains a documented
      cancellation requirement its only implementations (tests) already meet

## Related Issues

Part of the audio-parser differential migration; follows #901. Not closing an
issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

