### PR TITLE
feat(media-core): a Rust PSI parser that answers the shared corpus

### DIFF
--- a/media-core/scripts/mutate-psi.sh
+++ b/media-core/scripts/mutate-psi.sh
@@ -81,8 +81,21 @@ mutate "collect a section that numbers itself beyond its own table" table.rs \
             return None;
         }'
 
+mutate "let a PAT declare less than its own syntax costs" table.rs \
+  'pub(crate) const MIN_PAT_SECTION_LENGTH: usize = 9;' \
+  'pub(crate) const MIN_PAT_SECTION_LENGTH: usize = 0;'
+
+mutate "give a PMT the shorter floor a PAT has" table.rs \
+  'pub(crate) const MIN_PMT_SECTION_LENGTH: usize = 13;' \
+  'pub(crate) const MIN_PMT_SECTION_LENGTH: usize = 9;'
+
+mutate "keep the section in flight after refusing its declaration" assembler.rs \
+  '                self.discard_section();
+                // Everything handed in is given up' \
+  '                // Everything handed in is given up'
+
 mutate "let a PAT or PMT declare the whole twelve-bit length" table.rs \
-  'if length > MAX_SECTION_LENGTH {' 'if length > 0x0FFF {'
+  'length > MAX_SECTION_LENGTH {' 'length > 0x0FFF {'
 
 mutate "stop requiring the long section syntax" table.rs \
   'if prefix[1] & 0x80 == 0 || prefix[1] & 0x40 != 0 {' 'if prefix[1] & 0x40 != 0 {'

--- a/media-core/scripts/mutate-psi.sh
+++ b/media-core/scripts/mutate-psi.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 ManuGH
+# Licensed under the PolyForm Noncommercial License 1.0.0
+#
+# Mutation test for the Rust PSI parser.
+#
+# The corpus and the adversarial tests pass. That is worth exactly as much as the
+# proof that they would stop passing if the parser were wrong. This applies one
+# deliberate defect at a time and requires the suite to go red for it. A mutation
+# that SURVIVES is a semantics nothing pins, and is a finding.
+#
+# Usage: media-core/scripts/mutate-psi.sh   (from anywhere)
+
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1   # media-core/
+
+SRC=src/psi
+BACKUP=$(mktemp -d)
+cp -R "$SRC" "$BACKUP/psi"
+restore() { rm -rf "$SRC"; cp -R "$BACKUP/psi" "$SRC"; }
+cleanup() { restore; rm -rf "$BACKUP"; }
+trap cleanup EXIT
+
+killed=0
+survived=0
+broken=0
+
+# mutate <name> <file> <from> <to>
+mutate() {
+  local name=$1 file=$2 from=$3 to=$4
+  restore
+
+  if ! FROM="$from" TO="$to" python3 - "$SRC/$file" <<'PY'
+import os, sys
+path = sys.argv[1]
+src = open(path).read()
+frm, to = os.environ["FROM"], os.environ["TO"]
+if src.count(frm) != 1:
+    sys.exit(f"anchor appears {src.count(frm)} times, need exactly 1")
+open(path, "w").write(src.replace(frm, to))
+PY
+  then
+    printf '  ANCHOR   %-56s (source changed; mutation not applied)\n' "$name"
+    broken=$((broken + 1))
+    return
+  fi
+
+  local out
+  out=$(cargo test --lib psi:: 2>&1)
+  local rc=$?
+
+  if [ $rc -eq 0 ]; then
+    printf '  SURVIVED %-56s <-- nothing pins this\n' "$name"
+    survived=$((survived + 1))
+  elif grep -qE 'could not compile|^error\[E[0-9]+\]:' <<<"$out"; then
+    printf '  ANCHOR   %-56s (mutation did not compile)\n' "$name"
+    broken=$((broken + 1))
+  else
+    printf '  killed   %-56s (%s)\n' "$name" \
+      "$(grep -oE '^test psi::[a-z_:]+ \.\.\. FAILED' <<<"$out" | head -1 | sed 's/^test //; s/ \.\.\. FAILED//')"
+    killed=$((killed + 1))
+  fi
+}
+
+echo "Mutating the Rust PSI parser; every mutation must make the suite red."
+echo
+
+mutate "stop checking that a section's bytes are intact" table.rs \
+  'if crc::mpeg2(section) != 0 {' 'if false {'
+
+mutate "accept a completed section of any table" table.rs \
+  'if section[0] != expected_table_id {' 'if false {'
+
+mutate "act on a table announced for later" table.rs \
+  'if section[5] & 0x01 != 1 {' 'if false {'
+
+mutate "call a table complete before all its sections are here" table.rs \
+  '        let wanted = usize::from(last_section_number) + 1;
+        if generation.sections.len() != wanted {
+            return false;
+        }
+        (0..=last_section_number).all(|n| generation.sections.contains_key(&n))' \
+  '        true'
+
+mutate "accept a PMT whichever programme it names" mod.rs \
+  'if header.id_extension != self.selected_program_number() {
+            return;
+        }' 'if false {
+            return;
+        }'
+
+mutate "let a foreign PMT reach the tracker before it is refused" mod.rs \
+  '        if header.id_extension != self.selected_program_number() {
+            return;
+        }
+        if !self.pmt_tracker.add(
+            header.version,
+            header.section_number,
+            header.last_section_number,
+            section,
+            packets,
+        ) {
+            return;
+        }' \
+  '        let complete = self.pmt_tracker.add(
+            header.version,
+            header.section_number,
+            header.last_section_number,
+            section,
+            packets,
+        );
+        if header.id_extension != self.selected_program_number() {
+            return;
+        }
+        if !complete {
+            return;
+        }'
+
+mutate "let the last section of a PAT re-choose the programme" pat.rs \
+  'for section in sections {' 'for section in sections.iter().rev() {'
+
+mutate "accept an audio stream on a PID that cannot carry one" pmt.rs \
+  'if declares_audio(stream_type, block) && can_carry_elementary_stream(pid) {' \
+  'if declares_audio(stream_type, block) {'
+
+mutate "bound an elementary stream entry by the section, not the loop" pmt.rs \
+  'if entry_end > end {' 'if entry_end > section.len() {'
+
+mutate "stop the descriptor walk at the first tag it does not know" descriptors.rs \
+  '            tag::REGISTRATION => {' '            _ => return false,
+            tag::REGISTRATION => {'
+
+echo
+echo "killed:   $killed"
+echo "survived: $survived"
+echo "anchor:   $broken"
+if [ "$survived" -ne 0 ] || [ "$broken" -ne 0 ]; then
+  exit 1
+fi

--- a/media-core/scripts/mutate-psi.sh
+++ b/media-core/scripts/mutate-psi.sh
@@ -74,6 +74,25 @@ mutate "accept a completed section of any table" table.rs \
 mutate "act on a table announced for later" table.rs \
   'if section[5] & 0x01 != 1 {' 'if false {'
 
+mutate "collect a section that numbers itself beyond its own table" table.rs \
+  'if section_number > last_section_number {
+            return None;
+        }' 'if false {
+            return None;
+        }'
+
+mutate "let a PAT or PMT declare the whole twelve-bit length" table.rs \
+  'if length > MAX_SECTION_LENGTH {' 'if length > 0x0FFF {'
+
+mutate "stop requiring the long section syntax" table.rs \
+  'if prefix[1] & 0x80 == 0 || prefix[1] & 0x40 != 0 {' 'if prefix[1] & 0x40 != 0 {'
+
+mutate "stop requiring the fixed zero bit" table.rs \
+  'if prefix[1] & 0x80 == 0 || prefix[1] & 0x40 != 0 {' 'if prefix[1] & 0x80 == 0 {'
+
+mutate "resume the scan inside a section whose length was refused" assembler.rs \
+  'return consumed + chunk.len();' 'return consumed;'
+
 mutate "call a table complete before all its sections are here" table.rs \
   '        let wanted = usize::from(last_section_number) + 1;
         if generation.sections.len() != wanted {

--- a/media-core/src/lib.rs
+++ b/media-core/src/lib.rs
@@ -10,3 +10,4 @@
 //! against a corpus without a process, a socket or a Go daemon in the way.
 
 pub mod audio;
+pub mod psi;

--- a/media-core/src/psi/adversarial_test.rs
+++ b/media-core/src/psi/adversarial_test.rs
@@ -119,6 +119,18 @@ fn chunk_of(packets: &[Vec<u8>]) -> Vec<u8> {
     packets.iter().flat_map(|p| p.iter().copied()).collect()
 }
 
+/// A PAT sized so its first packet leaves exactly 181 bytes, which lets a
+/// pointer field put what follows two bytes from the end of the next payload.
+fn pat_of_364_bytes() -> Vec<u8> {
+    let mut programs = vec![(1u16, 256u16)];
+    for i in 0..87u16 {
+        programs.push((100 + i, 0x0400 + i));
+    }
+    let s = pat_section(0, 0, 0, &programs);
+    assert_eq!(s.len(), 364, "the split-header PAT is no longer 364 bytes");
+    s
+}
+
 /// A core already following programme 1 on PID 256.
 fn following_program_one() -> (PsiCore, usize) {
     let mut core = PsiCore::new(1);
@@ -561,6 +573,140 @@ fn a_descriptor_longer_than_its_block_ends_the_walk_without_reading_on() {
         outcome.facts.audio_tracks[0].language, "und",
         "a descriptor that does not fit was read anyway"
     );
+}
+
+/// An impossible declaration must leave the assembler empty, and keep it empty
+/// however many packets follow.
+///
+/// The defect this pins was not a wrong fact. A section declaring nothing after
+/// its length field was collected: the header phase filled the buffer to three
+/// bytes and set the section length to three, and neither phase can act on
+/// `len(buf) == section_len` - the first wants fewer than three bytes, the
+/// second fewer than the section length. Nothing could emit or discard it, and
+/// every later packet on that PID appended to the stale buffer and pushed a
+/// whole 188-byte copy of itself into the packet list. One byte and one packet
+/// retained per packet, indefinitely, on input nobody has to be trusted for.
+///
+/// Facts never moved while that happened, which is why the shared corpus cannot
+/// see this and why the check reads the assembler directly. Found by review of
+/// this parser, settled on the Go reference first, and held here to the same
+/// contract: a PAT may not declare fewer than 9 bytes, a PMT fewer than 13.
+#[test]
+fn an_impossible_declaration_leaves_the_assembler_empty_and_keeps_it_empty() {
+    let section_a = pat_of_364_bytes();
+    let stub = [0x00u8, 0xB0, 0x00]; // a PAT declaring nothing after its length
+    let mut payload1 = vec![181u8];
+    payload1.extend_from_slice(&section_a[183..]);
+    payload1.extend_from_slice(&stub[..2]);
+    assert_eq!(payload1.len(), TS_PACKET_LEN - 4);
+
+    let mut core = PsiCore::new(1);
+    core.ingest(
+        0,
+        &chunk_of(&[
+            psi_packets(0, 0, &section_a)[0].clone(),
+            ts_packet(0, true, 1, 0xFF, &payload1),
+            ts_packet(0, false, 2, 0xFF, &stub[2..]),
+        ]),
+    )
+    .expect("aligned");
+
+    let empty = |core: &PsiCore, when: &str| {
+        for (which, held) in ["PAT", "PMT"].iter().zip(core.retained()) {
+            assert_eq!(
+                held,
+                (0, 0, 0),
+                "{when}: the {which} assembler holds {} bytes, waits for {}, and keeps {} packets \
+                 for a section that was refused",
+                held.0,
+                held.1,
+                held.2
+            );
+        }
+    };
+    empty(&core, "after the refused declaration");
+
+    // The packets that follow carry valid three-byte declarations, so the scan
+    // walks them and reaches the last byte with too little left to be a header -
+    // the branch that used to append to whatever was stuck in the buffer.
+    let mut filler = Vec::with_capacity(TS_PACKET_LEN - 4);
+    while filler.len() + stub.len() <= TS_PACKET_LEN - 4 {
+        filler.extend_from_slice(&stub);
+    }
+    for round in 0..1000usize {
+        let cc = u8::try_from((3 + round) & 0x0F).expect("masked to four bits");
+        core.ingest(0, &ts_packet(0, false, cc, 0xFF, &filler))
+            .expect("aligned");
+        if round % 100 == 0 || round == 999 {
+            empty(&core, "after continuation packets");
+        }
+    }
+
+    // And the PID still works: a payload unit start is read normally.
+    let recovery = pat_section(2, 0, 0, &[(1, 512)]);
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(0, 0, &recovery)))
+        .expect("aligned");
+    assert_eq!(
+        outcome.facts.pmt_pid, 512,
+        "the PID stopped working after the refusal"
+    );
+}
+
+/// Twelve bytes after the length field is a length a PAT may declare and a PMT
+/// may not: the PMT carries a PCR PID and a `program_info_length` the PAT does
+/// not, so their floors differ.
+///
+/// The section built here is intact in every other way - correct `table_id`,
+/// correct syntax bits, a CRC that checks out - so the only thing standing
+/// between it and being accepted as this programme's table is the floor. Under a
+/// PAT-sized floor it is accepted and `has_pmt` becomes true.
+#[test]
+fn a_pmt_declaring_a_length_only_a_pat_may_use_is_refused() {
+    let (mut core, _) = following_program_one();
+
+    // table_id 0x02, section_length 12, programme 1, current, section 0 of 0.
+    let mut body = vec![
+        0x02u8, 0xB0, 0x0C, 0x00, 0x01, 0xC1, 0x00, 0x00, 0xE1, 0x01, 0xF0,
+    ];
+    let crc = crc::mpeg2(&body);
+    body.extend_from_slice(&crc.to_be_bytes());
+    assert_eq!(body.len(), 15, "a section_length of 12 is 15 bytes in all");
+    assert_eq!(
+        crc::mpeg2(&body),
+        0,
+        "the stub has to be intact, or it proves nothing"
+    );
+
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(256, 0, &body)))
+        .expect("aligned");
+    assert!(
+        !outcome.facts.has_pmt,
+        "a PMT shorter than its own mandatory syntax was accepted as this programme's table"
+    );
+    assert_eq!(outcome.facts.program_number, 0);
+
+    // And the real table is still readable afterwards.
+    let good = pmt_section(
+        1,
+        0,
+        0,
+        0,
+        &[Es {
+            stream_type: 0x1B,
+            pid: 257,
+            descriptors: vec![],
+        }],
+    );
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(256, 1, &good)))
+        .expect("aligned");
+    assert!(
+        outcome.facts.has_pmt,
+        "the PID stopped working after the refusal"
+    );
+    assert_eq!(outcome.facts.video_pid, 257);
 }
 
 // --- segmentation ---------------------------------------------------------

