### PR TITLE
fix(vod): a failed build reclaims its workdir before it publishes the failure

### DIFF
--- a/backend/internal/control/recordings/self_healing_test.go
+++ b/backend/internal/control/recordings/self_healing_test.go
@@ -126,6 +126,15 @@ func TestPhase4_SelfHealing_Integration(t *testing.T) {
 	assert.Equal(t, vod.ArtifactStateFailed, failedMeta.State)
 	assert.Equal(t, string(vod.ReasonTruthMismatch), failedMeta.Error)
 
+	// The retry below builds into the same cacheDir this failed build used as its
+	// WorkDir, so it is only safe once that WorkDir has been reclaimed. The monitor
+	// reclaims it before publishing FAILED, so observing FAILED above is already proof
+	// the teardown happened -- no polling needed. If that ordering ever regresses, the
+	// teardown lands inside the retry instead, deletes the runner output it waits for
+	// and strands it until BuildStartTimeout, and the assertions below read this
+	// build's stale FAILED/TruthMismatch metadata.
+	require.NoDirExists(t, cacheDir, "Failed build must reclaim its WorkDir before publishing FAILED")
+
 	// Step 3: Recordings layer polls build state; should detect TruthMismatch and invalidate truth
 	_, _, metaAfterFail, metaOk, err := recordings.LoadRecordingBuildState(ctx, hlsRoot, vodManager, serviceRef, variant)
 	require.NoError(t, err)

--- a/backend/internal/control/vod/cleanup_publish_test.go
+++ b/backend/internal/control/vod/cleanup_publish_test.go
@@ -200,3 +200,33 @@ func TestVOD_AtomicPublish_Failure_NoFinal(t *testing.T) {
 	removeAllCalls := mockFS.GetRemoveAllCalls()
 	assert.Contains(t, removeAllCalls, "/tmp/failure-test")
 }
+
+// TestVOD_Cleanup_PrecedesFailureCallback pins the ordering the recordings self-healing
+// loop depends on: the failure callback publishes this job's terminal state, and an
+// observer may react to it by starting a retry into the same WorkDir. If the teardown
+// ran after the callback it would delete that retry's workspace, stranding it in
+// waitForRunnerArtifacts until BuildStartTimeout.
+func TestVOD_Cleanup_PrecedesFailureCallback(t *testing.T) {
+	ctx := context.Background()
+	clock := NewMockClock(time.Now())
+	mockFS := &MockFS{}
+
+	runner := NewMockRunner(errors.New("start failed"), nil)
+
+	var removedBeforeCallback bool
+	mon := NewBuildMonitor(BuildMonitorConfig{
+		JobID:  "test-cleanup-order",
+		Spec:   Spec{WorkDir: "/tmp/cleanup-order-test", OutputTemp: "output.m3u8"},
+		Runner: runner,
+		Clock:  clock,
+		FS:     mockFS,
+		OnFailed: func(jobID string, spec Spec, finalPath string, reason string) {
+			removedBeforeCallback = assert.Contains(t, mockFS.GetRemoveAllCalls(), "/tmp/cleanup-order-test")
+		},
+	})
+
+	mon.Run(ctx)
+
+	assert.True(t, removedBeforeCallback, "WorkDir must already be reclaimed when the failure callback fires")
+	assert.Len(t, mockFS.GetRemoveAllCalls(), 1, "WorkDir teardown must run exactly once")
+}

--- a/backend/internal/control/vod/monitor.go
+++ b/backend/internal/control/vod/monitor.go
@@ -44,6 +44,7 @@ type BuildMonitor struct {
 	handle Handle
 
 	stopOnce    sync.Once // Ensures Stop is called at most once
+	cleanupOnce sync.Once // Ensures WorkDir teardown runs at most once
 	notifyOnce  sync.Once // Ensures completion callbacks called at most once
 	onSucceeded func(jobID string, spec Spec, finalPath string)
 	onFailed    func(jobID string, spec Spec, finalPath string, reason string)
@@ -87,6 +88,13 @@ func (m *BuildMonitor) notifyFailure(reason string) {
 	log.Debug().Str("jobId", m.jobID).Str("reason", reason).Msg("VOD monitor: notifyFailure called")
 	m.notifyOnce.Do(func() {
 		log.Debug().Str("jobId", m.jobID).Bool("hasCallback", m.onFailed != nil).Msg("VOD monitor: notifyFailure executing")
+		// Reclaim WorkDir before publishing the terminal state, not after. The callback
+		// makes this job's failure observable, and an observer may react by starting a
+		// retry into the same WorkDir; a teardown that lands afterwards deletes the
+		// retry's workspace and strands it in waitForRunnerArtifacts until
+		// BuildStartTimeout. The deferred cleanup in Run stays as the backstop for paths
+		// that never notify.
+		m.cleanup()
 		if m.onFailed != nil {
 			m.onFailed(m.jobID, m.spec, m.finalPath, reason)
 			log.Debug().Str("jobId", m.jobID).Msg("VOD monitor: failure callback completed")
@@ -281,17 +289,19 @@ func (m *BuildMonitor) runnerArtifactsReady(outputPath string) (bool, error) {
 
 // cleanup attempts to remove WorkDir on failure (best-effort).
 func (m *BuildMonitor) cleanup() {
-	status := m.GetStatus()
-	if status.State == StateSucceeded {
-		// On success, keep WorkDir or let caller decide
-		// (or optionally clean temp files, but not final output)
-		return
-	}
+	m.cleanupOnce.Do(func() {
+		status := m.GetStatus()
+		if status.State == StateSucceeded {
+			// On success, keep WorkDir or let caller decide
+			// (or optionally clean temp files, but not final output)
+			return
+		}
 
-	// On any failure/cancel, attempt to clean WorkDir
-	if m.spec.WorkDir != "" {
-		_ = m.fs.RemoveAll(m.spec.WorkDir)
-	}
+		// On any failure/cancel, attempt to clean WorkDir
+		if m.spec.WorkDir != "" {
+			_ = m.fs.RemoveAll(m.spec.WorkDir)
+		}
+	})
 }
 
 // publish atomically moves OutputTemp to FinalPath.


### PR DESCRIPTION
## Summary

`BuildMonitor.Run` deferred `cleanup()`, so the WorkDir teardown ran *after* the
failure callback had already published the terminal state. The callback is what
makes a job's failure observable, and an observer may react to it by starting a
retry into the same WorkDir — both builds in the recordings self-healing loop use
the same `cacheDir`. A teardown landing inside that retry deletes the runner
output the retry is waiting for, stranding it in `waitForRunnerArtifacts` until
`BuildStartTimeout` (10s).

`notifyFailure` now reclaims the WorkDir *before* invoking the callback, making
the teardown a happens-before of the published failure. `cleanup()` is guarded by
a `sync.Once`; the deferred call in `Run` stays as the backstop for paths that
never notify.

## Why it surfaced

`TestPhase4_SelfHealing_Integration` was flaky in CI (#919, run 33533598615):
the retry never reached READY, so the assertion read the first build's stale
`FAILED`/`TruthMismatch` metadata. The 10s `BuildStartTimeout` is twice the
test's 5s window, so no second metadata write ever happened.

## Evidence

The ordering was proven by forcing the interleaving (100ms in the mock runner,
30ms before `RemoveAll`) against the **unmodified** test: **3/3 failures before
the fix, 5/5 passes after**.

`TestVOD_Cleanup_PrecedesFailureCallback` pins the ordering directly — it asserts
the WorkDir is already in `RemoveAll` calls when the callback fires, and that the
teardown runs exactly once (the `sync.Once`).

## Safety of the reordering

The single production `OnFailed` handler is `Manager.markFailedFromBuild`
(`build.go:118`), which only mutates in-memory metadata and the jobs map. It does
not read `WorkDir`, so reclaiming the directory before the callback cannot
starve it.

## Base

Rebased onto `main@6659488d` before the first push, so CI tests what will
actually land — branch protection is `strict: false` here. `main` had not touched
any of the three files since the original base.

`make pre-push` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
