### PR TITLE
docs(agents): the checks that said a branch was fine when it was not

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,12 +241,47 @@ successful release is not a successful release.
   even though nothing is outstanding; confirm with
   `git cherry origin/main <branch>` — every line prefixed `-` means every commit
   is already in `main` and the branch is only a stale pointer.
+- A `+` from `git cherry` is not proof that work is outstanding. It compares
+  patch IDs, and any commit whose conflicts were resolved on the way in has a
+  different patch ID from its original — so content that IS in `main` reports as
+  missing. Seen 2026-09-02: a branch reported 2 of 34 commits outstanding, and
+  both were exactly the commits whose conflicts had been resolved during the
+  split. Before acting on a `+`, grep `main` for what that commit actually
+  added. Count content, not patch IDs.
 - Before removing a worktree, run `git status --porcelain` inside it. Agent
   worktrees routinely hold uncommitted test files. Commit them or save a patch
   first. Never `git worktree remove --force` a dirty tree merely to tidy up.
 - Periodically reconcile: `git branch -vv`, `git worktree list`, and
   `gh pr list --state all` together. Anything local without a matching open PR
   is either finished (delete it), parked (note it), or forgotten (decide).
+
+#### Before merging a branch that has fallen behind
+
+- Ask first whether its work already landed by another route. A branch whose
+  headline work reached `main` independently is not merged forward, it is
+  closed. Compare tips, not the three-dot diff:
+  `git diff --shortstat origin/main <branch>`. Deletions far exceeding
+  insertions mean taking that branch would REVERT `main`. Seen 2026-09-02:
+  +8,505/−87,921 on one branch, and on another `main` had implemented the very
+  feature the branch still refused with an error.
+- `git diff --numstat origin/main <branch> -- <file>` per key file says which
+  side is ahead. A file that is byte-identical, or where the branch has fewer
+  lines, is a file the branch can no longer contribute.
+- Branch protection here is `strict: false`, so a PR may merge while far behind
+  `main` and its CI never builds the combination. Either rebase before merging
+  so CI tests what will actually land, or build and test merged `main`
+  afterwards. Do not assume a green PR proves the merge result.
+
+#### Linters do not agree across machines
+
+- CI pins its linter version. A local `golangci-lint` of a different version
+  reports different findings — seen 2026-09-02: local reported 0 issues where
+  CI reported 3 G115s. A clean local run is not a green gate.
+- When CI reports N findings of one pattern, grep the tree for the pattern
+  instead of fixing the N reported lines. Same day: CI named 3 sites,
+  `grep` found 6, and the other 3 would have failed a later run.
+- `go vet` stops at the first errors per package and does not see everything a
+  test binary will. `go test` is what proves a package with its tests compiles.
 
 ### Deployment and safety
 


### PR DESCRIPTION
Three traps from yesterday's branch cleanup. Each one produced a confident wrong answer rather than an error, which is why they are worth writing down.

**The first is a correction to an existing rule.** "Closing a branch out" names `git cherry origin/main <branch>` and reads as if a `+` means outstanding work. It does not — `git cherry` compares patch IDs, and a commit whose conflicts were resolved on the way into `main` has a different patch ID from the original. `feature/controlled-preemption-sagas` reported 2 of 34 commits outstanding, and both were exactly the two whose conflicts had been resolved during the split; their content was in `main` the whole time. Followed as written, that branch is either kept forever or deleted on a signal that means nothing.

**The second is a check nobody was doing at all:** whether a stale branch's work has already landed by another route. Two parked branches had their headline work reach `main` independently, and merging either forward would have reverted it — `feat/av1-icq-q22` shows +8,505/−87,921 against `main`, and on `feat/native-api-contract-codegen` `main` had implemented the very feature the branch still refused with an error. The three-dot diff hides this because it reads from the merge base; comparing tips shows it at once. Recorded alongside it: branch protection is `strict: false`, so a PR can merge far behind `main` and its CI never builds the combination that actually lands — which is how #918 merged without ever being built against #919.

**The third is that a clean local lint run is not a green gate.** CI pins `golangci-lint` v2.8.0; a local 2.12.2 reported 0 issues where CI reported 3 G115s. Grepping for the pattern CI named found 6 sites, so fixing only the reported lines would have left the other three to fail a later run.

No code changes, and `make generate-config` produces no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
