### PR TITLE
fix(v3): an administrator that cannot read status is a hole, not a boundary

### DIFF
--- a/backend/internal/control/http/v3/rbac.go
+++ b/backend/internal/control/http/v3/rbac.go
@@ -60,22 +60,34 @@ func normalizeScopes(scopes []string) []Scope {
 	return out
 }
 
+// applyImpliedScopes expands a token's scopes to everything they stand for.
+//
+// v3:admin implies v3:status: an administrator that cannot read the system's
+// own status is a hole, not a boundary. The reverse does not hold, so a
+// monitoring token can still carry v3:status alone and see nothing else.
+//
+// Every branch that grants v3:admin grants v3:status with it. has() already
+// answers yes for the wildcards, but the set itself is logged as token_scopes
+// on a 403 - if the two disagree, the log lies about why the request failed.
 func applyImpliedScopes(set scopeSet) {
 	if set == nil {
 		return
 	}
 	if _, ok := set[ScopeAll]; ok {
 		set[ScopeV3Admin] = struct{}{}
+		set[ScopeV3Status] = struct{}{}
 		set[ScopeV3Write] = struct{}{}
 		set[ScopeV3Read] = struct{}{}
 		return
 	}
 	if _, ok := set[ScopeV3All]; ok {
 		set[ScopeV3Admin] = struct{}{}
+		set[ScopeV3Status] = struct{}{}
 		set[ScopeV3Write] = struct{}{}
 		set[ScopeV3Read] = struct{}{}
 	}
 	if _, ok := set[ScopeV3Admin]; ok {
+		set[ScopeV3Status] = struct{}{}
 		set[ScopeV3Write] = struct{}{}
 		set[ScopeV3Read] = struct{}{}
 	}
@@ -91,6 +103,7 @@ func applyImpliedScopes(set scopeSet) {
 	}
 	if _, ok := set["admin"]; ok {
 		set[ScopeV3Admin] = struct{}{}
+		set[ScopeV3Status] = struct{}{}
 		set[ScopeV3Write] = struct{}{}
 		set[ScopeV3Read] = struct{}{}
 	}

--- a/backend/internal/control/http/v3/rbac_scope_implication_test.go
+++ b/backend/internal/control/http/v3/rbac_scope_implication_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+package v3
+
+import "testing"
+
+// TestScopeImplications pins the direction of the admin/status relation.
+// An administrator sees the system's own status; a monitoring token that sees
+// the status stays blind to everything else.
+func TestScopeImplications(t *testing.T) {
+	tests := []struct {
+		name    string
+		granted []string
+		allowed []Scope
+		denied  []Scope
+	}{
+		{
+			name:    "v3:admin implies status, write and read",
+			granted: []string{string(ScopeV3Admin)},
+			allowed: []Scope{ScopeV3Admin, ScopeV3Status, ScopeV3Write, ScopeV3Read},
+		},
+		{
+			name:    "v3:* implies status",
+			granted: []string{string(ScopeV3All)},
+			allowed: []Scope{ScopeV3Status, ScopeV3Admin},
+		},
+		{
+			name:    "* implies status",
+			granted: []string{string(ScopeAll)},
+			allowed: []Scope{ScopeV3Status, ScopeV3Admin},
+		},
+		{
+			name:    "legacy admin alias implies status",
+			granted: []string{"admin"},
+			allowed: []Scope{ScopeV3Status, ScopeV3Admin},
+		},
+		{
+			name:    "v3:status alone grants nothing else",
+			granted: []string{string(ScopeV3Status)},
+			allowed: []Scope{ScopeV3Status},
+			denied:  []Scope{ScopeV3Read, ScopeV3Write, ScopeV3Admin},
+		},
+		{
+			name:    "v3:write does not reach status",
+			granted: []string{string(ScopeV3Write)},
+			allowed: []Scope{ScopeV3Write, ScopeV3Read},
+			denied:  []Scope{ScopeV3Status, ScopeV3Admin},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			set := newScopeSet(tc.granted)
+			for _, scope := range tc.allowed {
+				if !set.has(scope) {
+					t.Errorf("scopes %v: has(%q) = false, want true", tc.granted, scope)
+				}
+			}
+			for _, scope := range tc.denied {
+				if set.has(scope) {
+					t.Errorf("scopes %v: has(%q) = true, want false", tc.granted, scope)
+				}
+			}
+		})
+	}
+}
+
+// TestAdminScopeSetContainsStatus guards the logged set, not just the answer.
+// has() short-circuits the wildcards, so a set that disagrees with it would
+// still authorize correctly while reporting the wrong token_scopes on a 403.
+func TestAdminScopeSetContainsStatus(t *testing.T) {
+	for _, granted := range []string{string(ScopeAll), string(ScopeV3All), string(ScopeV3Admin), "admin"} {
+		set := newScopeSet([]string{granted})
+		if _, ok := set[ScopeV3Status]; !ok {
+			t.Errorf("scope %q: set is missing %q, so a 403 would log an incomplete token_scopes", granted, ScopeV3Status)
+		}
+	}
+}


### PR DESCRIPTION
`v3:admin` did not imply `v3:status`, so a token holding admin alone was refused the system's own status. Every branch that grants admin now grants status with it: both wildcards, `v3:admin` itself, and the legacy `admin` alias. The reverse still does not hold — a monitoring token can carry `v3:status` and see nothing else, which is the point of having the scope separate.

The **set** is corrected, not only the answer. `has()` short-circuits the wildcards, so authorization was already going to be right for `*` and `v3:*` — but the set is what a 403 logs as `token_scopes`, and a set that disagrees with `has()` makes the log state a reason that is not the reason.

## Verification
- `go test ./internal/control/http/v3/` — green, whole package (6.99s), not just the new tests.
- Counter-check against the **unpatched** `rbac.go` from `origin/main`: the new tests fail on all four granting branches and on both wildcard sets. They gate the behaviour rather than describe it.
- `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)