### PR TITLE
fix(ci): bound the ffmpeg install so a stalled mirror cannot eat the job

### DIFF
--- a/.github/workflows/ci-deep-scheduled.yml
+++ b/.github/workflows/ci-deep-scheduled.yml
@@ -56,10 +56,15 @@ jobs:
           make ui-build
 
       - name: Install ffmpeg
+        # A stalled apt mirror must not eat the job budget (run 33599181411 hung
+        # the equivalent PR step for 21m37s and got a passing suite cancelled).
+        # Slowest healthy install across the nightly jobs is 295s, so 10m bounds
+        # a hang at ~2x that without firing on a merely slow mirror.
+        timeout-minutes: 10
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update
+          sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=15 ffmpeg
           ffmpeg -version
 
       - name: Run race suite
@@ -97,10 +102,15 @@ jobs:
           GOTOOLCHAIN: auto
 
       - name: Install ffmpeg
+        # A stalled apt mirror must not eat the job budget (run 33599181411 hung
+        # the equivalent PR step for 21m37s and got a passing suite cancelled).
+        # Slowest healthy install across the nightly jobs is 295s, so 10m bounds
+        # a hang at ~2x that without firing on a merely slow mirror.
+        timeout-minutes: 10
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update
+          sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=15 ffmpeg
           ffmpeg -version
 
       - name: Run integration and invariants (fail-fast)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,17 @@ jobs:
           GOTOOLCHAIN: auto
 
       - name: Install ffmpeg for full verification suite
+        # Run 33599181411 stalled here for 21m37s on an unresponsive apt mirror,
+        # burning the 25m job budget and cancelling an otherwise passing suite.
+        # Slowest healthy install for this job is 89s; 5m leaves ~3x headroom.
+        timeout-minutes: 5
         run: |
           set -euo pipefail
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already installed"
           else
-            sudo apt-get update
-            sudo apt-get install -y ffmpeg
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update
+            sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=15 ffmpeg
           fi
           ffmpeg -version | head -n 1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,13 +48,16 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: Install ffmpeg
+        # Bounds an apt-mirror stall so it cannot consume the 35m job budget.
+        # Slowest install observed for this job is 94s; 5m leaves ~3x headroom.
+        timeout-minutes: 5
         run: |
           set -euo pipefail
           if command -v ffmpeg >/dev/null 2>&1; then
             echo "ffmpeg already installed"
           else
-            sudo apt-get update
-            sudo apt-get install -y ffmpeg
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update
+            sudo apt-get install -y --no-install-recommends -o Acquire::Retries=3 -o Acquire::http::Timeout=15 ffmpeg
           fi
           ffmpeg -version | head -n 1
 


### PR DESCRIPTION
# Pull Request

## Summary

