### PR TITLE
fix(config): a failure names the variable that fixes it, not the field that failed

### DIFF
--- a/backend/internal/config/validation.go
+++ b/backend/internal/config/validation.go
@@ -5,6 +5,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -90,10 +92,53 @@ func Validate(cfg AppConfig) error {
 	validateEngineAndResilience(v, cfg)
 
 	if !v.IsValid() {
-		return v.Err()
+		return annotateValidationEnv(v.Err())
 	}
 
 	return nil
+}
+
+// annotateValidationEnv names the environment variable an operator actually
+// sets, next to the field path the validator reports. Without it a failure
+// reads "RecordingTargetSigningKey" and the operator has to find
+// XG2G_RECORDINGS_TARGET_SIGNING_KEY somewhere else before the daemon can
+// start.
+//
+// The lookup lives here rather than in validate.Error, because internal/config
+// imports internal/validate and not the other way round. Fields the registry
+// does not know, and fields it knows without an environment variable, are
+// passed through untouched: an annotation that cannot be trusted is worse than
+// none.
+func annotateValidationEnv(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var verr validate.ValidationError
+	if !errors.As(err, &verr) {
+		return err
+	}
+
+	registry, regErr := GetRegistry()
+	if regErr != nil {
+		return err
+	}
+
+	annotated := validate.New()
+	changed := false
+	for _, e := range verr.Errors() {
+		field := e.Field
+		if entry, ok := registry.ByField[field]; ok && entry.Env != "" {
+			field = fmt.Sprintf("%s (env %s)", field, entry.Env)
+			changed = true
+		}
+		annotated.AddError(field, e.Message, e.Value)
+	}
+	if !changed {
+		return err
+	}
+
+	return annotated.Err()
 }
 
 func validateHousehold(v *validate.Validator, cfg AppConfig) {

--- a/backend/internal/config/validation_test.go
+++ b/backend/internal/config/validation_test.go
@@ -655,3 +655,61 @@ func TestValidate_MonetizationAmazonMappingsRequireProviderConfig(t *testing.T) 
 		t.Fatalf("expected Monetization.Amazon.SharedSecretFile validation error, got %v", err)
 	}
 }
+
+// TestValidate_AnnotatesEnvNames pins the operator-facing half of a validation
+// failure: the message has to name the variable that actually fixes it.
+func TestValidate_AnnotatesEnvNames(t *testing.T) {
+	t.Run("field with env is annotated", func(t *testing.T) {
+		cfg := baseValidationConfig()
+		cfg.RecordingTargetSigningKey = "too-short"
+
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("Validate() = nil, want error for short signing key")
+		}
+		if !strings.Contains(err.Error(), "XG2G_RECORDINGS_TARGET_SIGNING_KEY") {
+			t.Errorf("error does not name the env var an operator sets: %v", err)
+		}
+		if !strings.Contains(err.Error(), "must be configured and at least 32 characters") {
+			t.Errorf("annotation dropped the original message: %v", err)
+		}
+	})
+
+	t.Run("field outside the registry is untouched", func(t *testing.T) {
+		cfg := baseValidationConfig()
+		cfg.ForceHTTPS = true
+		cfg.TLSEnabled = false
+		cfg.TrustedProxies = ""
+
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("Validate() = nil, want error for HTTPS without TLS")
+		}
+		if !strings.Contains(err.Error(), "HTTPS_WITHOUT_TLS") {
+			t.Fatalf("expected the forbidden-rule failure, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "HTTPS_WITHOUT_TLS (env") {
+			t.Errorf("forbidden rule name is not a config field and must not be annotated: %v", err)
+		}
+	})
+
+	t.Run("multiple failures keep their separator", func(t *testing.T) {
+		cfg := baseValidationConfig()
+		cfg.RecordingTargetSigningKey = "too-short"
+		cfg.ForceHTTPS = true
+		cfg.TLSEnabled = false
+		cfg.TrustedProxies = ""
+
+		err := Validate(cfg)
+		if err == nil {
+			t.Fatal("Validate() = nil, want two errors")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "XG2G_RECORDINGS_TARGET_SIGNING_KEY") || !strings.Contains(msg, "HTTPS_WITHOUT_TLS") {
+			t.Errorf("annotation lost one of the two failures: %v", err)
+		}
+		if !strings.Contains(msg, "; ") {
+			t.Errorf("multi-error formatting lost: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
`Validate` reported the Go field path, so an operator read `RecordingTargetSigningKey` and still had to find `XG2G_RECORDINGS_TARGET_SIGNING_KEY` somewhere else before the daemon would start. The registry already maps one to the other — the failure just never asked.

The lookup sits at the end of `Validate` rather than in `validate.Error`, because `internal/config` imports `internal/validate` and not the reverse; and in `Validate` rather than at the loader, because the same failure reaches an operator through four doors: startup, hot reload, `PUT /system/config`, and `xg2g config validate`.

Fields the registry does not know, and fields it knows without an environment variable, pass through untouched. An annotation that cannot be trusted is worse than none.

## Verification
- `go test ./internal/config/` green (0.84s), `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)