### PR TITLE
test(mediafacts): the race detector measures itself, so the clock test steps aside

### DIFF
--- a/backend/internal/stream/ingest/mediafacts/deadline_test.go
+++ b/backend/internal/stream/ingest/mediafacts/deadline_test.go
@@ -27,19 +27,31 @@ func capture(t *testing.T, name string) []byte {
 // DefaultIngestDeadline, the headroom the number was chosen for is gone and this
 // says so before a stalled core starts looking like a slow one.
 func TestIngestStaysFarInsideItsDeadline(t *testing.T) {
-	// A wall-clock guard measures the parser. Under coverage it measures the
-	// counters coverage inserted into the parser, which is a different thing and
-	// not one DefaultIngestDeadline was derived from - atomic counters on every
-	// block turn the 4 MiB chunk from ~15ms into ~54ms without the parser having
-	// changed at all.
+	// A wall-clock guard measures the parser. Under instrumentation it measures
+	// what the instrumentation added to the parser, which is a different thing and
+	// not one DefaultIngestDeadline was derived from. Coverage counters on every
+	// block turn the 4 MiB chunk from ~15ms into ~54ms; the race detector, which
+	// checks shadow memory on every access, turns the same chunk into ~120ms on a
+	// development machine and ~300ms on a CI runner. The parser is unchanged in
+	// both cases.
 	//
-	// Skipping here is not a loosened gate. The property is still checked on every
-	// ordinary run and on the race job; what is dropped is a timing claim from the
-	// one run that cannot make it honestly. The alternative - raising the limit
-	// until instrumented timings fit under it - would fit the contract to the
-	// measuring instrument and leave the real headroom unguarded.
-	if testing.CoverMode() != "" {
+	// The detector has nothing to find here to trade for that: Ingest parses on the
+	// calling goroutine, over a buffer only this test holds, and neither this
+	// package nor esaudio starts a goroutine or shares state. So under -race this
+	// measurement can report a slower clock and nothing else, and skipping it costs
+	// the race runs no coverage they would otherwise have.
+	//
+	// Skipping is not a loosened gate. The property is checked on every
+	// uninstrumented run, which is the PR suite (`go test ./...`) and every plain
+	// local run; what is dropped is a timing claim from the runs that cannot make
+	// it honestly. The alternative - raising the limit until instrumented timings
+	// fit under it - would fit the contract to the measuring instrument and leave
+	// the real headroom unguarded.
+	switch {
+	case testing.CoverMode() != "":
 		t.Skip("wall-clock ingest headroom is not meaningful under coverage instrumentation")
+	case raceDetectorEnabled:
+		t.Skip("wall-clock ingest headroom is not meaningful under the race detector")
 	}
 
 	for _, name := range []string{"test_hevc_stream.ts", "verify_aac.ts", "verify_seg.ts"} {

--- a/backend/internal/stream/ingest/mediafacts/race_off_test.go
+++ b/backend/internal/stream/ingest/mediafacts/race_off_test.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//go:build !race
+
+package mediafacts
+
+// The ordinary build: see race_on_test.go.
+const raceDetectorEnabled = false

--- a/backend/internal/stream/ingest/mediafacts/race_on_test.go
+++ b/backend/internal/stream/ingest/mediafacts/race_on_test.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//go:build race
+
+package mediafacts
+
+// Whether this binary was built with -race. There is no testing.RaceEnabled, so
+// the build tag is the only thing a test can ask; see race_off_test.go for the
+// other half. Nothing here changes behaviour under the detector - it exists so a
+// wall-clock measurement can tell that it is being taken through one.
+const raceDetectorEnabled = true


### PR DESCRIPTION
`TestIngestStaysFarInsideItsDeadline` is a wall-clock guard. It already stepped aside under coverage, where atomic counters on every block take the 4 MiB chunk from ~15ms to ~54ms. The race detector does the same thing harder — shadow-memory checks on every access take the same chunk to ~120ms locally and ~300ms on a runner — and the test did not know about it. The job most likely to be slow was the job the timing claim could not survive.

There is no `testing.RaceEnabled`, so the build tag is the only thing a test can ask. `race_on_test.go` / `race_off_test.go` are the two halves of that question and change no behaviour themselves.

Skipping costs the race runs nothing. Ingest parses on the calling goroutine over a buffer only the test holds, and neither this package nor `esaudio` starts a goroutine or shares state — the detector has nothing here to find that it could trade for the slower clock. The property is still checked on every uninstrumented run. Raising the limit until instrumented timings fit under it would fit the contract to the measuring instrument and leave the real headroom unguarded.

## Verification
- Plain run: `--- PASS: TestIngestStaysFarInsideItsDeadline (0.17s)` — still a real gate.
- Under `-race`: `--- SKIP` , and the full package stays green (`ok ... 1.686s`).
- `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)