Run [33599181411](https://github.com/ManuGH/xg2g/actions/runs/33599181411) spent **21m37s** in `Install ffmpeg` against an unresponsive apt mirror, exhausted the `race-pr` job's 25-minute budget, and got an otherwise **passing** race suite cancelled. The step had no timeout and no apt retry/connect deadline, so a hung mirror was indistinguishable from slow work until the whole job died.

This bounds every unbounded copy of that step: a step-level `timeout-minutes`, plus `Acquire::Retries=3` and `Acquire::http::Timeout=15` on both apt calls so a dead mirror fails fast instead of blocking.

Timeouts are sized from **each job's own step history**, not copied:

| Job | File | Job budget | n | median | slowest healthy | step timeout | ratio |
|---|---|---|---|---|---|---|---|
| `race-pr` | `ci.yml` | 25m | 40 | 24s | 89s | **5m** | 3.4x |
| `nightly-race` | `ci-deep-scheduled.yml` | 120m | 53 | 21s | **295s** | **10m** | 2.0x |
| `nightly-integration` | `ci-deep-scheduled.yml` | 90m | 8 | 21s | 64s | **10m** | 2.0x (pooled) |
| `Go Coverage Report` | `coverage.yml` | 35m | 38 | 21s | 94s | **5m** | 3.2x |

Two judgment calls worth reviewing:

- **5m would have been wrong for the deep jobs.** `nightly-race` has a *passing* run ([32210400365](https://github.com/ManuGH/xg2g/actions/runs/32210400365)) where this step took **295s = 4m55s**. A blind 5m cap would have cut it with five seconds to spare, trading a rare stall for a recurring flake. 10m is ~2x that and still ~8% of the 120m budget.
- **`nightly-integration` is sized off the pooled tail, not its own 8 samples.** It runs the byte-identical step on the same runner image at the same cron slot as `nightly-race`, so both draw from one apt-mirror population. Treating its 64s max as a ceiling would invent a flake source.

`--no-install-recommends` is the one thing copied rather than derived: `pr-required-gates.yml` (~line 156) already installs ffmpeg that way and then actually encodes an HLS fixture with it, so the recommends-less package is proven sufficient in this repo.

## Change Contract

### Fixed

- A stalled apt mirror can no longer consume a job's entire time budget and cancel passing tests. Four `Install ffmpeg` steps across three workflows are now individually bounded.

### Improved

- Both apt calls retry (3x) and stop waiting on a dead mirror after 15s instead of hanging indefinitely.
- ffmpeg installs skip recommends, cutting download volume and mirror exposure.

### New

- None

### Removed

- None

### Explicitly Unchanged

- No job-level `timeout-minutes` changed.
- No test, build, or coverage command changed.
- The existing `command -v ffmpeg` early-exit guards in `ci.yml` and `coverage.yml` are kept as-is; the deep-scheduled steps are **not** given that guard, to keep this diff to the stall fix.
- ffmpeg remains a hard prerequisite everywhere it was one; nothing became optional or skippable.

### Risks

- **Low.** The only new failure mode is a step that exceeds its cap. Every cap is >=2x the slowest healthy install ever observed for that job, over 8-53 samples each. A trip means the mirror is genuinely wedged, which is the intended signal.
- Thinnest evidence is `nightly-integration` (n=8), mitigated by pooling with `nightly-race` rather than sizing to its own max.
- `--no-install-recommends` could in principle drop a codec some suite depends on. Mitigated by the `pr-required-gates.yml` precedent, which encodes real HLS with the same package set.

### Acceptance Criteria

- [x] `actionlint` clean on all three workflows
- [ ] `race-pr` completes on this PR with the ffmpeg step well under 5m
- [ ] Next nightly `CI Deep Scheduled` run completes with both ffmpeg steps under 10m
- [ ] `Coverage` completes with its ffmpeg step under 5m

### Migration Exit Condition

None.

### Deviations From the Agreed Scope

- **`ci.yml` was added to the scope.** The task was scoped to `ci-deep-scheduled.yml` and `coverage.yml`, on the premise that `ci.yml` had already been fixed. It had not been — no `Acquire::Retries` existed on any local or remote branch, verified again after a fresh `git fetch`. Hardening three secondary jobs while the actual incident site stayed bare would have left the reported bug live, so `ci.yml` is included here. That hunk is self-contained and can be dropped if the fix exists elsewhere unpushed.

## Scope

- In scope: the four unbounded `Install ffmpeg` steps in `ci.yml`, `ci-deep-scheduled.yml` (x2), `coverage.yml`.
- Out of scope: job-level budgets; other `apt-get` call sites; `pr-required-gates.yml` (already uses `--no-install-recommends`, and its own bounding is a separate question); the pre-existing nightly failures visible in run history, which are unrelated to mirror stalls.

## Risk and Rollout

- Risk level: **low**
- Rollout: takes effect on next run of each workflow. No migration, no state, no ordering constraint.
- Fallback: revert this commit; behavior returns exactly to the unbounded steps.

## Verification

```bash
actionlint .github/workflows/ci.yml .github/workflows/ci-deep-scheduled.yml .github/workflows/coverage.yml
```

Exit 0, no output, on all three files.

Historical step durations were pulled from the Actions API and used to size each cap:

```bash
gh api repos/ManuGH/xg2g/actions/runs/<id>/jobs \
  --jq '.jobs[] as $j | $j.steps[]? | select(.name|test("ffmpeg";"i"))
        | [$j.name, .started_at, .completed_at] | @tsv'
```

- Manual checks: incident confirmed directly against the API — run 33599181411, step `06:31:23Z -> 06:53:00Z` = 21m37s, job `cancelled`. Each patch asserted its expected match count before writing (2 sites in `ci-deep-scheduled.yml`, 1 each elsewhere), so no silent partial application.
- Sample sizes per job are in the table above; full sorted distributions were reviewed, not just min/max.

## Checklist

- [x] Tests added/updated for changed behavior — n/a, CI configuration only; verified with `actionlint` and step-duration history
- [x] Documentation updated & rendered — n/a, no docs template touched
- [x] No secrets or credentials introduced
- [x] Backward compatibility considered — no interface, no consumer; revert is a clean no-op

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
