### PR TITLE
fix(mediafacts): an audio stream is accepted once, or not at all

### DIFF
--- a/backend/internal/stream/ingest/mediafacts/core.go
+++ b/backend/internal/stream/ingest/mediafacts/core.go
@@ -974,7 +974,11 @@ func (c *GoCore) processCompletePSISectionLocked(isPAT bool, table []byte, rawPa
 						// than stopped at the video entry: the audio streams that
 						// follow it are needed to tell "video descrambled, audio did
 						// not" apart from "nothing descrambled".
-						if isAudioStreamType(st, descriptors) {
+						// One decision, for one stream: either this entry is an audio
+						// elementary stream that could exist, or it is nothing. The
+						// PID list, the track list and the observers are all built
+						// inside this branch so they cannot describe different sets.
+						if isAudioStreamType(st, descriptors) && canCarryElementaryStream(elemPID) {
 							c.audioPIDs = appendPID(c.audioPIDs, elemPID)
 							codec := AudioCodecFromStreamType(st, descriptors)
 							lang := LanguageFromDescriptors(descriptors)

--- a/backend/internal/stream/ingest/mediafacts/parse.go
+++ b/backend/internal/stream/ingest/mediafacts/parse.go
@@ -318,10 +318,27 @@ func hasAudioDescriptor(descriptors []byte) bool {
 	return false
 }
 
+// NullPID is the packet identifier reserved for stuffing; nothing that carries
+// an elementary stream ever uses it.
+const NullPID = 0x1FFF
+
+// canCarryElementaryStream reports whether a PID could name an elementary stream
+// at all.
+//
+// PID 0 is the PAT and 0x1FFF is the null packet. A PMT entry naming either is
+// malformed: no payload is ever routed to such a stream, and nothing watches it
+// for descrambling, so a declaration on one describes something that cannot
+// exist. It is refused once, where a stream is accepted, rather than filtered
+// out of one of the lists afterwards - filtering one list and not the others is
+// how audioPIDs and audioTracks came to disagree about which streams there are.
+func canCarryElementaryStream(pid uint16) bool {
+	return pid != 0 && pid != NullPID
+}
+
+// appendPID adds a PID that has already been accepted, keeping the PMT's order
+// and adding it once. It does not decide admissibility; canCarryElementaryStream
+// does, at the point of acceptance.
 func appendPID(list []uint16, pid uint16) []uint16 {
-	if pid == 0 || pid == 0x1FFF {
-		return list
-	}
 	for _, existing := range list {
 		if existing == pid {
 			return list

--- a/backend/internal/stream/ingest/mediafacts/psi_corpus_test.go
+++ b/backend/internal/stream/ingest/mediafacts/psi_corpus_test.go
@@ -1378,31 +1378,31 @@ func psiElementaryStreamCases() []psiCorpusCase {
 		}(),
 
 		func() psiCorpusCase {
+			// The invalid PIDs are placed before, between and after the valid
+			// ones, and the valid ones include both neighbours of the reserved
+			// values, so neither the rejection nor the ordering can be an
+			// accident of where an entry happened to sit.
 			w := psiExpect{
 				hasPAT: true, hasPMT: true, programNumber: 1, pmtPID: psiPMTPID1,
 				videoPID: psiVideoPID, videoCodec: CodecH264,
-				audioPIDs: []uint16{psiAudioPID1},
+				audioPIDs: []uint16{0x0001, 0x1FFE, psiAudioPID1},
 				tracks: []psiTrackExpect{
-					{pid: 0x1FFF, streamType: 0x06, codec: "ac3", lang: "deu",
-						channels: 2, componentType: 0x02, hasComponentType: true},
-					{pid: 0x0000, streamType: 0x06, codec: "ac3", lang: "eng",
-						channels: 2, componentType: 0x02, hasComponentType: true},
-					trackAC3(psiAudioPID1, "fra", 0x02, 2, false),
+					trackAC3(0x0001, "eng", 0x02, 2, false),
+					trackAC3(0x1FFE, "fra", 0x02, 2, false),
+					trackAC3(psiAudioPID1, "spa", 0x02, 2, false),
 				},
 				events: identity(2), patPackets: []int{0}, pmtPackets: []int{1},
 			}
-			return psiCase("audio_declared_on_a_reserved_pid_is_not_a_stream_that_can_be_watched",
-				"the null PID and PID 0 can never carry an elementary stream, so neither becomes an audio PID",
+			return psiCase("audio_declared_on_a_pid_that_cannot_carry_a_stream_is_not_declared_at_all",
+				"PID 0 is the PAT and 0x1FFF is stuffing, so a track on either would be one nothing ever routes payload to; the PIDs next to them are ordinary streams",
 				1).
 				chunk(flatten(psiPackets(0, 0, 0, basePAT), psiPackets(psiPMTPID1, 0, 0,
 					pmtV(0, esH264(psiVideoPID),
 						esAC3(0x1FFF, descs(descLanguage("deu", 0x00), descAC3(0x02))),
-						esAC3(0x0000, descs(descLanguage("eng", 0x00), descAC3(0x02))),
-						esAC3(psiAudioPID1, descs(descLanguage("fra", 0x00), descAC3(0x02)))))), w).
-				noting("audioPIDs excludes PID 0 and the null PID; audioTracks does not. So the track " +
-					"list offers two streams that the PID list says are not there, and that nothing " +
-					"will ever route payload to or watch for descrambling. Which of the two lists is " +
-					"right has not been decided - appendPID filters, appendAudioTrack does not.").
+						esAC3(0x0001, descs(descLanguage("eng", 0x00), descAC3(0x02))),
+						esAC3(0x0000, descs(descLanguage("nld", 0x00), descAC3(0x02))),
+						esAC3(0x1FFE, descs(descLanguage("fra", 0x00), descAC3(0x02))),
+						esAC3(psiAudioPID1, descs(descLanguage("spa", 0x00), descAC3(0x02)))))), w).
 				done()
 		}(),
 
@@ -1822,7 +1822,7 @@ func TestPSICorpus_CoversWhatItClaimsTo(t *testing.T) {
 		"descriptors_the_parser_does_not_know_are_stepped_over",
 		"a_registration_descriptor_is_enough_to_name_the_codec",
 		"private_data_without_an_audio_descriptor_is_not_audio",
-		"audio_declared_on_a_reserved_pid_is_not_a_stream_that_can_be_watched",
+		"audio_declared_on_a_pid_that_cannot_carry_a_stream_is_not_declared_at_all",
 		"an_ac3_descriptor_can_carry_no_usable_channel_count",
 	} {
 		if !names[required] {
@@ -1940,6 +1940,73 @@ func TestPSI_ResetAndATargetSwitchAgreeAboutWhatIsForgotten(t *testing.T) {
 			t.Errorf("after %s: HasPMT=%v ProgramNumber=%d PMTVersion=%d; all three describe the "+
 				"PMT in force and there is none, so all three must be zero",
 				tc.what, tc.facts.HasPMT, tc.facts.ProgramNumber, tc.facts.PMTVersion)
+		}
+	}
+}
+
+// TestPSI_TheAudioStreamsAgreeAboutWhichStreamsThereAre holds the three places a
+// declared audio stream is recorded to one set.
+//
+// AudioPIDs and AudioTracks are both in Facts, but the observers are not: they
+// are internal state that decides which elementary streams are actually read.
+// All three are built from one PMT entry, and they drifted once already - the
+// PID list filtered the reserved PIDs and the track list did not, so the tracks
+// offered two streams the PID list said were not there.
+func TestPSI_TheAudioStreamsAgreeAboutWhichStreamsThereAre(t *testing.T) {
+	pat := patSection(psiTSID, 0, 0, 0, 1, patProgram{1, psiPMTPID1})
+	pmt := pmtSection(1, psiVideoPID, 0, 0, 0, 1, nil,
+		esH264(psiVideoPID),
+		esAC3(0x1FFF, descs(descLanguage("deu", 0x00), descAC3(0x02))),
+		esAC3(0x0001, descs(descLanguage("eng", 0x00), descAC3(0x02))),
+		esAC3(0x0000, descs(descLanguage("nld", 0x00), descAC3(0x02))),
+		esAC3(0x1FFE, descs(descLanguage("fra", 0x00), descAC3(0x02))),
+		esMP2(psiAudioPID2, descs(descLanguage("ita", 0x00))),
+	)
+
+	c := NewGoCore(1)
+	res, err := c.Ingest(context.Background(), 0,
+		chunkOf(flatten(psiPackets(0, 0, 0, pat), psiPackets(psiPMTPID1, 0, 0, pmt))...))
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	pidSet := map[uint16]bool{}
+	for _, p := range res.Facts.AudioPIDs {
+		pidSet[p] = true
+	}
+	trackSet := map[uint16]bool{}
+	for _, tr := range res.Facts.AudioTracks {
+		trackSet[tr.PID] = true
+	}
+	if len(pidSet) != len(trackSet) {
+		t.Errorf("AudioPIDs names %d streams and AudioTracks names %d", len(pidSet), len(trackSet))
+	}
+	for pid := range trackSet {
+		if !pidSet[pid] {
+			t.Errorf("PID %d has a track but is not an audio PID", pid)
+		}
+		if !canCarryElementaryStream(pid) {
+			t.Errorf("PID %d cannot carry an elementary stream and must not have been accepted", pid)
+		}
+	}
+	for pid := range pidSet {
+		if !trackSet[pid] {
+			t.Errorf("PID %d is an audio PID but has no track", pid)
+		}
+	}
+
+	// The observers follow the accepted tracks, and only the codecs whose frame
+	// headers this path reads. An observer on anything else would be reading an
+	// elementary stream nobody declared.
+	for pid := range c.audioObservers {
+		if !trackSet[pid] {
+			t.Errorf("PID %d has an observer but no accepted track", pid)
+		}
+	}
+	for _, tr := range res.Facts.AudioTracks {
+		_, hasObserver := c.audioObservers[tr.PID]
+		if want := observableAudioCodec(tr.Codec); hasObserver != want {
+			t.Errorf("PID %d codec %q: observer=%v, want %v", tr.PID, tr.Codec, hasObserver, want)
 		}
 	}
 }

--- a/backend/scripts/mutate-psi-corpus.sh
+++ b/backend/scripts/mutate-psi-corpus.sh
@@ -202,8 +202,29 @@ mutate "count a multichannel declaration as six channels" "$PARSE" \
 mutate "report no language instead of und" "$PARSE" \
   'return "und"' 'return ""'
 
-mutate "let a PID of 0x1FFF become an audio stream" "$PARSE" \
-  'if pid == 0 || pid == 0x1FFF {' 'if false {'
+# Findings 4's three shapes: no guard at all, and each of the two lists keeping a
+# guard the other lost. The third is expressible only because the mutation moves
+# the append outside the accepted branch - in the source both lists are built
+# inside one decision, which is what stops them drifting.
+mutate "accept an audio stream on a PID that cannot carry one" "$CORE" \
+  'if isAudioStreamType(st, descriptors) && canCarryElementaryStream(elemPID) {' \
+  'if isAudioStreamType(st, descriptors) {'
+
+mutate "guard the PID list but not the track list" "$CORE" \
+  'if isAudioStreamType(st, descriptors) && canCarryElementaryStream(elemPID) {
+							c.audioPIDs = appendPID(c.audioPIDs, elemPID)' \
+  'if isAudioStreamType(st, descriptors) {
+							if canCarryElementaryStream(elemPID) {
+								c.audioPIDs = appendPID(c.audioPIDs, elemPID)
+							}'
+
+mutate "guard the track list but not the PID list" "$CORE" \
+  'if isAudioStreamType(st, descriptors) && canCarryElementaryStream(elemPID) {
+							c.audioPIDs = appendPID(c.audioPIDs, elemPID)' \
+  'if isAudioStreamType(st, descriptors) {
+							c.audioPIDs = appendPID(c.audioPIDs, elemPID)
+						}
+						if isAudioStreamType(st, descriptors) && canCarryElementaryStream(elemPID) {'
 
 mutate "read the AC-3 component type without its presence flag" "$PARSE" \
   'if len(body) < 2 || body[0]&ac3ComponentTypeFlagBit == 0 {' 'if len(body) < 2 {'

--- a/testdata/psi-corpus/corpus.txt
+++ b/testdata/psi-corpus/corpus.txt
@@ -637,15 +637,14 @@ case descriptors_the_parser_does_not_know_are_stepped_over
   psi pat=0 pmt=1
 end
 
-case audio_declared_on_a_reserved_pid_is_not_a_stream_that_can_be_watched
-  desc the null PID and PID 0 can never carry an elementary stream, so neither becomes an audio PID
-  note audioPIDs excludes PID 0 and the null PID; audioTracks does not. So the track list offers two streams that the PID list says are not there, and that nothing will ever route payload to or watch for descrambling. Which of the two lists is right has not been decided - appendPID filters, appendAudioTrack does not.
+case audio_declared_on_a_pid_that_cannot_carry_a_stream_is_not_declared_at_all
+  desc PID 0 is the PAT and 0x1FFF is stuffing, so a track on either would be one nothing ever routes payload to; the PIDs next to them are ordinary streams
   init target=1
-  chunk 474000100000b00d0001c100000001e100e8f95e7dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff474100100002b03f0001c10000e101f0001be101f00006fffff00a0a04646575006a02800206e000f00a0a04656e67006a02800206e102f00a0a04667261006a0280028fa1d15effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  facts through=376 hasPAT=1 hasPMT=1 pmtVersion=0 programNumber=1 pmtPID=256 videoPID=257 videoCodec=h264 audioPIDs=258
-  track pid=8191 streamType=6 codec=ac3 lang=deu channels=2 multichannel=0 componentType=2 hasComponentType=1
-  track pid=0 streamType=6 codec=ac3 lang=eng channels=2 multichannel=0 componentType=2 hasComponentType=1
-  track pid=258 streamType=6 codec=ac3 lang=fra channels=2 multichannel=0 componentType=2 hasComponentType=1
+  chunk 474000100000b00d0001c100000001e100e8f95e7dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff474100100002b05d0001c10000e101f0001be101f00006fffff00a0a04646575006a02800206e001f00a0a04656e67006a02800206e000f00a0a046e6c64006a02800206fffef00a0a04667261006a02800206e102f00a0a04737061006a028002479cc399ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  facts through=376 hasPAT=1 hasPMT=1 pmtVersion=0 programNumber=1 pmtPID=256 videoPID=257 videoCodec=h264 audioPIDs=1,8190,258
+  track pid=1 streamType=6 codec=ac3 lang=eng channels=2 multichannel=0 componentType=2 hasComponentType=1
+  track pid=8190 streamType=6 codec=ac3 lang=fra channels=2 multichannel=0 componentType=2 hasComponentType=1
+  track pid=258 streamType=6 codec=ac3 lang=spa channels=2 multichannel=0 componentType=2 hasComponentType=1
   events identity identity
   psi pat=0 pmt=1
 end


### PR DESCRIPTION
**Reference PR R3** of the step 5a adjudication ([#927](https://github.com/ManuGH/xg2g/pull/927)), after [#929](https://github.com/ManuGH/xg2g/pull/929) and [#930](https://github.com/ManuGH/xg2g/pull/930). **Finding 4.**

> An elementary stream declaration is either accepted as a valid audio stream or not at all. `AudioPIDs`, `AudioTracks` and the observers may never represent different sets of the same PMT entry.

Step 5b is still blocked. No Rust PSI parser here.

## The defect

One PMT entry produced **three** records — the audio PID list, the track list, and an observer for the codecs whose frame headers are read — and only the first asked whether the PID could carry a stream at all. `appendPID` filtered PID 0 and the null PID; `appendAudioTrack` and the observer map did not.

So a PMT naming audio on `0x1FFF` gave `AudioPIDs=[258]` and **three** tracks, two of them on PIDs the PID list said were not there: streams nothing routes payload to, nothing watches for descrambling, and nothing can ever observe.

## The fix

The guard moves to the one place a stream is accepted:

```go
if isAudioStreamType(st, descriptors) && canCarryElementaryStream(elemPID) {
```

All three records are built inside that decision, so they cannot describe different sets. `appendPID` keeps the PMT's order and adds a PID once; it no longer decides admissibility — **a list deciding for itself what belongs in it is how the three drifted.** This is the shared acceptance point you asked for, not a filter bolted onto one list afterwards.

PID 0 is the PAT and `0x1FFF` is stuffing. Their neighbours — `0x0001` and `0x1FFE` — are ordinary and stay accepted.

## Tests

The corpus case places invalid PIDs **before, between and after** valid ones, and includes both neighbours of the reserved values, so neither the rejection nor the surviving order can be an accident of position:

```
0x1FFF (rejected) → 0x0001 (kept) → 0x0000 (rejected) → 0x1FFE (kept) → 0x0102 (kept)
audioPIDs = 1, 8190, 258
```

`TestPSI_TheAudioStreamsAgreeAboutWhichStreamsThereAre` states the invariant directly and **reaches past `Facts`**: the observers are internal state deciding which elementary streams are actually read, so a test comparing only the two public lists would not have seen a third set drifting. It asserts `set(AudioPIDs) == set(AudioTracks.PID)`, that every accepted PID is admissible, and that an observer exists exactly when the track's codec is one this path reads.

## Evidence

- corpus **55/55** green; the diff touches **exactly one case** — the one that recorded the defect, re-authored by hand with its `note` removed
- mutation **29 killed, 1 equivalent, 0 survivors, 0 broken anchors**, including all three divergence mutations:
  - no guard at all → red
  - guard the PID list but not the track list (the original defect shape) → red
  - guard the track list but not the PID list (the mirror) → red
- `-race` green; full backend `go test -count=1 ./...` green; `make pre-push` green

On your third requested mutation — re-allowing an observer on an invalid PID **is not separately expressible**, because the observer is created inside the same accepted branch. That is the point of centralising, and the two list-divergence mutations above cover the same ground.

## Remaining

Two `note` cases remain, both now adjudicated by you, both belonging to **R5**: the foreign-`table_id` scan stop (normative, no code change) and the PMT `program_number` mismatch (a real fix, which must reject **before** `pmtTracker.addSection`). **R4** (stream type `0x87`) comes first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
