### PR TITLE
fix(scan): a receiver that is in use is not a receiver to probe

### DIFF
--- a/backend/internal/app/bootstrap/background_scan_detector.go
+++ b/backend/internal/app/bootstrap/background_scan_detector.go
@@ -80,8 +80,16 @@ func backgroundScanReceiverStreaming(ctx context.Context, receiver backgroundSca
 
 	wg.Wait()
 
-	if statusKnown, statusActive := backgroundScanParseOWIBool(statusValue(status)); statusKnown && statusActive {
-		return true, nil
+	if status != nil {
+		if statusKnown, statusActive := backgroundScanParseOWIBool(status.IsStreaming); statusKnown && statusActive {
+			return true, nil
+		}
+		if recKnown, isRecording := backgroundScanParseOWIBool(status.IsRecording); recKnown && isRecording {
+			return true, nil
+		}
+		if standbyKnown, inStandby := backgroundScanParseOWIBool(status.InStandby); standbyKnown && !inStandby {
+			return true, nil
+		}
 	}
 
 	if about != nil {

--- a/backend/internal/app/bootstrap/background_scan_detector_test.go
+++ b/backend/internal/app/bootstrap/background_scan_detector_test.go
@@ -131,3 +131,49 @@ func TestBackgroundScanPlaybackDetector_ReturnsReceiverErrorWhenAllFallbacksFail
 		t.Fatal("expected inactive playback when receiver probes fail")
 	}
 }
+
+func TestBackgroundScanPlaybackDetector_TreatsHDMIActiveAsPlayback(t *testing.T) {
+	store := &backgroundScanTestStore{}
+	receiver := &backgroundScanTestReceiver{
+		status: &openwebif.StatusInfo{InStandby: "false", IsStreaming: "false", IsRecording: "false"},
+	}
+
+	active, err := newBackgroundScanPlaybackDetector(store, receiver)(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Fatal("expected active playback when receiver is awake / active on HDMI (inStandby=false)")
+	}
+}
+
+func TestBackgroundScanPlaybackDetector_TreatsRecordingAsPlayback(t *testing.T) {
+	store := &backgroundScanTestStore{}
+	receiver := &backgroundScanTestReceiver{
+		status: &openwebif.StatusInfo{InStandby: "true", IsStreaming: "false", IsRecording: "true"},
+	}
+
+	active, err := newBackgroundScanPlaybackDetector(store, receiver)(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !active {
+		t.Fatal("expected active playback when receiver is recording (isRecording=true)")
+	}
+}
+
+func TestBackgroundScanPlaybackDetector_AllowsScanningWhenInStandbyAndIdle(t *testing.T) {
+	store := &backgroundScanTestStore{}
+	receiver := &backgroundScanTestReceiver{
+		status: &openwebif.StatusInfo{InStandby: "true", IsStreaming: "false", IsRecording: "false"},
+		about:  testAboutInfo([]openwebif.AboutTuner{}, []any{}),
+	}
+
+	active, err := newBackgroundScanPlaybackDetector(store, receiver)(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if active {
+		t.Fatal("expected idle playback (active=false) when receiver is in standby and not recording/streaming")
+	}
+}


### PR DESCRIPTION
When the Enigma2 receiver is powered on (`InStandby == false`, e.g. someone is watching live TV over HDMI) or actively recording (`IsRecording == true`), `backgroundScanReceiverStreaming` now reports it as active and the scan manager pauses background capability probing.

Without that, the probe repeatedly opens and closes OpenWebIF streams and ffprobes behind a viewer's back: it contends for the same tuner the person is watching through, and it drives OSCam through rapid CA PMT list updates for a picture nobody asked for.

## Notes
- Rebased onto current `origin/main` — the branch had drifted 72 commits behind. `background_scan_detector.go` was untouched on `main` in the meantime, so the rebase was clean.
- The follow-up `style: gofmt` commit is folded into this one; it was a fixup to this change, not a change of its own. Tree is byte-identical to the two-commit version.

## Verification
- `go test ./internal/app/bootstrap/` green (8.76s), `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)