--- a/media-core/src/psi/adversarial_test.rs
+++ b/media-core/src/psi/adversarial_test.rs
@@ -1,0 +1,687 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! What the parser does with bytes nobody would send on purpose.
+//!
+//! The shared corpus states the semantics both implementations owe each other.
+//! These tests are the other half: input the corpus does not describe, where the
+//! only thing owed is that the parser stays bounded, keeps its state coherent,
+//! and never panics. Nothing here invents a new semantic - where a case would
+//! need one to have an answer, it asserts only that the answer is refusal.
+
+use super::crc;
+use super::table::{MAX_SECTION_LEN, MIN_SECTION_LEN};
+use super::{IngestError, PsiCore, TS_PACKET_LEN};
+
+// --- builders -------------------------------------------------------------
+
+/// Appends the CRC a section carries about itself.
+fn seal(mut body: Vec<u8>) -> Vec<u8> {
+    let crc = crc::mpeg2(&body);
+    body.extend_from_slice(&crc.to_be_bytes());
+    body
+}
+
+/// A section header, with `section_length` describing what follows it.
+fn section_header(
+    table_id: u8,
+    id_extension: u16,
+    section_len: usize,
+    version: u8,
+    section_number: u8,
+    last_section_number: u8,
+    current_next: u8,
+) -> Vec<u8> {
+    vec![
+        table_id,
+        0xB0 | u8::try_from((section_len >> 8) & 0x0F).expect("masked to a nibble"),
+        u8::try_from(section_len & 0xFF).expect("masked to a byte"),
+        u8::try_from(id_extension >> 8).expect("a u16 halves into bytes"),
+        u8::try_from(id_extension & 0xFF).expect("masked to a byte"),
+        0xC0 | ((version & 0x1F) << 1) | (current_next & 0x01),
+        section_number,
+        last_section_number,
+    ]
+}
+
+/// A PAT naming `programs` as (number, PMT PID) pairs.
+fn pat_section(version: u8, section_number: u8, last: u8, programs: &[(u16, u16)]) -> Vec<u8> {
+    let section_len = 5 + 4 * programs.len() + 4;
+    let mut out = section_header(0x00, 1, section_len, version, section_number, last, 1);
+    for (number, pid) in programs {
+        out.push(u8::try_from(number >> 8).expect("a u16 halves"));
+        out.push(u8::try_from(number & 0xFF).expect("masked"));
+        out.push(0xE0 | u8::try_from((pid >> 8) & 0x1F).expect("masked"));
+        out.push(u8::try_from(pid & 0xFF).expect("masked"));
+    }
+    seal(out)
+}
+
+/// One elementary stream entry of a PMT.
+struct Es {
+    stream_type: u8,
+    pid: u16,
+    descriptors: Vec<u8>,
+}
+
+/// A PMT for `program`, listing `streams`.
+fn pmt_section(program: u16, version: u8, section_number: u8, last: u8, streams: &[Es]) -> Vec<u8> {
+    let es_bytes: usize = streams.iter().map(|s| 5 + s.descriptors.len()).sum();
+    let section_len = 9 + es_bytes + 4;
+    let mut out = section_header(0x02, program, section_len, version, section_number, last, 1);
+    out.extend_from_slice(&[0xE1, 0x01, 0xF0, 0x00]); // PCR PID, program_info_length 0
+    for stream in streams {
+        out.push(stream.stream_type);
+        out.push(0xE0 | u8::try_from((stream.pid >> 8) & 0x1F).expect("masked"));
+        out.push(u8::try_from(stream.pid & 0xFF).expect("masked"));
+        out.push(0xF0 | u8::try_from((stream.descriptors.len() >> 8) & 0x0F).expect("masked"));
+        out.push(u8::try_from(stream.descriptors.len() & 0xFF).expect("masked"));
+        out.extend_from_slice(&stream.descriptors);
+    }
+    seal(out)
+}
+
+/// One 188-byte packet carrying `payload`, padded with `pad`.
+fn ts_packet(pid: u16, pusi: bool, cc: u8, pad: u8, payload: &[u8]) -> Vec<u8> {
+    assert!(
+        payload.len() <= TS_PACKET_LEN - 4,
+        "payload does not fit a packet"
+    );
+    let mut packet = vec![pad; TS_PACKET_LEN];
+    packet[0] = 0x47;
+    packet[1] = u8::try_from((pid >> 8) & 0x1F).expect("masked") | if pusi { 0x40 } else { 0 };
+    packet[2] = u8::try_from(pid & 0xFF).expect("masked");
+    packet[3] = 0x10 | (cc & 0x0F);
+    packet[4..4 + payload.len()].copy_from_slice(payload);
+    packet
+}
+
+/// The packets one section needs, with the pointer field on the first.
+fn psi_packets(pid: u16, start_cc: u8, section: &[u8]) -> Vec<Vec<u8>> {
+    let mut body = vec![0x00];
+    body.extend_from_slice(section);
+    let mut out = Vec::new();
+    let mut cc = start_cc;
+    let mut pusi = true;
+    let mut rest = body.as_slice();
+    while !rest.is_empty() {
+        let take = rest.len().min(TS_PACKET_LEN - 4);
+        out.push(ts_packet(pid, pusi, cc, 0xFF, &rest[..take]));
+        rest = &rest[take..];
+        cc = (cc + 1) & 0x0F;
+        pusi = false;
+    }
+    out
+}
+
+fn chunk_of(packets: &[Vec<u8>]) -> Vec<u8> {
+    packets.iter().flat_map(|p| p.iter().copied()).collect()
+}
+
+/// A core already following programme 1 on PID 256.
+fn following_program_one() -> (PsiCore, usize) {
+    let mut core = PsiCore::new(1);
+    let packets = psi_packets(0, 0, &pat_section(0, 0, 0, &[(1, 256)]));
+    let count = packets.len();
+    core.ingest(0, &chunk_of(&packets))
+        .expect("a PAT is packet aligned");
+    (core, count)
+}
+
+// --- shape of the call ----------------------------------------------------
+
+#[test]
+fn a_chunk_that_is_not_whole_packets_is_refused_entirely() {
+    let mut core = PsiCore::new(1);
+    for len in [1usize, 187, 189, TS_PACKET_LEN * 2 - 1] {
+        let err = core
+            .ingest(0, &vec![0x47; len])
+            .expect_err("an unaligned chunk is refused");
+        assert_eq!(err, IngestError::UnalignedChunk { len });
+    }
+    // The refusals left nothing behind: a PAT still selects.
+    let packets = psi_packets(0, 0, &pat_section(0, 0, 0, &[(1, 256)]));
+    let outcome = core.ingest(0, &chunk_of(&packets)).expect("aligned");
+    assert_eq!(outcome.facts.pmt_pid, 256);
+}
+
+#[test]
+fn an_empty_chunk_consumes_nothing_and_reports_where_it_was() {
+    let mut core = PsiCore::new(1);
+    let outcome = core
+        .ingest(9_400_000, &[])
+        .expect("an empty chunk is aligned");
+    assert_eq!(outcome.processed_through, 9_400_000);
+    assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn a_chunk_reports_the_offset_one_past_its_last_byte() {
+    let mut core = PsiCore::new(1);
+    let packets = psi_packets(0, 0, &pat_section(0, 0, 0, &[(1, 256)]));
+    let data = chunk_of(&packets);
+    let outcome = core.ingest(9_400_000, &data).expect("aligned");
+    assert_eq!(
+        outcome.processed_through,
+        9_400_000 + i64::try_from(data.len()).expect("small")
+    );
+}
+
+// --- packets that carry nothing -------------------------------------------
+
+#[test]
+fn packets_that_cannot_carry_a_table_change_nothing() {
+    let section = pat_section(0, 0, 0, &[(1, 256)]);
+    let good = psi_packets(0, 0, &section)[0].clone();
+
+    let mut broken_sync = good.clone();
+    broken_sync[0] = 0x48;
+
+    let mut no_payload = good.clone();
+    no_payload[3] &= 0x0F; // adaptation_field_control = 0
+
+    let mut adaptation_only = good.clone();
+    adaptation_only[3] = 0x20 | (adaptation_only[3] & 0x0F);
+
+    // An adaptation field claiming the rest of the packet leaves no payload
+    // behind it, whatever the flag says.
+    let mut adaptation_eats_payload = good.clone();
+    adaptation_eats_payload[3] = 0x30 | (adaptation_eats_payload[3] & 0x0F);
+    adaptation_eats_payload[4] = 183;
+
+    let wrong_pid = ts_packet(0x0064, true, 0, 0xFF, &{
+        let mut p = vec![0x00];
+        p.extend_from_slice(&section);
+        p
+    });
+
+    for (what, packet) in [
+        ("a bad sync byte", broken_sync),
+        ("no payload", no_payload),
+        ("adaptation only", adaptation_only),
+        (
+            "an adaptation field that eats the payload",
+            adaptation_eats_payload,
+        ),
+        ("a PID nothing is read on", wrong_pid),
+        ("the null PID", ts_packet(0x1FFF, false, 0, 0xFF, &[])),
+    ] {
+        let mut core = PsiCore::new(1);
+        let outcome = core.ingest(0, &packet).expect("one packet is aligned");
+        assert_eq!(outcome.facts.pmt_pid, 0, "{what} named a PMT PID");
+        assert!(!outcome.facts.has_pat, "{what} counted as a PAT");
+        assert!(outcome.events.is_empty(), "{what} produced an event");
+    }
+}
+
+// --- sections that are not tables -----------------------------------------
+
+#[test]
+fn sections_that_cannot_be_read_are_refused() {
+    let good = pat_section(0, 0, 0, &[(1, 256)]);
+
+    let mut bad_crc = good.clone();
+    let last = bad_crc.len() - 1;
+    bad_crc[last] ^= 0xFF;
+
+    let not_current = {
+        let mut s = section_header(0x00, 1, 5 + 4 + 4, 0, 0, 0, 0);
+        s.extend_from_slice(&[0x00, 0x01, 0xE1, 0x00]);
+        seal(s)
+    };
+
+    let foreign_table = {
+        let mut s = good.clone();
+        s[0] = 0x42; // service description section
+        let body_len = s.len() - 4;
+        let crc = crc::mpeg2(&s[..body_len]);
+        s[body_len..].copy_from_slice(&crc.to_be_bytes());
+        s
+    };
+
+    // Eleven bytes with a valid CRC: one short of the fields the parser reads.
+    let too_short = seal(vec![0x00, 0xB0, 0x08, 0x00, 0x01, 0xC1, 0x00]);
+    assert_eq!(too_short.len(), MIN_SECTION_LEN - 1);
+
+    for (what, section) in [
+        ("a broken CRC", bad_crc),
+        ("a table announced for later", not_current),
+        ("another table's section", foreign_table),
+        ("a section too short to hold its fields", too_short),
+    ] {
+        let mut core = PsiCore::new(1);
+        let outcome = core
+            .ingest(0, &chunk_of(&psi_packets(0, 0, &section)))
+            .expect("aligned");
+        assert_eq!(outcome.facts.pmt_pid, 0, "{what} was accepted");
+        assert!(!outcome.facts.has_pat, "{what} was accepted");
+    }
+}
+
+#[test]
+fn section_lengths_at_and_past_their_bounds_are_survived() {
+    // section_length is twelve bits, so this is the largest a section can claim.
+    let claims_the_maximum = {
+        let mut payload = vec![0x00, 0x00, 0xB0 | 0x0F, 0xFF];
+        payload.resize(TS_PACKET_LEN - 4, 0x00);
+        ts_packet(0, true, 0, 0x00, &payload)
+    };
+    assert_eq!(MAX_SECTION_LEN, 3 + 0x0FFF);
+
+    // A length of zero names a section shorter than its own header.
+    let claims_nothing = ts_packet(0, true, 0, 0xFF, &[0x00, 0x00, 0xB0, 0x00]);
+
+    // A pointer field past the end of the payload.
+    let pointer_past_the_end = ts_packet(0, true, 0, 0xFF, &[0xFF, 0x00, 0xB0, 0x0D]);
+
+    for (what, packet) in [
+        ("a section claiming the maximum length", claims_the_maximum),
+        ("a section claiming no length", claims_nothing),
+        ("a pointer field past the payload", pointer_past_the_end),
+    ] {
+        let mut core = PsiCore::new(1);
+        let outcome = core.ingest(0, &packet).expect("aligned");
+        assert!(!outcome.facts.has_pat, "{what} produced a table");
+    }
+}
+
+#[test]
+fn a_table_is_not_read_until_every_section_of_it_is_here() {
+    let mut core = PsiCore::new(1);
+    // Section 0 of 2 carries the target, so a table read early would find it.
+    let section0 = pat_section(0, 0, 1, &[(1, 256)]);
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(0, 0, &section0)))
+        .expect("aligned");
+    assert_eq!(outcome.facts.pmt_pid, 0, "half a table was read");
+
+    // The section the table actually declares completes it.
+    let section1 = pat_section(0, 1, 1, &[(9, 0x0900)]);
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(0, 1, &section1)))
+        .expect("aligned");
+    assert_eq!(outcome.facts.pmt_pid, 256);
+}
+
+/// A section numbered outside the table is collected like any other, and the
+/// generation then holds more sections than the table declares - so it stops
+/// completing, and goes on not completing even once the section that was
+/// genuinely missing arrives. Only a new generation clears it.
+///
+/// Verified against the Go reference before being asserted here: both
+/// implementations do exactly this. The corpus states the first half of it
+/// (`a_section_numbered_outside_the_table_does_not_complete_it`) and not the
+/// second, so this test is Rust-side coverage of shared behaviour rather than a
+/// semantic of its own.
+#[test]
+fn a_stray_section_number_holds_the_generation_until_a_new_one_starts() {
+    let mut core = PsiCore::new(1);
+    for (what, packets) in [
+        (
+            "section 0 of 2",
+            psi_packets(0, 0, &pat_section(0, 0, 1, &[(1, 256)])),
+        ),
+        (
+            "a section numbered 5",
+            psi_packets(0, 1, &pat_section(0, 5, 1, &[(9, 0x0900)])),
+        ),
+        (
+            "section 1 of 2",
+            psi_packets(0, 2, &pat_section(0, 1, 1, &[(9, 0x0900)])),
+        ),
+    ] {
+        let outcome = core.ingest(0, &chunk_of(&packets)).expect("aligned");
+        assert_eq!(outcome.facts.pmt_pid, 0, "the table completed after {what}");
+    }
+
+    // A new version is a new generation, and the stray does not travel with it.
+    for packets in [
+        psi_packets(0, 3, &pat_section(1, 0, 1, &[(1, 256)])),
+        psi_packets(0, 4, &pat_section(1, 1, 1, &[(9, 0x0900)])),
+    ] {
+        core.ingest(0, &chunk_of(&packets)).expect("aligned");
+    }
+    let outcome = core.ingest(0, &[]).expect("aligned");
+    assert_eq!(
+        outcome.facts.pmt_pid, 256,
+        "a new generation did not recover"
+    );
+}
+
+#[test]
+fn a_table_declaring_255_sections_never_completes_and_stays_bounded() {
+    let mut core = PsiCore::new(1);
+    for number in 0..=60u8 {
+        let section = pat_section(0, number, 255, &[(1, 256)]);
+        let outcome = core
+            .ingest(0, &chunk_of(&psi_packets(0, number & 0x0F, &section)))
+            .expect("aligned");
+        assert_eq!(outcome.facts.pmt_pid, 0, "an incomplete table was read");
+    }
+}
+
+#[test]
+fn a_repeated_section_number_replaces_rather_than_accumulates() {
+    let mut core = PsiCore::new(1);
+    for round in 0..40u8 {
+        let section = pat_section(0, 0, 0, &[(1, 256 + u16::from(round % 2))]);
+        let outcome = core
+            .ingest(0, &chunk_of(&psi_packets(0, round & 0x0F, &section)))
+            .expect("aligned");
+        assert!(outcome.facts.pmt_pid == 256 || outcome.facts.pmt_pid == 257);
+    }
+}
+
+// --- programme identity ---------------------------------------------------
+
+#[test]
+fn a_pmt_for_another_programme_leaves_the_table_being_assembled_alone() {
+    let (mut core, pat_packets) = following_program_one();
+    assert!(pat_packets >= 1);
+
+    let mine0 = pmt_section(
+        1,
+        0,
+        0,
+        1,
+        &[Es {
+            stream_type: 0x1B,
+            pid: 257,
+            descriptors: vec![],
+        }],
+    );
+    let foreign = pmt_section(
+        2,
+        0,
+        0,
+        0,
+        &[Es {
+            stream_type: 0x1B,
+            pid: 999,
+            descriptors: vec![],
+        }],
+    );
+    let mine1 = pmt_section(
+        1,
+        0,
+        1,
+        1,
+        &[Es {
+            stream_type: 0x03,
+            pid: 258,
+            descriptors: vec![],
+        }],
+    );
+
+    let outcome = core
+        .ingest(
+            0,
+            &chunk_of(
+                &[
+                    psi_packets(256, 0, &mine0),
+                    psi_packets(256, 1, &foreign),
+                    psi_packets(256, 2, &mine1),
+                ]
+                .concat(),
+            ),
+        )
+        .expect("aligned");
+
+    assert!(outcome.facts.has_pmt, "the table never completed");
+    assert_eq!(outcome.facts.program_number, 1);
+    assert_eq!(outcome.facts.video_pid, 257, "section 0 was lost");
+    assert_eq!(outcome.facts.audio_pids, vec![258], "section 1 was lost");
+    for packet in &outcome.active.pmt {
+        assert!(
+            !chunk_of(&psi_packets(256, 1, &foreign))
+                .windows(TS_PACKET_LEN)
+                .any(|w| w == packet),
+            "a refused table's packet reached the active PMT"
+        );
+    }
+}
+
+#[test]
+fn an_elementary_stream_entry_never_reads_the_sections_own_crc() {
+    // The entry declares four descriptor bytes that are not inside the loop, so
+    // the four after it are the CRC. Nothing may read them.
+    let (mut core, _) = following_program_one();
+    let mut section = pmt_section(
+        1,
+        0,
+        0,
+        0,
+        &[
+            Es {
+                stream_type: 0x1B,
+                pid: 257,
+                descriptors: vec![],
+            },
+            Es {
+                stream_type: 0x06,
+                pid: 258,
+                descriptors: vec![0x6A, 0x02, 0x80, 0x02],
+            },
+        ],
+    );
+    // Drop the descriptors, keep the length claiming them, reseal.
+    let keep = section.len() - 8;
+    section.truncate(keep);
+    section.extend_from_slice(&[0, 0, 0, 0]);
+    let new_len = section.len() - 3;
+    section[1] = 0xB0 | u8::try_from((new_len >> 8) & 0x0F).expect("masked");
+    section[2] = u8::try_from(new_len & 0xFF).expect("masked");
+    let body_len = section.len() - 4;
+    let crc = crc::mpeg2(&section[..body_len]);
+    section[body_len..].copy_from_slice(&crc.to_be_bytes());
+
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(256, 0, &section)))
+        .expect("aligned");
+    assert!(outcome.facts.has_pmt);
+    assert_eq!(
+        outcome.facts.video_pid, 257,
+        "the entry before the bad one was lost"
+    );
+    assert!(
+        outcome.facts.audio_pids.is_empty(),
+        "an entry whose descriptors ran past the loop produced a track: {:?}",
+        outcome.facts.audio_tracks
+    );
+}
+
+#[test]
+fn a_descriptor_longer_than_its_block_ends_the_walk_without_reading_on() {
+    let (mut core, _) = following_program_one();
+    // A language descriptor claiming 200 bytes inside a 6-byte block, followed
+    // by what would be an AC-3 descriptor if the walk carried on.
+    let descriptors = vec![0x0A, 0xC8, b'd', b'e', b'u', 0x00];
+    let section = pmt_section(
+        1,
+        0,
+        0,
+        0,
+        &[Es {
+            stream_type: 0x03,
+            pid: 258,
+            descriptors,
+        }],
+    );
+    let outcome = core
+        .ingest(0, &chunk_of(&psi_packets(256, 0, &section)))
+        .expect("aligned");
+    assert_eq!(outcome.facts.audio_pids, vec![258]);
+    assert_eq!(
+        outcome.facts.audio_tracks[0].language, "und",
+        "a descriptor that does not fit was read anyway"
+    );
+}
+
+// --- segmentation ---------------------------------------------------------
+
+#[test]
+fn where_a_chunk_was_cut_does_not_change_what_the_stream_meant() {
+    // The same packets in the same order, offered as one call and as many. A
+    // chunk boundary is transport segmentation: the assembler carries a partial
+    // section across calls, so the stream is the same stream.
+    let packets = [
+        psi_packets(0, 0, &pat_section(0, 0, 0, &[(1, 256)])),
+        psi_packets(
+            256,
+            0,
+            &pmt_section(
+                1,
+                0,
+                0,
+                0,
+                &[
+                    Es {
+                        stream_type: 0x1B,
+                        pid: 257,
+                        descriptors: vec![],
+                    },
+                    Es {
+                        stream_type: 0x06,
+                        pid: 258,
+                        descriptors: vec![
+                            0x0A, 0x04, b'd', b'e', b'u', 0x00, 0x6A, 0x02, 0x80, 0x02,
+                        ],
+                    },
+                ],
+            ),
+        ),
+    ]
+    .concat();
+
+    let mut whole = PsiCore::new(1);
+    let all = chunk_of(&packets);
+    let expected = whole.ingest(0, &all).expect("aligned").facts;
+
+    for group in 1..=packets.len() {
+        let mut split = PsiCore::new(1);
+        let mut offset = 0i64;
+        for window in packets.chunks(group) {
+            let data = chunk_of(window);
+            split.ingest(offset, &data).expect("aligned");
+            offset += i64::try_from(data.len()).expect("small");
+        }
+        let got = split.ingest(offset, &[]).expect("aligned").facts;
+        assert_eq!(
+            got, expected,
+            "cutting the stream every {group} packets changed it"
+        );
+    }
+}
+
+// --- arbitrary bytes ------------------------------------------------------
+
+/// A deterministic generator, so a failure is reproducible from its seed and the
+/// crate keeps its zero dependencies.
+struct Xorshift(u64);
+
+impl Xorshift {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn byte(&mut self) -> u8 {
+        u8::try_from(self.next() & 0xFF).expect("masked to a byte")
+    }
+}
+
+#[test]
+fn arbitrary_bytes_never_panic_and_never_grow_without_bound() {
+    let mut rng = Xorshift(0x2026_0903_5B00_1234);
+    for seed_round in 0..400 {
+        let mut core = PsiCore::new(u16::from(rng.byte()));
+        for _ in 0..12 {
+            let packets = 1 + usize::from(rng.byte() % 8);
+            let mut data = vec![0u8; packets * TS_PACKET_LEN];
+            for byte in &mut data {
+                *byte = rng.byte();
+            }
+            // Half the rounds get well-formed framing, so the parser is driven
+            // past the sync check rather than bouncing off it every time.
+            if seed_round % 2 == 0 {
+                for packet in data.chunks_exact_mut(TS_PACKET_LEN) {
+                    packet[0] = 0x47;
+                    packet[1] &= 0x5F; // keep PID small, PUSI as drawn
+                    packet[2] = 0x00;
+                    packet[3] = 0x10 | (packet[3] & 0x0F);
+                }
+            }
+            let outcome = core
+                .ingest(0, &data)
+                .expect("packet aligned by construction");
+            assert!(
+                outcome.facts.audio_pids.len() <= 64,
+                "audio PID list grew without bound"
+            );
+            assert!(
+                outcome.facts.audio_tracks.len() <= 64,
+                "track list grew without bound"
+            );
+            assert!(
+                outcome.active.pat.len() <= 256,
+                "raw PAT grew without bound"
+            );
+            assert!(
+                outcome.active.pmt.len() <= 256,
+                "raw PMT grew without bound"
+            );
+            assert!(outcome.events.len() <= 4096, "events grew without bound");
+        }
+    }
+}
+
+#[test]
+fn uniform_bytes_never_panic() {
+    for fill in [0x00u8, 0xFF, 0x47] {
+        let mut core = PsiCore::new(1);
+        let outcome = core
+            .ingest(0, &vec![fill; TS_PACKET_LEN * 32])
+            .expect("aligned");
+        assert!(!outcome.facts.has_pmt, "uniform {fill:#04x} produced a PMT");
+    }
+}
+
+#[test]
+fn every_single_byte_mutation_of_a_good_stream_is_survived() {
+    let packets = [
+        psi_packets(0, 0, &pat_section(0, 0, 0, &[(1, 256)])),
+        psi_packets(
+            256,
+            0,
+            &pmt_section(
+                1,
+                0,
+                0,
+                0,
+                &[Es {
+                    stream_type: 0x1B,
+                    pid: 257,
+                    descriptors: vec![],
+                }],
+            ),
+        ),
+    ]
+    .concat();
+    let good = chunk_of(&packets);
+
+    for index in 0..good.len() {
+        for xor in [0x01u8, 0x80, 0xFF] {
+            let mut broken = good.clone();
+            broken[index] ^= xor;
+            let mut core = PsiCore::new(1);
+            // The only requirement is that it answers at all.
+            let outcome = core.ingest(0, &broken).expect("aligned");
+            assert!(outcome.facts.audio_pids.len() <= 64);
+        }
+    }
+}

