### PR TITLE
test(api): synchronize lamedb RF discovery dial assertion

### DIFF
--- a/backend/internal/api/http_test.go
+++ b/backend/internal/api/http_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -895,6 +896,14 @@ func TestProductionLiveRoute_EnforceMode_MissingResolver_RejectsWithZeroDials(t 
 func TestProductionBootstrap_LamedbRFDiscovery_PopulatesResolver(t *testing.T) {
 	var streamDials, lamedbQueries int32
 
+	// The bootstrap reserves the topology lease before it dials the receiver
+	// (LivePipelineConnector.Connect runs admission, then the dial), so the lease
+	// showing up below is not yet evidence that the dial happened. The mock
+	// announces the dial here and the test waits for that announcement, instead
+	// of reading the counter at whatever moment the lease appeared.
+	streamDialed := make(chan struct{})
+	var announceDial sync.Once
+
 	// The carrier the mock receiver claims to know: 11914 MHz vertical on Astra 19.2E,
 	// carrying transport stream 0x0888 - which is the TSID in the requested service ref.
 	const lamedb = "eDVB services /5/\n" +
@@ -910,6 +919,7 @@ func TestProductionBootstrap_LamedbRFDiscovery_PopulatesResolver(t *testing.T) {
 		}
 
 		atomic.AddInt32(&streamDials, 1)
+		announceDial.Do(func() { close(streamDialed) })
 		w.Header().Set("Content-Type", "video/mp2t")
 		w.WriteHeader(http.StatusOK)
 		samplePkt := make([]byte, ring.TSPacketSize)
@@ -971,7 +981,16 @@ func TestProductionBootstrap_LamedbRFDiscovery_PopulatesResolver(t *testing.T) {
 		return false
 	}, 2*time.Second, 20*time.Millisecond, "must resolve exact authoritative 11914 MHz Vertical RF parameters from the receiver service database")
 
-	// 5. The service database was read, and Enigma2 was dialed once
+	// 5. The dial the next assertion counts, once it has actually reached the mock.
+	//    A single request produces a single Connect - the session manager does not
+	//    re-dial on its own - so once the first dial is in, the count is settled.
+	select {
+	case <-streamDialed:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Enigma2 stream endpoint was never dialed (lamedb queries: %d)", atomic.LoadInt32(&lamedbQueries))
+	}
+
+	// 6. The service database was read, and Enigma2 was dialed once
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&lamedbQueries), int32(1), "receiver service database should be read for RF discovery")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&streamDials), "Enigma2 stream endpoint should be dialed once")
 }


### PR DESCRIPTION
Fixes the flaky `TestProductionBootstrap_LamedbRFDiscovery_PopulatesResolver`.

Test-only. One file, `+20/-1`. No production code changed, and no relation to #902 — this branch sits directly on `main` (`3f48fc47`) and carries a single commit.

## Root cause

The test waited for the topology lease to become visible, then read the counter that the upstream dial increments. Those are two separate events: `LivePipelineConnector.Connect` runs a strict sequence of **topology admission first, upstream dial second**.

```
1. ReserveStreamLeaseAtomic(...)   → populates runtime.ActiveMultiplexes  ← test waited here
2. dialHTTP(...)                   → reaches the mock, increments streamDials  ← test asserted on this
```

`require.Eventually` returned as soon as step 1 landed, and the assertion then read step 2's counter before the dial had happened. Failure was always identical:

```
http_test.go:976: Error: Not equal:
                  expected: 1
                  actual  : 0
```

Production behaviour was never wrong — the test was missing a synchronisation point.

## Fix

The mock receiver announces the dial on a channel, closed immediately after the counter is incremented, and the test blocks on that announcement before asserting. `close` → receive gives the happens-before edge, so the counter read can never observe a pre-increment value.

The assertion itself is untouched: still `assert.Equal(t, int32(1), ...)`. No sleep, no weakened comparison. A dial that genuinely never happens now fails as a missing dial (explicit `t.Fatalf`) rather than as an off-by-timing count.

Waiting for the *first* dial does not by itself prove a second never follows. That was checked structurally instead: `Manager.Acquire` runs `Connect` exactly once per request and has no retry path, so the count is settled once the first dial is in. Noted rather than used as a reason to grow the fix.

## Verification

Reproduced on unmodified `main`: **3 failures in 22 runs**, all the same assertion.

After the fix:

| Run | Result |
|---|---|
| `-count=50` | `ok github.com/ManuGH/xg2g/internal/api 2.138s` |
| `-race -count=50` | `ok github.com/ManuGH/xg2g/internal/api 3.497s` |
| 30× separate processes | 30/30 `ok` |
| Full `./internal/api/` package | `ok ... 7.514s` |

`gofmt` and `go vet ./internal/api/` clean.

Do not merge until CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)