### PR TITLE
test(remotecore): publish a marker by rename, so waiting on it can read it

### DIFF
--- a/backend/internal/stream/ingest/remotecore/identity_linux_test.go
+++ b/backend/internal/stream/ingest/remotecore/identity_linux_test.go
@@ -67,6 +67,11 @@ func startGroup(t *testing.T, args ...string) *exec.Cmd {
 // the test would be racing the shell: a TERM that arrives before the trap is in
 // place takes the default action, and the descendant dies quietly instead of
 // recording anything.
+//
+// The record itself is published by rename. The shell's > creates and truncates
+// before printf writes, so a handler that wrote the marker in place would put an
+// empty file at that path first, and a reader watching for the path to exist can
+// win that race and read nothing.
 func leaderWithARecordingDescendant(t *testing.T) (script, marker, ready string) {
 	t.Helper()
 	dir := t.TempDir()
@@ -75,7 +80,7 @@ func leaderWithARecordingDescendant(t *testing.T) (script, marker, ready string)
 	ready = filepath.Join(dir, "ready")
 	body := "#!/bin/sh\n" +
 		"# $1: where the descendant records the signal. $2: its handler is armed.\n" +
-		"( trap 'printf reached > \"$1\"; exit 0' TERM\n" +
+		"( trap 'printf reached > \"${1}.part\"; mv \"${1}.part\" \"$1\"; exit 0' TERM\n" +
 		"  : > \"$2\"\n" +
 		"  sleep 300 & wait ) &\n" +
 		"exit 0\n"
@@ -86,6 +91,12 @@ func leaderWithARecordingDescendant(t *testing.T) (script, marker, ready string)
 }
 
 // waitForFile blocks until path exists, or fails the test.
+//
+// Existence is the whole observation, so a marker whose content is then read has
+// to arrive complete or not at all - written somewhere else and renamed into
+// place. A marker written straight to its path is observable, and empty, from
+// the moment it is created. A marker that only signals by existing - the ready
+// handshake below is written with `: >` and holds nothing - has nothing to tear.
 func waitForFile(t *testing.T, path, what string) {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)

--- a/backend/internal/stream/ingest/remotecore/process_test.go
+++ b/backend/internal/stream/ingest/remotecore/process_test.go
@@ -183,7 +183,14 @@ func TestHelperProcess(t *testing.T) {
 		if err := child.Start(); err != nil {
 			os.Exit(5)
 		}
-		if err := os.WriteFile(marker, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+		// Published by rename, because the reader waits for the path to exist and
+		// then parses what it holds: os.WriteFile creates the file before it puts
+		// the pid in it, and an empty marker parses as no pid at all.
+		tmp := marker + ".part"
+		if err := os.WriteFile(tmp, []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			os.Exit(7)
+		}
+		if err := os.Rename(tmp, marker); err != nil {
 			os.Exit(7)
 		}
 		signal.Ignore(syscall.SIGTERM)


### PR DESCRIPTION
## The flake

`waitForFile` returns as soon as the path **exists**. Two callers then read what it
holds — and both writers created the file before they filled it, so each marker was
observable, and empty, for a window in between.

- `leaderWithARecordingDescendant`: `trap 'printf reached > "$1"' TERM`. The shell's
  `>` creates and truncates `$1` *before* `printf` runs.
- Helper mode `spawn-a-descendant-then-wait-to-be-owned`: `os.WriteFile` opens with
  `O_CREATE|O_TRUNC` before it writes the pid.

`TestIdentity_TheGroupOutlivesTheLeader` waits for existence and immediately requires
the content to be `"reached"`. When it wins the race it reads `""`. Caught on CI in
[run 33777752157](https://github.com/ManuGH/xg2g/actions/runs/33777752157/job/100723588981):

```
--- FAIL: TestIdentity_TheGroupOutlivesTheLeader (0.01s)
    identity_linux_test.go:237: descendant wrote "" (<nil>)
```

`TestIdentity_AFailedAcquisitionTakesTheWholeGroup` has the same defect one step
further along: it `strconv.Atoi`s the pid out of a marker that may still be empty.
It has not been seen failing, but it is the same race.

Linux-only, so it does not reproduce on macOS. **Pre-existing** — last touched by
5a7ab198, already on `main`, and unrelated to the media-core migration work in
[#927](https://github.com/ManuGH/xg2g/pull/927), which is only where CI happened to hit it.

## The fix

Neither marker is written in place any more. Each goes to a sibling `.part` path and
is renamed over it. `rename(2)` is atomic, so the path exists only once it holds the
whole record, and existence becomes a sound thing to wait on.

The `ready` handshake is deliberately left alone: it is written with `: > "$2"`,
carries no content, and has nothing to tear. `waitForFile`'s doc comment now states
the contract it depends on, so the next content-bearing marker does not reintroduce this.

Note `TestProcess_TheWholeGroupIsAskedBeforeItIsKilled` already polls for *content*
rather than existence, so the other helper markers were never exposed to this.

## Verification

No native Linux CI runner was available locally, so **this was run on Linux in Docker
(`golang:1.26`, `linux/arm64`, `/bin/sh` → `dash`, same shell as CI) — not on a
GitHub x86 runner.** CI on this PR is the authoritative Linux run.

**The race, isolated.** A probe that makes the exact observation the test makes —
wait for existence, then read — against both writers, 300 iterations each. It
spin-polls instead of sleeping 5 ms, which samples the window far harder than the
real test; that is why the rate is so high:

```
in place (before)  torn=284/300  never-appeared=0
rename   (after)   torn=0/300    never-appeared=0
```

**The tests themselves**, on Linux under `-race`:

- full `TestIdentity` set, `-count=50` → `ok ... 166.000s`
- the two content-reading tests, `-count=200` → `ok ... 10.908s`

**Gates:** `make pre-push` ✅ · `make test-race-pr` on macOS ✅ (with the caveat that
`identity_linux_test.go` is `//go:build linux` and is therefore *not* compiled by that
run — it proves no cross-platform regression, nothing about the fix).

**Pre-existing failures in the container, not caused by this change.** Running the
`test-race-pr` scope on Linux in Docker fails three tests. I re-ran the identical
command against a pristine `origin/main` tree in the same container and reproduced
them, so they are environment artifacts (a container has no init to reap orphaned
descendants), not regressions:

| Test | On this branch | On pristine `origin/main` |
|---|---|---|
| `TestProcess_ClosingTakesTheWholeProcessGroup` | FAIL | FAIL |
| `TestProcess_TheGracePeriodBelongsToTheGroup` | FAIL | FAIL |
| `procgroup/TestGroupKill` | FAIL under full-scope load | passes alone, FAILs under load — package untouched here |

These do not fail on CI, and this PR touches neither `internal/procgroup` nor the
code paths those two tests exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