--- a/media-core/src/psi/adversarial_test.rs
+++ b/media-core/src/psi/adversarial_test.rs
@@ -11,7 +11,7 @@
 //! need one to have an answer, it asserts only that the answer is refusal.
 
 use super::crc;
-use super::table::{MAX_SECTION_LEN, MIN_SECTION_LEN};
+use super::table::{MAX_SECTION_BYTES, MAX_SECTION_LENGTH, MIN_SECTION_LEN};
 use super::{IngestError, PsiCore, TS_PACKET_LEN};
 
 // --- builders -------------------------------------------------------------
@@ -261,13 +261,42 @@ fn sections_that_cannot_be_read_are_refused() {
 
 #[test]
 fn section_lengths_at_and_past_their_bounds_are_survived() {
-    // section_length is twelve bits, so this is the largest a section can claim.
+    // The largest either table may declare: waited for, not refused.
     let claims_the_maximum = {
-        let mut payload = vec![0x00, 0x00, 0xB0 | 0x0F, 0xFF];
+        let mut payload = vec![
+            0x00,
+            0x00,
+            0xB0 | u8::try_from((MAX_SECTION_LENGTH >> 8) & 0x0F).expect("masked"),
+            u8::try_from(MAX_SECTION_LENGTH & 0xFF).expect("masked"),
+        ];
         payload.resize(TS_PACKET_LEN - 4, 0x00);
         ts_packet(0, true, 0, 0x00, &payload)
     };
-    assert_eq!(MAX_SECTION_LEN, 3 + 0x0FFF);
+    assert_eq!(MAX_SECTION_BYTES, 1024);
+
+    // One more than that: refused where it declares itself.
+    let claims_one_too_many = {
+        let over = MAX_SECTION_LENGTH + 1;
+        ts_packet(
+            0,
+            true,
+            0,
+            0xFF,
+            &[
+                0x00,
+                0x00,
+                0xB0 | u8::try_from((over >> 8) & 0x0F).expect("masked"),
+                u8::try_from(over & 0xFF).expect("masked"),
+            ],
+        )
+    };
+
+    // The whole twelve-bit field, which these tables may not use.
+    let claims_the_field_width = ts_packet(0, true, 0, 0xFF, &[0x00, 0x00, 0xBF, 0xFF]);
+
+    // The long-form syntax bit clear, and the bit that must be zero set.
+    let wrong_syntax = ts_packet(0, true, 0, 0xFF, &[0x00, 0x00, 0x30, 0x0D]);
+    let fixed_bit_set = ts_packet(0, true, 0, 0xFF, &[0x00, 0x00, 0xF0, 0x0D]);
 
     // A length of zero names a section shorter than its own header.
     let claims_nothing = ts_packet(0, true, 0, 0xFF, &[0x00, 0x00, 0xB0, 0x00]);
@@ -277,6 +306,13 @@ fn section_lengths_at_and_past_their_bounds_are_survived() {
 
     for (what, packet) in [
         ("a section claiming the maximum length", claims_the_maximum),
+        ("a section claiming one byte too many", claims_one_too_many),
+        (
+            "a section claiming the whole field width",
+            claims_the_field_width,
+        ),
+        ("a section that is not the long form", wrong_syntax),
+        ("a section with the fixed bit set", fixed_bit_set),
         ("a section claiming no length", claims_nothing),
         ("a pointer field past the payload", pointer_past_the_end),
     ] {
@@ -304,48 +340,57 @@ fn a_table_is_not_read_until_every_section_of_it_is_here() {
     assert_eq!(outcome.facts.pmt_pid, 256);
 }
 
-/// A section numbered outside the table is collected like any other, and the
-/// generation then holds more sections than the table declares - so it stops
-/// completing, and goes on not completing even once the section that was
-/// genuinely missing arrives. Only a new generation clears it.
+/// A section numbering itself beyond the table it names is not a member of that
+/// table, so the table it interrupts is unaffected by it - the sections already
+/// collected stay collected and the one that was genuinely missing still
+/// completes it.
 ///
-/// Verified against the Go reference before being asserted here: both
-/// implementations do exactly this. The corpus states the first half of it
-/// (`a_section_numbered_outside_the_table_does_not_complete_it`) and not the
-/// second, so this test is Rust-side coverage of shared behaviour rather than a
-/// semantic of its own.
+/// This replaces a test that asserted the opposite. Both implementations used to
+/// collect such a section, and the tracker keys sections by number, so the extra
+/// entry made the generation's count permanently wrong and the table never
+/// completed again. Writing this parser is what surfaced it; it was settled and
+/// repaired on the Go side first, and this is the corrected contract.
 #[test]
-fn a_stray_section_number_holds_the_generation_until_a_new_one_starts() {
+fn a_section_numbered_beyond_its_table_leaves_that_table_alone() {
     let mut core = PsiCore::new(1);
-    for (what, packets) in [
-        (
-            "section 0 of 2",
-            psi_packets(0, 0, &pat_section(0, 0, 1, &[(1, 256)])),
-        ),
-        (
-            "a section numbered 5",
-            psi_packets(0, 1, &pat_section(0, 5, 1, &[(9, 0x0900)])),
-        ),
-        (
-            "section 1 of 2",
-            psi_packets(0, 2, &pat_section(0, 1, 1, &[(9, 0x0900)])),
-        ),
-    ] {
-        let outcome = core.ingest(0, &chunk_of(&packets)).expect("aligned");
-        assert_eq!(outcome.facts.pmt_pid, 0, "the table completed after {what}");
-    }
+    let strays = [
+        pat_section(0, 5, 1, &[(9, 0x0900)]),
+        pat_section(0, 255, 1, &[(9, 0x0901)]),
+        pat_section(0, 2, 1, &[(9, 0x0902)]),
+    ];
 
-    // A new version is a new generation, and the stray does not travel with it.
-    for packets in [
-        psi_packets(0, 3, &pat_section(1, 0, 1, &[(1, 256)])),
-        psi_packets(0, 4, &pat_section(1, 1, 1, &[(9, 0x0900)])),
-    ] {
-        core.ingest(0, &chunk_of(&packets)).expect("aligned");
+    let mut cc = 0u8;
+    let push = |core: &mut PsiCore, section: &[u8], cc: &mut u8| {
+        let outcome = core
+            .ingest(0, &chunk_of(&psi_packets(0, *cc, section)))
+            .expect("aligned");
+        *cc = (*cc + 1) & 0x0F;
+        outcome
+    };
+
+    push(&mut core, &pat_section(0, 0, 1, &[(1, 256)]), &mut cc);
+    for stray in &strays {
+        let outcome = push(&mut core, stray, &mut cc);
+        assert_eq!(
+            outcome.facts.pmt_pid, 0,
+            "a stray section completed the table"
+        );
+        assert!(
+            outcome.events.is_empty(),
+            "a stray section changed the programme"
+        );
     }
-    let outcome = core.ingest(0, &[]).expect("aligned");
+    let outcome = push(&mut core, &pat_section(0, 1, 1, &[(9, 0x0900)]), &mut cc);
     assert_eq!(
         outcome.facts.pmt_pid, 256,
-        "a new generation did not recover"
+        "the table did not complete once its own missing section arrived"
+    );
+    // The strays left nothing behind: the raw table is the two sections that
+    // belong to it, and neither stray packet is among them.
+    assert_eq!(
+        outcome.active.pat.len(),
+        2,
+        "the raw table carries a section that is not its own"
     );
 }
 

--- a/media-core/src/psi/assembler.rs
+++ b/media-core/src/psi/assembler.rs
@@ -158,12 +158,12 @@ impl SectionAssembler {
             if payload[at] != expected_table_id {
                 break;
             }
-            let section_len =
-                (usize::from(payload[at + 1] & 0x0F) << 8) | usize::from(payload[at + 2]);
-            let full = section_len + 3;
-            // section_length is twelve bits wide, so a section can never claim
-            // more than this and no untrusted length reaches an allocation.
-            debug_assert!(full <= super::table::MAX_SECTION_LEN);
+            let Some(full) = super::table::declaration(&payload[at..]) else {
+                // An impossible declaration ends the scan of this payload. What
+                // follows it cannot be located: the length that would say where
+                // is the one that has just been refused.
+                break;
+            };
             if available >= full {
                 completed.push(Completed {
                     bytes: payload[at..at + full].to_vec(),
@@ -201,8 +201,23 @@ impl SectionAssembler {
             if self.buf.len() < 3 {
                 return consumed;
             }
-            let section_len = (usize::from(self.buf[1] & 0x0F) << 8) | usize::from(self.buf[2]);
-            self.section_len = section_len + 3;
+            let Some(full) = super::table::declaration(&self.buf) else {
+                // The header is complete and says something a PAT or PMT cannot
+                // say. It is the only thing that could tell this assembler how
+                // much to collect, so there is nothing to wait for: the section
+                // is dropped rather than reserving space on its word.
+                self.discard_section();
+                // Everything handed in is given up, not only the header bytes.
+                // The caller resumes its scan at what this returns, and there is
+                // nowhere in the rest of this payload it could resume: the
+                // length that would say where the next section starts is the one
+                // just refused. Returning the header bytes alone would put the
+                // scan a byte or two into the body of the section that was
+                // refused, and let those bytes be read as a table_id and a
+                // length of their own.
+                return consumed + chunk.len();
+            };
+            self.section_len = full;
         }
 
         if self.section_len > 0 && self.buf.len() < self.section_len {

--- a/media-core/src/psi/assembler.rs
+++ b/media-core/src/psi/assembler.rs
@@ -37,6 +37,17 @@ pub(crate) struct SectionAssembler {
 }
 
 impl SectionAssembler {
+    /// What this assembler is holding: buffered bytes, the section length it is
+    /// waiting for, and packets kept for a section not yet emitted.
+    ///
+    /// Exposed for the one test that has to see that an impossible declaration
+    /// left nothing behind. That defect never moved a fact, so a test comparing
+    /// facts would have watched it happen and reported nothing.
+    #[cfg(test)]
+    pub(super) fn retained(&self) -> (usize, usize, usize) {
+        (self.buf.len(), self.section_len, self.raw_packets.len())
+    }
+
     /// Forgets everything, the continuity counter included.
     ///
     /// Used where the stream itself has become untrustworthy: after a
@@ -121,7 +132,7 @@ impl SectionAssembler {
                         self.reset();
                         return completed;
                     };
-                    self.feed(&payload[1..end], packet, &mut completed);
+                    self.feed(expected_table_id, &payload[1..end], packet, &mut completed);
                     if !self.buf.is_empty() {
                         // The bytes before the pointer were supposed to finish
                         // the section in flight and did not, so it never will.
@@ -137,7 +148,7 @@ impl SectionAssembler {
             // Continuation bytes with nothing to continue.
             return completed;
         } else {
-            at = self.feed(payload, packet, &mut completed);
+            at = self.feed(expected_table_id, payload, packet, &mut completed);
         }
 
         while at < payload.len() {
@@ -158,7 +169,7 @@ impl SectionAssembler {
             if payload[at] != expected_table_id {
                 break;
             }
-            let Some(full) = super::table::declaration(&payload[at..]) else {
+            let Some(full) = super::table::declaration(expected_table_id, &payload[at..]) else {
                 // An impossible declaration ends the scan of this payload. What
                 // follows it cannot be located: the length that would say where
                 // is the one that has just been refused.
@@ -182,8 +193,20 @@ impl SectionAssembler {
     }
 
     /// Adds `chunk` to the section in flight, completing it if it fits, and
-    /// returns how many bytes were taken.
-    fn feed(&mut self, chunk: &[u8], packet: &[u8], completed: &mut Vec<Completed>) -> usize {
+    /// returns how many bytes were taken - or, when the header completes into a
+    /// declaration the expected table cannot make, the whole input.
+    ///
+    /// What the assembler holds is given up entirely in that case. The defect
+    /// this closes was not a wrong fact: a section declaring nothing after its
+    /// length field left three bytes here that neither phase could act on, and
+    /// every later packet on the PID was then retained.
+    fn feed(
+        &mut self,
+        expected_table_id: u8,
+        chunk: &[u8],
+        packet: &[u8],
+        completed: &mut Vec<Completed>,
+    ) -> usize {
         if chunk.is_empty() {
             return 0;
         }
@@ -201,7 +224,7 @@ impl SectionAssembler {
             if self.buf.len() < 3 {
                 return consumed;
             }
-            let Some(full) = super::table::declaration(&self.buf) else {
+            let Some(full) = super::table::declaration(expected_table_id, &self.buf) else {
                 // The header is complete and says something a PAT or PMT cannot
                 // say. It is the only thing that could tell this assembler how
                 // much to collect, so there is nothing to wait for: the section

--- a/media-core/src/psi/assembler.rs
+++ b/media-core/src/psi/assembler.rs
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! Getting whole PSI sections back out of 188-byte packets.
+//!
+//! One of these follows one PSI PID. It owns the continuity counter for that
+//! PID, the bytes of a section that has not finished arriving, and the packets
+//! those bytes came from - the last because a subscriber is handed the original
+//! packets rather than a re-encoded table, so the transport it joins is the one
+//! that was broadcast.
+
+/// A section that has arrived in full, with the packets it came from.
+pub(crate) struct Completed {
+    /// The section, from its `table_id` through its CRC.
+    pub(crate) bytes: Vec<u8>,
+    /// Every packet that carried part of it, in arrival order.
+    pub(crate) packets: Vec<Vec<u8>>,
+}
+
+/// Section assembly for one PSI PID.
+#[derive(Default)]
+pub(crate) struct SectionAssembler {
+    /// Bytes of the section still arriving.
+    buf: Vec<u8>,
+    /// Its total length once the header has been read, otherwise 0.
+    section_len: usize,
+    /// The continuity counter of the last packet accepted on this PID.
+    last_cc: u8,
+    /// Whether `last_cc` means anything yet.
+    has_cc: bool,
+    /// The last packet accepted, kept whole so an exact repeat can be told from
+    /// a different packet that reuses the counter.
+    last_packet: Vec<u8>,
+    /// The packets the bytes in `buf` came from.
+    raw_packets: Vec<Vec<u8>>,
+}
+
+impl SectionAssembler {
+    /// Forgets everything, the continuity counter included.
+    ///
+    /// Used where the stream itself has become untrustworthy: after a
+    /// discontinuity, or when the PID stops being one this core follows. The
+    /// next packet is then treated as the first, which is what stops a stale
+    /// counter from rejecting a stream that has legitimately restarted.
+    pub(crate) fn reset(&mut self) {
+        self.buf.clear();
+        self.section_len = 0;
+        self.has_cc = false;
+        self.last_packet.clear();
+        self.raw_packets.clear();
+    }
+
+    /// Drops the section in flight but keeps following the PID.
+    ///
+    /// Separate from [`Self::reset`] on purpose: a pointer field saying "a new
+    /// section starts here" makes whatever was half-collected unusable, but says
+    /// nothing about the continuity counter, and forgetting that too would make
+    /// the next packet look like the start of a fresh stream.
+    fn discard_section(&mut self) {
+        self.buf.clear();
+        self.section_len = 0;
+        self.raw_packets.clear();
+    }
+
+    /// Takes one packet's payload and returns the sections it completed, in the
+    /// order they finished.
+    ///
+    /// `expected_table_id` ends the scan of a payload rather than filtering it:
+    /// a section of another table means the rest of this payload is not laid out
+    /// the way this PID's tables are, and its length field is not something to
+    /// navigate by. Whether a completed section is *accepted* is decided
+    /// elsewhere, on the finished section, so that one arriving in pieces cannot
+    /// reach interpretation without the same check.
+    pub(crate) fn accept(
+        &mut self,
+        packet: &[u8],
+        pusi: bool,
+        payload: &[u8],
+        expected_table_id: u8,
+    ) -> Vec<Completed> {
+        let mut completed = Vec::new();
+        let cc = packet[3] & 0x0F;
+
+        if self.has_cc {
+            if cc == self.last_cc {
+                if packet == self.last_packet.as_slice() {
+                    // The transport saying the same thing twice, which is what a
+                    // repeated counter with identical bytes means.
+                    return completed;
+                }
+                // One counter value cannot describe two different packets, so
+                // whatever was in flight cannot be trusted.
+                self.reset();
+                if !pusi {
+                    return completed;
+                }
+            } else if cc != (self.last_cc.wrapping_add(1)) & 0x0F {
+                // A packet went missing, and it may have carried section bytes.
+                self.reset();
+                if !pusi {
+                    return completed;
+                }
+            }
+        }
+        self.last_cc = cc;
+        self.has_cc = true;
+        self.last_packet.clear();
+        self.last_packet.extend_from_slice(packet);
+
+        let mut at;
+        if pusi {
+            let Some(&pointer) = payload.first() else {
+                return completed;
+            };
+            let pointer = usize::from(pointer);
+            if pointer > 0 {
+                if !self.buf.is_empty() {
+                    let Some(end) = 1usize.checked_add(pointer).filter(|e| *e <= payload.len())
+                    else {
+                        self.reset();
+                        return completed;
+                    };
+                    self.feed(&payload[1..end], packet, &mut completed);
+                    if !self.buf.is_empty() {
+                        // The bytes before the pointer were supposed to finish
+                        // the section in flight and did not, so it never will.
+                        self.discard_section();
+                    }
+                }
+                at = 1 + pointer;
+            } else {
+                self.discard_section();
+                at = 1;
+            }
+        } else if self.buf.is_empty() {
+            // Continuation bytes with nothing to continue.
+            return completed;
+        } else {
+            at = self.feed(payload, packet, &mut completed);
+        }
+
+        while at < payload.len() {
+            if payload[at] == 0xFF {
+                // PSI stuffing: the rest of the payload is padding.
+                break;
+            }
+            let available = payload.len() - at;
+            if available < 3 {
+                // The section header itself is split across the packet boundary.
+                // Its length is in the bytes that have not arrived, so there is
+                // nothing to do but keep these and wait.
+                self.buf.extend_from_slice(&payload[at..]);
+                self.section_len = 0;
+                self.raw_packets.push(packet.to_vec());
+                break;
+            }
+            if payload[at] != expected_table_id {
+                break;
+            }
+            let section_len =
+                (usize::from(payload[at + 1] & 0x0F) << 8) | usize::from(payload[at + 2]);
+            let full = section_len + 3;
+            // section_length is twelve bits wide, so a section can never claim
+            // more than this and no untrusted length reaches an allocation.
+            debug_assert!(full <= super::table::MAX_SECTION_LEN);
+            if available >= full {
+                completed.push(Completed {
+                    bytes: payload[at..at + full].to_vec(),
+                    packets: vec![packet.to_vec()],
+                });
+                at += full;
+                continue;
+            }
+            self.buf.extend_from_slice(&payload[at..]);
+            self.section_len = full;
+            self.raw_packets.push(packet.to_vec());
+            break;
+        }
+
+        completed
+    }
+
+    /// Adds `chunk` to the section in flight, completing it if it fits, and
+    /// returns how many bytes were taken.
+    fn feed(&mut self, chunk: &[u8], packet: &[u8], completed: &mut Vec<Completed>) -> usize {
+        if chunk.is_empty() {
+            return 0;
+        }
+        let mut chunk = chunk;
+        let mut consumed = 0usize;
+
+        // The three header bytes first: until they are all here, the section's
+        // length is unknown and there is nothing to fill.
+        if self.buf.len() < 3 {
+            let take = chunk.len().min(3 - self.buf.len());
+            self.buf.extend_from_slice(&chunk[..take]);
+            self.raw_packets.push(packet.to_vec());
+            chunk = &chunk[take..];
+            consumed += take;
+            if self.buf.len() < 3 {
+                return consumed;
+            }
+            let section_len = (usize::from(self.buf[1] & 0x0F) << 8) | usize::from(self.buf[2]);
+            self.section_len = section_len + 3;
+        }
+
+        if self.section_len > 0 && self.buf.len() < self.section_len {
+            let take = chunk.len().min(self.section_len - self.buf.len());
+            self.buf.extend_from_slice(&chunk[..take]);
+            if consumed == 0 {
+                // Not already recorded by the header phase for this packet.
+                self.raw_packets.push(packet.to_vec());
+            }
+            consumed += take;
+            if self.buf.len() >= self.section_len {
+                completed.push(Completed {
+                    bytes: self.buf[..self.section_len].to_vec(),
+                    packets: self.raw_packets.clone(),
+                });
+                self.discard_section();
+            }
+        }
+
+        consumed
+    }
+}

--- a/media-core/src/psi/corpus_test.rs
+++ b/media-core/src/psi/corpus_test.rs
@@ -1,0 +1,727 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! The shared PSI corpus, read and enforced.
+//!
+//! The file this reads is generated from the Go side's authored expectations and
+//! checked into the repository. Both implementations are held to it, which is
+//! what makes agreement a property of a reviewable artefact rather than of two
+//! parsers written by the same hand on the same day.
+//!
+//! The reader below is deliberately fail-closed. A corpus it cannot parse
+//! exactly is a corpus that would silently check less than it claims to, and a
+//! test that checks three cases and passes is worse than one that fails.
+
+use super::{ChannelDeclaration, PsiCore, PsiEvent, TS_PACKET_LEN};
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+/// The format version this reader understands.
+const FORMAT_VERSION: &str = "1";
+
+/// The number of cases the corpus had when this reader was written.
+///
+/// A floor rather than an equality so cases added later run without a change
+/// here, and a floor at all so a reader bug that finds three cases cannot pass.
+const MINIMUM_CASES: usize = 63;
+
+fn corpus_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../testdata/psi-corpus/corpus.txt")
+}
+
+/// One call into the core.
+#[derive(Debug)]
+enum Call {
+    /// `ingest` of these bytes.
+    Chunk(Vec<u8>),
+    /// `set_target_program`.
+    Target(u16),
+}
+
+/// What a call has to produce.
+#[derive(Debug, Default)]
+struct Expect {
+    through: i64,
+    has_pat: bool,
+    has_pmt: bool,
+    pmt_version: u8,
+    program_number: u16,
+    pmt_pid: u16,
+    video_pid: u16,
+    video_codec: String,
+    audio_pids: Vec<u16>,
+    tracks: Vec<ExpectTrack>,
+    events: Vec<String>,
+    pat_packets: Vec<usize>,
+    pmt_packets: Vec<usize>,
+}
+
+/// One expected audio track line.
+#[derive(Debug, PartialEq, Eq)]
+struct ExpectTrack {
+    pid: u16,
+    stream_type: u8,
+    codec: String,
+    language: String,
+    channels: u8,
+    multichannel: bool,
+    component_type: u8,
+    has_component_type: bool,
+}
+
+/// One call and its expectation.
+#[derive(Debug)]
+struct Step {
+    call: Call,
+    expect: Expect,
+}
+
+/// One case: a core built with a target, then a sequence of calls.
+#[derive(Debug)]
+struct Case {
+    name: String,
+    note: Option<String>,
+    initial_target: u16,
+    steps: Vec<Step>,
+}
+
+/// Parses hex, refusing anything that is not exactly hex.
+fn parse_hex(text: &str) -> Result<Vec<u8>, String> {
+    if !text.len().is_multiple_of(2) {
+        return Err(format!("odd-length hex, {} characters", text.len()));
+    }
+    let bytes = text.as_bytes();
+    let mut out = Vec::with_capacity(text.len() / 2);
+    let mut at = 0;
+    while at < bytes.len() {
+        let hi = (bytes[at] as char)
+            .to_digit(16)
+            .ok_or_else(|| format!("bad hex digit at {at}"))?;
+        let lo = (bytes[at + 1] as char)
+            .to_digit(16)
+            .ok_or_else(|| format!("bad hex digit at {}", at + 1))?;
+        out.push(u8::try_from(hi * 16 + lo).expect("two hex digits are one byte"));
+        at += 2;
+    }
+    Ok(out)
+}
+
+/// Splits `k=v k=v` into a map, refusing a repeated key or a field with no value.
+fn parse_fields(text: &str) -> Result<Vec<(String, String)>, String> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut seen = BTreeSet::new();
+    for field in text.split_whitespace() {
+        let (key, value) = field
+            .split_once('=')
+            .ok_or_else(|| format!("field without a value: {field}"))?;
+        if !seen.insert(key.to_owned()) {
+            return Err(format!("field {key} appears twice"));
+        }
+        out.push((key.to_owned(), value.to_owned()));
+    }
+    Ok(out)
+}
+
+/// Reads a field set, requiring exactly `wanted` and nothing else.
+fn take_fields(text: &str, wanted: &[&str]) -> Result<Vec<String>, String> {
+    let fields = parse_fields(text)?;
+    for (key, _) in &fields {
+        if !wanted.contains(&key.as_str()) {
+            return Err(format!("unknown field {key}"));
+        }
+    }
+    wanted
+        .iter()
+        .map(|want| {
+            fields
+                .iter()
+                .find(|(key, _)| key == want)
+                .map(|(_, value)| value.clone())
+                .ok_or_else(|| format!("missing field {want}"))
+        })
+        .collect()
+}
+
+fn parse_bit(text: &str) -> Result<bool, String> {
+    match text {
+        "0" => Ok(false),
+        "1" => Ok(true),
+        other => Err(format!("expected 0 or 1, got {other}")),
+    }
+}
+
+fn parse_num<T: std::str::FromStr>(text: &str) -> Result<T, String> {
+    text.parse().map_err(|_| format!("not a number: {text}"))
+}
+
+/// Parses a possibly empty comma separated list.
+fn parse_list<T: std::str::FromStr>(text: &str) -> Result<Vec<T>, String> {
+    if text.is_empty() {
+        return Ok(Vec::new());
+    }
+    text.split(',').map(parse_num).collect()
+}
+
+/// Reads a `facts` line into the expectation it belongs to.
+fn apply_facts(expect: &mut Expect, rest: &str) -> Result<(), String> {
+    let values = take_fields(
+        rest,
+        &[
+            "through",
+            "hasPAT",
+            "hasPMT",
+            "pmtVersion",
+            "programNumber",
+            "pmtPID",
+            "videoPID",
+            "videoCodec",
+            "audioPIDs",
+        ],
+    )?;
+    expect.through = parse_num(&values[0])?;
+    expect.has_pat = parse_bit(&values[1])?;
+    expect.has_pmt = parse_bit(&values[2])?;
+    expect.pmt_version = parse_num(&values[3])?;
+    expect.program_number = parse_num(&values[4])?;
+    expect.pmt_pid = parse_num(&values[5])?;
+    expect.video_pid = parse_num(&values[6])?;
+    expect.video_codec = values[7].clone();
+    expect.audio_pids = parse_list(&values[8])?;
+    Ok(())
+}
+
+/// Reads one `track` line.
+fn apply_track(expect: &mut Expect, rest: &str) -> Result<(), String> {
+    let values = take_fields(
+        rest,
+        &[
+            "pid",
+            "streamType",
+            "codec",
+            "lang",
+            "channels",
+            "multichannel",
+            "componentType",
+            "hasComponentType",
+        ],
+    )?;
+    expect.tracks.push(ExpectTrack {
+        pid: parse_num(&values[0])?,
+        stream_type: parse_num(&values[1])?,
+        codec: values[2].clone(),
+        language: values[3].clone(),
+        channels: parse_num(&values[4])?,
+        multichannel: parse_bit(&values[5])?,
+        component_type: parse_num(&values[6])?,
+        has_component_type: parse_bit(&values[7])?,
+    });
+    Ok(())
+}
+
+/// Reads the `psi` line naming which packets the active tables are.
+fn apply_psi(expect: &mut Expect, rest: &str) -> Result<(), String> {
+    let values = take_fields(rest, &["pat", "pmt"])?;
+    expect.pat_packets = parse_list(&values[0])?;
+    expect.pmt_packets = parse_list(&values[1])?;
+    Ok(())
+}
+
+/// The corpus reader, one line at a time.
+///
+/// A struct rather than one long loop so each kind of line is answered in one
+/// small place, and so "what is allowed here" is a question about the state
+/// rather than about how far down a function the reader happens to be.
+/// Which of a call's expectation lines have been seen. They have to arrive in
+/// this order and exactly once, which is what stops a corpus from quietly
+/// describing a call twice or not at all.
+#[derive(Default)]
+struct StepLines {
+    facts: bool,
+    events: bool,
+    psi: bool,
+}
+
+#[derive(Default)]
+struct Reader {
+    cases: Vec<Case>,
+    current: Option<Case>,
+    pending: Option<(Call, Expect)>,
+    saw_version: bool,
+    seen: StepLines,
+}
+
+impl Reader {
+    /// Files the call that has finished, refusing one that never got its
+    /// expectation.
+    fn close_step(&mut self) -> Result<(), String> {
+        let Some((call, expect)) = self.pending.take() else {
+            return Ok(());
+        };
+        if !(self.seen.facts && self.seen.events && self.seen.psi) {
+            return Err("a call is missing its facts, events or psi line".into());
+        }
+        self.current
+            .as_mut()
+            .ok_or_else(|| "a call outside a case".to_owned())?
+            .steps
+            .push(Step { call, expect });
+        Ok(())
+    }
+
+    /// The lines that open, describe and close a case.
+    fn case_line(&mut self, keyword: &str, rest: &str) -> Result<(), String> {
+        match keyword {
+            "version" => {
+                if self.saw_version {
+                    return Err("the corpus declares its version twice".into());
+                }
+                if rest != FORMAT_VERSION {
+                    return Err(format!("unsupported corpus format version {rest}"));
+                }
+                self.saw_version = true;
+            }
+            "case" => {
+                if !self.saw_version {
+                    return Err("a case before the format version".into());
+                }
+                if self.current.is_some() {
+                    return Err("a case inside a case".into());
+                }
+                if rest.is_empty() {
+                    return Err("a case with no name".into());
+                }
+                self.current = Some(Case {
+                    name: rest.to_owned(),
+                    note: None,
+                    initial_target: 0,
+                    steps: Vec::new(),
+                });
+            }
+            "desc" => {
+                let case = self.current.as_mut().ok_or("desc outside a case")?;
+                if !case.steps.is_empty() {
+                    return Err("desc after the first call".into());
+                }
+            }
+            "note" => {
+                let case = self.current.as_mut().ok_or("note outside a case")?;
+                if case.note.is_some() {
+                    return Err("a case with two notes".into());
+                }
+                case.note = Some(rest.to_owned());
+            }
+            "init" => {
+                let values = take_fields(rest, &["target"])?;
+                let target = parse_num(&values[0])?;
+                self.current
+                    .as_mut()
+                    .ok_or("init outside a case")?
+                    .initial_target = target;
+            }
+            "end" => {
+                let case = self.current.take().ok_or("end outside a case")?;
+                if !rest.is_empty() {
+                    return Err(format!("trailing text after end: {rest}"));
+                }
+                if case.steps.is_empty() {
+                    return Err(format!("case {} has no calls", case.name));
+                }
+                self.cases.push(case);
+            }
+            other => return Err(format!("unknown keyword {other}")),
+        }
+        Ok(())
+    }
+
+    /// A line that starts a call.
+    fn call_line(&mut self, keyword: &str, rest: &str) -> Result<(), String> {
+        if self.current.is_none() {
+            return Err("a call outside a case".into());
+        }
+        let call = if keyword == "chunk" {
+            Call::Chunk(parse_hex(rest)?)
+        } else {
+            Call::Target(parse_num(rest)?)
+        };
+        self.pending = Some((call, Expect::default()));
+        self.seen = StepLines::default();
+        Ok(())
+    }
+
+    /// A line that says what the call in progress has to produce.
+    fn expectation_line(&mut self, keyword: &str, rest: &str) -> Result<(), String> {
+        let (seen_facts, seen_events) = (self.seen.facts, self.seen.events);
+        let (_, expect) = self
+            .pending
+            .as_mut()
+            .ok_or_else(|| format!("{keyword} with no call"))?;
+        match keyword {
+            "facts" => {
+                if seen_facts {
+                    return Err("two facts lines for one call".into());
+                }
+                self.seen.facts = true;
+                apply_facts(expect, rest)?;
+            }
+            "track" => {
+                if !seen_facts || seen_events {
+                    return Err("a track line outside the facts it belongs to".into());
+                }
+                apply_track(expect, rest)?;
+            }
+            "events" => {
+                if !seen_facts {
+                    return Err("events before facts".into());
+                }
+                if seen_events {
+                    return Err("two events lines for one call".into());
+                }
+                self.seen.events = true;
+                expect.events = rest.split_whitespace().map(str::to_owned).collect();
+            }
+            "psi" => {
+                if !seen_events {
+                    return Err("psi before events".into());
+                }
+                if self.seen.psi {
+                    return Err("two psi lines for one call".into());
+                }
+                self.seen.psi = true;
+                apply_psi(expect, rest)?;
+            }
+            other => return Err(format!("unknown keyword {other}")),
+        }
+        Ok(())
+    }
+
+    /// Everything that has to be true once the last line has been read.
+    fn finish(self) -> Result<Vec<Case>, String> {
+        if self.current.is_some() {
+            return Err("the corpus ended inside a case".into());
+        }
+        if self.pending.is_some() {
+            return Err("the corpus ended inside a call".into());
+        }
+        if !self.saw_version {
+            return Err("the corpus never declared its format version".into());
+        }
+        Ok(self.cases)
+    }
+}
+
+/// Reads the whole corpus, or says exactly where it stopped making sense.
+fn parse_corpus(text: &str) -> Result<Vec<Case>, String> {
+    let mut reader = Reader::default();
+    for (line_no, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (keyword, rest) = line.split_once(' ').unwrap_or((line, ""));
+        let rest = rest.trim();
+        let at = |e: String| format!("line {}: {e}", line_no + 1);
+
+        if matches!(keyword, "chunk" | "target" | "end") {
+            reader.close_step().map_err(&at)?;
+        }
+        match keyword {
+            "chunk" | "target" => reader.call_line(keyword, rest).map_err(&at)?,
+            "facts" | "track" | "events" | "psi" => {
+                reader.expectation_line(keyword, rest).map_err(&at)?;
+            }
+            _ => reader.case_line(keyword, rest).map_err(&at)?,
+        }
+    }
+    reader.finish()
+}
+
+/// The case's own packet sequence: every chunk concatenated, cut into packets.
+/// The raw PSI expectations index into it.
+fn case_packets(case: &Case) -> Vec<Vec<u8>> {
+    let mut all = Vec::new();
+    for step in &case.steps {
+        if let Call::Chunk(bytes) = &step.call {
+            all.extend_from_slice(bytes);
+        }
+    }
+    all.chunks_exact(TS_PACKET_LEN)
+        .map(<[u8]>::to_vec)
+        .collect()
+}
+
+fn render_track(
+    pid: u16,
+    stream_type: u8,
+    codec: &str,
+    language: &str,
+    d: ChannelDeclaration,
+) -> String {
+    format!(
+        "pid={pid} streamType={stream_type} codec={codec} lang={language} channels={} multichannel={} componentType={} hasComponentType={}",
+        d.channels,
+        u8::from(d.multichannel),
+        d.component_type,
+        u8::from(d.has_component_type)
+    )
+}
+
+fn render_expected_track(t: &ExpectTrack) -> String {
+    format!(
+        "pid={} streamType={} codec={} lang={} channels={} multichannel={} componentType={} hasComponentType={}",
+        t.pid,
+        t.stream_type,
+        t.codec,
+        t.language,
+        t.channels,
+        u8::from(t.multichannel),
+        t.component_type,
+        u8::from(t.has_component_type)
+    )
+}
+
+/// Names each raw packet by where it came from in the case's packet sequence, so
+/// a disagreement reads as an index rather than as 188 bytes of hex. A packet the
+/// case never contained is reported as bytes, which is what a reconstructed
+/// preamble would produce.
+fn render_packets(packets: &[Vec<u8>], sequence: &[Vec<u8>]) -> String {
+    packets
+        .iter()
+        .map(|packet| {
+            sequence
+                .iter()
+                .position(|candidate| candidate == packet)
+                .map_or_else(|| unplaced(packet), |index| index.to_string())
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// A packet the case never contained, written out in full: that is what a
+/// reconstructed preamble rather than a forwarded one would look like.
+fn unplaced(packet: &[u8]) -> String {
+    let mut out = String::with_capacity(1 + packet.len() * 2);
+    out.push('!');
+    for byte in packet {
+        write!(out, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    out
+}
+
+fn render_indices(indices: &[usize]) -> String {
+    indices
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Everything one call has to get right, compared exactly.
+///
+/// Nothing is sorted or normalised before comparison: where order is part of the
+/// contract - the audio lists follow the table, events follow the stream, raw
+/// packets follow `section_number` - sorting would hide precisely the
+/// disagreements worth finding.
+fn compare(outcome: &super::Outcome, expect: &Expect, sequence: &[Vec<u8>]) -> Vec<String> {
+    let mut bad = Vec::new();
+
+    let got_facts = format!(
+        "through={} hasPAT={} hasPMT={} pmtVersion={} programNumber={} pmtPID={} videoPID={} videoCodec={} audioPIDs={}",
+        outcome.processed_through,
+        u8::from(outcome.facts.has_pat),
+        u8::from(outcome.facts.has_pmt),
+        outcome.facts.pmt_version,
+        outcome.facts.program_number,
+        outcome.facts.pmt_pid,
+        outcome.facts.video_pid,
+        outcome.facts.video_codec.as_str(),
+        join_pids(&outcome.facts.audio_pids)
+    );
+    let want_facts = format!(
+        "through={} hasPAT={} hasPMT={} pmtVersion={} programNumber={} pmtPID={} videoPID={} videoCodec={} audioPIDs={}",
+        expect.through,
+        u8::from(expect.has_pat),
+        u8::from(expect.has_pmt),
+        expect.pmt_version,
+        expect.program_number,
+        expect.pmt_pid,
+        expect.video_pid,
+        expect.video_codec,
+        join_pids(&expect.audio_pids)
+    );
+    if got_facts != want_facts {
+        bad.push(format!(
+            "  facts got  {got_facts}\n  facts want {want_facts}"
+        ));
+    }
+
+    if outcome.facts.audio_tracks.len() == expect.tracks.len() {
+        for (n, track) in outcome.facts.audio_tracks.iter().enumerate() {
+            let got = render_track(
+                track.pid,
+                track.stream_type,
+                &track.codec,
+                &track.language,
+                track.declared,
+            );
+            let want = render_expected_track(&expect.tracks[n]);
+            if got != want {
+                bad.push(format!("  track {n} got  {got}\n  track {n} want {want}"));
+            }
+        }
+    } else {
+        bad.push(format!(
+            "  tracks got {}, want {}",
+            outcome.facts.audio_tracks.len(),
+            expect.tracks.len()
+        ));
+    }
+
+    let got_events: Vec<&str> = outcome
+        .events
+        .iter()
+        .map(|e| match e {
+            PsiEvent::ProgramIdentityChanged => "identity",
+        })
+        .collect();
+    if got_events.join(" ") != expect.events.join(" ") {
+        bad.push(format!(
+            "  events got  [{}]\n  events want [{}]",
+            got_events.join(" "),
+            expect.events.join(" ")
+        ));
+    }
+
+    let got_psi = format!(
+        "pat={} pmt={}",
+        render_packets(&outcome.active.pat, sequence),
+        render_packets(&outcome.active.pmt, sequence)
+    );
+    let want_psi = format!(
+        "pat={} pmt={}",
+        render_indices(&expect.pat_packets),
+        render_indices(&expect.pmt_packets)
+    );
+    if got_psi != want_psi {
+        bad.push(format!("  psi got  {got_psi}\n  psi want {want_psi}"));
+    }
+
+    bad
+}
+
+fn join_pids(pids: &[u16]) -> String {
+    pids.iter()
+        .map(u16::to_string)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[test]
+fn the_rust_core_answers_the_shared_corpus() {
+    let path = corpus_path();
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let cases = parse_corpus(&text).unwrap_or_else(|e| panic!("parse corpus: {e}"));
+
+    assert!(
+        cases.len() >= MINIMUM_CASES,
+        "the corpus reader found {} cases and the corpus had at least {MINIMUM_CASES}; \
+         a reader that finds fewer would pass while checking less",
+        cases.len()
+    );
+
+    let mut calls = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in &cases {
+        let sequence = case_packets(case);
+        let mut core = PsiCore::new(case.initial_target);
+        let mut offset = 0i64;
+
+        for (index, step) in case.steps.iter().enumerate() {
+            calls += 1;
+            let outcome = match &step.call {
+                Call::Chunk(bytes) => {
+                    let result = core
+                        .ingest(offset, bytes)
+                        .unwrap_or_else(|e| panic!("{}: step {}: {e}", case.name, index + 1));
+                    offset += i64::try_from(bytes.len()).expect("a chunk fits an i64");
+                    result
+                }
+                Call::Target(program) => core.set_target_program(*program),
+            };
+
+            let bad = compare(&outcome, &step.expect, &sequence);
+            if !bad.is_empty() {
+                failures.push(format!(
+                    "{} step {} of {}:\n{}",
+                    case.name,
+                    index + 1,
+                    case.steps.len(),
+                    bad.join("\n")
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} calls across {} cases disagree:\n{}",
+        failures.len(),
+        calls,
+        cases.len(),
+        failures.join("\n\n")
+    );
+    println!("corpus: {} cases, {calls} calls, all exact", cases.len());
+}
+
+#[test]
+fn the_corpus_carries_no_unadjudicated_semantics() {
+    let text = std::fs::read_to_string(corpus_path()).expect("read corpus");
+    let cases = parse_corpus(&text).expect("parse corpus");
+    let noted: Vec<&str> = cases
+        .iter()
+        .filter(|c| c.note.is_some())
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(
+        noted.is_empty(),
+        "a note marks behaviour nobody has ruled on, and a second implementation must not be \
+         written to reproduce it. Still noted: {noted:?}"
+    );
+}
+
+#[test]
+fn the_corpus_reader_refuses_what_it_cannot_read_exactly() {
+    let good = "version 1\n\
+                case a\n  desc d\n  init target=1\n  chunk 47\n  facts through=1 hasPAT=0 hasPMT=0 \
+                pmtVersion=0 programNumber=0 pmtPID=0 videoPID=0 videoCodec=unknown audioPIDs=\n  \
+                events\n  psi pat= pmt=\nend\n";
+    assert!(parse_corpus(good).is_ok(), "the control case must parse");
+
+    for (what, text) in [
+        ("unknown keyword", good.replace("  desc d", "  colour blue")),
+        ("unknown field", good.replace("hasPAT=0", "hasPAT=0 hasSDT=1")),
+        ("duplicate field", good.replace("hasPAT=0", "hasPAT=0 hasPAT=1")),
+        ("missing field", good.replace(" hasPMT=0", "")),
+        ("bad hex", good.replace("chunk 47", "chunk 4z")),
+        ("odd hex", good.replace("chunk 47", "chunk 475")),
+        ("field without a value", good.replace("hasPAT=0", "hasPAT")),
+        ("two facts lines", good.replace("  events\n", "  facts through=1 hasPAT=0 hasPMT=0 pmtVersion=0 programNumber=0 pmtPID=0 videoPID=0 videoCodec=unknown audioPIDs=\n  events\n")),
+        ("unsupported version", good.replace("version 1", "version 2")),
+        ("no version", good.replace("version 1\n", "")),
+        ("case inside a case", good.replace("  desc d", "case b")),
+        ("call with no expectation", good.replace("  facts through=1 hasPAT=0 hasPMT=0 pmtVersion=0 programNumber=0 pmtPID=0 videoPID=0 videoCodec=unknown audioPIDs=\n", "")),
+        ("trailing text after end", good.replace("end\n", "end now\n")),
+        ("unterminated case", good.replace("end\n", "")),
+        ("not a number", good.replace("init target=1", "init target=x")),
+        ("bad boolean", good.replace("hasPAT=0", "hasPAT=2")),
+        ("psi before events", good.replace("  events\n  psi pat= pmt=\n", "  psi pat= pmt=\n  events\n")),
+    ] {
+        assert!(
+            parse_corpus(&text).is_err(),
+            "the reader accepted a corpus with {what}, so a damaged corpus could check less than it claims"
+        );
+    }
+}

--- a/media-core/src/psi/crc.rs
+++ b/media-core/src/psi/crc.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! The CRC a PSI section carries about itself.
+
+/// The ISO/IEC 13818-1 Annex B polynomial.
+const POLYNOMIAL: u32 = 0x04C1_1DB7;
+
+/// Computes the MPEG-2 systems CRC over `data`.
+///
+/// Written bit by bit rather than with a lookup table. The table form is faster
+/// and the sections this runs over are a few hundred bytes at most, so the
+/// difference is not worth the thing the table costs: a second place where the
+/// polynomial is encoded, and one that cannot be read against the standard
+/// without expanding it back out again.
+///
+/// A section carries its own CRC in the last four bytes, so running this over
+/// the whole section - the CRC included - yields zero when the bytes are
+/// intact. That is how the caller uses it, and it is why nothing here strips or
+/// appends anything.
+pub(crate) fn mpeg2(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        for bit in (0..8).rev() {
+            let incoming = u32::from((byte >> bit) & 1);
+            let outgoing = crc >> 31;
+            crc <<= 1;
+            if outgoing != incoming {
+                crc ^= POLYNOMIAL;
+            }
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mpeg2;
+
+    /// Appends the CRC of `body`, which is what a well-formed section does.
+    fn sealed(body: &[u8]) -> Vec<u8> {
+        let mut out = body.to_vec();
+        out.extend_from_slice(&mpeg2(body).to_be_bytes());
+        out
+    }
+
+    #[test]
+    fn a_sealed_section_checks_to_zero() {
+        for body in [
+            &b""[..],
+            &b"\x00"[..],
+            &b"\x02\xb0\x17\x00\x01\xc1\x00\x00"[..],
+            &[0xFF; 183][..],
+        ] {
+            assert_eq!(mpeg2(&sealed(body)), 0, "body {body:02x?}");
+        }
+    }
+
+    #[test]
+    fn a_single_flipped_bit_anywhere_is_caught() {
+        let body = b"\x02\xb0\x17\x00\x01\xc1\x00\x00\xe1\x01\xf0\x00";
+        let section = sealed(body);
+        for byte in 0..section.len() {
+            for bit in 0..8u8 {
+                let mut broken = section.clone();
+                broken[byte] ^= 1 << bit;
+                assert_ne!(
+                    mpeg2(&broken),
+                    0,
+                    "flipping byte {byte} bit {bit} went unnoticed"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_truncated_section_does_not_check_out() {
+        let section = sealed(b"\x00\xb0\x0d\x00\x01\xc1\x00\x00\x00\x01\xe1\x00");
+        for cut in 1..section.len() {
+            assert_ne!(
+                mpeg2(&section[..cut]),
+                0,
+                "a section cut to {cut} bytes checked out"
+            );
+        }
+    }
+
+    /// The empty input is the initial register, which is what makes the
+    /// four-byte all-ones section the only one that trivially checks out.
+    #[test]
+    fn the_empty_input_is_the_initial_register() {
+        assert_eq!(mpeg2(&[]), 0xFFFF_FFFF);
+    }
+}

--- a/media-core/src/psi/descriptors.rs
+++ b/media-core/src/psi/descriptors.rs
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! What the descriptors of one elementary stream say about it.
+//!
+//! The block handed in here has already been bounded by the elementary stream
+//! loop, so nothing in this file can reach a section's CRC. What it still has to
+//! survive is a descriptor whose own declared length runs past the block: the
+//! walk stops there rather than reading what follows, because a length that is
+//! wrong is not a reason to guess where the next descriptor starts.
+
+/// Descriptor tags this parser assigns meaning to.
+mod tag {
+    /// ISO 639 language descriptor.
+    pub(super) const LANGUAGE: u8 = 0x0A;
+    /// AC-3 descriptor, ETSI EN 300 468 Annex D.
+    pub(super) const AC3: u8 = 0x6A;
+    /// Enhanced AC-3 descriptor.
+    pub(super) const ENHANCED_AC3: u8 = 0x7A;
+    /// DTS descriptor.
+    pub(super) const DTS: u8 = 0x7B;
+    /// AAC descriptor.
+    pub(super) const AAC: u8 = 0x7C;
+    /// DTS-HD descriptor.
+    pub(super) const DTS_HD: u8 = 0x7D;
+    /// Registration descriptor, whose format identifier names some codecs.
+    pub(super) const REGISTRATION: u8 = 0x05;
+}
+
+/// The format identifiers a registration descriptor can use to mean audio.
+const AUDIO_FORMAT_IDS: [&[u8; 4]; 5] = [b"AC-3", b"EAC3", b"DTS1", b"DTS2", b"DTS3"];
+
+/// Walks a descriptor block, yielding `(tag, body)` for each descriptor that
+/// fits inside it.
+///
+/// Stops at the first descriptor whose declared length runs past the block, and
+/// at a trailing byte too short to be a header. Both are the same decision: the
+/// length field is the only thing that says where the next descriptor begins, so
+/// a length that does not fit ends the walk instead of starting a guess.
+fn walk(block: &[u8]) -> impl Iterator<Item = (u8, &[u8])> {
+    let mut at = 0usize;
+    core::iter::from_fn(move || {
+        let header_end = at.checked_add(2)?;
+        if header_end > block.len() {
+            return None;
+        }
+        let tag = block[at];
+        let length = usize::from(block[at + 1]);
+        let body_end = header_end.checked_add(length)?;
+        if body_end > block.len() {
+            return None;
+        }
+        let body = &block[header_end..body_end];
+        at = body_end;
+        Some((tag, body))
+    })
+}
+
+/// Whether a descriptor block says its stream carries audio.
+///
+/// Only consulted for stream types that do not say so themselves. Stream type
+/// 0x06 is "PES carrying private data", which is what European broadcasters use
+/// for AC-3, E-AC-3 and DTS - and also what subtitles and teletext use, so
+/// without a descriptor saying otherwise it is not audio.
+pub(crate) fn declares_audio(block: &[u8]) -> bool {
+    for (tag, body) in walk(block) {
+        match tag {
+            tag::AC3 | tag::ENHANCED_AC3 | tag::DTS | tag::AAC | tag::DTS_HD => return true,
+            tag::REGISTRATION => {
+                let head = &body[..body.len().min(4)];
+                if AUDIO_FORMAT_IDS
+                    .iter()
+                    .any(|id| id.starts_with(head) && head.len() == 4)
+                {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// The codec a private-data stream's descriptors name, if any of them do.
+pub(crate) fn private_stream_codec(block: &[u8]) -> Option<&'static str> {
+    for (tag, body) in walk(block) {
+        match tag {
+            tag::AC3 => return Some("ac3"),
+            tag::ENHANCED_AC3 => return Some("eac3"),
+            tag::AAC => return Some("aac"),
+            tag::DTS | tag::DTS_HD => return Some("dts"),
+            tag::REGISTRATION if body.len() >= 4 => match &body[..4] {
+                b"AC-3" => return Some("ac3"),
+                b"EAC3" => return Some("eac3"),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The ISO 639-2 language a block names, or `und` when none does.
+///
+/// `und` is the code for "undetermined", so a stream that says nothing and a
+/// stream that says it does not know are reported the same way - which is what
+/// the code exists for.
+pub(crate) fn language(block: &[u8]) -> String {
+    for (tag, body) in walk(block) {
+        if tag == tag::LANGUAGE
+            && body.len() >= 3
+            && let Ok(code) = core::str::from_utf8(&body[..3])
+        {
+            return code.to_owned();
+        }
+    }
+    "und".to_owned()
+}
+
+/// What a descriptor block declares about an audio stream's channel layout.
+///
+/// Deliberately not a channel count. The descriptors carry a coarse class, and
+/// above stereo they say "more than two" without naming a number - an AC-3
+/// service at 5.1 and one at 7.1 declare the same value. Turning that into a
+/// number is an inference, and it belongs to whoever knows what they will do
+/// with the answer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ChannelDeclaration {
+    /// The declared count where the declaration names one, otherwise 0.
+    pub channels: u8,
+    /// A declaration of more than two channels that carries no exact count.
+    pub multichannel: bool,
+    /// The raw component type byte this was read from, kept so a policy layer
+    /// can reach conclusions this type deliberately does not.
+    pub component_type: u8,
+    /// Whether a component type was present at all, which is a different thing
+    /// from one that happens to be zero.
+    pub has_component_type: bool,
+}
+
+impl ChannelDeclaration {
+    /// Whether the declaration says anything about the channel count.
+    #[must_use]
+    pub const fn known(&self) -> bool {
+        self.channels > 0 || self.multichannel
+    }
+}
+
+/// AC-3 `component_type`, ETSI EN 300 468 Annex D. The low nibble is the declared
+/// number of channels; from `MULTI_FIRST` upward it says only "more than two".
+mod ac3_channels {
+    /// `component_type_flag`, the first bit of the descriptor body.
+    pub(super) const COMPONENT_TYPE_FLAG: u8 = 0x80;
+    /// The bits of the component type that name the channel count.
+    pub(super) const MASK: u8 = 0x0F;
+    /// A single channel.
+    pub(super) const MONO: u8 = 0x00;
+    /// Two independent mono programmes.
+    pub(super) const DUAL_MONO: u8 = 0x01;
+    /// Two channels.
+    pub(super) const STEREO: u8 = 0x02;
+    /// Two channels, Dolby surround encoded.
+    pub(super) const STEREO_SURROUND: u8 = 0x03;
+    /// The first value meaning multichannel with no count declared.
+    pub(super) const MULTI_FIRST: u8 = 0x04;
+    /// The last such value.
+    pub(super) const MULTI_LAST: u8 = 0x06;
+}
+
+/// `AAC_type`, ETSI EN 300 468 Table 26. Only the values whose channel meaning
+/// is unambiguous appear; the table also names audio description, hard of
+/// hearing and mixed supplementary variants whose count the value does not fix.
+mod aac_type {
+    /// `AAC_type_flag`, the bit after `profile_and_level`.
+    pub(super) const FLAG: u8 = 0x80;
+    /// Mono.
+    pub(super) const MONO: u8 = 0x01;
+    /// Stereo.
+    pub(super) const STEREO: u8 = 0x03;
+    /// Surround.
+    pub(super) const SURROUND: u8 = 0x05;
+    /// HE-AAC mono.
+    pub(super) const HE_MONO: u8 = 0x43;
+    /// HE-AAC stereo.
+    pub(super) const HE_STEREO: u8 = 0x45;
+    /// HE-AAC surround.
+    pub(super) const HE_SURROUND: u8 = 0x47;
+}
+
+/// Reads the declared channel information out of a descriptor block.
+///
+/// Only AC-3, E-AC-3 and AAC declare channels in a descriptor, and only when the
+/// optional component type is present. MPEG-1/2 layer II carries its channel
+/// mode in the audio frame header, which is elementary stream payload this file
+/// never sees, so it declares nothing here. DTS likewise.
+pub(crate) fn channel_declaration(block: &[u8]) -> ChannelDeclaration {
+    for (tag, body) in walk(block) {
+        let declared = match tag {
+            tag::AC3 | tag::ENHANCED_AC3 => ac3_declaration(body),
+            tag::AAC => aac_declaration(body),
+            _ => None,
+        };
+        if let Some(declared) = declared {
+            return declared;
+        }
+    }
+    ChannelDeclaration::default()
+}
+
+/// Reads an AC-3 or E-AC-3 descriptor body. Its first byte is a set of presence
+/// flags; the component type, when the flag says it is there, follows it.
+fn ac3_declaration(body: &[u8]) -> Option<ChannelDeclaration> {
+    if body.len() < 2 || body[0] & ac3_channels::COMPONENT_TYPE_FLAG == 0 {
+        return None;
+    }
+    let component_type = body[1];
+    let mut declared = ChannelDeclaration {
+        component_type,
+        has_component_type: true,
+        ..ChannelDeclaration::default()
+    };
+    match component_type & ac3_channels::MASK {
+        ac3_channels::MONO => declared.channels = 1,
+        ac3_channels::DUAL_MONO | ac3_channels::STEREO | ac3_channels::STEREO_SURROUND => {
+            declared.channels = 2;
+        }
+        ac3_channels::MULTI_FIRST..=ac3_channels::MULTI_LAST => declared.multichannel = true,
+        // Reserved. The component type is still worth carrying, but it names no
+        // channel count this code is willing to claim.
+        _ => {}
+    }
+    Some(declared)
+}
+
+/// Reads an AAC descriptor body: `profile_and_level`, a flag bit, then the AAC
+/// type when that flag is set.
+fn aac_declaration(body: &[u8]) -> Option<ChannelDeclaration> {
+    if body.len() < 3 || body[1] & aac_type::FLAG == 0 {
+        return None;
+    }
+    let value = body[2];
+    let mut declared = ChannelDeclaration {
+        component_type: value,
+        has_component_type: true,
+        ..ChannelDeclaration::default()
+    };
+    match value {
+        aac_type::MONO | aac_type::HE_MONO => declared.channels = 1,
+        aac_type::STEREO | aac_type::HE_STEREO => declared.channels = 2,
+        aac_type::SURROUND | aac_type::HE_SURROUND => declared.multichannel = true,
+        _ => {}
+    }
+    Some(declared)
+}

--- a/media-core/src/psi/mod.rs
+++ b/media-core/src/psi/mod.rs
@@ -1,0 +1,458 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! What a transport stream's own tables say the programme is.
+//!
+//! This is the Rust side of a differential migration. The Go implementation in
+//! `backend/internal/stream/ingest/mediafacts` is the reference for as long as
+//! this step lasts, and the two are held together by a corpus checked in at
+//! `testdata/psi-corpus/corpus.txt`: a sequence of calls and the facts, events
+//! and raw tables expected after each one. Both implementations are checked
+//! against that file, so agreement is a property of a reviewable artefact rather
+//! than of anybody's memory of what the other one does.
+//!
+//! Nothing here is authoritative. This is a library that answers the corpus; it
+//! is not wired into the core's socket, and Go remains the parser production
+//! reads.
+//!
+//! The transport this file understands is only what PSI needs: packet framing,
+//! the PID, the payload unit start flag, the continuity counter, the adaptation
+//! field's effect on where the payload begins, and the pointer field. There is
+//! no PES here, no elementary stream payload, no timing.
+
+mod assembler;
+mod crc;
+mod descriptors;
+mod pat;
+mod pmt;
+mod table;
+
+#[cfg(test)]
+mod adversarial_test;
+#[cfg(test)]
+mod corpus_test;
+#[cfg(test)]
+mod perf_test;
+
+use assembler::SectionAssembler;
+use table::{SectionHeader, TableTracker};
+
+pub use descriptors::ChannelDeclaration;
+pub use pmt::{AudioTrack, VideoCodec};
+
+/// The size of a transport stream packet.
+pub const TS_PACKET_LEN: usize = 188;
+
+/// The byte every transport stream packet starts with.
+pub const SYNC_BYTE: u8 = 0x47;
+
+/// The PID the programme association table is carried on.
+const PAT_PID: u16 = 0x0000;
+
+/// The table identifier of a programme association section.
+const TABLE_ID_PAT: u8 = 0x00;
+
+/// The table identifier of a programme map section.
+const TABLE_ID_PMT: u8 = 0x02;
+
+/// Why a chunk was refused.
+///
+/// A refusal means nothing was interpreted. There is no partial success: a core
+/// that consumed less than it was given has moved past bytes the caller is about
+/// to throw away, and saying so afterwards is too late to be useful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestError {
+    /// The chunk was not a whole number of transport stream packets.
+    UnalignedChunk {
+        /// How many bytes were offered.
+        len: usize,
+    },
+}
+
+impl core::fmt::Display for IngestError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnalignedChunk { len } => {
+                write!(
+                    f,
+                    "chunk of {len} bytes is not {TS_PACKET_LEN}-byte packet aligned"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for IngestError {}
+
+/// Something the core saw that a caller would have to act on.
+///
+/// Facts describe a state; events describe a moment, and their order within a
+/// call is the order they happened in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PsiEvent {
+    /// The programme this stream carries is no longer the one it was: a new PMT
+    /// version, a different programme, a changed stream layout.
+    ///
+    /// It is not a generation. What a caller does with it is the caller's
+    /// decision, and this event carries no opinion about it.
+    ProgramIdentityChanged,
+}
+
+/// What the core knows about the stream right now.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PsiFacts {
+    /// A PAT naming the programme being followed has been accepted.
+    pub has_pat: bool,
+    /// A PMT for that programme has been accepted.
+    pub has_pmt: bool,
+    /// The version of the PMT in force.
+    pub pmt_version: u8,
+    /// The programme number that PMT declared.
+    pub program_number: u16,
+    /// The PID the PAT named for the programme, or 0 while none has been.
+    pub pmt_pid: u16,
+    /// The video stream's PID, or 0 while no table has named one.
+    pub video_pid: u16,
+    /// Its codec.
+    pub video_codec: VideoCodec,
+    /// The audio PIDs, in the order the table lists them.
+    pub audio_pids: Vec<u16>,
+    /// The audio tracks, in the same order.
+    pub audio_tracks: Vec<AudioTrack>,
+}
+
+/// The raw packets of the tables in force.
+///
+/// The core parses these and hands the bytes back anyway, because a subscriber
+/// joining mid-stream is given the tables as they were broadcast. Rebuilding
+/// them would mean encoding PSI in a second place, with a second answer.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ActivePsi {
+    /// The packets of the PAT in force.
+    pub pat: Vec<Vec<u8>>,
+    /// The packets of the PMT in force.
+    pub pmt: Vec<Vec<u8>>,
+}
+
+/// What one call meant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Outcome {
+    /// The offset one past the last byte interpreted.
+    pub processed_through: i64,
+    /// What happened during the call, in order.
+    pub events: Vec<PsiEvent>,
+    /// The state afterwards.
+    pub facts: PsiFacts,
+    /// The raw tables afterwards.
+    pub active: ActivePsi,
+}
+
+/// Reads the programme association and programme map tables of one transport.
+///
+/// Not safe for concurrent use, and deliberately not internally synchronised:
+/// the caller already serialises access to the bytes it hands in.
+#[derive(Default)]
+pub struct PsiCore {
+    /// The programme to follow, or 0 for whichever the PAT offers first.
+    target_program_number: u16,
+
+    /// Section assembly for PID 0.
+    pat_assembler: SectionAssembler,
+    /// Section assembly for the selected PMT PID.
+    pmt_assembler: SectionAssembler,
+    /// Sections of the PAT generation being collected.
+    pat_tracker: TableTracker,
+    /// Sections of the PMT generation being collected.
+    pmt_tracker: TableTracker,
+
+    /// The programme and PID the PAT chose, held as one.
+    selection: Option<pat::Selection>,
+
+    /// A PAT naming the programme has been accepted.
+    has_pat_version: bool,
+    /// Its version.
+    pat_version: u8,
+    /// A PMT for the programme has been accepted.
+    has_pmt_version: bool,
+    /// Its version.
+    pmt_version: u8,
+    /// The programme number it declared.
+    pmt_program_number: u16,
+
+    /// The raw packets of the PAT in force.
+    raw_pat: Vec<Vec<u8>>,
+    /// The raw packets of the PMT in force.
+    raw_pmt: Vec<Vec<u8>>,
+
+    /// What the PMT in force said the programme is made of.
+    streams: pmt::Streams,
+
+    /// What the call in progress has meant so far.
+    events: Vec<PsiEvent>,
+}
+
+impl PsiCore {
+    /// A core with no stream state, following `target_program_number`.
+    ///
+    /// A target of 0 means "whichever programme the PAT offers first".
+    #[must_use]
+    pub fn new(target_program_number: u16) -> Self {
+        Self {
+            target_program_number,
+            ..Self::default()
+        }
+    }
+
+    /// Interprets one chunk of transport stream.
+    ///
+    /// `start_offset` is the chunk's position in the caller's own byte
+    /// coordinate system, and the offset reported back is in that same system.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IngestError::UnalignedChunk`] when the chunk is not a whole
+    /// number of packets. Nothing is interpreted in that case.
+    pub fn ingest(&mut self, start_offset: i64, data: &[u8]) -> Result<Outcome, IngestError> {
+        if !data.len().is_multiple_of(TS_PACKET_LEN) {
+            return Err(IngestError::UnalignedChunk { len: data.len() });
+        }
+        self.events.clear();
+        for packet in data.chunks_exact(TS_PACKET_LEN) {
+            self.index_packet(packet);
+        }
+        let consumed = i64::try_from(data.len()).unwrap_or(i64::MAX);
+        Ok(self.outcome(start_offset.saturating_add(consumed)))
+    }
+
+    /// Selects the programme to follow.
+    ///
+    /// Changing it discards everything read about the previous one. Selecting
+    /// the programme already being followed is not a change and costs nothing.
+    ///
+    /// It interprets no bytes, so it reports no position in the stream.
+    pub fn set_target_program(&mut self, program_number: u16) -> Outcome {
+        self.events.clear();
+        if self.target_program_number != program_number {
+            self.target_program_number = program_number;
+            self.has_pat_version = false;
+            self.pat_version = 0;
+            self.forget_pmt_identity();
+            self.selection = None;
+            self.pat_assembler.reset();
+            self.pmt_assembler.reset();
+            self.pat_tracker.reset();
+            self.pmt_tracker.reset();
+            self.raw_pat.clear();
+            self.reset_program_state();
+        }
+        self.outcome(0)
+    }
+
+    /// The PID the PAT named, or 0 while none has been.
+    fn pmt_pid(&self) -> u16 {
+        self.selection.map_or(0, |s| s.pmt_pid)
+    }
+
+    /// The programme number the PAT chose, or 0 while none has been.
+    fn selected_program_number(&self) -> u16 {
+        self.selection.map_or(0, |s| s.program_number)
+    }
+
+    /// Builds the answer for the call that is ending.
+    fn outcome(&self, processed_through: i64) -> Outcome {
+        Outcome {
+            processed_through,
+            events: self.events.clone(),
+            facts: PsiFacts {
+                has_pat: self.has_pat_version,
+                has_pmt: self.has_pmt_version,
+                pmt_version: self.pmt_version,
+                program_number: self.pmt_program_number,
+                pmt_pid: self.pmt_pid(),
+                video_pid: self.streams.video_pid,
+                video_codec: self.streams.video_codec,
+                audio_pids: self.streams.audio_pids.clone(),
+                audio_tracks: self.streams.audio_tracks.clone(),
+            },
+            active: ActivePsi {
+                pat: self.raw_pat.clone(),
+                pmt: self.raw_pmt.clone(),
+            },
+        }
+    }
+
+    /// Routes one packet to the table it belongs to, if any.
+    fn index_packet(&mut self, packet: &[u8]) {
+        if packet[0] != SYNC_BYTE {
+            return;
+        }
+        let pid = (u16::from(packet[1] & 0x1F) << 8) | u16::from(packet[2]);
+        let pusi = packet[1] & 0x40 != 0;
+        let adaptation = (packet[3] >> 4) & 0x03;
+        // 0x01 is payload only, 0x03 is an adaptation field ahead of a payload.
+        // The other two carry no payload at all.
+        if adaptation != 0x01 && adaptation != 0x03 {
+            return;
+        }
+        let mut payload_at = 4;
+        if adaptation == 0x03 {
+            payload_at = 5 + usize::from(packet[4]);
+            if payload_at >= TS_PACKET_LEN {
+                // The adaptation field claims the rest of the packet, so there
+                // is no payload behind it whatever the flag said.
+                return;
+            }
+        }
+        let payload = &packet[payload_at..];
+
+        if pid == PAT_PID {
+            self.feed_table(true, packet, pusi, payload);
+        } else if self.pmt_pid() > 0 && pid == self.pmt_pid() {
+            self.feed_table(false, packet, pusi, payload);
+        }
+        // Everything else is an elementary stream. This step reads tables only.
+    }
+
+    /// Assembles one packet's payload and interprets whatever it completed.
+    fn feed_table(&mut self, is_pat: bool, packet: &[u8], pusi: bool, payload: &[u8]) {
+        let expected = if is_pat { TABLE_ID_PAT } else { TABLE_ID_PMT };
+        let completed = if is_pat {
+            self.pat_assembler.accept(packet, pusi, payload, expected)
+        } else {
+            self.pmt_assembler.accept(packet, pusi, payload, expected)
+        };
+        for section in completed {
+            self.accept_section(is_pat, &section.bytes, &section.packets);
+        }
+    }
+
+    /// Decides whether a completed section describes this stream, and reads it
+    /// if it does.
+    fn accept_section(&mut self, is_pat: bool, section: &[u8], packets: &[Vec<u8>]) {
+        let expected = if is_pat { TABLE_ID_PAT } else { TABLE_ID_PMT };
+        let Some(header) = SectionHeader::read(section, expected) else {
+            return;
+        };
+        if is_pat {
+            self.accept_pat_section(&header, section, packets);
+        } else {
+            self.accept_pmt_section(&header, section, packets);
+        }
+    }
+
+    /// Collects a PAT section and, once the table is whole, chooses a programme.
+    fn accept_pat_section(&mut self, header: &SectionHeader, section: &[u8], packets: &[Vec<u8>]) {
+        if !self.pat_tracker.add(
+            header.version,
+            header.section_number,
+            header.last_section_number,
+            section,
+            packets,
+        ) {
+            return;
+        }
+
+        let chosen = pat::select(&self.pat_tracker.sections(), self.target_program_number);
+        let Some(chosen) = chosen else {
+            // A complete PAT in force that does not name the programme is the
+            // transport saying it is not here. Keeping the PID it used to be on
+            // would leave this core reading a table for a programme this PAT
+            // does not carry.
+            if self.selection.is_some() {
+                self.drop_program_selection();
+            }
+            return;
+        };
+
+        // The selection changes when either half of it does. A PID that stays
+        // the same while the programme on it changes - which only an unnamed
+        // target can do - is still a different selection.
+        if self.selection != Some(chosen) {
+            self.selection = Some(chosen);
+            self.pmt_assembler.reset();
+            self.pmt_tracker.reset();
+            self.forget_pmt_identity();
+            self.reset_program_state();
+        }
+        self.has_pat_version = true;
+        self.pat_version = header.version;
+        self.raw_pat = self.pat_tracker.packets();
+    }
+
+    /// Collects a PMT section for the selected programme, and reads the table
+    /// once it is whole.
+    fn accept_pmt_section(&mut self, header: &SectionHeader, section: &[u8], packets: &[Vec<u8>]) {
+        // The PAT chose a programme and the PID its table is on together, so a
+        // section on that PID naming a different programme is not this
+        // programme's table.
+        //
+        // Refused here, before the tracker, and not once it completes: a new
+        // generation discards the sections already collected, so a table that
+        // was never going to be accepted would destroy one that was being
+        // assembled correctly.
+        if header.id_extension != self.selected_program_number() {
+            return;
+        }
+        if !self.pmt_tracker.add(
+            header.version,
+            header.section_number,
+            header.last_section_number,
+            section,
+            packets,
+        ) {
+            return;
+        }
+
+        let changed = !self.has_pmt_version
+            || header.version != self.pmt_version
+            || header.id_extension != self.pmt_program_number;
+        if changed {
+            self.has_pmt_version = true;
+            self.pmt_version = header.version;
+            self.pmt_program_number = header.id_extension;
+            self.reset_program_state();
+            self.streams = pmt::interpret(&self.pmt_tracker.sections());
+        }
+        self.raw_pmt = self.pmt_tracker.packets();
+    }
+
+    /// Gives up everything the current PMT said about which programme this is.
+    ///
+    /// Having a PMT, the programme number and the table version are one fact -
+    /// what the table in force says - so they are given up together. Leaving the
+    /// number and the version behind a false `has_pmt` would describe a
+    /// programme that has already been discarded.
+    fn forget_pmt_identity(&mut self) {
+        self.has_pmt_version = false;
+        self.pmt_version = 0;
+        self.pmt_program_number = 0;
+    }
+
+    /// Gives up the PAT's choice of programme and PID, and everything downstream.
+    ///
+    /// `has_pat` goes with it. It never meant "a PAT arrived"; it is only set
+    /// where a PAT named the programme being followed, so leaving it standing
+    /// would be the same half-fact as a programme number outliving its
+    /// programme. The raw PAT goes for the same reason.
+    fn drop_program_selection(&mut self) {
+        self.selection = None;
+        self.has_pat_version = false;
+        self.pat_version = 0;
+        self.raw_pat.clear();
+        self.pmt_assembler.reset();
+        self.pmt_tracker.reset();
+        self.forget_pmt_identity();
+        self.reset_program_state();
+    }
+
+    /// Drops everything read about the streams of a programme, and says so.
+    ///
+    /// What the caller does with the event is the caller's decision; this layer
+    /// reports that the programme's identity changed and nothing more.
+    fn reset_program_state(&mut self) {
+        self.streams = pmt::Streams::default();
+        self.raw_pmt.clear();
+        self.events.push(PsiEvent::ProgramIdentityChanged);
+    }
+}

--- a/media-core/src/psi/mod.rs
+++ b/media-core/src/psi/mod.rs
@@ -36,7 +36,7 @@ mod corpus_test;
 mod perf_test;
 
 use assembler::SectionAssembler;
-use table::{SectionHeader, TableTracker};
+use table::{SectionHeader, TABLE_ID_PAT, TABLE_ID_PMT, TableTracker};
 
 pub use descriptors::ChannelDeclaration;
 pub use pmt::{AudioTrack, VideoCodec};
@@ -49,12 +49,6 @@ pub const SYNC_BYTE: u8 = 0x47;
 
 /// The PID the programme association table is carried on.
 const PAT_PID: u16 = 0x0000;
-
-/// The table identifier of a programme association section.
-const TABLE_ID_PAT: u8 = 0x00;
-
-/// The table identifier of a programme map section.
-const TABLE_ID_PMT: u8 = 0x02;
 
 /// Why a chunk was refused.
 ///
@@ -247,6 +241,13 @@ impl PsiCore {
             self.reset_program_state();
         }
         self.outcome(0)
+    }
+
+    /// What the two section assemblers are holding. See
+    /// [`SectionAssembler::retained`].
+    #[cfg(test)]
+    pub(super) fn retained(&self) -> [(usize, usize, usize); 2] {
+        [self.pat_assembler.retained(), self.pmt_assembler.retained()]
     }
 
     /// The PID the PAT named, or 0 while none has been.

--- a/media-core/src/psi/pat.rs
+++ b/media-core/src/psi/pat.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! Which programme of a transport this core follows.
+
+use super::table::SectionHeader;
+
+/// A programme entry of a PAT: four bytes, a number and the PID its table is on.
+const ENTRY_BYTES: usize = 4;
+
+/// The programme number reserved for the network information table. It names a
+/// table, not a service, and following it would tune to neither.
+const NIT_PROGRAM_NUMBER: u16 = 0;
+
+/// The programme a PAT selects, and the PID its table is carried on.
+///
+/// The two are one decision and are never apart: a PAT entry names them
+/// together, and a PMT on that PID has to agree with that number before it can
+/// describe this programme. Holding only the PID would make any table on it
+/// this programme's, which is exactly what a shared PID makes untrue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Selection {
+    /// The programme number chosen.
+    pub(crate) program_number: u16,
+    /// The PID its table is carried on.
+    pub(crate) pmt_pid: u16,
+}
+
+/// Chooses a programme out of a complete PAT.
+///
+/// `target` names the programme to follow, or is 0 to follow whichever the table
+/// offers first. "First" is the table's own order - sections by `section_number`
+/// ascending, and within a section the order the entries are listed - and the
+/// sections arrive here already in that order however they were transmitted.
+///
+/// The first match ends the search whether or not a target was named. A later
+/// section does not get to re-choose: an unnamed target means "whichever comes
+/// first", and something that came later is not first.
+pub(crate) fn select(sections: &[&[u8]], target: u16) -> Option<Selection> {
+    for section in sections {
+        if section.len() < super::table::MIN_SECTION_LEN {
+            continue;
+        }
+        for entry in SectionHeader::body(section).chunks_exact(ENTRY_BYTES) {
+            let program_number = (u16::from(entry[0]) << 8) | u16::from(entry[1]);
+            let pmt_pid = (u16::from(entry[2] & 0x1F) << 8) | u16::from(entry[3]);
+            if program_number == NIT_PROGRAM_NUMBER {
+                continue;
+            }
+            if target > 0 && program_number != target {
+                continue;
+            }
+            return Some(Selection {
+                program_number,
+                pmt_pid,
+            });
+        }
+    }
+    None
+}

--- a/media-core/src/psi/perf_test.rs
+++ b/media-core/src/psi/perf_test.rs
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! How long a chunk takes to interpret.
+//!
+//! Not a benchmark to be optimised against. The number that matters is the
+//! distance to the deadline a caller would impose - 500 ms for one chunk in the
+//! Go pipeline - and the shape of the curve as chunks grow. A parser whose cost
+//! is linear in the bytes and three orders of magnitude inside the budget needs
+//! no tuning; one that is neither needs a look before it is wired to anything.
+//!
+//! Timed with `Instant` rather than a benchmark harness, because the crate has
+//! no dependencies and stable Rust has no built-in one. Allocation counts are
+//! not reported: counting them needs a global allocator, which needs `unsafe`,
+//! which this crate forbids. What is asserted instead is that the state stays
+//! bounded, which is the property the count would have been evidence for.
+
+use super::{PsiCore, TS_PACKET_LEN};
+use std::time::{Duration, Instant};
+
+/// Sizes a caller would hand in. The Go normalizer's staging buffer is 4 MiB, so
+/// that is the largest chunk this path ever sees.
+const TARGET_SIZES: [usize; 4] = [64 * 1024, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024];
+
+/// How many times each size is timed, fewer for the larger ones so the whole
+/// thing stays inside a test run.
+const ROUNDS: [usize; 4] = [200, 100, 40, 20];
+
+/// The longest a caller would wait for one chunk before deciding the core has
+/// stopped answering. Nothing here should come near it.
+const CALLER_DEADLINE: Duration = Duration::from_millis(500);
+
+/// What one chunk may cost before this test complains.
+///
+/// The shipped binary is a release build, and that is the number worth holding
+/// to something tight. A debug build of the same code is roughly seven times
+/// slower here by construction - overflow checks on, nothing inlined - so
+/// holding it to the release bound would fail for a reason that has nothing to
+/// do with the parser. Debug keeps the caller's own deadline as a stall
+/// detector, which is what a wall-clock assertion in a test run under unknown
+/// load can honestly claim.
+fn budget() -> Duration {
+    if cfg!(debug_assertions) {
+        CALLER_DEADLINE
+    } else {
+        CALLER_DEADLINE / 10
+    }
+}
+
+fn seal(mut body: Vec<u8>) -> Vec<u8> {
+    let crc = super::crc::mpeg2(&body);
+    body.extend_from_slice(&crc.to_be_bytes());
+    body
+}
+
+fn pat(version: u8) -> Vec<u8> {
+    seal(vec![
+        0x00,
+        0xB0,
+        0x0D,
+        0x00,
+        0x01,
+        0xC0 | ((version & 0x1F) << 1) | 1,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0xE1,
+        0x00,
+    ])
+}
+
+fn pmt(version: u8) -> Vec<u8> {
+    seal(vec![
+        0x02,
+        0xB0,
+        0x1C,
+        0x00,
+        0x01,
+        0xC0 | ((version & 0x1F) << 1) | 1,
+        0x00,
+        0x00,
+        0xE1,
+        0x01,
+        0xF0,
+        0x00,
+        0x1B,
+        0xE1,
+        0x01,
+        0xF0,
+        0x00,
+        0x06,
+        0xE1,
+        0x02,
+        0xF0,
+        0x0A,
+        0x0A,
+        0x04,
+        b'd',
+        b'e',
+        b'u',
+        0x00,
+        0x6A,
+        0x02,
+        0x80,
+        0x02,
+    ])
+}
+
+fn psi_packet(pid: u16, cc: u8, section: &[u8]) -> Vec<u8> {
+    let mut packet = vec![0xFFu8; TS_PACKET_LEN];
+    packet[0] = 0x47;
+    packet[1] = 0x40 | u8::try_from((pid >> 8) & 0x1F).expect("masked");
+    packet[2] = u8::try_from(pid & 0xFF).expect("masked");
+    packet[3] = 0x10 | (cc & 0x0F);
+    packet[4] = 0x00;
+    packet[5..5 + section.len()].copy_from_slice(section);
+    packet
+}
+
+fn null_packet() -> Vec<u8> {
+    let mut packet = vec![0xFFu8; TS_PACKET_LEN];
+    packet[0] = 0x47;
+    packet[1] = 0x1F;
+    packet[2] = 0xFF;
+    packet[3] = 0x10;
+    packet
+}
+
+/// A transport shaped like a real one: tables repeat on a carousel and almost
+/// everything between them is something this parser does not read.
+fn representative(packets: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(packets * TS_PACKET_LEN);
+    let null = null_packet();
+    for index in 0..packets {
+        let carousel = index % 100;
+        let version = u8::try_from((index / 100) % 32).expect("masked to five bits");
+        if carousel == 0 {
+            out.extend_from_slice(&psi_packet(
+                0,
+                u8::try_from(index / 100 % 16).expect("masked"),
+                &pat(0),
+            ));
+        } else if carousel == 1 {
+            out.extend_from_slice(&psi_packet(
+                256,
+                u8::try_from(index / 100 % 16).expect("masked"),
+                &pmt(version),
+            ));
+        } else {
+            out.extend_from_slice(&null);
+        }
+    }
+    out
+}
+
+/// Every packet a table, which no transport does. The worst case for a parser
+/// that only spends time on tables.
+fn all_tables(packets: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(packets * TS_PACKET_LEN);
+    for index in 0..packets {
+        let version = u8::try_from(index % 32).expect("masked to five bits");
+        if index % 2 == 0 {
+            out.extend_from_slice(&psi_packet(
+                0,
+                u8::try_from(index % 16).expect("masked"),
+                &pat(0),
+            ));
+        } else {
+            out.extend_from_slice(&psi_packet(
+                256,
+                u8::try_from(index % 16).expect("masked"),
+                &pmt(version),
+            ));
+        }
+    }
+    out
+}
+
+fn percentile(sorted: &[Duration], fraction: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "an index into a list of at most a few hundred timings"
+    )]
+    let index = ((sorted.len() as f64 - 1.0) * fraction).round() as usize;
+    sorted[index.min(sorted.len() - 1)]
+}
+
+fn measure(name: &str, build: fn(usize) -> Vec<u8>) {
+    for (size, rounds) in TARGET_SIZES.iter().zip(ROUNDS) {
+        let packets = size / TS_PACKET_LEN;
+        let data = build(packets);
+        let mut timings = Vec::with_capacity(rounds);
+
+        for _ in 0..rounds {
+            let mut core = PsiCore::new(1);
+            let started = Instant::now();
+            let outcome = core
+                .ingest(0, &data)
+                .expect("packet aligned by construction");
+            timings.push(started.elapsed());
+            // Read something out so the call cannot be optimised away, and check
+            // the state stayed bounded while it ran.
+            assert!(outcome.facts.audio_pids.len() <= 8);
+            assert!(outcome.active.pat.len() <= 8);
+            assert!(outcome.active.pmt.len() <= 8);
+        }
+
+        timings.sort_unstable();
+        let p50 = percentile(&timings, 0.50);
+        let p99 = percentile(&timings, 0.99);
+        let max = *timings.last().expect("rounds is never zero");
+        println!(
+            "  {name:<15} {:>5} KiB ({packets:>5} packets) n={rounds:<4} p50={p50:>12.3?} p99={p99:>12.3?} max={max:>12.3?}",
+            data.len() / 1024
+        );
+
+        assert!(
+            max < budget(),
+            "{name} at {} KiB took {max:?}, against a budget of {:?}",
+            data.len() / 1024,
+            budget()
+        );
+    }
+}
+
+#[test]
+fn interpreting_a_chunk_stays_far_inside_what_a_caller_would_wait() {
+    println!(
+        "PSI parse cost, one Ingest per timing ({} build, budget {:?}):",
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        },
+        budget()
+    );
+    measure("representative", representative);
+    measure("every packet PSI", all_tables);
+}

--- a/media-core/src/psi/perf_test.rs
+++ b/media-core/src/psi/perf_test.rs
@@ -54,6 +54,22 @@ fn seal(mut body: Vec<u8>) -> Vec<u8> {
     body
 }
 
+/// Checks that a hand-written section says how long it actually is.
+///
+/// The length byte of these fixtures is written out rather than computed, and a
+/// wrong one is not visible from the outside: the section is simply refused, the
+/// transport benchmarks the reject path instead of the parse path, and the
+/// upper-bound assertions hold trivially at zero.
+fn assert_length_field_matches(section: &[u8]) {
+    let declared = (usize::from(section[1] & 0x0F) << 8) | usize::from(section[2]);
+    assert_eq!(
+        declared + 3,
+        section.len(),
+        "section declares {declared} after its length field but is {} bytes",
+        section.len()
+    );
+}
+
 fn pat(version: u8) -> Vec<u8> {
     seal(vec![
         0x00,
@@ -75,7 +91,7 @@ fn pmt(version: u8) -> Vec<u8> {
     seal(vec![
         0x02,
         0xB0,
-        0x1C,
+        0x21,
         0x00,
         0x01,
         0xC0 | ((version & 0x1F) << 1) | 1,
@@ -232,6 +248,8 @@ fn measure(name: &str, build: fn(usize) -> Vec<u8>) {
 
 #[test]
 fn interpreting_a_chunk_stays_far_inside_what_a_caller_would_wait() {
+    assert_length_field_matches(&pat(0));
+    assert_length_field_matches(&pmt(0));
     println!(
         "PSI parse cost, one Ingest per timing ({} build, budget {:?}):",
         if cfg!(debug_assertions) {

--- a/media-core/src/psi/pmt.rs
+++ b/media-core/src/psi/pmt.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! What a programme is made of, according to its own table.
+
+use super::descriptors::{self, ChannelDeclaration};
+
+/// Bytes of an elementary stream entry ahead of its descriptors.
+const ENTRY_HEADER_BYTES: usize = 5;
+
+/// Where `program_info_length` sits in a PMT section.
+const PROGRAM_INFO_LENGTH_AT: usize = 10;
+
+/// Where the elementary stream loop starts once `program_info` is skipped.
+const ES_LOOP_BASE: usize = 12;
+
+/// The PID reserved for stuffing. Nothing that carries an elementary stream ever
+/// uses it.
+const NULL_PID: u16 = 0x1FFF;
+
+/// The video codec a programme's table declares.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum VideoCodec {
+    /// No video stream has been named.
+    #[default]
+    Unknown,
+    /// H.264 / AVC.
+    H264,
+    /// H.265 / HEVC.
+    H265,
+    /// MPEG-1 or MPEG-2 video.
+    Mpeg2,
+}
+
+impl VideoCodec {
+    /// The name this codec is written as.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::H264 => "h264",
+            Self::H265 => "h265",
+            Self::Mpeg2 => "mpeg2",
+        }
+    }
+}
+
+/// One audio elementary stream a programme's table declares.
+///
+/// Everything here is a declaration read from the table. Nothing in this crate's
+/// PSI path listens to the audio itself, so nothing here is a measurement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioTrack {
+    /// The PID the stream is carried on.
+    pub pid: u16,
+    /// The stream type the table gave it.
+    pub stream_type: u8,
+    /// The codec named by that stream type, or by a descriptor when the type
+    /// alone does not say.
+    pub codec: String,
+    /// The ISO 639-2 language, or `und`.
+    pub language: String,
+    /// What the descriptors declare about the channel layout.
+    pub declared: ChannelDeclaration,
+}
+
+/// What one complete PMT says a programme is made of.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Streams {
+    /// The PID of the video stream, or 0 when the table names none.
+    pub video_pid: u16,
+    /// Its codec.
+    pub video_codec: VideoCodec,
+    /// The audio PIDs, in the order the table lists them.
+    pub audio_pids: Vec<u16>,
+    /// The audio tracks, in the same order.
+    pub audio_tracks: Vec<AudioTrack>,
+}
+
+/// Whether a PID could name an elementary stream at all.
+///
+/// PID 0 is the PAT and 0x1FFF is the null packet. A table naming either is
+/// malformed: no payload is ever routed to such a stream and nothing can watch
+/// it, so a declaration on one describes something that cannot exist.
+const fn can_carry_elementary_stream(pid: u16) -> bool {
+    pid != 0 && pid != NULL_PID
+}
+
+/// Reads the elementary streams out of every section of a complete PMT.
+pub(crate) fn interpret(sections: &[&[u8]]) -> Streams {
+    let mut streams = Streams::default();
+    for section in sections {
+        if section.len() < super::table::MIN_SECTION_LEN {
+            continue;
+        }
+        interpret_section(section, &mut streams);
+    }
+    streams
+}
+
+/// Walks one section's elementary stream loop.
+fn interpret_section(section: &[u8], streams: &mut Streams) {
+    let program_info_len = (usize::from(section[PROGRAM_INFO_LENGTH_AT] & 0x0F) << 8)
+        | usize::from(section[PROGRAM_INFO_LENGTH_AT + 1]);
+    let Some(start) = ES_LOOP_BASE.checked_add(program_info_len) else {
+        return;
+    };
+    // The loop ends where the CRC begins. Everything read below is bounded by
+    // this, which is why no descriptor can ever be the section's own CRC.
+    let end = section.len() - 4;
+
+    let mut at = start;
+    while at + ENTRY_HEADER_BYTES <= end {
+        let stream_type = section[at];
+        let pid = (u16::from(section[at + 1] & 0x1F) << 8) | u16::from(section[at + 2]);
+        let info_len = (usize::from(section[at + 3] & 0x0F) << 8) | usize::from(section[at + 4]);
+
+        let Some(entry_end) = at
+            .checked_add(ENTRY_HEADER_BYTES)
+            .and_then(|s| s.checked_add(info_len))
+        else {
+            return;
+        };
+        if entry_end > end {
+            // The entry declares more than the loop holds, so it is not an
+            // entry. Its own length is the only thing naming where the next one
+            // starts, so nothing after it can be located either: the walk stops
+            // rather than reading past the bound or guessing a boundary.
+            return;
+        }
+        let block = &section[at + ENTRY_HEADER_BYTES..entry_end];
+
+        match stream_type {
+            0x1B => set_video(streams, pid, VideoCodec::H264),
+            0x24 | 0x27 => set_video(streams, pid, VideoCodec::H265),
+            0x01 | 0x02 => set_video(streams, pid, VideoCodec::Mpeg2),
+            _ => {
+                // One decision for one stream: either this entry is an audio
+                // elementary stream that could exist, or it is nothing. The PID
+                // list and the track list are both built here so they cannot end
+                // up describing different sets.
+                if declares_audio(stream_type, block) && can_carry_elementary_stream(pid) {
+                    add_audio(streams, pid, stream_type, block);
+                }
+            }
+        }
+        at = entry_end;
+    }
+}
+
+/// Records the video stream, if none has been named yet.
+///
+/// The first video entry the table lists is the one followed. A programme with
+/// two of them is followed on the first, rather than on whichever happened to be
+/// read last.
+fn set_video(streams: &mut Streams, pid: u16, codec: VideoCodec) {
+    if streams.video_pid == 0 {
+        streams.video_pid = pid;
+        streams.video_codec = codec;
+    }
+}
+
+/// Records an accepted audio stream in both lists, keeping table order and
+/// listing each PID once.
+fn add_audio(streams: &mut Streams, pid: u16, stream_type: u8, block: &[u8]) {
+    if !streams.audio_pids.contains(&pid) {
+        streams.audio_pids.push(pid);
+    }
+    let track = AudioTrack {
+        pid,
+        stream_type,
+        codec: audio_codec(stream_type, block).to_owned(),
+        language: descriptors::language(block),
+        declared: descriptors::channel_declaration(block),
+    };
+    match streams.audio_tracks.iter_mut().find(|t| t.pid == pid) {
+        Some(existing) => *existing = track,
+        None => streams.audio_tracks.push(track),
+    }
+}
+
+/// Whether a stream type carries audio.
+///
+/// The unambiguous types say so themselves. Type 0x06 is "PES carrying private
+/// data", which European broadcasters use for AC-3, E-AC-3 and DTS - and which
+/// subtitles and teletext also use, so it counts as audio only when a descriptor
+/// says so.
+fn declares_audio(stream_type: u8, block: &[u8]) -> bool {
+    match stream_type {
+        0x03 | 0x04 | 0x0F | 0x11 | 0x1C | 0x81 | 0x87 => true,
+        0x06 => descriptors::declares_audio(block),
+        _ => false,
+    }
+}
+
+/// The codec a stream type names, falling back to its descriptors where the type
+/// alone does not say.
+///
+/// ATSC A/52 registers 0x81 for AC-3 and 0x87 for Enhanced AC-3. They are
+/// different codecs and are named differently.
+fn audio_codec(stream_type: u8, block: &[u8]) -> &'static str {
+    match stream_type {
+        0x03 | 0x04 => "mp2",
+        0x0F | 0x11 | 0x1C => "aac",
+        0x81 => "ac3",
+        0x87 => "eac3",
+        0x06 => descriptors::private_stream_codec(block).unwrap_or("unknown"),
+        _ => "unknown",
+    }
+}

--- a/media-core/src/psi/table.rs
+++ b/media-core/src/psi/table.rs
@@ -12,6 +12,33 @@ use std::collections::BTreeMap;
 /// eight-byte header, four bytes of CRC, and nothing in between.
 pub(crate) const MIN_SECTION_LEN: usize = 12;
 
+/// The table identifier of a programme association section.
+pub(crate) const TABLE_ID_PAT: u8 = 0x00;
+
+/// The table identifier of a programme map section.
+pub(crate) const TABLE_ID_PMT: u8 = 0x02;
+
+/// The least a PAT may declare after its length field.
+///
+/// What its own mandatory syntax costs, counted from that field:
+/// `transport_stream_id` 2, version and `current_next` 1, `section_number` 1,
+/// `last_section_number` 1, CRC 4.
+pub(crate) const MIN_PAT_SECTION_LENGTH: usize = 9;
+
+/// The least a PMT may declare, which is more: it carries a `PCR_PID` and a
+/// `program_info_length` a PAT does not, so 12 is a length one table may declare
+/// and the other may not.
+pub(crate) const MIN_PMT_SECTION_LENGTH: usize = 13;
+
+/// What the expected table's own syntax costs.
+const fn min_section_length(expected_table_id: u8) -> usize {
+    if expected_table_id == TABLE_ID_PAT {
+        MIN_PAT_SECTION_LENGTH
+    } else {
+        MIN_PMT_SECTION_LENGTH
+    }
+}
+
 /// The most a PAT or PMT section may declare after its length field.
 ///
 /// `section_length` is a twelve bit field, but ISO/IEC 13818-1 does not let
@@ -29,19 +56,25 @@ pub(crate) const MAX_SECTION_BYTES: usize = MAX_SECTION_LENGTH + 3;
 /// Reads the three bytes that open a section and reports the total length they
 /// declare.
 ///
-/// `None` for a declaration a PAT or PMT cannot make. Three things make one
+/// `None` for a declaration the expected table cannot make. Four things make one
 /// impossible, and they are asked together because they are read from the same
 /// two bytes and all knowable the moment those bytes arrive:
 ///
 /// - `section_syntax_indicator` must be 1, since both tables use the long form
 /// - the bit after it must be 0, fixed by the syntax rather than reserved
+/// - `section_length` must reach what that table's own syntax costs
 /// - `section_length` must not exceed 1021
+///
+/// The floor is not a check for zero. It is what makes the exact-equality that
+/// once wedged the assembler impossible: with a floor of at least nine, filling
+/// the three header bytes always leaves the buffer short of the section length,
+/// so the fill phase always has something left to do.
 ///
 /// One helper for one question, asked everywhere it comes up: by the scan that
 /// meets a header whole inside a payload, by the assembler deciding how many
 /// bytes to collect, and by the completed-section check. A second definition of
 /// "how long may this be" is how two paths come to disagree about it.
-pub(crate) fn declaration(prefix: &[u8]) -> Option<usize> {
+pub(crate) fn declaration(expected_table_id: u8, prefix: &[u8]) -> Option<usize> {
     if prefix.len() < 3 {
         return None;
     }
@@ -49,7 +82,7 @@ pub(crate) fn declaration(prefix: &[u8]) -> Option<usize> {
         return None;
     }
     let length = (usize::from(prefix[1] & 0x0F) << 8) | usize::from(prefix[2]);
-    if length > MAX_SECTION_LENGTH {
+    if length < min_section_length(expected_table_id) || length > MAX_SECTION_LENGTH {
         return None;
     }
     let total = length + 3;
@@ -77,7 +110,7 @@ impl SectionHeader {
     ///
     /// - it is long enough to hold the fields that will be read,
     /// - it is the table this PID is being read for,
-    /// - it declares a length and a syntax those tables may declare,
+    /// - it declares a length and a syntax that table may declare,
     /// - its bytes are intact,
     /// - it is in force rather than announced for later,
     /// - it numbers itself inside the table it names.
@@ -97,7 +130,7 @@ impl SectionHeader {
         // Defence in depth. Both paths that reach here refused an impossible
         // declaration before acting on it, and asking again costs nothing
         // against a section that arrived some way nobody has thought of yet.
-        declaration(section)?;
+        declaration(expected_table_id, section)?;
         if crc::mpeg2(section) != 0 {
             return None;
         }

--- a/media-core/src/psi/table.rs
+++ b/media-core/src/psi/table.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 ManuGH
+// Licensed under the PolyForm Noncommercial License 1.0.0
+// Since v2.0.0, this software is restricted to non-commercial use only.
+
+//! What a completed section has to be before anything is read out of it, and
+//! how the sections of one table are collected into a generation.
+
+use super::crc;
+use std::collections::BTreeMap;
+
+/// The shortest section that can hold every field this parser reads: the
+/// eight-byte header, four bytes of CRC, and nothing in between.
+pub(crate) const MIN_SECTION_LEN: usize = 12;
+
+/// The largest a section can be, from `section_length` being twelve bits: three
+/// header bytes ahead of the field plus the 4093 it can name.
+pub(crate) const MAX_SECTION_LEN: usize = 3 + 0x0FFF;
+
+/// The fields of a section header this parser reads.
+pub(crate) struct SectionHeader {
+    /// The `transport_stream_id` of a PAT, or the `program_number` of a PMT.
+    pub(crate) id_extension: u16,
+    /// The version of the table this section is part of.
+    pub(crate) version: u8,
+    /// Where this section sits in the table.
+    pub(crate) section_number: u8,
+    /// The last section number the table has.
+    pub(crate) last_section_number: u8,
+}
+
+impl SectionHeader {
+    /// Reads a section that has arrived in full, refusing the ones that cannot
+    /// be interpreted at this point in the stream.
+    ///
+    /// Four things are asked, in this order:
+    ///
+    /// - it is long enough to hold the fields that will be read,
+    /// - it is the table this PID is being read for,
+    /// - its bytes are intact,
+    /// - it is in force rather than announced for later.
+    ///
+    /// The table check is here, on the completed section, and not only where a
+    /// header happens to be scanned inside one payload: a section whose first
+    /// bytes land at the end of a packet is assembled without that scan ever
+    /// seeing its `table_id`, and a CRC does not discriminate between tables. It
+    /// only says the bytes arrived as they were sent.
+    pub(crate) fn read(section: &[u8], expected_table_id: u8) -> Option<Self> {
+        if section.len() < MIN_SECTION_LEN {
+            return None;
+        }
+        if section[0] != expected_table_id {
+            return None;
+        }
+        if crc::mpeg2(section) != 0 {
+            return None;
+        }
+        // current_next_indicator. A table announced for later describes a
+        // programme that is not on air, and acting on it would describe the
+        // stream as it is going to be rather than as it is.
+        if section[5] & 0x01 != 1 {
+            return None;
+        }
+        Some(Self {
+            id_extension: (u16::from(section[3]) << 8) | u16::from(section[4]),
+            version: (section[5] >> 1) & 0x1F,
+            section_number: section[6],
+            last_section_number: section[7],
+        })
+    }
+
+    /// The bytes between the header and the CRC, which is where a table's own
+    /// content lives.
+    pub(crate) fn body(section: &[u8]) -> &[u8] {
+        // Every caller has been through `read`, so the length is at least
+        // MIN_SECTION_LEN and both ends are inside the slice.
+        &section[8..section.len() - 4]
+    }
+}
+
+/// The sections of one table, collected until every one of them is here.
+///
+/// A multi-section table is not a table until it is complete. Reading a partial
+/// one would describe a programme by whichever half arrived first, and the half
+/// that describes the video is not more authoritative than the half that
+/// describes the audio.
+#[derive(Default)]
+pub(crate) struct TableTracker {
+    /// The generation being collected, if any.
+    in_flight: Option<Generation>,
+}
+
+/// One version of one table, part-collected.
+struct Generation {
+    /// The version every section of this generation carries.
+    version: u8,
+    /// The last section number every section of it declares.
+    last_section_number: u8,
+    /// Sections by section number.
+    sections: BTreeMap<u8, Vec<u8>>,
+    /// The packets each section arrived in.
+    packets: BTreeMap<u8, Vec<Vec<u8>>>,
+}
+
+impl TableTracker {
+    /// Forgets whatever was being collected.
+    pub(crate) fn reset(&mut self) {
+        self.in_flight = None;
+    }
+
+    /// Adds one section and reports whether the table is now complete.
+    ///
+    /// A section whose version or `last_section_number` differs from the one being
+    /// collected starts a new generation and discards the old one: the two are
+    /// describing different tables, and mixing their sections would produce a
+    /// programme that was never broadcast.
+    pub(crate) fn add(
+        &mut self,
+        version: u8,
+        section_number: u8,
+        last_section_number: u8,
+        section: &[u8],
+        packets: &[Vec<u8>],
+    ) -> bool {
+        let restart = match &self.in_flight {
+            Some(generation) => {
+                generation.version != version
+                    || generation.last_section_number != last_section_number
+            }
+            None => true,
+        };
+        if restart {
+            self.in_flight = Some(Generation {
+                version,
+                last_section_number,
+                sections: BTreeMap::new(),
+                packets: BTreeMap::new(),
+            });
+        }
+
+        let generation = self
+            .in_flight
+            .as_mut()
+            .expect("a generation was just put in place");
+        generation.sections.insert(section_number, section.to_vec());
+        generation.packets.insert(section_number, packets.to_vec());
+
+        // Two questions, and the count is asked first because it is the one a
+        // section numbered outside the table fails: such a section is collected
+        // like any other, so a table that was complete stops being complete
+        // while a stray number is held. Only once the count matches is each slot
+        // actually looked for.
+        let wanted = usize::from(last_section_number) + 1;
+        if generation.sections.len() != wanted {
+            return false;
+        }
+        (0..=last_section_number).all(|n| generation.sections.contains_key(&n))
+    }
+
+    /// The sections of the completed table, in `section_number` order.
+    ///
+    /// Order is the table's, never arrival's: the sections of a table say where
+    /// they belong, and a transport that sends them out of order is describing
+    /// the same programme. Only the numbers the table declares are walked, so a
+    /// section numbered outside it is never read even while it is held.
+    pub(crate) fn sections(&self) -> Vec<&[u8]> {
+        let mut out = Vec::new();
+        if let Some(generation) = &self.in_flight {
+            for number in 0..=generation.last_section_number {
+                if let Some(section) = generation.sections.get(&number) {
+                    out.push(section.as_slice());
+                }
+            }
+        }
+        out
+    }
+
+    /// Every packet of the completed table, in `section_number` order, each listed
+    /// once however many sections it carried.
+    pub(crate) fn packets(&self) -> Vec<Vec<u8>> {
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        if let Some(generation) = &self.in_flight {
+            for number in 0..=generation.last_section_number {
+                let Some(packets) = generation.packets.get(&number) else {
+                    continue;
+                };
+                for packet in packets {
+                    if !out.contains(packet) {
+                        out.push(packet.clone());
+                    }
+                }
+            }
+        }
+        out
+    }
+}

--- a/media-core/src/psi/table.rs
+++ b/media-core/src/psi/table.rs
@@ -204,11 +204,18 @@ impl TableTracker {
         generation.sections.insert(section_number, section.to_vec());
         generation.packets.insert(section_number, packets.to_vec());
 
-        // Two questions, and the count is asked first because it is the one a
-        // section numbered outside the table fails: such a section is collected
-        // like any other, so a table that was complete stops being complete
-        // while a stray number is held. Only once the count matches is each slot
-        // actually looked for.
+        // Every section admitted here has already been held to
+        //
+        //     section_number <= last_section_number
+        //
+        // by SectionHeader::read, so one numbering itself outside its own table
+        // never reaches this map. A generation holding exactly
+        // last_section_number+1 distinct numbers is therefore complete over
+        // 0..=last: there is nowhere else those numbers could have come from.
+        //
+        // The per-slot check below is kept anyway. It is redundant under that
+        // admission rule and would be the thing still standing if the rule were
+        // ever removed, which is the only kind of redundancy worth paying for.
         let wanted = usize::from(last_section_number) + 1;
         if generation.sections.len() != wanted {
             return false;
@@ -220,8 +227,8 @@ impl TableTracker {
     ///
     /// Order is the table's, never arrival's: the sections of a table say where
     /// they belong, and a transport that sends them out of order is describing
-    /// the same programme. Only the numbers the table declares are walked, so a
-    /// section numbered outside it is never read even while it is held.
+    /// the same programme. Only the declared range `0..=last_section_number` is
+    /// walked, and admission guarantees nothing is stored outside it.
     pub(crate) fn sections(&self) -> Vec<&[u8]> {
         let mut out = Vec::new();
         if let Some(generation) = &self.in_flight {

--- a/media-core/src/psi/table.rs
+++ b/media-core/src/psi/table.rs
@@ -12,9 +12,50 @@ use std::collections::BTreeMap;
 /// eight-byte header, four bytes of CRC, and nothing in between.
 pub(crate) const MIN_SECTION_LEN: usize = 12;
 
-/// The largest a section can be, from `section_length` being twelve bits: three
-/// header bytes ahead of the field plus the 4093 it can name.
-pub(crate) const MAX_SECTION_LEN: usize = 3 + 0x0FFF;
+/// The most a PAT or PMT section may declare after its length field.
+///
+/// `section_length` is a twelve bit field, but ISO/IEC 13818-1 does not let
+/// either of these tables use all of it: for both, the first two bits of the
+/// field shall be `00` and the value shall not exceed 1021. The field width is
+/// not the bound, and treating it as one would have this parser collect four
+/// kilobytes for a section that cannot legally be longer than one - on nothing
+/// better than the say-so of a stream that has already declared something
+/// impossible.
+pub(crate) const MAX_SECTION_LENGTH: usize = 1021;
+
+/// The most a PAT or PMT section can be in total.
+pub(crate) const MAX_SECTION_BYTES: usize = MAX_SECTION_LENGTH + 3;
+
+/// Reads the three bytes that open a section and reports the total length they
+/// declare.
+///
+/// `None` for a declaration a PAT or PMT cannot make. Three things make one
+/// impossible, and they are asked together because they are read from the same
+/// two bytes and all knowable the moment those bytes arrive:
+///
+/// - `section_syntax_indicator` must be 1, since both tables use the long form
+/// - the bit after it must be 0, fixed by the syntax rather than reserved
+/// - `section_length` must not exceed 1021
+///
+/// One helper for one question, asked everywhere it comes up: by the scan that
+/// meets a header whole inside a payload, by the assembler deciding how many
+/// bytes to collect, and by the completed-section check. A second definition of
+/// "how long may this be" is how two paths come to disagree about it.
+pub(crate) fn declaration(prefix: &[u8]) -> Option<usize> {
+    if prefix.len() < 3 {
+        return None;
+    }
+    if prefix[1] & 0x80 == 0 || prefix[1] & 0x40 != 0 {
+        return None;
+    }
+    let length = (usize::from(prefix[1] & 0x0F) << 8) | usize::from(prefix[2]);
+    if length > MAX_SECTION_LENGTH {
+        return None;
+    }
+    let total = length + 3;
+    debug_assert!(total <= MAX_SECTION_BYTES);
+    Some(total)
+}
 
 /// The fields of a section header this parser reads.
 pub(crate) struct SectionHeader {
@@ -36,8 +77,10 @@ impl SectionHeader {
     ///
     /// - it is long enough to hold the fields that will be read,
     /// - it is the table this PID is being read for,
+    /// - it declares a length and a syntax those tables may declare,
     /// - its bytes are intact,
-    /// - it is in force rather than announced for later.
+    /// - it is in force rather than announced for later,
+    /// - it numbers itself inside the table it names.
     ///
     /// The table check is here, on the completed section, and not only where a
     /// header happens to be scanned inside one payload: a section whose first
@@ -51,6 +94,10 @@ impl SectionHeader {
         if section[0] != expected_table_id {
             return None;
         }
+        // Defence in depth. Both paths that reach here refused an impossible
+        // declaration before acting on it, and asking again costs nothing
+        // against a section that arrived some way nobody has thought of yet.
+        declaration(section)?;
         if crc::mpeg2(section) != 0 {
             return None;
         }
@@ -60,11 +107,24 @@ impl SectionHeader {
         if section[5] & 0x01 != 1 {
             return None;
         }
+        let section_number = section[6];
+        let last_section_number = section[7];
+        // A section numbers itself within its own table: 13818-1 has
+        // section_number count from zero and last_section_number name the
+        // highest, so a section claiming to be the sixth of two is not a member
+        // of the table it names. Refused here rather than collected and found
+        // wanting later - the tracker keys sections by number, so an impossible
+        // one is an entry the generation can never account for, and a table
+        // arriving correctly would stop completing because of a section that
+        // was never part of it.
+        if section_number > last_section_number {
+            return None;
+        }
         Some(Self {
             id_extension: (u16::from(section[3]) << 8) | u16::from(section[4]),
             version: (section[5] >> 1) & 0x1F,
-            section_number: section[6],
-            last_section_number: section[7],
+            section_number,
+            last_section_number,
         })
     }
 


### PR DESCRIPTION
**Step 5b.** Rust reads PAT, PMT and their descriptors as a library, and is held to the same language-independent corpus the Go reference is held to.

> **76 cases, 125 calls, every compared field exact.**

Rebased onto [#935](https://github.com/ManuGH/xg2g/pull/935) (R6) and [#936](https://github.com/ManuGH/xg2g/pull/936) (R7), which between them settled four ways a PAT or PMT section can declare something it cannot be — **all four found by writing or reviewing this parser**. The corpus grew from 63/100 to 76/125 and drives both languages.

**Nothing is wired.** This is not `RemoteCore.Ingest`, there is no wire change, and Go remains the parser production reads. What this PR establishes is narrower and has to come first: that a second implementation, written against the frozen contract rather than against the first implementation's code, arrives at the same answer on every call of every case.

## Modules

| File | Owns |
|---|---|
| `psi/crc.rs` | the MPEG-2 section CRC, **bit by bit rather than by table** — the table form would be a second place the polynomial is written down, and one nobody can read against the standard |
| `psi/table.rs::declaration` | the one place asking whether a section may declare what it declares: syntax bits, and `section_length` ≤ **1021** |
| `psi/assembler.rs` | packet framing, continuity, pointer fields, getting whole sections out of packets |
| `psi/table.rs` | what a completed section must be before anything is read out of it; multi-section collection |
| `psi/pat.rs` | which programme this core follows |
| `psi/pmt.rs` | what that programme is made of |
| `psi/descriptors.rs` | what one elementary stream's descriptors say |

The transport understood here is only what PSI needs. **No PES, no elementary stream payload, no timing, no random access** — those are steps 6 and 7. `ipc.rs` stays transport and is untouched.

## The corpus reader is fail-closed

A reader that finds three cases and passes is worse than one that fails. An unknown keyword, a repeated field, a missing field, bad or odd-length hex, a call without an expectation, expectation lines out of order, an unsupported format version, or trailing text after `end` all stop it. **Seventeen damaged corpora are checked to be refused**, and the case count has a floor (`>= 63`, not `== 63`) so later cases run automatically while a reader bug cannot quietly check less than it claims.

`the_corpus_carries_no_unadjudicated_semantics` asserts **0 notes** — a second implementation must not be written to reproduce behaviour nobody has ruled on.

## Adversarial, beyond the corpus

Sections at and past every bound, `section_length` 0 and maximum, pointer fields past the payload, 255-section tables, stray section numbers, foreign tables, foreign programmes, descriptors and ES entries declaring more than they hold, adaptation fields that eat the payload, bad sync, wrong PID, uniform `0x00`/`0xFF`/`0x47`, arbitrary bytes from a deterministic generator, and **every single-byte mutation of a good stream**. None panics; every container is asserted bounded.

`where_a_chunk_was_cut_does_not_change_what_the_stream_meant` checks every grouping of the same packets. Chunk boundaries are transport segmentation, not semantics — unlike the audio observer, where the feed boundary *is* the input.

## Mutations — 18 applied, 18 killed

`media-core/scripts/mutate-psi.sh`, each naming the test that caught it:

| Mutation | Killed by |
|---|---|
| stop checking a section's CRC | `sections_that_cannot_be_read_are_refused` |
| accept a completed section of any table | `the_rust_core_answers_the_shared_corpus` |
| act on a table announced for later | `sections_that_cannot_be_read_are_refused` |
| call a table complete before all sections are here | `a_pmt_for_another_programme_leaves_...` |
| accept a PMT whichever programme it names | `a_pmt_for_another_programme_leaves_...` |
| **let a foreign PMT reach the tracker before it is refused** | `a_pmt_for_another_programme_leaves_...` |
| let the last section of a PAT re-choose | `the_rust_core_answers_the_shared_corpus` |
| accept audio on a PID that cannot carry one | `the_rust_core_answers_the_shared_corpus` |
| bound an ES entry by the section, not the loop | `the_rust_core_answers_the_shared_corpus` |
| stop the descriptor walk at the first unknown tag | `the_rust_core_answers_the_shared_corpus` |
| collect a section numbered beyond its own table | `a_section_numbered_beyond_its_table_leaves_that_table_alone` |
| let a PAT or PMT declare the whole twelve-bit length | `section_lengths_at_and_past_their_bounds_are_survived` |
| stop requiring the long section syntax | `the_rust_core_answers_the_shared_corpus` |
| stop requiring the fixed zero bit | `the_rust_core_answers_the_shared_corpus` |
| resume the scan inside a section whose length was refused | `the_rust_core_answers_the_shared_corpus` |
| let a PAT declare less than its own syntax costs | `section_lengths_at_and_past_their_bounds_are_survived` |
| give a PMT the shorter floor a PAT has | `a_pmt_declaring_a_length_only_a_pat_may_use_is_refused` |
| keep the section in flight after refusing its declaration | `an_impossible_declaration_leaves_the_assembler_empty_and_keeps_it_empty` |

The ordering mutation matters most: moving the programme-number check *after* `pmt_tracker.add` compiles and passes the simple rejection cases, and is caught only by the between-sections test.

## What R6 changed here

The first version of this PR took `section_length`'s twelve-bit field width for its bound — **4095**. That is wrong for these tables: 13818-1 caps a PAT or PMT section at **1021** after the length field, 1024 in all, with the two bits above that cap required to be `00`. The Go reference had the same mistake, so agreeing with it would have made a shared error permanent. R6 fixed both sides; this PR now enforces 1021/1024 and validates the header *before* deciding how much to collect.

Two more, same shape:

- **`section_syntax_indicator` must be 1 and the bit after it 0.** Neither implementation checked them.
- **A section numbering itself beyond its own table is refused before the tracker.** The earlier version of this PR contained a test *asserting the opposite* — that such a section poisons the generation so the table never completes again. Both implementations did that, so it looked like agreement. It was a shared defect; the test is gone and the corrected behaviour replaces it.

Also fixed here after review: an impossible declaration now gives up the **whole payload** it was found in. Returning only the header bytes put the scan a byte or two into the body of the section just refused, and let those bytes be read as a `table_id` and length of their own.

## Performance

Release, one `ingest` per timing. *(Corrected after review: the perf fixture's PMT carried a wrong `section_length` byte and was refused on every run, so the earlier figures in this PR timed the reject path. These are higher and honest.)*

| Chunk | representative transport | every packet a table |
|---|---|---|
| 63 KiB | p50 10.7 µs | p50 293 µs |
| 255 KiB | p50 38.5 µs | p50 1.18 ms |
| 1023 KiB | p50 133 µs | p50 4.70 ms |
| **4095 KiB** | **p50 506 µs**, max 645 µs | **p50 18.8 ms**, max 18.9 ms |

Linear in the bytes at every size. Against the 500 ms a caller allows for one chunk, that is ~1100× of headroom on a realistic transport and ~38× on one where every packet is a table.

The budget the test asserts is profile-aware: a debug build is ~7.5× slower here by construction, so holding it to the release bound would fail CI for a reason that has nothing to do with the parser. **Allocation counts are not reported** — counting them needs a global allocator, which needs `unsafe`, which this crate forbids. What is asserted instead is that state stays bounded, which is the property the count would have been evidence for.

## Scope

```
Go production files changed   0
Wire / IPC / workflow         untouched
Cargo.lock                    unchanged (crate still has zero dependencies)
unsafe                        forbidden, and none present
```

`cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --locked` (47 tests) — all clean. The corpus floor stays `>= 63` so later cases run automatically; the actual count is now **76 cases / 125 calls / 0 notes**.

## What Rust still does NOT do after this PR

```
Rust PSI parser exists as a tested library.

Rust PSI is NOT authoritative.
Rust PSI is NOT wired into RemoteCore.Ingest.
Rust does NOT yet own the production TS/PES path.
Go remains authoritative.
```

## R7 closed the open blocker

The shared defect this PR's review surfaced — a `section_length` of 0 arriving with its header split across a packet boundary wedging the assembler, after which every further packet retained a full 188-byte copy — is fixed in [#936](https://github.com/ManuGH/xg2g/pull/936) and adopted here.

Not by special-casing zero. Each table has a floor equal to what its own mandatory syntax costs — **PAT 9, PMT 13** — so 12 is a length one table may declare and the other may not. With a floor of at least 9, filling the three header bytes always leaves the buffer short of the section length, and the exact equality the wedge needed **cannot occur**.

`an_impossible_declaration_leaves_the_assembler_empty_and_keeps_it_empty` reads the assembler directly over a thousand continuation packets. The defect never moved a fact, so the shared corpus cannot see it.

**READY_FOR_5C: requires separate approval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)



