### PR TITLE
fix(openwebif): reduce aggressive polling with tiered intervals and standby awareness

### DIFF
--- a/backend/internal/app/bootstrap/bootstrap.go
+++ b/backend/internal/app/bootstrap/bootstrap.go
@@ -419,7 +419,7 @@ func WireServices(ctx context.Context, version, commit, buildDate, explicitConfi
 	}
 
 	if owiClient != nil && topoSvc != nil {
-		syncPoller := receivertopology.NewExternalSyncPoller(owiClient, topoSvc, 3*time.Second, logger)
+		syncPoller := receivertopology.NewExternalSyncPoller(owiClient, topoSvc, receivertopology.DefaultPollInterval, logger)
 		topoSvc.SetPoller(syncPoller)
 		go syncPoller.Run(ctx)
 	}

--- a/backend/internal/openwebif/about_cache_test.go
+++ b/backend/internal/openwebif/about_cache_test.go
@@ -1,0 +1,109 @@
+package openwebif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbout_CachingSingleflightAndLKGFallback(t *testing.T) {
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/about" {
+			count := atomic.AddInt64(&requestCount, 1)
+			if count == 1 {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"info":{"model":"Vu+ Uno 4K","tuners":[{"name":"Tuner A","type":"DVB-S2"}]}}`))
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"result":false,"message":"receiver error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+
+	// 1. Initial fetch - hits HTTP endpoint
+	about1, err := client.About(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, about1)
+	assert.Equal(t, "Vu+ Uno 4K", about1.Info.Model)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&requestCount))
+
+	// 2. Second fetch within 15s TTL - served directly from cache without HTTP request
+	about2, err := client.About(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, about2)
+	assert.Equal(t, "Vu+ Uno 4K", about2.Info.Model)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&requestCount), "Should be served from cache without HTTP call")
+
+	// 3. Force cache expiration
+	client.aboutCacheMu.Lock()
+	client.aboutCacheAt = time.Now().Add(-20 * time.Second)
+	client.aboutCacheMu.Unlock()
+
+	// 4. Fetch when backend errors -> falls back to Last-Known-Good (LKG) cached about info
+	about3, err := client.About(context.Background())
+	require.NoError(t, err, "Should serve LKG cached about info on backend failure")
+	require.NotNil(t, about3)
+	assert.Equal(t, "Vu+ Uno 4K", about3.Info.Model)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&requestCount), "HTTP endpoint was called but failed")
+
+	// 5. Invalidation
+	client.InvalidateAboutCache()
+	client.aboutCacheMu.RLock()
+	assert.Nil(t, client.aboutCache)
+	client.aboutCacheMu.RUnlock()
+}
+
+func TestGetStatusInfo_CachingSingleflightAndLKGFallback(t *testing.T) {
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/statusinfo" {
+			count := atomic.AddInt64(&requestCount, 1)
+			if count == 1 {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"inStandby":"true","servicename":"Das Erste HD"}`))
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"result":false,"message":"receiver error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+
+	// 1. Initial fetch
+	st1, err := client.GetStatusInfo(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, st1)
+	assert.Equal(t, "true", st1.InStandby)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&requestCount))
+
+	// 2. Second fetch within 3s TTL
+	st2, err := client.GetStatusInfo(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, st2)
+	assert.Equal(t, "true", st2.InStandby)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&requestCount), "Should be served from 3s cache without HTTP call")
+
+	// 3. Invalidate
+	client.InvalidateStatusCache()
+	client.statusCacheMu.RLock()
+	assert.Nil(t, client.statusCache)
+	client.statusCacheMu.RUnlock()
+}

--- a/backend/internal/openwebif/client.go
+++ b/backend/internal/openwebif/client.go
@@ -75,6 +75,21 @@ type Client struct {
 	timerCache   []Timer
 	timerCacheAt time.Time
 	timerGroup   singleflight.Group
+
+	// About metadata caching & deduplication
+	aboutCacheMu sync.RWMutex
+	aboutCache   *AboutInfo
+	aboutCacheAt time.Time
+	aboutGroup   singleflight.Group
+
+	// Status info caching & deduplication
+	statusCacheMu sync.RWMutex
+	statusCache   *StatusInfo
+	statusCacheAt time.Time
+	statusGroup   singleflight.Group
+
+	// Current service request deduplication
+	currentGroup singleflight.Group
 }
 
 // Cacher provides caching capabilities for OpenWebIF requests.

--- a/backend/internal/openwebif/lkg_bound_test.go
+++ b/backend/internal/openwebif/lkg_bound_test.go
@@ -1,0 +1,120 @@
+package openwebif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// firstOKThenFail serves one successful body, then fails every later request.
+func firstOKThenFail(t *testing.T, path, body string, count *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if atomic.AddInt64(count, 1) == 1 {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"result":false,"message":"receiver error"}`))
+	}))
+}
+
+// An unreachable receiver must stop being reported as observed once the cached
+// reading ages past the LKG window. Before the bound, one successful fetch made
+// every later failure serve that cache forever.
+func TestAbout_LKGFallbackExpiresPastBound(t *testing.T) {
+	var requests int64
+	server := firstOKThenFail(t, "/api/about", `{"info":{"model":"Vu+ Uno 4K"}}`, &requests)
+	defer server.Close()
+
+	client := New(server.URL)
+
+	_, err := client.About(context.Background())
+	require.NoError(t, err)
+
+	// Still inside the LKG window: the stale reading is served on failure.
+	client.aboutCacheMu.Lock()
+	client.aboutCacheAt = time.Now().Add(-(maxAboutLKGAge - time.Second))
+	client.aboutCacheMu.Unlock()
+
+	about, err := client.About(context.Background())
+	require.NoError(t, err, "within maxAboutLKGAge the cached reading is still served")
+	require.NotNil(t, about)
+	assert.Equal(t, "Vu+ Uno 4K", about.Info.Model)
+
+	// Past the window: the caller gets the error back instead of stale data.
+	client.aboutCacheMu.Lock()
+	client.aboutCacheAt = time.Now().Add(-(maxAboutLKGAge + time.Second))
+	client.aboutCacheMu.Unlock()
+
+	about, err = client.About(context.Background())
+	require.Error(t, err, "past maxAboutLKGAge the failure must surface, not stale about info")
+	assert.Nil(t, about)
+}
+
+func TestGetStatusInfo_LKGFallbackExpiresPastBound(t *testing.T) {
+	var requests int64
+	server := firstOKThenFail(t, "/api/statusinfo", `{"inStandby":"true","servicename":"Das Erste HD"}`, &requests)
+	defer server.Close()
+
+	client := New(server.URL)
+
+	_, err := client.GetStatusInfo(context.Background())
+	require.NoError(t, err)
+
+	client.statusCacheMu.Lock()
+	client.statusCacheAt = time.Now().Add(-(maxStatusLKGAge - time.Second))
+	client.statusCacheMu.Unlock()
+
+	st, err := client.GetStatusInfo(context.Background())
+	require.NoError(t, err, "within maxStatusLKGAge the cached reading is still served")
+	require.NotNil(t, st)
+	assert.Equal(t, "true", st.InStandby)
+
+	client.statusCacheMu.Lock()
+	client.statusCacheAt = time.Now().Add(-(maxStatusLKGAge + time.Second))
+	client.statusCacheMu.Unlock()
+
+	st, err = client.GetStatusInfo(context.Background())
+	require.Error(t, err, "past maxStatusLKGAge the failure must surface, not stale standby state")
+	assert.Nil(t, st)
+}
+
+func TestGetTimers_LKGFallbackExpiresPastBound(t *testing.T) {
+	var requests int64
+	server := firstOKThenFail(t, "/api/timerlist", `{"timers":[{"servicereference":"1:0:1:1","name":"Tatort","begin":1,"end":2}]}`, &requests)
+	defer server.Close()
+
+	client := New(server.URL)
+
+	timers, err := client.GetTimers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, timers, 1)
+
+	client.timerCacheMu.Lock()
+	client.timerCacheAt = time.Now().Add(-(maxTimerLKGAge - time.Second))
+	client.timerCacheMu.Unlock()
+
+	timers, err = client.GetTimers(context.Background())
+	require.NoError(t, err, "within maxTimerLKGAge the cached list is still served")
+	require.Len(t, timers, 1)
+
+	client.timerCacheMu.Lock()
+	client.timerCacheAt = time.Now().Add(-(maxTimerLKGAge + time.Second))
+	client.timerCacheMu.Unlock()
+
+	timers, err = client.GetTimers(context.Background())
+	require.Error(t, err, "past maxTimerLKGAge the failure must surface, not a stale recording list")
+	assert.Nil(t, timers)
+}

--- a/backend/internal/openwebif/singleflight_ctx_test.go
+++ b/backend/internal/openwebif/singleflight_ctx_test.go
@@ -1,0 +1,88 @@
+package openwebif
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// blockingServer answers path only after release is closed, so a caller's context
+// can be cancelled while the upstream request is provably still in flight.
+func blockingServer(t *testing.T, path, body string, started chan<- struct{}, release <-chan struct{}) *httptest.Server {
+	t.Helper()
+	var once atomic.Bool
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if once.CompareAndSwap(false, true) {
+			close(started)
+		}
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// The singleflight body must not derive its timeout from the caller's context.
+// The shared result belongs to every joined waiter, so the leader cancelling
+// must not abort the upstream call. Cancelling the only caller mid-flight proves
+// the detach: with the leader's ctx captured, the request dies with it.
+func assertFlightSurvivesCallerCancel(t *testing.T, path, body string, call func(*Client, context.Context) error) {
+	t.Helper()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	server := blockingServer(t, path, body, started, release)
+	defer server.Close()
+
+	client := New(server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- call(client, ctx) }()
+
+	<-started // the upstream request is now in flight
+	cancel()  // the caller gives up
+	close(release)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err, "cancelling the caller must not cancel the shared singleflight request")
+	case <-time.After(10 * time.Second):
+		t.Fatal("call did not return after the upstream request was released")
+	}
+}
+
+func TestAbout_SingleflightDetachedFromCallerContext(t *testing.T) {
+	assertFlightSurvivesCallerCancel(t, "/api/about", `{"info":{"model":"Vu+ Uno 4K"}}`,
+		func(c *Client, ctx context.Context) error {
+			_, err := c.About(ctx)
+			return err
+		})
+}
+
+func TestGetStatusInfo_SingleflightDetachedFromCallerContext(t *testing.T) {
+	assertFlightSurvivesCallerCancel(t, "/api/statusinfo", `{"inStandby":"false"}`,
+		func(c *Client, ctx context.Context) error {
+			_, err := c.GetStatusInfo(ctx)
+			return err
+		})
+}
+
+// GetCurrent has no last-known-good fallback, so a poisoned flight surfaces
+// directly as the caller's error.
+func TestGetCurrent_SingleflightDetachedFromCallerContext(t *testing.T) {
+	assertFlightSurvivesCallerCancel(t, "/api/getcurrent", `{"info":{"servicename":"Das Erste HD"}}`,
+		func(c *Client, ctx context.Context) error {
+			_, err := c.GetCurrent(ctx)
+			return err
+		})
+}

--- a/backend/internal/openwebif/status.go
+++ b/backend/internal/openwebif/status.go
@@ -48,7 +48,10 @@ func (c *Client) About(ctx context.Context) (*AboutInfo, error) {
 		}
 		c.aboutCacheMu.RUnlock()
 
-		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// Detach from the leader's request context: this singleflight result is shared
+		// by every joined waiter, so one caller disconnecting must not cancel the
+		// upstream call for all of them. Use an independent, bounded timeout instead.
+		reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 
 		body, err := c.get(reqCtx, "/api/about", "about", nil)
@@ -106,7 +109,10 @@ func (c *Client) GetStatusInfo(ctx context.Context) (*StatusInfo, error) {
 		}
 		c.statusCacheMu.RUnlock()
 
-		reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		// Detach from the leader's request context: this singleflight result is shared
+		// by every joined waiter, so one caller disconnecting must not cancel the
+		// upstream call for all of them. Use an independent, bounded timeout instead.
+		reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
 		defer cancel()
 
 		body, err := c.get(reqCtx, "/api/statusinfo", "status.info", nil)
@@ -147,7 +153,10 @@ func (c *Client) GetStatusInfo(ctx context.Context) (*StatusInfo, error) {
 // GetCurrent fetches detailed current service information (PIDs, etc) with singleflight deduplication.
 func (c *Client) GetCurrent(ctx context.Context) (*CurrentInfo, error) {
 	val, err, _ := c.currentGroup.Do("get.current", func() (any, error) {
-		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// Detach from the leader's request context: this singleflight result is shared
+		// by every joined waiter, so one caller disconnecting must not cancel the
+		// upstream call for all of them. Use an independent, bounded timeout instead.
+		reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 
 		body, err := c.get(reqCtx, "/api/getcurrent", "get.current", nil)

--- a/backend/internal/openwebif/status.go
+++ b/backend/internal/openwebif/status.go
@@ -10,6 +10,21 @@ import (
 const (
 	defaultAboutCacheTTL  = 15 * time.Second
 	defaultStatusCacheTTL = 3 * time.Second
+
+	// maxAboutLKGAge and maxStatusLKGAge bound the last-known-good fallback served on
+	// a fetch failure. Unbounded, a single successful fetch makes every later failure
+	// return that cache forever (nothing calls InvalidateAboutCache/InvalidateStatusCache
+	// in production), and receivertopology records the result as EvidenceObserved with
+	// ObservedAt = now — reporting an unplugged receiver as freshly observed.
+	//
+	// Both payloads carry liveness, not just identity: the background-scan detector
+	// reads about.Info.Streams and about.Info.Tuners to decide whether the receiver is
+	// in use before probing it. The window is therefore one relaxed poll cycle
+	// (receivertopology.StandbyPollInterval, restated here to avoid an import cycle),
+	// after which the caller gets the error back and the evidence grade falls to
+	// EvidenceUnknown, as it did before caching was introduced.
+	maxAboutLKGAge  = 30 * time.Second
+	maxStatusLKGAge = 30 * time.Second
 )
 
 // InvalidateAboutCache clears the cached about metadata.
@@ -74,10 +89,10 @@ func (c *Client) About(ctx context.Context) (*AboutInfo, error) {
 
 	if err != nil {
 		c.aboutCacheMu.RLock()
-		if c.aboutCache != nil {
+		if age := time.Since(c.aboutCacheAt); c.aboutCache != nil && age < maxAboutLKGAge {
 			cached := *c.aboutCache
 			c.aboutCacheMu.RUnlock()
-			c.loggerFor(ctx).Warn().Err(err).Msg("OpenWebIF about fetch failed or timed out; serving Last-Known-Good cached about info")
+			c.loggerFor(ctx).Warn().Err(err).Dur("lkg_age", age).Msg("OpenWebIF about fetch failed or timed out; serving Last-Known-Good cached about info")
 			return &cached, nil
 		}
 		c.aboutCacheMu.RUnlock()
@@ -135,10 +150,10 @@ func (c *Client) GetStatusInfo(ctx context.Context) (*StatusInfo, error) {
 
 	if err != nil {
 		c.statusCacheMu.RLock()
-		if c.statusCache != nil {
+		if age := time.Since(c.statusCacheAt); c.statusCache != nil && age < maxStatusLKGAge {
 			cached := *c.statusCache
 			c.statusCacheMu.RUnlock()
-			c.loggerFor(ctx).Warn().Err(err).Msg("OpenWebIF status fetch failed or timed out; serving Last-Known-Good cached status info")
+			c.loggerFor(ctx).Warn().Err(err).Dur("lkg_age", age).Msg("OpenWebIF status fetch failed or timed out; serving Last-Known-Good cached status info")
 			return &cached, nil
 		}
 		c.statusCacheMu.RUnlock()

--- a/backend/internal/openwebif/status.go
+++ b/backend/internal/openwebif/status.go
@@ -7,62 +7,166 @@ import (
 	"time"
 )
 
-// About fetches receiver metadata from /api/about (best-effort).
+const (
+	defaultAboutCacheTTL  = 15 * time.Second
+	defaultStatusCacheTTL = 3 * time.Second
+)
+
+// InvalidateAboutCache clears the cached about metadata.
+func (c *Client) InvalidateAboutCache() {
+	c.aboutCacheMu.Lock()
+	c.aboutCache = nil
+	c.aboutCacheAt = time.Time{}
+	c.aboutCacheMu.Unlock()
+}
+
+// InvalidateStatusCache clears the cached statusinfo metadata.
+func (c *Client) InvalidateStatusCache() {
+	c.statusCacheMu.Lock()
+	c.statusCache = nil
+	c.statusCacheAt = time.Time{}
+	c.statusCacheMu.Unlock()
+}
+
+// About fetches receiver metadata from /api/about with 15s caching,
+// singleflight request deduplication, and last-known-good fallback.
 func (c *Client) About(ctx context.Context) (*AboutInfo, error) {
-	body, err := c.get(ctx, "/api/about", "about", nil)
-	if err != nil {
-		return nil, err
+	c.aboutCacheMu.RLock()
+	if c.aboutCache != nil && time.Since(c.aboutCacheAt) < defaultAboutCacheTTL {
+		cached := *c.aboutCache
+		c.aboutCacheMu.RUnlock()
+		return &cached, nil
 	}
-	var info AboutInfo
-	if err := json.Unmarshal(body, &info); err != nil {
-		return nil, fmt.Errorf("parse about response: %w", err)
-	}
-	return &info, nil
-}
+	c.aboutCacheMu.RUnlock()
 
-// GetStatusInfo fetches current receiver status (recording, standby, service).
-func (c *Client) GetStatusInfo(ctx context.Context) (*StatusInfo, error) {
-	// Short cache TTL (1s) to avoid hammering but allow rapid UI updates
-	const cacheKey = "statusinfo"
-	if c.cache != nil {
-		if cached, ok := c.cache.Get(cacheKey); ok {
-			if result, ok := cached.(*StatusInfo); ok {
-				return result, nil
-			}
+	val, err, _ := c.aboutGroup.Do("about.info", func() (any, error) {
+		c.aboutCacheMu.RLock()
+		if c.aboutCache != nil && time.Since(c.aboutCacheAt) < defaultAboutCacheTTL {
+			cached := *c.aboutCache
+			c.aboutCacheMu.RUnlock()
+			return &cached, nil
 		}
-	}
+		c.aboutCacheMu.RUnlock()
 
-	body, err := c.get(ctx, "/api/statusinfo", "status.info", nil)
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		body, err := c.get(reqCtx, "/api/about", "about", nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var info AboutInfo
+		if err := json.Unmarshal(body, &info); err != nil {
+			return nil, fmt.Errorf("parse about response: %w", err)
+		}
+
+		c.aboutCacheMu.Lock()
+		c.aboutCache = &info
+		c.aboutCacheAt = time.Now()
+		c.aboutCacheMu.Unlock()
+
+		return &info, nil
+	})
+
 	if err != nil {
+		c.aboutCacheMu.RLock()
+		if c.aboutCache != nil {
+			cached := *c.aboutCache
+			c.aboutCacheMu.RUnlock()
+			c.loggerFor(ctx).Warn().Err(err).Msg("OpenWebIF about fetch failed or timed out; serving Last-Known-Good cached about info")
+			return &cached, nil
+		}
+		c.aboutCacheMu.RUnlock()
 		return nil, err
 	}
 
-	var info StatusInfo
-	if err := json.Unmarshal(body, &info); err != nil {
-		return nil, fmt.Errorf("failed to decode status info: %w", err)
-	}
-
-	if c.cache != nil {
-		c.cache.Set(cacheKey, &info, 2*time.Second) // 2s
-	}
-
-	return &info, nil
+	info := val.(*AboutInfo)
+	copied := *info
+	return &copied, nil
 }
 
-// GetCurrent fetches detailed current service information (PIDs, etc).
-func (c *Client) GetCurrent(ctx context.Context) (*CurrentInfo, error) {
-	// Status data changes rapidly, so very short TTL or no cache
-	// We want fresh data for readiness checks.
-	body, err := c.get(ctx, "/api/getcurrent", "get.current", nil)
+// GetStatusInfo fetches current receiver status (recording, standby, service)
+// with 3s caching, singleflight request deduplication, and last-known-good fallback.
+func (c *Client) GetStatusInfo(ctx context.Context) (*StatusInfo, error) {
+	c.statusCacheMu.RLock()
+	if c.statusCache != nil && time.Since(c.statusCacheAt) < defaultStatusCacheTTL {
+		cached := *c.statusCache
+		c.statusCacheMu.RUnlock()
+		return &cached, nil
+	}
+	c.statusCacheMu.RUnlock()
+
+	val, err, _ := c.statusGroup.Do("status.info", func() (any, error) {
+		c.statusCacheMu.RLock()
+		if c.statusCache != nil && time.Since(c.statusCacheAt) < defaultStatusCacheTTL {
+			cached := *c.statusCache
+			c.statusCacheMu.RUnlock()
+			return &cached, nil
+		}
+		c.statusCacheMu.RUnlock()
+
+		reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		body, err := c.get(reqCtx, "/api/statusinfo", "status.info", nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var info StatusInfo
+		if err := json.Unmarshal(body, &info); err != nil {
+			return nil, fmt.Errorf("failed to decode status info: %w", err)
+		}
+
+		c.statusCacheMu.Lock()
+		c.statusCache = &info
+		c.statusCacheAt = time.Now()
+		c.statusCacheMu.Unlock()
+
+		return &info, nil
+	})
+
 	if err != nil {
+		c.statusCacheMu.RLock()
+		if c.statusCache != nil {
+			cached := *c.statusCache
+			c.statusCacheMu.RUnlock()
+			c.loggerFor(ctx).Warn().Err(err).Msg("OpenWebIF status fetch failed or timed out; serving Last-Known-Good cached status info")
+			return &cached, nil
+		}
+		c.statusCacheMu.RUnlock()
 		return nil, err
 	}
 
-	var info CurrentInfo
-	if err := json.Unmarshal(body, &info); err != nil {
-		return nil, fmt.Errorf("failed to decode current info: %w", err)
+	info := val.(*StatusInfo)
+	copied := *info
+	return &copied, nil
+}
+
+// GetCurrent fetches detailed current service information (PIDs, etc) with singleflight deduplication.
+func (c *Client) GetCurrent(ctx context.Context) (*CurrentInfo, error) {
+	val, err, _ := c.currentGroup.Do("get.current", func() (any, error) {
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		body, err := c.get(reqCtx, "/api/getcurrent", "get.current", nil)
+		if err != nil {
+			return nil, err
+		}
+
+		var info CurrentInfo
+		if err := json.Unmarshal(body, &info); err != nil {
+			return nil, fmt.Errorf("failed to decode current info: %w", err)
+		}
+		return &info, nil
+	})
+
+	if err != nil {
+		return nil, err
 	}
-	return &info, nil
+	info := val.(*CurrentInfo)
+	return info, nil
 }
 
 // GetSignal fetches signal statistics (SNR, BER, etc).

--- a/backend/internal/openwebif/timers.go
+++ b/backend/internal/openwebif/timers.go
@@ -44,7 +44,10 @@ func (c *Client) GetTimers(ctx context.Context) ([]Timer, error) {
 		}
 		c.timerCacheMu.RUnlock()
 
-		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// Detach from the leader's request context: this singleflight result is shared
+		// by every joined waiter, so one caller disconnecting must not cancel the
+		// upstream call for all of them. Use an independent, bounded timeout instead.
+		reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 
 		body, err := c.get(reqCtx, "/api/timerlist", "timers.list", nil)

--- a/backend/internal/openwebif/timers.go
+++ b/backend/internal/openwebif/timers.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const defaultTimerCacheTTL = 5 * time.Second
+const defaultTimerCacheTTL = 15 * time.Second
 
 // InvalidateTimerCache clears the cached timer list (e.g. after a mutation).
 func (c *Client) InvalidateTimerCache() {

--- a/backend/internal/openwebif/timers.go
+++ b/backend/internal/openwebif/timers.go
@@ -12,7 +12,16 @@ import (
 	"time"
 )
 
-const defaultTimerCacheTTL = 15 * time.Second
+const (
+	defaultTimerCacheTTL = 15 * time.Second
+
+	// maxTimerLKGAge bounds the last-known-good fallback below, for the same reason as
+	// maxAboutLKGAge/maxStatusLKGAge in status.go: receivertopology derives active and
+	// upcoming recordings from this list, so an unbounded fallback keeps reporting a
+	// recording that ended — or misses one that started — for as long as the receiver
+	// stays unreachable.
+	maxTimerLKGAge = 30 * time.Second
+)
 
 // InvalidateTimerCache clears the cached timer list (e.g. after a mutation).
 func (c *Client) InvalidateTimerCache() {
@@ -71,11 +80,11 @@ func (c *Client) GetTimers(ctx context.Context) ([]Timer, error) {
 
 	if err != nil {
 		c.timerCacheMu.RLock()
-		if c.timerCache != nil {
+		if age := time.Since(c.timerCacheAt); c.timerCache != nil && age < maxTimerLKGAge {
 			cached := make([]Timer, len(c.timerCache))
 			copy(cached, c.timerCache)
 			c.timerCacheMu.RUnlock()
-			c.loggerFor(ctx).Warn().Err(err).Msg("OpenWebIF timer fetch failed or timed out; serving Last-Known-Good cached timers")
+			c.loggerFor(ctx).Warn().Err(err).Dur("lkg_age", age).Msg("OpenWebIF timer fetch failed or timed out; serving Last-Known-Good cached timers")
 			return cached, nil
 		}
 		c.timerCacheMu.RUnlock()

--- a/backend/internal/openwebif/timers_cache_test.go
+++ b/backend/internal/openwebif/timers_cache_test.go
@@ -53,9 +53,9 @@ func TestGetTimers_CachingSingleflightAndLKGFallback(t *testing.T) {
 	assert.Equal(t, "Test Timer 1", timers2[0].Name)
 	assert.Equal(t, int64(1), atomic.LoadInt64(&requestCount), "Should be served from 5s cache without HTTP call")
 
-	// 3. Force cache expiration (simulate time passing > 5s)
+	// 3. Force cache expiration (simulate time passing > 15s TTL)
 	client.timerCacheMu.Lock()
-	client.timerCacheAt = time.Now().Add(-10 * time.Second)
+	client.timerCacheAt = time.Now().Add(-20 * time.Second)
 	client.timerCacheMu.Unlock()
 
 	// 4. Fetch when backend errors -> falls back to Last-Known-Good (LKG) cached timers

--- a/backend/internal/receivertopology/poller.go
+++ b/backend/internal/receivertopology/poller.go
@@ -14,6 +14,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
+const (
+	// DefaultPollInterval is the baseline polling cadence during active receiver usage.
+	DefaultPollInterval = 10 * time.Second
+	// StandbyPollInterval is the relaxed cadence used when the receiver is confirmed to be in standby and idle.
+	StandbyPollInterval = 30 * time.Second
+)
+
 // OpenWebIFPoller defines the minimal OpenWebIF client interface required for continuous background synchronization.
 type OpenWebIFPoller interface {
 	About(ctx context.Context) (*openwebif.AboutInfo, error)
@@ -30,10 +37,10 @@ type ExternalSyncPoller struct {
 	log      zerolog.Logger
 }
 
-// NewExternalSyncPoller creates a background poller with a configurable poll interval (default: 3 seconds).
+// NewExternalSyncPoller creates a background poller with a configurable poll interval (default: 10 seconds).
 func NewExternalSyncPoller(client OpenWebIFPoller, service *Service, interval time.Duration, logger zerolog.Logger) *ExternalSyncPoller {
 	if interval <= 0 {
-		interval = 3 * time.Second
+		interval = DefaultPollInterval
 	}
 	return &ExternalSyncPoller{
 		client:   client,
@@ -45,14 +52,23 @@ func NewExternalSyncPoller(client OpenWebIFPoller, service *Service, interval ti
 
 // CollectRuntimeSnapshot polls all available OpenWebIF endpoints and synthesizes a ReceiverRuntimeSnapshot with explicit evidence levels.
 func CollectRuntimeSnapshot(ctx context.Context, client OpenWebIFPoller, now time.Time) ReceiverRuntimeSnapshot {
+	snap, _ := CollectRuntimeSnapshotWithAbout(ctx, client, now)
+	return snap
+}
+
+// CollectRuntimeSnapshotWithAbout polls all available OpenWebIF endpoints, synthesizes a ReceiverRuntimeSnapshot,
+// and returns the raw AboutInfo metadata if retrieved to avoid redundant HTTP requests during topology discovery.
+func CollectRuntimeSnapshotWithAbout(ctx context.Context, client OpenWebIFPoller, now time.Time) (ReceiverRuntimeSnapshot, *openwebif.AboutInfo) {
 	snap := ReceiverRuntimeSnapshot{
 		ObservedAt:      now,
 		StandbyEvidence: EvidenceUnknown,
 		StreamPresence:  StreamPresenceUnknown,
 	}
 	if client == nil {
-		return snap
+		return snap, nil
 	}
+
+	var fetchedAbout *openwebif.AboutInfo
 
 	// 1. /api/statusinfo: Standby and status flags
 	if status, err := client.GetStatusInfo(ctx); err == nil && status != nil {
@@ -77,31 +93,34 @@ func CollectRuntimeSnapshot(ctx context.Context, client OpenWebIFPoller, now tim
 	}
 
 	// 2. /api/getcurrent: Authoritative current live service details (PIDs, exact service ref)
-	if curr, err := client.GetCurrent(ctx); err == nil && curr != nil && curr.Info.ServiceRef != "" {
-		mux, err := ParseServiceRef(curr.Info.ServiceRef)
-		var muxPtr *MultiplexID
-		var rfPlane *RFPlane
-		if err == nil {
-			muxPtr = &mux
-			rfPlane = mux.RFPlane
-		}
-		pids := make(map[string]any)
-		if curr.Info.VideoPID != nil {
-			pids["vpid"] = curr.Info.VideoPID
-		}
-		if curr.Info.AudioPID != nil {
-			pids["apid"] = curr.Info.AudioPID
-		}
-		if curr.Info.PMTPID != nil {
-			pids["pmtpid"] = curr.Info.PMTPID
-		}
-		snap.HDMIPlayback = &ObservedService{
-			ServiceRef:  curr.Info.ServiceRef,
-			ServiceName: curr.Info.ServiceName,
-			MultiplexID: muxPtr,
-			RFPlane:     rfPlane,
-			PIDs:        pids,
-			Evidence:    EvidenceObserved,
+	// ONLY query live service details if receiver is NOT in Standby (in Standby HDMI is inactive, saving redundant requests).
+	if !snap.InStandby {
+		if curr, err := client.GetCurrent(ctx); err == nil && curr != nil && curr.Info.ServiceRef != "" {
+			mux, err := ParseServiceRef(curr.Info.ServiceRef)
+			var muxPtr *MultiplexID
+			var rfPlane *RFPlane
+			if err == nil {
+				muxPtr = &mux
+				rfPlane = mux.RFPlane
+			}
+			pids := make(map[string]any)
+			if curr.Info.VideoPID != nil {
+				pids["vpid"] = curr.Info.VideoPID
+			}
+			if curr.Info.AudioPID != nil {
+				pids["apid"] = curr.Info.AudioPID
+			}
+			if curr.Info.PMTPID != nil {
+				pids["pmtpid"] = curr.Info.PMTPID
+			}
+			snap.HDMIPlayback = &ObservedService{
+				ServiceRef:  curr.Info.ServiceRef,
+				ServiceName: curr.Info.ServiceName,
+				MultiplexID: muxPtr,
+				RFPlane:     rfPlane,
+				PIDs:        pids,
+				Evidence:    EvidenceObserved,
+			}
 		}
 	}
 
@@ -137,6 +156,7 @@ func CollectRuntimeSnapshot(ctx context.Context, client OpenWebIFPoller, now tim
 
 	// 4. /api/about: Hardware tuners and streams
 	if about, err := client.About(ctx); err == nil && about != nil {
+		fetchedAbout = about
 		snap.StreamPresence = ParseStreamPresence(about.Info.Streams)
 		for i, t := range about.Info.Tuners {
 			snap.Tuners = append(snap.Tuners, ObservedTunerSlot{
@@ -165,7 +185,7 @@ func CollectRuntimeSnapshot(ctx context.Context, client OpenWebIFPoller, now tim
 		}
 	}
 
-	return snap
+	return snap, fetchedAbout
 }
 
 // resolveDemodulatorIdentity accurately maps an observed stream to the authoritative topology demodulator.
@@ -255,27 +275,24 @@ func (p *ExternalSyncPoller) SyncOnce(ctx context.Context) error {
 		return nil
 	}
 
-	// 1. Elevate topology if needed from /api/about
-	about, err := p.client.About(ctx)
-	if err == nil && about != nil {
-		if p.service.Topology().Confidence == ConfidenceDefault {
-			discovered := DiscoverTopology(about)
-			if err := p.service.UpdateTopologyWithPriority(discovered, false); err != nil {
-				p.log.Debug().Err(err).Msg("failed to update topology to observed")
-			} else {
-				p.log.Info().
-					Str("model", discovered.Model).
-					Int("inputs", len(discovered.Inputs)).
-					Int("demods", len(discovered.Demodulators)).
-					Msg("elevated receiver topology from default to observed")
-			}
+	// 1. Collect multi-endpoint evidentiary snapshot (fetches about metadata once)
+	now := time.Now()
+	snapshot, about := CollectRuntimeSnapshotWithAbout(ctx, p.client, now)
+	p.service.UpdateEvidentiarySnapshot(snapshot)
+
+	// 2. Elevate topology if needed from the fetched about metadata
+	if p.service.Topology().Confidence == ConfidenceDefault && about != nil {
+		discovered := DiscoverTopology(about)
+		if err := p.service.UpdateTopologyWithPriority(discovered, false); err != nil {
+			p.log.Debug().Err(err).Msg("failed to update topology to observed")
+		} else {
+			p.log.Info().
+				Str("model", discovered.Model).
+				Int("inputs", len(discovered.Inputs)).
+				Int("demods", len(discovered.Demodulators)).
+				Msg("elevated receiver topology from default to observed")
 		}
 	}
-
-	// 2. Collect multi-endpoint evidentiary snapshot
-	now := time.Now()
-	snapshot := CollectRuntimeSnapshot(ctx, p.client, now)
-	p.service.UpdateEvidentiarySnapshot(snapshot)
 
 	// 3. Extract external allocations using the evidentiary snapshot and update service
 	activeDemods := p.service.ActiveDemods()
@@ -316,8 +333,10 @@ func (p *ExternalSyncPoller) SyncOnce(ctx context.Context) error {
 }
 
 // Run executes the continuous background poll loop until ctx is cancelled.
+// Dynamically throttles to StandbyPollInterval when receiver is confirmed in standby and idle.
 func (p *ExternalSyncPoller) Run(ctx context.Context) {
-	ticker := time.NewTicker(p.interval)
+	currentInterval := p.interval
+	ticker := time.NewTicker(currentInterval)
 	defer ticker.Stop()
 
 	// Initial sync immediately
@@ -329,6 +348,22 @@ func (p *ExternalSyncPoller) Run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			_ = p.SyncOnce(ctx)
+
+			// Adaptive throttling: relax poll interval in standby if no active local recordings or streams
+			nextInterval := p.interval
+			snap := p.service.EvidentiarySnapshot()
+			activeDemods := p.service.ActiveDemods()
+			if snap.InStandby && len(snap.ActiveRecordings) == 0 && len(activeDemods) == 0 {
+				if nextInterval < StandbyPollInterval {
+					nextInterval = StandbyPollInterval
+				}
+			}
+
+			if nextInterval != currentInterval {
+				currentInterval = nextInterval
+				ticker.Reset(currentInterval)
+				p.log.Debug().Dur("interval", currentInterval).Msg("adjusted external sync polling interval")
+			}
 		}
 	}
 }

--- a/backend/internal/receivertopology/poller_test.go
+++ b/backend/internal/receivertopology/poller_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ManuGH/xg2g/internal/openwebif"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -214,4 +215,60 @@ func TestExtractExternalAllocations_CorrelatesXG2GStreams(t *testing.T) {
 	assert.Equal(t, "external_stream_client", allocs[0].Source)
 	require.NotNil(t, allocs[0].DemodID)
 	assert.Equal(t, DemodulatorID("tuner_b"), *allocs[0].DemodID)
+}
+
+func TestCollectRuntimeSnapshot_StandbySkipsGetCurrent(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	var getCurrentCalled bool
+	client := &mockPollerClient{
+		statusInfoFunc: func(ctx context.Context) (*openwebif.StatusInfo, error) {
+			return &openwebif.StatusInfo{
+				InStandby: "true",
+			}, nil
+		},
+		currentFunc: func(ctx context.Context) (*openwebif.CurrentInfo, error) {
+			getCurrentCalled = true
+			return &openwebif.CurrentInfo{}, nil
+		},
+	}
+
+	snap := CollectRuntimeSnapshot(ctx, client, now)
+
+	assert.True(t, snap.InStandby)
+	assert.Equal(t, EvidenceObserved, snap.StandbyEvidence)
+	assert.False(t, getCurrentCalled, "GetCurrent must NOT be called when receiver is in standby")
+}
+
+func TestExternalSyncPoller_SyncOnce_TopologyElevation(t *testing.T) {
+	ctx := context.Background()
+
+	var aboutCalls int
+	client := &mockPollerClient{
+		aboutFunc: func(ctx context.Context) (*openwebif.AboutInfo, error) {
+			aboutCalls++
+			var about openwebif.AboutInfo
+			about.Info.Model = "Vu+ Uno 4K SE"
+			about.Info.Tuners = []openwebif.AboutTuner{
+				{Name: "Tuner A", Type: "DVB-S2"},
+			}
+			return &about, nil
+		},
+		statusInfoFunc: func(ctx context.Context) (*openwebif.StatusInfo, error) {
+			return &openwebif.StatusInfo{InStandby: "true"}, nil
+		},
+	}
+
+	svc, err := NewService(ReceiverTopology{Confidence: ConfidenceDefault}, EvaluationModeAuditOnly)
+	require.NoError(t, err)
+
+	poller := NewExternalSyncPoller(client, svc, 10*time.Second, zerolog.Nop())
+
+	err = poller.SyncOnce(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, ConfidenceObserved, svc.Topology().Confidence)
+	assert.Equal(t, "Vu+ Uno 4K SE", svc.Topology().Model)
+	assert.Equal(t, 1, aboutCalls, "About should only be called once during SyncOnce")
 }


### PR DESCRIPTION
# Pull Request

> **Status: both findings fixed, cleared to merge.** The two review findings this
> PR was parked on are addressed in `dfc3163d` and `3e996eae`. Finding 2 is closed
> by the bound, not by the staleness signal — the caveat under it records what is
> deliberately left for a later branch. Reviewed and accepted by @ManuGH.

## Summary

Reduces how hard the receiver is polled: tiered intervals plus standby
awareness, so a receiver that is asleep is not hammered at the active rate.

## Provenance

This commit was pushed onto `feat/shadow-latency-isolation` by mistake, where it
had nothing to do with that PR's subject (step 4b.2a of the audio-parser
migration, #902). It was carved back out so #902 is again exactly three
`mediafacts` files.

- was `8e5c6225` on `feat/shadow-latency-isolation`
- now `93b573bd` on `fix/openwebif-polling-tiers`, cherry-picked onto `main@3f48fc47`
- the code is unchanged by the move; only the parent differs

## Review findings

Both were raised by the Claude review on #902 and are reproduced in full below,
so that resolving the now-outdated threads on #902 did not lose them.

- [x] **1 — singleflight closures capture the leader's `ctx`** — fixed in `dfc3163d`
- [x] **2 — the last-known-good fallback has no age bound** — bounded in `3e996eae`

### How they were fixed

**1 — `dfc3163d`.** The timeout now derives from `context.WithoutCancel(ctx)`,
the pattern already used and commented in `control/http/v3/receiver_current.go`.
Values still cross into the flight; cancellation no longer does. Applied at four
sites, not the three listed: `GetTimers` in `timers.go` has the same defect and
the same shared client.

**2 — `3e996eae`.** Bounded at `maxAboutLKGAge` / `maxStatusLKGAge` /
`maxTimerLKGAge`, all 30s — one relaxed poll cycle. Past the window the caller
gets the error back and the evidence grade falls to `EvidenceUnknown`, as it did
before caching existed. `timers.go` had this defect too and is bounded with them.

The window is 30s rather than a metadata lifetime because all three payloads
carry liveness, not identity: `background_scan_detector.go` reads
`about.Info.Streams` and `about.Info.Tuners` to decide whether a receiver is in
use before probing it. Answering that from minutes-old data reopens the tuner
conflict #916 closed. The served age is now on the warning line, so a receiver
riding the fallback is visible in the logs instead of silent.

**Caveat on 2, stated rather than buried.** You offered two remedies — bound the
window, *or* thread a staleness signal so the poller can use `EvidenceInferred`
for fallback-sourced data. This implements the bound only. Inside the 30s window
the poller still records LKG data as `EvidenceObserved` with `ObservedAt = now`.
Threading the signal means changing the `OpenWebIFPoller` interface, which is a
separate subject and belongs on its own branch.

### Verification

The six new tests fail against the previous code — checked by reverting the fix
and re-running, not assumed:

```
--- FAIL: TestAbout_LKGFallbackExpiresPastBound
--- FAIL: TestGetStatusInfo_LKGFallbackExpiresPastBound
--- FAIL: TestGetTimers_LKGFallbackExpiresPastBound
--- FAIL: TestAbout_SingleflightDetachedFromCallerContext
--- FAIL: TestGetStatusInfo_SingleflightDetachedFromCallerContext
--- FAIL: TestGetCurrent_SingleflightDetachedFromCallerContext
```

The detach tests cancel the only caller while the upstream request is provably
in flight (the test server blocks until released), so they assert the mechanism
rather than racing two goroutines.

With the fix: `openwebif` and `receivertopology` green under `-race`;
`make pre-push` green; `golangci-lint` reports zero findings in
`internal/openwebif`. The two `gosec` findings it reports in `receivertopology`
are pre-existing — those files are byte-identical to `origin/main` and untouched
by these commits.

### 1 — singleflight closures capture the leader's `ctx`

*Originally [#902 (comment)](https://github.com/ManuGH/xg2g/pull/902#discussion_r3889141199), verbatim — kept for the record:*

> **Bug:** singleflight closures capture the *first* caller's `ctx`, so one caller's cancellation/deadline poisons every joined waiter.
>
> `About` (here, line 51), `GetStatusInfo` (line 109), and `GetCurrent` (line 150) all do `context.WithTimeout(ctx, N*time.Second)` inside a `singleflight.Group.Do` body. `singleflight.Do` runs the function on behalf of whichever caller arrives first and hands the *same* `(val, err)` to every caller that joins that flight. If the leader's request context is cancelled (e.g. client disconnect) or has a shorter deadline, every other joined caller gets that cancellation error or a truncated deadline — even if their own context is perfectly healthy.
>
> The codebase already guards against exactly this pattern elsewhere: [`receiver_current.go`](https://github.com/ManuGH/xg2g/blob/93b573bd/backend/internal/control/http/v3/receiver_current.go#L72-L79) wraps its singleflight body in `context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)`, with a comment explaining why. Since the v3 HTTP server holds one shared `*openwebif.Client` across concurrent requests, two unrelated requests (e.g. `/system/info` and `/receiver/context`) can join the same `about.info`/`status.info`/`get.current` singleflight key, and one disconnecting can break the other's result. `About`/`GetStatusInfo` partially mask this via last-known-good fallback, but `GetCurrent` has no fallback and returns the leader's error straight through.
>
> Suggested fix: derive the per-request timeout from a detached context, matching the existing pattern — `context.WithTimeout(context.WithoutCancel(ctx), N*time.Second)` — at all three call sites (lines 51, 109, 150).

### 2 — the last-known-good fallback has no age bound

*Originally [#902 (comment)](https://github.com/ManuGH/xg2g/pull/902#discussion_r3889141401), verbatim — kept for the record:*

> **Bug:** the last-known-good fallback has no age bound, so an unreachable receiver can be reported as freshly observed indefinitely.
>
> This error-path fallback (and the equivalent in `About` at lines 72-81) returns `c.statusCache` with `err == nil` whenever it's non-nil — unlike the happy path a few lines above (line 93), there's no `time.Since(c.statusCacheAt) < defaultStatusCacheTTL` check here. Once a single fetch has ever succeeded, every subsequent failure (receiver powered off, unplugged, network down) silently serves that cache forever, no matter how old it is. `InvalidateStatusCache`/`InvalidateAboutCache` exist but have no production callers, so nothing ever clears it.
>
> Downstream, [`receivertopology/poller.go`](https://github.com/ManuGH/xg2g/blob/93b573bd/backend/internal/receivertopology/poller.go#L63-L76) treats this successful-but-arbitrarily-stale result as fresh: it sets `StandbyEvidence = EvidenceObserved` and `ObservedAt = now` for data of unbounded age. Before this PR, a fetch failure propagated as an error and left `StandbyEvidence = EvidenceUnknown` — this is a real behavior regression, not pre-existing (pre-PR, `About` had no cache at all and `GetStatusInfo` returned the error directly on failure).
>
> Consider bounding the LKG window (e.g. a `maxLKGAge` distinct from the happy-path TTL) or threading a staleness signal through (e.g. tagging the result so the poller can use `EvidenceInferred` instead of `EvidenceObserved` for LKG-sourced data) so downstream consumers can tell a live read from stale fallback data.

## Files

```
backend/internal/app/bootstrap/bootstrap.go
backend/internal/openwebif/about_cache_test.go
backend/internal/openwebif/client.go
backend/internal/openwebif/lkg_bound_test.go
backend/internal/openwebif/singleflight_ctx_test.go
backend/internal/openwebif/status.go
backend/internal/openwebif/timers.go
backend/internal/openwebif/timers_cache_test.go
backend/internal/receivertopology/poller.go
backend/internal/receivertopology/poller_test.go
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


